### PR TITLE
Chore: Updated list of needs for backend-tests action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -222,7 +222,8 @@ jobs:
           path: client/playwright-report
           retention-days: 30
   backend-tests:
-    needs: [backend-docker-build, install-dev-tools]
+    needs:
+      ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Updated the "needs" list for `backend-tests` job to match the needs for `e2e` job in workflows/test.yaml