### PR TITLE
173 number widget

### DIFF
--- a/client/app/components/form/widgets/ComboBox.tsx
+++ b/client/app/components/form/widgets/ComboBox.tsx
@@ -3,11 +3,7 @@
 import { Autocomplete, TextField } from "@mui/material";
 import { WidgetProps } from "@rjsf/utils/lib/types";
 import { useCallback } from "react";
-import {
-  BC_GOV_LINKS_COLOR,
-  DARK_GREY_BG_COLOR,
-  BC_GOV_SEMANTICS_RED,
-} from "@/app/styles/colors";
+import { DARK_GREY_BG_COLOR, BC_GOV_SEMANTICS_RED } from "@/app/styles/colors";
 
 const ComboBox: React.FC<WidgetProps> = (props) => {
   const { id, onChange, rawErrors, schema, value } = props;
@@ -37,13 +33,6 @@ const ComboBox: React.FC<WidgetProps> = (props) => {
       borderColor: DARK_GREY_BG_COLOR,
     },
     "& .MuiOutlinedInput-notchedOutline": {
-      borderColor: borderColor,
-    },
-    "&:hover .MuiOutlinedInput-notchedOutline": {
-      borderColor: BC_GOV_LINKS_COLOR,
-      borderWidth: "1px",
-    },
-    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
       borderColor: borderColor,
     },
   };

--- a/client/app/components/form/widgets/SelectWidget.tsx
+++ b/client/app/components/form/widgets/SelectWidget.tsx
@@ -5,11 +5,7 @@ import FormControl from "@mui/material/FormControl";
 import InputLabel from "@mui/material/InputLabel";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import { WidgetProps } from "@rjsf/utils/lib/types";
-import {
-  BC_GOV_LINKS_COLOR,
-  DARK_GREY_BG_COLOR,
-  BC_GOV_SEMANTICS_RED,
-} from "@/app/styles/colors";
+import { DARK_GREY_BG_COLOR, BC_GOV_SEMANTICS_RED } from "@/app/styles/colors";
 
 const SelectWidget: React.FC<WidgetProps> = (props) => {
   const {
@@ -42,13 +38,6 @@ const SelectWidget: React.FC<WidgetProps> = (props) => {
       borderColor: DARK_GREY_BG_COLOR,
     },
     "& .MuiOutlinedInput-notchedOutline": {
-      borderColor: borderColor,
-    },
-    "&:hover .MuiOutlinedInput-notchedOutline": {
-      borderColor: BC_GOV_LINKS_COLOR,
-      borderWidth: "1px",
-    },
-    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
       borderColor: borderColor,
     },
   };

