### PR TITLE
feat/268 clean up review component

### DIFF
--- a/client/app/components/button/Review.tsx
+++ b/client/app/components/button/Review.tsx
@@ -5,6 +5,8 @@ import { Alert, Button, Box } from "@mui/material";
 import RecommendIcon from "@mui/icons-material/Recommend";
 import DoNotDisturbIcon from "@mui/icons-material/DoNotDisturb";
 import Modal from "@/app/components/modal/Modal";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
 
 interface Props {
   confirmApproveMessage: string;
@@ -16,7 +18,26 @@ interface Props {
   onReject: () => Promise<any>;
 }
 
-export default function Review({
+interface CloseProps {
+  onClose: () => void;
+}
+
+const CloseButton = ({ onClose }: CloseProps) => {
+  return (
+    <IconButton
+      aria-label="close"
+      color="inherit"
+      size="small"
+      onClick={() => {
+        onClose();
+      }}
+    >
+      <CloseIcon fontSize="inherit" />
+    </IconButton>
+  );
+};
+
+const Review = ({
   approvedMessage,
   confirmApproveMessage,
   confirmRejectMessage,
@@ -24,10 +45,11 @@ export default function Review({
   rejectedMessage,
   onApprove,
   onReject,
-}: Readonly<Props>) {
+}: Readonly<Props>) => {
   const [errorList, setErrorList] = useState([] as any[]);
   const [successMessageList, setSuccessMessageList] = useState([] as any[]);
   const [modalState, setModalState] = useState("" as string);
+  const [dismissAlert, setDismissAlert] = useState(false);
 
   const handleApprove = () => {
     setModalState("approve");
@@ -63,6 +85,10 @@ export default function Review({
     return setSuccessMessageList([{ message: rejectedMessage }]);
   };
 
+  const handleCloseAlert = () => {
+    setDismissAlert(true);
+  };
+
   const isReviewButtons =
     isStatusPending &&
     errorList.length === 0 &&
@@ -74,7 +100,11 @@ export default function Review({
     : confirmRejectMessage;
 
   return (
-    <>
+    <Box
+      sx={{
+        minHeight: "48px",
+      }}
+    >
       <Modal
         title="Please confirm"
         open={Boolean(modalState)}
@@ -165,17 +195,29 @@ export default function Review({
         </Box>
       )}
       {errorList.length > 0 &&
+        !dismissAlert &&
         errorList.map((e: any) => (
-          <Alert key={e.message} severity="error">
+          <Alert
+            key={e.message}
+            action={<CloseButton onClose={handleCloseAlert} />}
+            severity="error"
+          >
             {e?.stack ?? e.message}
           </Alert>
         ))}
       {successMessageList.length > 0 &&
+        !dismissAlert &&
         successMessageList.map((e: any) => (
-          <Alert key={e.message} severity="success">
+          <Alert
+            key={e.message}
+            action={<CloseButton onClose={handleCloseAlert} />}
+            severity="success"
+          >
             {e.message}
           </Alert>
         ))}
-    </>
+    </Box>
   );
-}
+};
+
+export default Review;

--- a/client/app/components/form/widgets/ComboBox.tsx
+++ b/client/app/components/form/widgets/ComboBox.tsx
@@ -5,9 +5,16 @@ import { WidgetProps } from "@rjsf/utils/lib/types";
 import { useCallback } from "react";
 import { DARK_GREY_BG_COLOR, BC_GOV_SEMANTICS_RED } from "@/app/styles/colors";
 
-const ComboBox: React.FC<WidgetProps> = (props) => {
-  const { id, onChange, rawErrors, schema, value, uiSchema } = props;
-
+const ComboBox: React.FC<WidgetProps> = ({
+  disabled,
+  id,
+  onChange,
+  rawErrors,
+  readonly,
+  schema,
+  value,
+  uiSchema,
+}) => {
   const handleChange = (e: React.ChangeEvent<{}>, option: any) => {
     onChange(option?.const || option?.value);
   };
@@ -41,6 +48,7 @@ const ComboBox: React.FC<WidgetProps> = (props) => {
     <Autocomplete
       disablePortal
       id={id}
+      disabled={disabled || readonly}
       autoHighlight
       options={options}
       defaultValue={getSelected()}

--- a/client/app/components/form/widgets/MultiSelectWidget.tsx
+++ b/client/app/components/form/widgets/MultiSelectWidget.tsx
@@ -10,9 +10,11 @@ interface Option {
 }
 
 const MultiSelectWidget: React.FC<WidgetProps> = ({
+  disabled,
   id,
   onChange,
   rawErrors,
+  readonly,
   schema,
   value,
   uiSchema,
@@ -56,8 +58,9 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
 
   return (
     <Autocomplete
-      disablePortal
       id={id}
+      disabled={disabled || readonly}
+      disablePortal
       multiple
       filterSelectedOptions
       autoHighlight

--- a/client/app/components/modal/Modal.tsx
+++ b/client/app/components/modal/Modal.tsx
@@ -17,6 +17,7 @@ const Modal: React.FC<Props> = ({ children, id, onClose, open, title }) => {
       id={id}
       onClose={onClose}
       open={open}
+      closeAfterTransition
       aria-labelledby={title}
       maxWidth="xl"
     >

--- a/client/app/components/modal/Modal.tsx
+++ b/client/app/components/modal/Modal.tsx
@@ -1,0 +1,60 @@
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import IconButton from "@mui/material/IconButton";
+
+interface Props {
+  children: React.ReactNode;
+  id?: string;
+  onClose: any;
+  open: boolean;
+  title?: string;
+}
+
+const Modal: React.FC<Props> = ({ children, id, onClose, open, title }) => {
+  return (
+    <Dialog
+      id={id}
+      onClose={onClose}
+      open={open}
+      aria-labelledby={title}
+      maxWidth="xl"
+    >
+      <DialogTitle
+        sx={{
+          bgcolor: "primary.main",
+          color: "#FFFFFF",
+          padding: "8px 16px",
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        {title}
+        {onClose ? (
+          <IconButton
+            aria-label="close"
+            data-testid="close-button"
+            onClick={onClose}
+            sx={{
+              color: "#FFFFFF",
+              paddingRight: "0",
+            }}
+          >
+            X
+          </IconButton>
+        ) : null}
+      </DialogTitle>
+      <DialogContent
+        sx={{
+          padding: "16px",
+        }}
+      >
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default Modal;

--- a/client/app/components/modal/Modal.tsx
+++ b/client/app/components/modal/Modal.tsx
@@ -36,7 +36,6 @@ const Modal: React.FC<Props> = ({ children, id, onClose, open, title }) => {
         {onClose ? (
           <IconButton
             aria-label="close"
-            data-testid="close-button"
             onClick={onClose}
             sx={{
               color: "#FFFFFF",

--- a/client/app/components/routes/operations/form/Operation.tsx
+++ b/client/app/components/routes/operations/form/Operation.tsx
@@ -3,9 +3,8 @@ import OperationsForm, {
 } from "@/app/components/form/OperationsForm";
 import { operationSchema } from "@/app/utils/jsonSchema/operations";
 import { RJSFSchema } from "@rjsf/utils";
-// import { actionHandler } from "@/app/utils/api";
 import { actionHandler } from "@/app/utils/actions";
-import Review from "./Review";
+import OperationReview from "./OperationReview";
 
 // 🛠️ Function to fetch NAICS codes
 async function getNaicsCodes() {
@@ -112,10 +111,11 @@ export default async function Operation({ numRow }: { numRow?: number }) {
   if (numRow) {
     operation = await getOperation(numRow);
   }
+
   // Render the OperationsForm component with schema and formData if the operation already exists
   return (
     <>
-      <Review operation={operation} status={operation?.status} />
+      <OperationReview operation={operation} />
       <OperationsForm
         schema={createOperationSchema(
           operationSchema,

--- a/client/app/components/routes/operations/form/Operation.tsx
+++ b/client/app/components/routes/operations/form/Operation.tsx
@@ -6,7 +6,6 @@ import { RJSFSchema } from "@rjsf/utils";
 // import { actionHandler } from "@/app/utils/api";
 import { actionHandler } from "@/app/utils/actions";
 import Review from "./Review";
-import { Status } from "@/app/types/types";
 
 // 🛠️ Function to fetch NAICS codes
 async function getNaicsCodes() {
@@ -116,9 +115,7 @@ export default async function Operation({ numRow }: { numRow?: number }) {
   // Render the OperationsForm component with schema and formData if the operation already exists
   return (
     <>
-      {operation?.status === Status.PENDING ? (
-        <Review operation={operation} />
-      ) : null}
+      <Review operation={operation} status={operation?.status} />
       <OperationsForm
         schema={createOperationSchema(
           operationSchema,

--- a/client/app/components/routes/operations/form/OperationReview.tsx
+++ b/client/app/components/routes/operations/form/OperationReview.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { actionHandler } from "@/app/utils/actions";
+import Review from "app/components/button/Review";
+import { Status } from "@/app/types/types";
+
+interface Props {
+  operation: any;
+}
+
+const OperationReview = ({ operation }: Props) => {
+  const approveRequest = async () => {
+    operation.status = Status.APPROVED;
+    const response = await actionHandler(
+      `registration/operations/${operation.id}/update-status`,
+      "PUT",
+      `dashboard/operations/${operation.id}`,
+      {
+        body: JSON.stringify(operation),
+      },
+    );
+
+    return response;
+  };
+
+  const rejectRequest = async () => {
+    operation.status = Status.REJECTED;
+    const response = await actionHandler(
+      `registration/operations/${operation.id}/update-status`,
+      "PUT",
+      `dashboard/operations/${operation.id}`,
+      {
+        body: JSON.stringify(operation),
+      },
+    );
+    return response;
+  };
+
+  return (
+    <Review
+      approvedMessage="You have approved the request for carbon tax exemption."
+      rejectedMessage="You have rejected the request for carbon tax exemption."
+      confirmApproveMessage="Are you sure you want to approve this request for carbon tax exemption?"
+      confirmRejectMessage="Are you sure you want to reject this request for carbon tax exemption?"
+      isStatusPending={operation.status === Status.PENDING}
+      onApprove={approveRequest}
+      onReject={rejectRequest}
+    />
+  );
+};
+
+export default OperationReview;

--- a/client/app/components/routes/operations/form/Review.tsx
+++ b/client/app/components/routes/operations/form/Review.tsx
@@ -52,7 +52,7 @@ export default function Review({ operation, status }: Readonly<Props>) {
     );
     if (response.error) {
       setModalState("");
-      setErrorList([{ message: response.error }]);
+      return setErrorList([{ message: response.error }]);
     }
 
     setModalState("");
@@ -80,7 +80,7 @@ export default function Review({ operation, status }: Readonly<Props>) {
   return (
     <>
       <Modal
-        title="Confirmation"
+        title="Please confirm"
         open={Boolean(modalState)}
         onClose={handleClose}
       >
@@ -99,26 +99,21 @@ export default function Review({ operation, status }: Readonly<Props>) {
         >
           <Button
             onClick={modalState === "approve" ? approveRequest : rejectRequest}
-            color="success"
-            variant="outlined"
+            color="primary"
+            variant="contained"
             aria-label="Confirm"
             sx={{
               marginRight: "12px",
-              border: "1px solid",
-              fontWeight: "bold",
+              textTransform: "capitalize",
             }}
           >
-            Confirm
+            {modalState}
           </Button>
           <Button
             onClick={handleClose}
-            color="error"
+            color="primary"
             variant="outlined"
             aria-label="Cancel"
-            sx={{
-              border: "1px solid",
-              fontWeight: "bold",
-            }}
           >
             Cancel
           </Button>

--- a/client/app/components/routes/operations/form/Review.tsx
+++ b/client/app/components/routes/operations/form/Review.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import { useState } from "react";
 import { Alert, Button, Box } from "@mui/material";
 import RecommendIcon from "@mui/icons-material/Recommend";
 import DoNotDisturbIcon from "@mui/icons-material/DoNotDisturb";
 import { actionHandler } from "@/app/utils/actions";
 import { OperationsFormData } from "@/app/components/form/OperationsForm";
-import React, { useState } from "react";
+import Modal from "@/app/components/modal/Modal";
 import { Status } from "@/app/types/types";
 
 interface Props {
@@ -15,6 +16,7 @@ interface Props {
 export default function Review(props: Readonly<Props>) {
   const [errorList, setErrorList] = useState([] as any[]);
   const [successMessageList, setSuccessMessageList] = useState([] as any[]);
+  const [modalState, setModalState] = useState("" as string);
 
   async function approveRequest() {
     props.operation.status = Status.APPROVED;
@@ -54,8 +56,66 @@ export default function Review(props: Readonly<Props>) {
     }
   }
 
+  const handleApprove = () => {
+    setModalState("approve");
+  };
+
+  const handleReject = () => {
+    setModalState("reject");
+  };
+
+  const handleClose = () => {
+    setModalState("");
+  };
+
   return (
     <>
+      <Modal
+        title="Confirmation"
+        open={Boolean(modalState)}
+        onClose={handleClose}
+      >
+        <Box sx={{ fontSize: "20px", margin: "8px 0" }}>
+          Are you sure you want to <b>{modalState}</b> this operation?
+        </Box>
+        <Box
+          sx={{
+            width: "100%",
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "center",
+            alignItems: "center",
+            marginTop: "24px",
+          }}
+        >
+          <Button
+            onClick={modalState === "approve" ? approveRequest : rejectRequest}
+            color="success"
+            variant="outlined"
+            aria-label="Confirm"
+            sx={{
+              marginRight: "12px",
+              border: "1px solid",
+              fontWeight: "bold",
+            }}
+          >
+            Confirm
+          </Button>
+          <Button
+            onClick={handleClose}
+            color="error"
+            variant="outlined"
+            aria-label="Cancel"
+            sx={{
+              border: "1px solid",
+              fontWeight: "bold",
+            }}
+          >
+            Cancel
+          </Button>
+        </Box>
+      </Modal>
+
       <Box
         sx={{
           display: "flex",
@@ -65,7 +125,9 @@ export default function Review(props: Readonly<Props>) {
       >
         <Box>
           <Button
-            onClick={approveRequest}
+            onClick={handleApprove}
+            /*     onClick={approveRequest} */
+
             className="mr-2"
             color="success"
             variant="outlined"
@@ -79,7 +141,8 @@ export default function Review(props: Readonly<Props>) {
             Approve <RecommendIcon />
           </Button>
           <Button
-            onClick={rejectRequest}
+            onClick={handleReject}
+            /*    onClick={rejectRequest} */
             color="error"
             variant="outlined"
             aria-label="Reject application"

--- a/client/app/components/routes/operations/form/Review.tsx
+++ b/client/app/components/routes/operations/form/Review.tsx
@@ -11,49 +11,54 @@ import { Status } from "@/app/types/types";
 
 interface Props {
   operation: OperationsFormData;
+  status: Status;
 }
 
-export default function Review(props: Readonly<Props>) {
+export default function Review({ operation, status }: Readonly<Props>) {
   const [errorList, setErrorList] = useState([] as any[]);
   const [successMessageList, setSuccessMessageList] = useState([] as any[]);
   const [modalState, setModalState] = useState("" as string);
 
   async function approveRequest() {
-    props.operation.status = Status.APPROVED;
+    operation.status = Status.APPROVED;
     const response = await actionHandler(
-      `registration/operations/${props.operation.id}/update-status`,
+      `registration/operations/${operation.id}/update-status`,
       "PUT",
-      `dashboard/operations/${props.operation.id}`,
+      `dashboard/operations/${operation.id}`,
       {
-        body: JSON.stringify(props.operation),
+        body: JSON.stringify(operation),
       },
     );
     if (response.error) {
-      setErrorList([{ message: response.error }]);
-    } else if (response.ok) {
-      setSuccessMessageList([
-        { message: "You have approved the request for carbon tax exemption." },
-      ]);
+      setModalState("");
+      return setErrorList([{ message: response.error }]);
     }
+
+    setModalState("");
+    return setSuccessMessageList([
+      { message: "You have approved the request for carbon tax exemption." },
+    ]);
   }
 
   async function rejectRequest() {
-    props.operation.status = Status.REJECTED;
+    operation.status = Status.REJECTED;
     const response = await actionHandler(
-      `registration/operations/${props.operation.id}/update-status`,
+      `registration/operations/${operation.id}/update-status`,
       "PUT",
-      `dashboard/operations/${props.operation.id}`,
+      `dashboard/operations/${operation.id}`,
       {
-        body: JSON.stringify(props.operation),
+        body: JSON.stringify(operation),
       },
     );
     if (response.error) {
+      setModalState("");
       setErrorList([{ message: response.error }]);
-    } else if (response.ok) {
-      setSuccessMessageList([
-        { message: "You have rejected the request for carbon tax exemption." },
-      ]);
     }
+
+    setModalState("");
+    return setSuccessMessageList([
+      { message: "You have rejected the request for carbon tax exemption." },
+    ]);
   }
 
   const handleApprove = () => {
@@ -67,6 +72,10 @@ export default function Review(props: Readonly<Props>) {
   const handleClose = () => {
     setModalState("");
   };
+
+  const isPending = status === Status.PENDING;
+  const isReviewButtons =
+    isPending && errorList.length === 0 && successMessageList.length === 0;
 
   return (
     <>
@@ -116,45 +125,44 @@ export default function Review(props: Readonly<Props>) {
         </Box>
       </Modal>
 
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "flex-end",
-        }}
-      >
-        <Box>
-          <Button
-            onClick={handleApprove}
-            /*     onClick={approveRequest} */
-
-            className="mr-2"
-            color="success"
-            variant="outlined"
-            aria-label="Approve application"
-            sx={{
-              marginRight: "12px",
-              border: "1px solid",
-              fontWeight: "bold",
-            }}
-          >
-            Approve <RecommendIcon />
-          </Button>
-          <Button
-            onClick={handleReject}
-            /*    onClick={rejectRequest} */
-            color="error"
-            variant="outlined"
-            aria-label="Reject application"
-            sx={{
-              border: "1px solid",
-              fontWeight: "bold",
-            }}
-          >
-            Reject <DoNotDisturbIcon />
-          </Button>
+      {isReviewButtons && (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-end",
+          }}
+        >
+          <Box>
+            <Button
+              onClick={handleApprove}
+              className="mr-2"
+              color="success"
+              variant="outlined"
+              aria-label="Approve application"
+              sx={{
+                marginRight: "12px",
+                border: "1px solid",
+                fontWeight: "bold",
+              }}
+            >
+              Approve <RecommendIcon />
+            </Button>
+            <Button
+              onClick={handleReject}
+              color="error"
+              variant="outlined"
+              aria-label="Reject application"
+              sx={{
+                border: "1px solid",
+                fontWeight: "bold",
+              }}
+            >
+              Reject <DoNotDisturbIcon />
+            </Button>
+          </Box>
         </Box>
-      </Box>
+      )}
       {errorList.length > 0 &&
         errorList.map((e: any) => (
           <Alert key={e.message} severity="error">


### PR DESCRIPTION
Implements #268 

We now have a confirmation modal to approve/deny the operation application. I made a generic `<Modal>` component using MUI that we can reuse in the future.

Refactored the `Review` component to be reusable since we have the same feature in the user operator form. 

The bug that was causing the `Alert` components to disappear right away is because the `<Review>` component was conditionally rendered based on the status. So when that changed the entire component would disappear. 

Note: I also snuck in two fixes for `ComboBox` and `MultiSelectWidget` as I noticed while working on this that they did not have a disabled state (ie: `status === PENDING`).