### PR TITLE
fix: header colour regression from mui theme update

### DIFF
--- a/client/app/(onboarding)/home/page.tsx
+++ b/client/app/(onboarding)/home/page.tsx
@@ -40,7 +40,7 @@ export default function Page() {
       <Grid container spacing={2}>
         <Grid item xs={12} md={6} order={{ xs: 2, md: 1 }}>
           <Typography
-            color="secondary"
+            color="primary.light"
             sx={{
               fontWeight: 700,
               fontSize: "24px",
@@ -112,7 +112,7 @@ export default function Page() {
         </Grid>
         <Grid item xs={12} md={6} order={{ xs: 1, md: 2 }}>
           <Typography
-            color="secondary"
+            color="primary.light"
             sx={{
               fontWeight: 700,
               fontSize: "24px",
@@ -174,7 +174,7 @@ export default function Page() {
             </Table>
           </TableContainer>{" "}
           <Typography
-            color="secondary"
+            color="primary.light"
             sx={{
               marginTop: "40px",
               fontWeight: 700,
@@ -243,7 +243,7 @@ export default function Page() {
           </Typography>
           {/* TEMP Links */}
           <Typography
-            color="secondary"
+            color="primary.light"
             sx={{
               marginTop: "40px",
               fontWeight: 700,

--- a/client/app/components/layout/Header.tsx
+++ b/client/app/components/layout/Header.tsx
@@ -77,6 +77,7 @@ export default function Header() {
           </Link>
           <Typography
             component="div"
+            color="white"
             sx={{
               flexGrow: 1,
               fontWeight: 700,

--- a/client/app/components/theme/theme.ts
+++ b/client/app/components/theme/theme.ts
@@ -4,6 +4,7 @@ import {
   BC_GOV_BACKGROUND_COLOR_BLUE,
   BC_GOV_LINKS_COLOR,
   BC_GOV_YELLOW,
+  BC_GOV_TEXT,
   DARK_GREY_BG_COLOR,
   LIGHT_GREY_BG_COLOR,
   BC_GOV_SEMANTICS_RED,
@@ -15,6 +16,9 @@ const theme = createTheme({
   typography: {
     fontFamily: "BCSans, sans-serif",
     // Include "sans-serif" as a fallback font family.
+    allVariants: {
+      color: BC_GOV_TEXT,
+    },
   },
   // To modify each color directly, provide an object with one or more of the color tokens. Only the main token is required; light, dark, and contrastText are optional, and if not provided, then their values are calculated
   palette: {
@@ -37,6 +41,9 @@ const theme = createTheme({
     },
     success: {
       main: BC_GOV_SEMANTICS_GREEN,
+    },
+    text: {
+      primary: BC_GOV_TEXT,
     },
   },
   components: {


### PR DESCRIPTION
Fix for the homepage header colour. This was caused by the MUI theme update PR. I also added a small change to typography so by default it will use the text colour from the bc gov design system.