--- a/client/app/components/form/widgets/TextWidget.tsx
+++ b/client/app/components/form/widgets/TextWidget.tsx
@@ -10,8 +10,10 @@ const TextWidget: React.FC<WidgetProps> = ({
   onChange,
   rawErrors,
   readonly,
+  schema,
   value,
 }) => {
+  const type = schema.type === "number" ? "number" : "text";
   const handleChange = (e: { target: { value: string } }) => {
     const val = e.target.value;
     onChange(val === "" ? undefined : val);
@@ -36,6 +38,7 @@ const TextWidget: React.FC<WidgetProps> = ({
       value={value}
       onChange={handleChange}
       sx={styles}
+      type={type}
     />
   );
 };

--- a/client/app/components/form/widgets/TextWidget.tsx
+++ b/client/app/components/form/widgets/TextWidget.tsx
@@ -14,10 +14,17 @@ const TextWidget: React.FC<WidgetProps> = ({
   value,
 }) => {
   const type = schema.type === "number" ? "number" : "text";
+  // in the future we will add an option to allow users to set a max value
+  const maxNum = 2147483647;
+
   const handleChange = (e: { target: { value: string } }) => {
     const val = e.target.value;
+    if (type === "number" && !isNaN(Number(val)) && Number(val) > maxNum)
+      return;
+
     onChange(val === "" ? undefined : val);
   };
+
   const isError = rawErrors && rawErrors.length > 0;
   const borderColor = isError ? BC_GOV_SEMANTICS_RED : DARK_GREY_BG_COLOR;
 

--- a/client/app/components/form/widgets/TextWidget.tsx
+++ b/client/app/components/form/widgets/TextWidget.tsx
@@ -2,11 +2,7 @@
 
 import { TextField } from "@mui/material";
 import { WidgetProps } from "@rjsf/utils/lib/types";
-import {
-  BC_GOV_LINKS_COLOR,
-  DARK_GREY_BG_COLOR,
-  BC_GOV_SEMANTICS_RED,
-} from "@/app/styles/colors";
+import { DARK_GREY_BG_COLOR, BC_GOV_SEMANTICS_RED } from "@/app/styles/colors";
 
 const TextWidget: React.FC<WidgetProps> = ({
   disabled,
@@ -20,7 +16,6 @@ const TextWidget: React.FC<WidgetProps> = ({
     const val = e.target.value;
     onChange(val === "" ? undefined : val);
   };
-
   const isError = rawErrors && rawErrors.length > 0;
   const borderColor = isError ? BC_GOV_SEMANTICS_RED : DARK_GREY_BG_COLOR;
 
@@ -29,12 +24,6 @@ const TextWidget: React.FC<WidgetProps> = ({
     "& .MuiOutlinedInput-root": {
       "& fieldset": {
         borderColor,
-      },
-      "&:hover fieldset": {
-        borderColor: BC_GOV_LINKS_COLOR,
-      },
-      "&.Mui-focused fieldset": {
-        borderColor: BC_GOV_LINKS_COLOR,
       },
     },
   };

--- a/client/app/components/theme/theme.ts
+++ b/client/app/components/theme/theme.ts
@@ -5,10 +5,10 @@ import {
   BC_GOV_LINKS_COLOR,
   BC_GOV_YELLOW,
   BC_GOV_TEXT,
-  DARK_GREY_BG_COLOR,
   LIGHT_GREY_BG_COLOR,
   BC_GOV_SEMANTICS_RED,
   BC_GOV_SEMANTICS_GREEN,
+  DARK_GREY_BG_COLOR,
 } from "@/app/styles/colors";
 import "@bcgov/bc-sans/css/BCSans.css";
 
@@ -60,6 +60,51 @@ const theme = createTheme({
         root: {
           "& a": {
             color: BC_GOV_LINKS_COLOR,
+          },
+        },
+      },
+    },
+
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          "& .MuiOutlinedInput-root": {
+            "&:hover fieldset": {
+              borderColor: BC_GOV_LINKS_COLOR,
+            },
+            "&.Mui-focused fieldset": {
+              borderColor: BC_GOV_LINKS_COLOR,
+            },
+          },
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          "&:hover .MuiOutlinedInput-notchedOutline": {
+            borderColor: BC_GOV_LINKS_COLOR,
+            borderWidth: "1px",
+          },
+          "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+            borderColor: BC_GOV_LINKS_COLOR,
+          },
+        },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          "& .MuiOutlinedInput-root": {
+            "& fieldset": {
+              borderColor: DARK_GREY_BG_COLOR,
+            },
+            "&:hover fieldset": {
+              borderColor: BC_GOV_LINKS_COLOR,
+            },
+            "&.Mui-focused fieldset": {
+              borderColor: BC_GOV_LINKS_COLOR,
+            },
           },
         },
       },

--- a/client/app/styles/globals.css
+++ b/client/app/styles/globals.css
@@ -37,3 +37,16 @@ body {
   margin: 0 auto;
   padding: 0;
 }
+
+/* Remove the arrows from input number fields */
+/* Chrome, Safari, Edge, Opera */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+input[type="number"] {
+  -moz-appearance: textfield;
+}

--- a/docs/rjsf-forms.md
+++ b/docs/rjsf-forms.md
@@ -2,6 +2,17 @@
 
 RJSF Documentation: [https://rjsf-team.github.io/react-jsonschema-form/docs/](https://rjsf-team.github.io/react-jsonschema-form/docs/)
 
+## Types
+
+Number fields will be automatically handled when the type is set to `number` in the schema as the default `TextWidget` will change the input to a number input and save the value as a number. This can be overridden using the `ui:widget` option in the `uiSchema`.
+
+```
+number_field {
+  type: 'number',
+  title: 'Number field'
+}
+```
+
 ## Custom widgets
 
 The `defaultTheme` includes many custom widgets which can be set in the forms `uiSchema` using the `ui:widget` option.


### PR DESCRIPTION
In this I refactored and moved some of the shared widget styles to the MUI theme that didn't need to be reactive before I figured out that we might not need a specific `NumberWidget`. Setting the `type` as I have in the `URLWidget` for example doesn't actually get passed in RJSF to the widget, even if I extend the widget props.  As such will be getting rid of that and `EmailWidget` in #316 using the `format` option.

Now in a fields schema if  `type: 'number'` is set then the `TextWidget` will be set to `type="number"`, the input won't accept letters and the value is saved as a number in the form data.  I looked into it and we can limit the decimal places in the future easily if needed.

The arrow increment buttons are disabled globally for number inputs via CSS in the `globals.css` file.

Let me know if you think we need a specific `NumberWidget`. I like this solution though maybe there is something I missed.
