### PR TITLE
318 multiselect widget

### DIFF
--- a/client/app/components/form/widgets/MultiSelectWidget.tsx
+++ b/client/app/components/form/widgets/MultiSelectWidget.tsx
@@ -57,6 +57,9 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
       filterSelectedOptions
       autoHighlight
       options={options}
+      value={value.map((val: string | number) => {
+        return options.find((option: Option) => option.const === val);
+      })}
       sx={styles}
       isOptionEqualToValue={(option: Option, val: Option) => {
         return option.const === val.const;

--- a/client/app/components/form/widgets/MultiSelectWidget.tsx
+++ b/client/app/components/form/widgets/MultiSelectWidget.tsx
@@ -4,6 +4,11 @@ import { TextField, Autocomplete, MenuItem } from "@mui/material";
 import { WidgetProps } from "@rjsf/utils/lib/types";
 import { DARK_GREY_BG_COLOR, BC_GOV_SEMANTICS_RED } from "@/app/styles/colors";
 
+interface Option {
+  const: string | number;
+  title: string;
+}
+
 const ComboBox: React.FC<WidgetProps> = ({
   id,
   onChange,
@@ -19,7 +24,7 @@ const ComboBox: React.FC<WidgetProps> = ({
   };
   const enumValues = fieldSchema?.enum as any;
   const enumNames = fieldSchema?.enumNames as any;
-  const options = enumValues.map((val, index) => ({
+  const options = enumValues.map((val: string | number, index: number) => ({
     const: val,
     title: enumNames[index] || val,
   }));
@@ -28,15 +33,14 @@ const ComboBox: React.FC<WidgetProps> = ({
     e: React.ChangeEvent<{}>,
     option: Array<{ const: string | number; title: string }>,
   ) => {
-    onChange(option.map((o) => o.const));
+    onChange(option.map((o: Option) => o.const));
   };
 
   const placeholder = uiSchema?.["ui:placeholder"]
     ? `${uiSchema["ui:placeholder"]}...`
     : "";
 
-  const displayPlaceholder =
-    typeof value === "undefined" || value?.length === 0;
+  const displayPlaceholder = value?.length === 0;
 
   const isError = rawErrors && rawErrors.length > 0;
   const borderColor = isError ? BC_GOV_SEMANTICS_RED : DARK_GREY_BG_COLOR;
@@ -53,10 +57,13 @@ const ComboBox: React.FC<WidgetProps> = ({
       disablePortal
       id={id}
       multiple
+      filterSelectedOptions
       autoHighlight
       options={options}
       sx={styles}
-      isOptionEqualToValue={(option: any, val: any) => option.const === val}
+      isOptionEqualToValue={(option: Option, val: any) => {
+        return option.const === val.const;
+      }}
       onChange={handleChange}
       getOptionLabel={(option: any) => String(option.title)}
       renderInput={(params) => (

--- a/client/app/components/form/widgets/MultiSelectWidget.tsx
+++ b/client/app/components/form/widgets/MultiSelectWidget.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { TextField, Autocomplete, MenuItem } from "@mui/material";
+import { WidgetProps } from "@rjsf/utils/lib/types";
+import { DARK_GREY_BG_COLOR, BC_GOV_SEMANTICS_RED } from "@/app/styles/colors";
+
+const ComboBox: React.FC<WidgetProps> = ({
+  id,
+  onChange,
+  rawErrors,
+  schema,
+  value,
+  uiSchema,
+}) => {
+  const fieldSchema = schema.items as {
+    enum: any[];
+    enumNames: any[];
+    type: string;
+  };
+  const enumValues = fieldSchema?.enum as any;
+  const enumNames = fieldSchema?.enumNames as any;
+  const options = enumValues.map((val, index) => ({
+    const: val,
+    title: enumNames[index] || val,
+  }));
+
+  const handleChange = (
+    e: React.ChangeEvent<{}>,
+    option: Array<{ const: string | number; title: string }>,
+  ) => {
+    onChange(option.map((o) => o.const));
+  };
+
+  const placeholder = uiSchema?.["ui:placeholder"]
+    ? `${uiSchema["ui:placeholder"]}...`
+    : "";
+
+  const displayPlaceholder =
+    typeof value === "undefined" || value?.length === 0;
+
+  const isError = rawErrors && rawErrors.length > 0;
+  const borderColor = isError ? BC_GOV_SEMANTICS_RED : DARK_GREY_BG_COLOR;
+
+  const styles = {
+    width: "100%",
+    "& .MuiOutlinedInput-notchedOutline": {
+      borderColor: borderColor,
+    },
+  };
+
+  return (
+    <Autocomplete
+      disablePortal
+      id={id}
+      multiple
+      autoHighlight
+      options={options}
+      sx={styles}
+      isOptionEqualToValue={(option: any, val: any) => option.const === val}
+      onChange={handleChange}
+      getOptionLabel={(option: any) => String(option.title)}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          placeholder={displayPlaceholder ? placeholder : ""}
+        />
+      )}
+      renderOption={(renderProps, option: any) => {
+        return (
+          <MenuItem {...renderProps} key={option.const} value={option.const}>
+            {option.title}
+          </MenuItem>
+        );
+      }}
+    />
+  );
+};
+export default ComboBox;

--- a/client/app/components/form/widgets/MultiSelectWidget.tsx
+++ b/client/app/components/form/widgets/MultiSelectWidget.tsx
@@ -6,10 +6,10 @@ import { DARK_GREY_BG_COLOR, BC_GOV_SEMANTICS_RED } from "@/app/styles/colors";
 
 interface Option {
   const: string | number;
-  title: string;
+  title: string | number;
 }
 
-const ComboBox: React.FC<WidgetProps> = ({
+const MultiSelectWidget: React.FC<WidgetProps> = ({
   id,
   onChange,
   rawErrors,
@@ -18,21 +18,18 @@ const ComboBox: React.FC<WidgetProps> = ({
   uiSchema,
 }) => {
   const fieldSchema = schema.items as {
-    enum: any[];
-    enumNames: any[];
+    enum: Array<string | number>;
+    enumNames: Array<string | number>;
     type: string;
   };
-  const enumValues = fieldSchema?.enum as any;
-  const enumNames = fieldSchema?.enumNames as any;
+  const enumValues = fieldSchema?.enum;
+  const enumNames = fieldSchema?.enumNames;
   const options = enumValues.map((val: string | number, index: number) => ({
     const: val,
     title: enumNames[index] || val,
   }));
 
-  const handleChange = (
-    e: React.ChangeEvent<{}>,
-    option: Array<{ const: string | number; title: string }>,
-  ) => {
+  const handleChange = (e: React.ChangeEvent<{}>, option: Array<Option>) => {
     onChange(option.map((o: Option) => o.const));
   };
 
@@ -61,11 +58,11 @@ const ComboBox: React.FC<WidgetProps> = ({
       autoHighlight
       options={options}
       sx={styles}
-      isOptionEqualToValue={(option: Option, val: any) => {
+      isOptionEqualToValue={(option: Option, val: Option) => {
         return option.const === val.const;
       }}
       onChange={handleChange}
-      getOptionLabel={(option: any) => String(option.title)}
+      getOptionLabel={(option: Option) => String(option.title)}
       renderInput={(params) => (
         <TextField
           {...params}
@@ -82,4 +79,5 @@ const ComboBox: React.FC<WidgetProps> = ({
     />
   );
 };
-export default ComboBox;
+
+export default MultiSelectWidget;

--- a/client/app/components/form/widgets/MultiSelectWidget.tsx
+++ b/client/app/components/form/widgets/MultiSelectWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TextField, Autocomplete, MenuItem } from "@mui/material";
+import { Autocomplete, Chip, MenuItem, TextField } from "@mui/material";
 import { WidgetProps } from "@rjsf/utils/lib/types";
 import { DARK_GREY_BG_COLOR, BC_GOV_SEMANTICS_RED } from "@/app/styles/colors";
 
@@ -72,6 +72,19 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
           placeholder={displayPlaceholder ? placeholder : ""}
         />
       )}
+      renderTags={(val: Array<Option>, getTagProps: any) => {
+        return val.map((option: Option, index: number) => {
+          return (
+            <Chip
+              key={option.const}
+              label={option.title}
+              {...getTagProps({
+                index,
+              })}
+            />
+          );
+        });
+      }}
       renderOption={(renderProps, option: any) => {
         return (
           <MenuItem {...renderProps} key={option.const} value={option.const}>

--- a/client/app/components/form/widgets/MultiSelectWidget.tsx
+++ b/client/app/components/form/widgets/MultiSelectWidget.tsx
@@ -27,10 +27,12 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
   // If no enumNames are provided, use the enum values as the names. The enumNames will not be saved in the formData.
   const enumValues = fieldSchema?.enum;
   const enumNames = fieldSchema?.enumNames;
-  const options = enumValues.map((val: string | number, index: number) => ({
-    id: val,
-    label: enumNames?.[index] || val,
-  }));
+  const options = enumValues.map(
+    (enumValue: string | number, index: number) => ({
+      id: enumValue,
+      label: enumNames?.[index] || enumValue,
+    }),
+  );
 
   const handleChange = (e: React.ChangeEvent<{}>, option: Array<Option>) => {
     onChange(option.map((o: Option) => o.id));
@@ -75,8 +77,8 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
           placeholder={displayPlaceholder ? placeholder : ""}
         />
       )}
-      renderTags={(val: Array<Option>, getTagProps: any) => {
-        return val.map((option: Option, index: number) => {
+      renderTags={(renderOptions: Array<Option>, getTagProps: any) => {
+        return renderOptions.map((option: Option, index: number) => {
           return (
             <Chip
               {...getTagProps}

--- a/client/app/components/form/widgets/MultiSelectWidget.tsx
+++ b/client/app/components/form/widgets/MultiSelectWidget.tsx
@@ -5,8 +5,8 @@ import { WidgetProps } from "@rjsf/utils/lib/types";
 import { DARK_GREY_BG_COLOR, BC_GOV_SEMANTICS_RED } from "@/app/styles/colors";
 
 interface Option {
-  const: string | number;
-  title: string | number;
+  id: string | number;
+  label: string | number;
 }
 
 const MultiSelectWidget: React.FC<WidgetProps> = ({
@@ -28,12 +28,12 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
   const enumValues = fieldSchema?.enum;
   const enumNames = fieldSchema?.enumNames;
   const options = enumValues.map((val: string | number, index: number) => ({
-    const: val,
-    title: enumNames?.[index] || val,
+    id: val,
+    label: enumNames?.[index] || val,
   }));
 
   const handleChange = (e: React.ChangeEvent<{}>, option: Array<Option>) => {
-    onChange(option.map((o: Option) => o.const));
+    onChange(option.map((o: Option) => o.id));
   };
 
   const placeholder = uiSchema?.["ui:placeholder"]
@@ -61,14 +61,14 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
       autoHighlight
       options={options}
       value={value.map((val: string | number) => {
-        return options.find((option: Option) => option.const === val);
+        return options.find((option: Option) => option.id === val);
       })}
       sx={styles}
       isOptionEqualToValue={(option: Option, val: Option) => {
-        return option.const === val.const;
+        return option.id === val.id;
       }}
       onChange={handleChange}
-      getOptionLabel={(option: Option) => String(option.title)}
+      getOptionLabel={(option: Option) => String(option.label)}
       renderInput={(params) => (
         <TextField
           {...params}
@@ -80,8 +80,8 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
           return (
             <Chip
               {...getTagProps}
-              key={option.const}
-              label={option.title}
+              key={option.id}
+              label={option.label}
               {...getTagProps({
                 index,
               })}
@@ -91,8 +91,8 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
       }}
       renderOption={(renderProps, option: Option) => {
         return (
-          <MenuItem {...renderProps} key={option.const} value={option.const}>
-            {option.title}
+          <MenuItem {...renderProps} key={option.id} value={option.id}>
+            {option.label}
           </MenuItem>
         );
       }}

--- a/client/app/components/form/widgets/MultiSelectWidget.tsx
+++ b/client/app/components/form/widgets/MultiSelectWidget.tsx
@@ -19,14 +19,17 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
 }) => {
   const fieldSchema = schema.items as {
     enum: Array<string | number>;
-    enumNames: Array<string | number>;
+    enumNames?: Array<string | number>;
     type: string;
   };
+
+  // Using enum and enumNames as anyOf was triggering a lot of validation errors for multiselect
+  // If no enumNames are provided, use the enum values as the names. The enumNames will not be saved in the formData.
   const enumValues = fieldSchema?.enum;
   const enumNames = fieldSchema?.enumNames;
   const options = enumValues.map((val: string | number, index: number) => ({
     const: val,
-    title: enumNames[index] || val,
+    title: enumNames?.[index] || val,
   }));
 
   const handleChange = (e: React.ChangeEvent<{}>, option: Array<Option>) => {
@@ -76,6 +79,7 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
         return val.map((option: Option, index: number) => {
           return (
             <Chip
+              {...getTagProps}
               key={option.const}
               label={option.title}
               {...getTagProps({
@@ -85,7 +89,7 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
           );
         });
       }}
-      renderOption={(renderProps, option: any) => {
+      renderOption={(renderProps, option: Option) => {
         return (
           <MenuItem {...renderProps} key={option.const} value={option.const}>
             {option.title}

--- a/client/app/components/form/widgets/index.ts
+++ b/client/app/components/form/widgets/index.ts
@@ -1,6 +1,7 @@
 export { default as ComboBox } from "./ComboBox";
 export { default as EmailWidget } from "./EmailWidget";
 export { default as FileWidget } from "./FileWidget";
+export { default as MultiSelectWidget } from "./MultiSelectWidget";
 export { default as PhoneWidget } from "./PhoneWidget";
 export { default as RadioWidget } from "./RadioWidget";
 export { default as SelectWidget } from "./SelectWidget";

--- a/client/app/components/routes/operations/form/Operation.tsx
+++ b/client/app/components/routes/operations/form/Operation.tsx
@@ -64,22 +64,24 @@ async function getOperation(id: number) {
 // 🛠️ Function to create an operation schema with updated enum values
 export const createOperationSchema = (
   schema: RJSFSchema,
-  naicsCodes: { id: number }[],
+  naicsCodes: { id: number; naics_code: string }[],
   regulatedProducts: {
-    name: any;
     id: number;
+    name: string;
   }[],
   reportingActivities: {
-    name: any;
     id: number;
+    name: string;
   }[],
 ) => {
   const localSchema = JSON.parse(JSON.stringify(schema));
   // naics codes
   if (Array.isArray(naicsCodes)) {
     // add to nested operation page1 schema
-    localSchema.properties.operationPage1.properties.naics_code_id.enum =
-      naicsCodes.map((code) => code.id);
+    localSchema.properties.operationPage1.properties.naics_code_id.anyOf =
+      naicsCodes.map((code) => {
+        return { const: code?.id, title: code?.naics_code };
+      });
   }
   // regulated products
   if (Array.isArray(regulatedProducts)) {

--- a/client/app/components/routes/operations/form/Operation.tsx
+++ b/client/app/components/routes/operations/form/Operation.tsx
@@ -65,8 +65,14 @@ async function getOperation(id: number) {
 export const createOperationSchema = (
   schema: RJSFSchema,
   naicsCodes: { id: number }[],
-  regulatedProducts: { id: number }[],
-  reportingActivities: { id: number }[],
+  regulatedProducts: {
+    name: any;
+    id: number;
+  }[],
+  reportingActivities: {
+    name: any;
+    id: number;
+  }[],
 ) => {
   const localSchema = JSON.parse(JSON.stringify(schema));
   // naics codes
@@ -78,12 +84,18 @@ export const createOperationSchema = (
   // regulated products
   if (Array.isArray(regulatedProducts)) {
     localSchema.properties.operationPage1.properties.regulated_products.items.enum =
-      regulatedProducts.map((product) => product.id);
+      regulatedProducts.map((product) => product?.id);
+
+    localSchema.properties.operationPage1.properties.regulated_products.items.enumNames =
+      regulatedProducts.map((product) => product?.name);
   }
   // reporting activities
   if (Array.isArray(reportingActivities)) {
     localSchema.properties.operationPage1.properties.reporting_activities.items.enum =
-      reportingActivities.map((product) => product.id);
+      reportingActivities.map((activity) => activity?.id);
+
+    localSchema.properties.operationPage1.properties.reporting_activities.items.enumNames =
+      reportingActivities.map((activity) => activity?.name);
   }
   return localSchema;
 };

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -30,7 +30,6 @@ const operationPage1: RJSFSchema = {
         type: "number",
       },
       title: "Regulated Product Name(s)",
-      uniqueItems: true,
     },
     reporting_activities: {
       type: "array",
@@ -38,8 +37,6 @@ const operationPage1: RJSFSchema = {
         type: "number",
       },
       title: "Reporting Activities",
-
-      uniqueItems: true,
     },
     process_flow_diagram: {
       type: "string",

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -300,7 +300,7 @@ export const operationUiSchema = {
     "ui:widget": "hidden",
   },
   naics_code_id: {
-    "ui:widget": "SelectWidget",
+    "ui:widget": "ComboBox",
     "ui:placeholder": "Select Primary NAICS code",
   },
   "Did you submit a GHG emissions report for reporting year 2022?": {

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -30,6 +30,7 @@ const operationPage1: RJSFSchema = {
         type: "number",
       },
       title: "Regulated Product Name(s)",
+      uniqueItems: true,
     },
     reporting_activities: {
       type: "array",
@@ -37,6 +38,8 @@ const operationPage1: RJSFSchema = {
         type: "number",
       },
       title: "Reporting Activities",
+
+      uniqueItems: true,
     },
     process_flow_diagram: {
       type: "string",
@@ -320,5 +323,13 @@ export const operationUiSchema = {
   },
   province: {
     "ui:widget": "ComboBox",
+  },
+  regulated_products: {
+    "ui:widget": "MultiSelectWidget",
+    "ui:placeholder": "Select regulated products",
+  },
+  reporting_activities: {
+    "ui:widget": "MultiSelectWidget",
+    "ui:placeholder": "Select reporting activities",
   },
 };

--- a/docs/rjsf-forms.md
+++ b/docs/rjsf-forms.md
@@ -30,9 +30,34 @@ phone_field {
 To enable validation of the phone widget the format must be set to `format: phone` in the form schema
 
 ```
-  phone_field {
-    type: 'string',
-    format: 'phone',
-    title: 'Phone field'
-  }
+phone_field {
+  type: 'string',
+  format: 'phone',
+  title: 'Phone field'
+}
+```
+
+### Multi select widget
+
+A select widget using MUI Autocomplete for fields with `type: array` to store multiple values. To enable the `MultiSelectWidget` set the widget type in the `uiSchema`:
+
+```
+multiselect_field {
+ 'ui:widget': 'MultiSelectWidget'
+}
+```
+
+An `enum` array is required in the array `items` section to set the available values. An optional `enumNames` array can be set if alternative option labels is required.
+
+```
+multiselect_field {
+  type: "array",
+  items: {
+    type: "string",
+    enum: ["one", "two", "three"]
+    // enumNames is optional
+    enumNames: ["Option 1", "Option 2", "Option 3"]
+  },
+  title: "MultiSelect field",
+}
 ```


### PR DESCRIPTION
Implements #318 

This one took a lot of experimentation to do and not trigger RJSF validation issues. I initially tried to do it using `anyOf` as we use for many select fields using the `ComboBox` widget though storing the values as an array triggered a lot of validation errors. Rather than removing those errors on the front end I wanted to use a way that was supported by RJSF.

I ended up using `enum` as these fields initially were so the values are saved the same as before this PR as an array of the selected `enum` values. I ended up using `enumNames` to set custom labels for each selection though that might be depreciated eventually. Open to other suggestions if you have any other ideas.

While there was talk of just adding onto the functionality of `ComboBox` I decided to make `MultiSelectWidget` to keep the logic clean and separate as there is a fair amount of differences in how we update and store the data.

Also fixed the `naics_code` field so it is showing the codes not the id.