### PR TITLE
232 update css theme

### DIFF
--- a/client/app/components/form/MultiStepHeader.tsx
+++ b/client/app/components/form/MultiStepHeader.tsx
@@ -8,10 +8,7 @@ const MultiStepHeader = ({ step, steps }: MultiStepHeaderProps) => {
     <div className="block md:flex flex-row mt-10 mb-6 justify-between w-full">
       {steps.map((s, i) => {
         const isLastStep = i === steps.length - 1;
-        const bgColor =
-          i === step
-            ? "bg-bc-gov-yellow"
-            : "bg-bc-gov-primary-brand-color-blue";
+        const bgColor = i === step ? "bg-bc-yellow" : "bg-bc-primary-blue";
 
         return (
           <div

--- a/client/app/components/form/widgets/FileWidget.tsx
+++ b/client/app/components/form/widgets/FileWidget.tsx
@@ -127,9 +127,7 @@ const FileWidget = ({
   );
 
   const disabledColour =
-    disabled || readonly
-      ? "text-dark-grey-bg-color"
-      : "text-bc-gov-links-color";
+    disabled || readonly ? "text-bc-bg-dark-grey" : "text-bc-link-blue";
 
   /*   File input styling options are limited so we are attaching a ref to it, hiding it and triggering it with a styled button. */
   return (

--- a/client/app/components/theme/theme.ts
+++ b/client/app/components/theme/theme.ts
@@ -1,8 +1,13 @@
 import { createTheme } from "@mui/material/styles";
 import {
   BC_GOV_PRIMARY_BRAND_COLOR_BLUE,
-  BC_GOV_LINKS_COLOR,
   BC_GOV_BACKGROUND_COLOR_BLUE,
+  BC_GOV_LINKS_COLOR,
+  BC_GOV_YELLOW,
+  DARK_GREY_BG_COLOR,
+  LIGHT_GREY_BG_COLOR,
+  BC_GOV_SEMANTICS_RED,
+  BC_GOV_SEMANTICS_GREEN,
 } from "@/app/styles/colors";
 import "@bcgov/bc-sans/css/BCSans.css";
 
@@ -21,7 +26,17 @@ const theme = createTheme({
       // contrastText: will be calculated to contrast with palette.primary.main
     },
     secondary: {
-      main: BC_GOV_BACKGROUND_COLOR_BLUE,
+      main: DARK_GREY_BG_COLOR,
+      light: LIGHT_GREY_BG_COLOR,
+    },
+    error: {
+      main: BC_GOV_SEMANTICS_RED,
+    },
+    warning: {
+      main: BC_GOV_YELLOW,
+    },
+    success: {
+      main: BC_GOV_SEMANTICS_GREEN,
     },
   },
   components: {

--- a/client/app/styles/colors.ts
+++ b/client/app/styles/colors.ts
@@ -2,8 +2,10 @@
 export const BC_GOV_LINKS_COLOR: string = "#1A5A96";
 export const BC_GOV_PRIMARY_BRAND_COLOR_BLUE: string = "#003366";
 export const BC_GOV_BACKGROUND_COLOR_BLUE: string = "#38598a";
+export const BC_GOV_TEXT: string = "#313132";
 // App specific colors
 export const DARK_GREY_BG_COLOR: string = "#E5E5E5";
 export const LIGHT_GREY_BG_COLOR: string = "#fafafc";
 export const BC_GOV_YELLOW: string = "#FCBA19";
 export const BC_GOV_SEMANTICS_RED: string = "#D8292F";
+export const BC_GOV_SEMANTICS_GREEN: string = "#2E8540";

--- a/client/app/styles/globals.css
+++ b/client/app/styles/globals.css
@@ -4,15 +4,19 @@
 @tailwind utilities;
 
 @layer components {
+  html,
+  body {
+    @apply text-bc-text;
+  }
   a {
-    @apply text-bc-gov-links-color;
+    @apply text-bc-link-blue;
   }
   .form-heading {
-    @apply text-2xl py-2 w-full font-bold border-solid text-bc-gov-background-color-blue border-bc-gov-background-color-blue border-l-0 border-r-0 mb-4;
+    @apply text-2xl py-2 w-full font-bold border-solid text-bc-bg-blue border-bc-bg-blue border-l-0 border-r-0 mb-4;
   }
   .form-heading-label {
     /* Selecting label child element so we can pass it in using ui:classNames in the form schema */
-    @apply [&>label]:text-2xl [&>label]:py-2 [&>label]:w-full [&>label]:font-bold [&>label]:border-solid [&>label]:text-bc-gov-background-color-blue [&>label]:border-bc-gov-background-color-blue [&>label]:border-l-0 [&>label]:border-r-0 [&>label]:mb-4;
+    @apply [&>label]:text-2xl [&>label]:py-2 [&>label]:w-full [&>label]:font-bold [&>label]:border-solid [&>label]:text-bc-bg-blue [&>label]:border-bc-bg-blue [&>label]:border-l-0 [&>label]:border-r-0 [&>label]:mb-4;
   }
 }
 

--- a/client/app/styles/rjsf/GroupTitleFieldTemplate.tsx
+++ b/client/app/styles/rjsf/GroupTitleFieldTemplate.tsx
@@ -4,7 +4,7 @@ function GroupTitleFieldTemplate(props: TitleFieldProps) {
   const { id, title } = props;
 
   return (
-    <header id={id} className="text-bc-gov-background-color-blue my-4 text-lg">
+    <header id={id} className="text-bc-bg-blue my-4 text-lg">
       {title}
     </header>
   );

--- a/client/app/utils/jsonSchema/userOperator.ts
+++ b/client/app/utils/jsonSchema/userOperator.ts
@@ -12,7 +12,7 @@ import {
 } from "@/app/components/form/titles/userOperatorTitles";
 
 const subheading = {
-  "ui:classNames": "text-bc-gov-primary-brand-color-blue text-start text-lg",
+  "ui:classNames": "text-bc-bg-blue text-start text-lg",
   "ui:FieldTemplate": TitleOnlyFieldTemplate,
 };
 

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -11,10 +11,13 @@
 import {
   BC_GOV_PRIMARY_BRAND_COLOR_BLUE,
   BC_GOV_BACKGROUND_COLOR_BLUE,
+  BC_GOV_TEXT,
   BC_GOV_LINKS_COLOR,
   BC_GOV_YELLOW,
   DARK_GREY_BG_COLOR,
   LIGHT_GREY_BG_COLOR,
+  BC_GOV_SEMANTICS_RED,
+  BC_GOV_SEMANTICS_GREEN,
 } from "./app/styles/colors";
 
 module.exports = {
@@ -33,12 +36,15 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        "bc-gov-primary-brand-color-blue": BC_GOV_PRIMARY_BRAND_COLOR_BLUE,
-        "bc-gov-background-color-blue": BC_GOV_BACKGROUND_COLOR_BLUE,
-        "bc-gov-links-color": BC_GOV_LINKS_COLOR,
-        "bc-gov-yellow": BC_GOV_YELLOW,
-        "dark-grey-bg-color": DARK_GREY_BG_COLOR,
-        "light-grey-bg-color": LIGHT_GREY_BG_COLOR,
+        "bc-text": BC_GOV_TEXT,
+        "bc-primary-blue": BC_GOV_PRIMARY_BRAND_COLOR_BLUE,
+        "bc-bg-blue": BC_GOV_BACKGROUND_COLOR_BLUE,
+        "bc-link-blue": BC_GOV_LINKS_COLOR,
+        "bc-yellow": BC_GOV_YELLOW,
+        "bc-bg-dark-grey": DARK_GREY_BG_COLOR,
+        "bc-bg-light-grey": LIGHT_GREY_BG_COLOR,
+        "bc-success-green": BC_GOV_SEMANTICS_GREEN,
+        "bc-error-red": BC_GOV_SEMANTICS_RED,
       },
       lineHeight: {
         12: "48px",

--- a/docs/css-theme-guide.md
+++ b/docs/css-theme-guide.md
@@ -1,0 +1,25 @@
+# CSS theming guide
+
+## Globals
+
+Colour variables are stored in the `colors.ts` file located in [`/client/app/styles/colors.ts`](/client/app/styles/colors.ts)
+
+Global CSS resets as well as custom Tailwind classes using `@apply`can be set in the `globals.css` file located in [`/client/app/styles/globals.css`](/client/app/styles/globals.css)
+
+## Tailwind
+
+[https://tailwindcss.com/](https://tailwindcss.com/)
+
+The Tailwind configuration file is located in [`/client/tailwind.config.css`](/client/tailwind.config.js). Here we can extend the theme and set custom variables for things such as colours and widths.
+
+Custom Tailwind classes using `@apply` can be set in the `globals.css` file located in [`/client/app/styles/globals.css`](/client/app/styles/globals.css)
+
+## Material UI (MUI)
+
+[https://mui.com/material-ui/](https://mui.com/material-ui/)
+
+This project uses Material UI for many components and inputs. Styles can be applied using the `sx` prop and regular CSS or using the `classNames` prop with Tailwind classes.
+
+[https://mui.com/base-ui/guides/working-with-tailwind-css/](https://mui.com/base-ui/guides/working-with-tailwind-css/)
+
+The MUI theme is located in [`/client/app/components/theme`](/client/app/components/theme). Here we can override the default MUI palette, typography and more.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -90,6 +90,8 @@ Client\middleware implements middleware to secured the app routes based on NextA
 
 ## Styling
 
+[CSS theme guide](/docs/css-theme-guide.md)
+
 ### MUI v5
 
 [Material-UI (MUI)](https://mui.com/material-ui/getting-started/) is a popular open-source UI framework for React applications that is based on Google's Material Design guidelines. It provides a wide range of reusable and customizable components and styles to help you build modern, attractive, and responsive web applications


### PR DESCRIPTION
A a lot of this was already completed in previous PRs and without a proper design system implemented there wasn't too much to do for this ticket, though it's something we've flagged with the designers.

I've tried to simplify the colour names to be a little bit less verbose as the old ones made for some long tailwind classes. Let me know if you have other naming suggestions though I think we should keep them fairly short.

I've also setup documentation linking to our global css file, Tailwind config and Mui theme.