### PR TITLE
feat: New User Form & Endpoints

### DIFF
--- a/bc_obps/registration/api/user.py
+++ b/bc_obps/registration/api/user.py
@@ -1,18 +1,37 @@
-from registration.models import User
-from registration.schema import UserOperatorUserOut, AppRoleOut
+import json
+from registration.models import AppRole, User
+from registration.schema import UserAppRoleOut, UserOut, UserProfileOut, UserIn, Message
 from .api_base import router
 from django.shortcuts import get_object_or_404
-import json
+from .api_base import router
+from django.forms import model_to_dict
+from ninja.responses import codes_4xx
 
 
 ##### GET #####
-@router.get("/user", response=UserOperatorUserOut)
+
+
+@router.get("/user", response=UserOut)
 def get_user(request):
     user: User = request.current_user
     return user
 
 
-@router.get("/get-user-role/{user_guid}", response=AppRoleOut)
+# endpoint to return user data if user exists in user table
+@router.get("/user-profile", response=UserProfileOut)
+def get_user_profile(request):
+    user = get_object_or_404(User, user_guid=json.loads(request.headers.get('Authorization')).get('user_guid'))
+    user_fields_dict = model_to_dict(user)
+
+    return {
+        **user_fields_dict,
+        "phone_number": str(user.phone_number),
+        "app_role": user.app_role,
+    }
+
+
+# endpoint to return user's role_name if user exists in user table
+@router.get("/user-app-role/{user_guid}", response=UserAppRoleOut)
 def get_user_role(request, user_guid: str):
     user: User = get_object_or_404(User, user_guid=user_guid)
     return user.app_role
@@ -20,14 +39,46 @@ def get_user_role(request, user_guid: str):
 
 ##### POST #####
 
+# Endpoint to create a new user
+@router.post("/user-profile/{identity_provider}", response={200: UserProfileOut, codes_4xx: Message})
+def create_user_profile(request, identity_provider: str, payload: UserIn):
+    try:
+        # Determine the role based on the identity provider
+        if identity_provider == "idir":
+            role = "cas_pending"
+        else:
+            role = "industry_user"
+
+        new_user = User.objects.create(
+            user_guid=json.loads(request.headers.get('Authorization')).get('user_guid'),
+            app_role=AppRole.objects.get(role_name=role),
+            first_name=payload.first_name,
+            last_name=payload.last_name,
+            email=payload.email,
+            position_title=payload.position_title,
+            phone_number=payload.phone_number,
+        )
+
+    except Exception as e:
+        return 400, {"message": str(e)}
+
+    return 200, new_user
+
 
 ##### PUT #####
 
+# Endpoint to update a user
+@router.put("/user-profile", response={200: UserOut, codes_4xx: Message})
+def update_user_profile(request, payload: UserIn):
+    user: User = request.current_user
+    try:
+        for attr, value in payload.dict().items():
+            setattr(user, attr, value)
+        user.save()
+    except Exception as e:
+        return 400, {"message": str(e)}
 
-##### POST #####
-
-
-##### PUT #####
+    return 200, user
 
 
 ##### DELETE #####

--- a/bc_obps/registration/schema/user.py
+++ b/bc_obps/registration/schema/user.py
@@ -1,12 +1,15 @@
+from pyexpat import model
 from ninja import ModelSchema
+from ninja import Field, Schema
 from registration.models import AppRole, User
 
 
-# AppRole schemas
-class AppRoleOut(ModelSchema):
-    class Config:
-        model = AppRole
-        model_fields = '__all__'
+class UserIn(Schema):
+    first_name: str
+    last_name: str
+    email: str
+    position_title: str
+    phone_number: str
 
 
 class UserOut(ModelSchema):
@@ -27,6 +30,26 @@ class UserOut(ModelSchema):
             "municipality",
             "province",
             "postal_code",
+            "email",
+            "phone_number",
+        ]
+
+
+class UserAppRoleOut(ModelSchema):
+    class Config:
+        model = AppRole
+        model_fields = ['role_name']
+
+
+class UserProfileOut(UserOut):
+    app_role: UserAppRoleOut  # Include AppRoleOut model as a field
+
+    class Config:
+        model = User
+        model_fields = [
+            "first_name",
+            "last_name",
+            "position_title",
             "email",
             "phone_number",
         ]

--- a/bc_obps/registration/tests/test_endpoints.py
+++ b/bc_obps/registration/tests/test_endpoints.py
@@ -19,7 +19,17 @@ from registration.models import (
     HistoricalOperation,
     HistoricalUserOperator,
 )
-from registration.schema import OperationCreateIn, OperationUpdateIn
+from registration.schema import OperationCreateIn, OperationUpdateIn, UserIn
+
+import uuid
+from django.core.management import call_command
+
+
+@pytest.fixture(scope='function')
+def app_role_fixture():
+    # Load the fixture data into the test database
+    call_command('loaddata', 'real/appRole.json')
+
 
 pytestmark = pytest.mark.django_db
 
@@ -495,3 +505,190 @@ class TestUserOperatorEndpoint:
 
         has_history_record = HistoricalUserOperator.objects.all()
         assert has_history_record.count() > 0, "History record was not created"
+
+class TestUserEndpoint:
+    endpoint = base_endpoint + "user"
+    endpoint_profile = endpoint + "-profile"
+
+    def setup_method(self):
+        self.user: User = baker.make(User)
+        self.auth_header = {'user_guid': str(self.user.user_guid)}
+        self.auth_header_dumps = json.dumps(self.auth_header)
+
+    # GET USER
+    def test_get_user(self):
+
+        # Act
+        response = client.get(self.endpoint, HTTP_AUTHORIZATION=self.auth_header_dumps)
+        content = response.json()
+
+        # Assert
+        assert response.status_code == 200
+
+        # Additional Assertions
+        assert 'first_name' in content and isinstance(content['first_name'], str) and content['first_name'] != ''
+        assert 'last_name' in content and isinstance(content['last_name'], str) and content['last_name'] != ''
+        assert (
+            'position_title' in content
+            and isinstance(content['position_title'], str)
+            and content['position_title'] != ''
+        )
+        assert 'email' in content and isinstance(content['email'], str) and '@' in content['email']
+        assert (
+            'street_address' in content
+            and isinstance(content['street_address'], str)
+            and content['street_address'] != ''
+        )
+        assert 'municipality' in content and isinstance(content['municipality'], str) and content['municipality'] != ''
+        assert 'province' in content and isinstance(content['province'], str) and content['province'] != ''
+        assert 'postal_code' in content and isinstance(content['postal_code'], str) and content['postal_code'] != ''
+
+        # Additional Assertion for user_guid
+        assert 'user_guid' not in content
+
+    # GET USER PROFILE
+    def test_get_user_profile(self):
+
+        # Arrange
+        url = f"{self.endpoint_profile}"
+
+        # Act
+        response = client.get(url, HTTP_AUTHORIZATION=self.auth_header_dumps)
+        content = response.json()
+
+        # Assert
+        assert response.status_code == 200
+
+        # Additional Assertions
+        assert 'first_name' in content and isinstance(content['first_name'], str) and content['first_name'] != ''
+        assert 'last_name' in content and isinstance(content['last_name'], str) and content['last_name'] != ''
+        assert (
+            'position_title' in content
+            and isinstance(content['position_title'], str)
+            and content['position_title'] != ''
+        )
+        assert 'email' in content and isinstance(content['email'], str) and '@' in content['email']
+        assert 'phone_number' in content and isinstance(content['phone_number'], str)
+
+        # Additional Assertion for user_guid
+        assert 'user_guid' not in content
+
+    # POST USER PROFILE BCEID
+    @pytest.mark.usefixtures('app_role_fixture')
+    def test_create_user_profile_bceidbusiness(self):
+
+        # Arrange
+        mock_payload = UserIn(
+            first_name='Bceid',
+            last_name='User',
+            email='bceid.user@email.com',
+            phone_number='123456789',
+            position_title='Tester',
+        )
+
+        # Act
+        # Construct the endpoint URL for identity_provider "bceidbusiness"
+        response = client.post(
+            f"{self.endpoint_profile}/bceidbusiness",
+            content_type=content_type_json,
+            data=mock_payload.json(),
+            HTTP_AUTHORIZATION=json.dumps({'user_guid': str(uuid.uuid4())}),
+        )
+        content = response.json()
+
+        # Assert
+        assert response.status_code == 200
+
+        # Additional Assertions
+        assert 'app_role' in content and content["app_role"]["role_name"] == "industry_user"
+        assert 'first_name' in content and isinstance(content['first_name'], str) and content['first_name'] == 'Bceid'
+        assert 'last_name' in content and isinstance(content['last_name'], str) and content['last_name'] == 'User'
+        assert (
+            'position_title' in content
+            and isinstance(content['position_title'], str)
+            and content['position_title'] == 'Tester'
+        )
+        assert 'email' in content and isinstance(content['email'], str) and content['email'] == 'bceid.user@email.com'
+        assert 'phone_number' in content and isinstance(content['phone_number'], str)
+
+        # Additional Assertion for user_guid
+        assert 'user_guid' not in content
+
+    # POST USER PROFILE IDIR
+    @pytest.mark.usefixtures('app_role_fixture')
+    def test_create_user_profile_idir(self):
+
+        # Arrange
+        mock_payload = UserIn(
+            first_name='Idir',
+            last_name='User',
+            email='idir.user@email.com',
+            phone_number='987654321',
+            position_title='Tester',
+        )
+
+        # Act
+        # Construct the endpoint URL for identity_provider "idir"
+        response = client.post(
+            f"{self.endpoint_profile}/idir",
+            content_type=content_type_json,
+            data=mock_payload.json(),
+            HTTP_AUTHORIZATION=json.dumps({'user_guid': str(uuid.uuid4())}),
+        )
+        content = response.json()
+
+        # Assert
+        assert response.status_code == 200
+
+        # Additional Assertions
+        assert 'app_role' in content and content["app_role"]["role_name"] == "cas_pending"
+        assert 'first_name' in content and isinstance(content['first_name'], str) and content['first_name'] == 'Idir'
+        assert 'last_name' in content and isinstance(content['last_name'], str) and content['last_name'] == 'User'
+        assert (
+            'position_title' in content
+            and isinstance(content['position_title'], str)
+            and content['position_title'] == 'Tester'
+        )
+        assert 'email' in content and isinstance(content['email'], str) and content['email'] == 'idir.user@email.com'
+        assert 'phone_number' in content and isinstance(content['phone_number'], str)
+
+        # Additional Assertion for user_guid
+        assert 'user_guid' not in content
+
+    # PUT USER PROFILE
+    def test_update_user_profile(self):
+
+        # Arrange
+        mock_payload = UserIn(
+            first_name='Test',
+            last_name='User',
+            email='test.user@email.com',
+            phone_number='123459876',
+            position_title='Boss',
+        )
+
+        # Act
+        response = client.put(
+            f"{self.endpoint_profile}",
+            content_type=content_type_json,
+            data=mock_payload.json(),
+            HTTP_AUTHORIZATION=self.auth_header_dumps,
+        )
+        content = response.json()
+
+        # Assert
+        assert response.status_code == 200
+
+        # Additional Assertions
+        assert 'first_name' in content and isinstance(content['first_name'], str) and content['first_name'] == 'Test'
+        assert 'last_name' in content and isinstance(content['last_name'], str) and content['last_name'] == 'User'
+        assert (
+            'position_title' in content
+            and isinstance(content['position_title'], str)
+            and content['position_title'] == 'Boss'
+        )
+        assert 'email' in content and isinstance(content['email'], str) and content['email'] == 'test.user@email.com'
+        assert 'phone_number' in content and isinstance(content['phone_number'], str)
+
+        # Additional Assertion for user_guid
+        assert 'user_guid' not in content

--- a/bc_obps/registration/tests/test_endpoints.py
+++ b/bc_obps/registration/tests/test_endpoints.py
@@ -506,6 +506,7 @@ class TestUserOperatorEndpoint:
         has_history_record = HistoricalUserOperator.objects.all()
         assert has_history_record.count() > 0, "History record was not created"
 
+
 class TestUserEndpoint:
     endpoint = base_endpoint + "user"
     endpoint_profile = endpoint + "-profile"

--- a/client/app/(authenticated)/dashboard/profile/page.tsx
+++ b/client/app/(authenticated)/dashboard/profile/page.tsx
@@ -1,23 +1,19 @@
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { Suspense } from "react";
+import Loading from "@/app/components/loading/SkeletonSpinner";
+import User from "@/app/components/routes/profile/User";
 
-export default async function Page() {
-  /* When calling from the server-side i.e., in Route Handlers, React Server Components, API routes,
-   * getServerSession requires passing the same object you would pass to NextAuth
-   */
-  const session = await getServerSession(authOptions);
-
+// 🏗️ Sync server component: dashboard\profile
+export default function Page() {
   return (
     <>
-      <h1>Profile Page With Server Side Session Information</h1>
-      {session && (
-        <>
-          <p>Name: {session?.user?.name}</p>
-          <p>Role: {session?.user?.app_role}</p>
-          <p>GUID: {session?.user?.user_guid}</p>
-          <p>IP: {session?.identity_provider}</p>
-        </>
-      )}
+      <div className="w-full form-group field field-object form-heading-label">
+        <div className="form-heading">
+          Please update or verify your information
+        </div>
+      </div>
+      <Suspense fallback={<Loading />}>
+        <User />
+      </Suspense>
     </>
   );
 }

--- a/client/app/api/auth/token/route.ts
+++ b/client/app/api/auth/token/route.ts
@@ -1,0 +1,10 @@
+import { getToken } from "next-auth/jwt";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const token = await getToken({
+    req: request,
+    secret: process.env.NEXTAUTH_SECRET,
+  });
+  return NextResponse.json(token, { status: 200 });
+}

--- a/client/app/components/form/SubmitButton.tsx
+++ b/client/app/components/form/SubmitButton.tsx
@@ -6,11 +6,13 @@ import { useFormStatus } from "react-dom";
 interface SubmitButtonProps {
   label: string;
   classNames?: string;
+  disabled?: boolean;
 }
 
 const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
   label,
   classNames,
+  disabled,
 }) => {
   const { pending } = useFormStatus();
   return (
@@ -18,8 +20,9 @@ const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
       <Button
         variant="contained"
         type="submit"
-        aria-disabled={pending}
+        aria-disabled={pending || pending}
         className="h-full"
+        sx={{ marginBottom: 10 }}
       >
         {label}
       </Button>

--- a/client/app/components/form/SubmitButton.tsx
+++ b/client/app/components/form/SubmitButton.tsx
@@ -20,7 +20,7 @@ const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
       <Button
         variant="contained"
         type="submit"
-        aria-disabled={pending || pending}
+        aria-disabled={disabled || pending}
         className="h-full"
         sx={{ marginBottom: 10 }}
       >

--- a/client/app/components/form/formDataTypes.ts
+++ b/client/app/components/form/formDataTypes.ts
@@ -55,7 +55,13 @@ export interface UserOperatorFormData extends UserFormData {
   // Not in form, but needed for API to create a contact based on the existing user-operator
   user_operator_id?: string;
 }
-
+export interface UserProfileFormData {
+  first_name: string;
+  last_name: string;
+  position_title: string;
+  email: string;
+  phone_number: string;
+}
 export interface SelectOperatorFormData {
   search_type: string;
   legal_name?: string;

--- a/client/app/components/loading/SkeletonSpinner.tsx
+++ b/client/app/components/loading/SkeletonSpinner.tsx
@@ -1,0 +1,5 @@
+import { Skeleton } from "@mui/material";
+
+export default function SkeletonSpinner() {
+  return <Skeleton variant="circular" width={40} height={40} />;
+}

--- a/client/app/components/navigation/Profile.tsx
+++ b/client/app/components/navigation/Profile.tsx
@@ -32,7 +32,7 @@ export default function Profile({ name }: { readonly name: string }) {
   return (
     <div className="flex items-center">
       <Link
-        data-testid="profile-nav-user"
+        data-testid="nav-user-profile"
         href="/dashboard/profile"
         sx={{ color: "white", marginRight: "10px" }}
       >

--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -1,0 +1,47 @@
+import { actionHandler } from "@/app/utils/actions";
+import UserForm from "@/app/components/routes/profile/form/UserForm";
+import { UserProfileFormData } from "@/app/components/form/formDataTypes";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+
+// 🚀 API call: GET user's data
+async function getUserFormData(): Promise<
+  UserProfileFormData | { error: string }
+> {
+  return actionHandler(`registration/user-profile`, "GET", "");
+}
+
+// 🏗️ Async server component: dashboard\profile
+// Gets session user's data from API then rendered to client side form
+export default async function User() {
+  // determines POST or PUT based on formData.error.includes("404")
+  let isCreate = false;
+  // get user's data
+  let formData: UserProfileFormData | { error: string } =
+    await getUserFormData();
+  if ("error" in formData) {
+    if (formData.error.includes("404")) {
+      // No user found, create formData to reflect new user in user table
+      isCreate = true;
+      // 👤 Use NextAuth.js hook to get information about the user's session
+      /* When calling from the server-side i.e., in Route Handlers, React Server Components, API routes,
+       * getServerSession requires passing the same object you would pass to NextAuth
+       */
+      const session = await getServerSession(authOptions);
+      const names = session?.user?.name?.split(" ");
+      formData = {
+        first_name: names?.[0] ?? "", // Use nullish coalescing here
+        last_name: names?.[1] ?? "", // Use nullish coalescing here
+        email: session?.user?.email || "",
+        phone_number: "",
+        position_title: "",
+      };
+    } else {
+      return (
+        <div>{`Server Error: ${formData.error}. Please try again later.`}</div>
+      );
+    }
+  }
+  // Render the UserForm with the formData values
+  return <UserForm formData={formData} isCreate={isCreate} />;
+}

--- a/client/app/components/routes/profile/form/UserForm.tsx
+++ b/client/app/components/routes/profile/form/UserForm.tsx
@@ -1,0 +1,96 @@
+"use client";
+import { useState } from "react";
+import FormBase from "@/app/components/form/FormBase";
+import { Alert } from "@mui/material";
+import SubmitButton from "@/app/components/form/SubmitButton";
+import { actionHandler } from "@/app/utils/actions";
+import { UserProfileFormData } from "@/app/components/form/formDataTypes";
+import { userSchema, userUiSchema } from "@/app/utils/jsonSchema/user";
+import { useSession, signOut } from "next-auth/react";
+
+// 📐 Interface: expected properties and their types for UserForm component
+
+interface Props {
+  formData?: UserProfileFormData;
+  isCreate: boolean;
+}
+// 🏗️ Client side component: dashboard\profile
+export default function UserForm({ formData, isCreate }: Props) {
+  // 🐜 To display errors
+  const [errorList, setErrorList] = useState([] as any[]);
+  // 🌀 Loading state for the Submit button
+  const [isLoading, setIsLoading] = useState(false);
+  // ✅ Success state for for the Submit button
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  // 👤 Use NextAuth.js hook to get information about the user's session
+  //  Destructuring assignment from data property of the object returned by useSession()
+  const { data: session } = useSession();
+  const idp = session?.identity_provider || "";
+
+  // 🛠️ Function to signout
+  const handleSignOut = async () => {
+    await fetch(`/api/auth/logout`, { method: "GET" });
+    await signOut();
+  };
+
+  // 🛠️ Function to submit user form data to API
+  const submitHandler = async (data: { formData?: UserProfileFormData }) => {
+    //Set states
+    setErrorList([]);
+    setIsLoading(true);
+    setIsSuccess(false);
+    // 🚀 API call: POST/PUT user form data
+    const response = await actionHandler(
+      isCreate
+        ? `registration/user-profile/${idp}`
+        : `registration/user-profile`,
+      isCreate ? "POST" : "PUT",
+      "",
+      {
+        body: JSON.stringify(data.formData),
+      },
+    );
+    // 🛑 Set loading to false after the API call is completed
+    setIsLoading(false);
+
+    if (response.error) {
+      setErrorList([{ message: response.error }]);
+      return;
+    }
+    if (isCreate) {
+      // 🛸 Routing: logout to re-login to apply new role to NextAuth JWT
+      await handleSignOut();
+    }
+    // ✅ Set success state to true
+    setIsSuccess(true);
+    // 🕐 Wait for 1 second and then reset success state
+    setTimeout(() => {
+      setIsSuccess(false);
+    }, 1000);
+  };
+
+  return (
+    <FormBase
+      className="[&>div>fieldset]:min-h-[40vh]"
+      formData={formData}
+      schema={userSchema}
+      uiSchema={userUiSchema}
+      onSubmit={submitHandler}
+    >
+      {errorList.length > 0 &&
+        errorList.map((e: any) => (
+          <Alert key={e.message} severity="error">
+            {e?.stack ?? e.message}
+          </Alert>
+        ))}
+      <div className="flex justify-end gap-3">
+        {/* Disable the button when loading or when success state is true */}
+        <SubmitButton
+          label={isSuccess ? "✅ Success" : "Submit"}
+          disabled={isLoading || isSuccess}
+        />
+      </div>
+    </FormBase>
+  );
+}

--- a/client/app/loading.tsx
+++ b/client/app/loading.tsx
@@ -1,5 +1,5 @@
-import Skeleton from "@mui/material/Skeleton";
+import SkeletonSpinner from "@/app/components/loading/SkeletonSpinner";
 
 export default function Loading() {
-  return <Skeleton variant="circular" width={40} height={40} />;
+  return <SkeletonSpinner />;
 }

--- a/client/app/utils/jsonSchema/user.ts
+++ b/client/app/utils/jsonSchema/user.ts
@@ -1,0 +1,22 @@
+import { RJSFSchema } from "@rjsf/utils";
+import FieldTemplate from "@/app/styles/rjsf/FieldTemplate";
+
+export const userSchema: RJSFSchema = {
+  type: "object",
+  required: ["first_name", "last_name", "phone_number", "position_title"],
+  properties: {
+    first_name: { type: "string", title: "First Name" },
+    last_name: { type: "string", title: "Last Name" },
+    phone_number: {
+      type: "string",
+      title: "Phone Number",
+      format: "phone",
+    },
+    email: { type: "string", title: "Email Address", readOnly: true },
+    position_title: { type: "string", title: "Position Title" },
+  },
+};
+
+export const userUiSchema = {
+  "ui:FieldTemplate": FieldTemplate,
+};

--- a/client/e2e/.env.local.example
+++ b/client/e2e/.env.local.example
@@ -2,11 +2,19 @@
 CAS_ADMIN_USERNAME=your-IDIR-that-is-in-users-fixture-with-cas_admin
 CAS_ADMIN_PASSWORD=your-password
 
-INDUSTRY_USER_USERNAME=bc-cas-dev
+INDUSTRY_USER_ADMIN_USERNAME=bc-cas-dev
+INDUSTRY_USER_ADMIN_PASSWORD=find-in-1password
+
+INDUSTRY_USER_USERNAME=bc-cas-dev-secondary
 INDUSTRY_USER_PASSWORD=find-in-1password
 
+NEW_USER_USERNAME=bc-cas-dev-three
+NEW_USER_PASSWORD=find-in-1password
+
+# STORAGE
 CAS_ADMIN_STORAGE="playwright/.auth/cas_admin.json"
 CAS_ANALYST_STORAGE="playwright/.auth/cas_analyst.json"
 CAS_PENDING_STORAGE="playwright/.auth/cas_pending.json"
 INDUSTRY_USER_STORAGE="playwright/.auth/industry_user.json"
 INDUSTRY_USER_ADMIN_STORAGE="playwright/.auth/industry_user_admin.json"
+NEW_USER_STORAGE="playwright/.auth/new_user.json"

--- a/client/e2e/auth/auth-setup.ts
+++ b/client/e2e/auth/auth-setup.ts
@@ -11,12 +11,19 @@ const casAdminUserName = process.env.CAS_ADMIN_USERNAME || "";
 const casAdminPassword = process.env.CAS_ADMIN_PASSWORD || "";
 const industryUserUserName = process.env.INDUSTRY_USER_USERNAME || "";
 const industryUserPassword = process.env.INDUSTRY_USER_PASSWORD || "";
+const industryUserAdminUserName =
+  process.env.INDUSTRY_USER_ADMIN_USERNAME || "";
+const industryUserAdminPassword =
+  process.env.INDUSTRY_USER_ADMIN_PASSWORD || "";
+const newUserName = process.env.NEW_USER_USERNAME || "";
+const newUserPassword = process.env.NEW_USER_PASSWORD || "";
 // State storage
 const casAdminAuthFile = process.env.CAS_ADMIN_STORAGE || "";
 const casAnalystAuthFile = process.env.CAS_ANALYST_STORAGE || "";
 const casPendingAuthFile = process.env.CAS_PENDING_STORAGE || "";
 const industryUserAuthFile = process.env.INDUSTRY_USER_STORAGE || "";
 const industryUserAdminAuthFile = process.env.INDUSTRY_USER_ADMIN_STORAGE || "";
+const newUserAuthFile = process.env.NEW_USER_STORAGE || "";
 
 // 🛠️ function: login with valid ID and stores auth state
 const setupAuth = async (
@@ -28,7 +35,6 @@ const setupAuth = async (
   authFile: string,
 ) => {
   // 🔑 Login
-  console.log(authFile);
   await page.goto("http://localhost:3000/home");
   await page.getByRole("button", { name: button }).click();
   await page.locator("#user").click();
@@ -38,7 +44,7 @@ const setupAuth = async (
   await page.getByRole("button", { name: "Continue" }).click();
 
   // Wait for the profile navigation link to be present
-  const profileNavSelector = '[data-testid="profile-nav-user"]';
+  const profileNavSelector = '[data-testid="nav-user-profile"]';
   await page.waitForSelector(profileNavSelector);
 
   // Assert that authenticated user profile link is visible
@@ -74,7 +80,7 @@ function updateSessionToken(jsonFilePath: string): void {
     fs.writeFileSync(jsonFilePath, JSON.stringify(data, null, 2));
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.log(`Error updating mock token ${jsonFilePath}:` + error);
+    console.error(`Error updating mock token ${jsonFilePath}:` + error);
   }
 }
 
@@ -114,9 +120,24 @@ setup("Setup Auth - industry_user", async ({ page, context }) => {
   );
 });
 
-setup("Setup Auth - industry_user_admin", async () => {
-  // Note: mocked auth session created using
-  // npx playwright codegen localhost:3000 --save-storage=playwright/.auth/industry_user_admin.json
-  // with hardcoded role in client/app/api/auth/[...nextauth]/route.ts
-  updateSessionToken(industryUserAdminAuthFile);
+setup("Setup Auth - industry_user_admin", async ({ page, context }) => {
+  await setupAuth(
+    page,
+    context,
+    "Industrial Operator Log In",
+    industryUserAdminUserName,
+    industryUserAdminPassword,
+    industryUserAdminAuthFile,
+  );
+});
+
+setup("Setup Auth - new user", async ({ page, context }) => {
+  await setupAuth(
+    page,
+    context,
+    "Industrial Operator Log In",
+    newUserName,
+    newUserPassword,
+    newUserAuthFile,
+  );
 });

--- a/client/e2e/auth/authentication.spec.ts
+++ b/client/e2e/auth/authentication.spec.ts
@@ -13,6 +13,7 @@ const casAnalystAuthFile = process.env.CAS_ANALYST_STORAGE || "";
 const casPendingAuthFile = process.env.CAS_PENDING_STORAGE || "";
 const industryUserAuthFile = process.env.INDUSTRY_USER_STORAGE || "";
 const industryUserAdminAuthFile = process.env.INDUSTRY_USER_ADMIN_STORAGE || "";
+const newUserAuthFile = process.env.NEW_USER_STORAGE || "";
 
 // Import role based dashboard navigation
 import casAdminDashboard from "@/app/data/dashboard/cas_admin.json";
@@ -75,7 +76,7 @@ test.describe("Test Dashboard", () => {
       await page.goto("http://localhost:3000/dashboard");
 
       // Wait for the profile navigation link to be present
-      const profileNavSelector = '[data-testid="profile-nav-user"]';
+      const profileNavSelector = '[data-testid="nav-user-profile"]';
       await page.waitForSelector(profileNavSelector);
 
       // Assert that authenticated user profile link is visible
@@ -104,6 +105,21 @@ test.describe("Test Dashboard", () => {
     test.use({ storageState: storageState });
     test("Test Role Based UX", async ({ page }) => {
       await assertDashboardNavigation(page, dashboardData);
+    });
+  });
+  test.describe("Test Auth Session - new user", () => {
+    const storageState = newUserAuthFile;
+    test.use({ storageState: storageState });
+    test("Test Role Based UX", async ({ page }) => {
+      await page.goto("http://localhost:3000/dashboard");
+      // New user has no role; so, redirected to: http://localhost:3000/dashboard/profile
+
+      // Wait for the navigation to complete
+      await page.waitForLoadState("load");
+
+      // Assert that the current URL ends with "/profile"
+      const currentUrl = page.url();
+      expect(currentUrl).toContain("/profile");
     });
   });
 });

--- a/client/middlewares/withAuthorization.tsx
+++ b/client/middlewares/withAuthorization.tsx
@@ -58,13 +58,24 @@ export const withAuthorization: MiddlewareFactory = (next: NextMiddleware) => {
       req: request,
       secret: process.env.NEXTAUTH_SECRET,
     });
-
     // Check if the path is in the unauthenticated allow list
     if (isUnauthenticatedAllowListedPath(pathname)) {
       return next(request, _next);
     }
     // Check if the user is authenticated
     if (token) {
+      // Check for the existence of token.app_role
+      if (!token.app_role) {
+        // route to profile form
+        if (pathname.endsWith("/profile")) {
+          return next(request, _next);
+        } else {
+          return NextResponse.redirect(
+            new URL(`/dashboard/profile`, request.url),
+          );
+        }
+      }
+
       // Redirect root or home requests to the dashboard
       if (pathname.endsWith("/") || pathname.endsWith("/home")) {
         return NextResponse.redirect(new URL(`/dashboard`, request.url));


### PR DESCRIPTION
Addresses [283](https://app.zenhub.com/workspaces/team-moose-sprint-board-60d216175a2689000ec774d0/issues/gh/bcgov/cas-registration/283) 

## 🚧 Changes
    - Modify client/app/api/auth/[...nextauth]/route.ts
    - Modify client/middlewares/withAuthorization.tsx
    - Add client/app/api/auth/token/route.ts
    - Modify client/app/utils/actions.ts 
    - Modify client/app/(authenticated)/dashboard/profile/page.tsx
    - Add client/app/components/routes/profile/*
    - Add client/app/utils/jsonSchema/user.ts
    - Modify client/app/components/form/formDataTypes.ts
    - Modify client/app/components/navigation/Profile.tsx
    - Modify client/app/components/form/SubmitButton.tsx
    - Add client/app/components/loading/SkeletonSpinner.tsx
    - Modify client/app/loading.tsx
    - Add UserProfileOut to bc_obps/registration/schema.py
    - Add GET endpoint for user profile:  bc_obps/registration/api/user.py
    - Add POST endpoint for user profile:  bc_obps/registration/api/user.py
    - Add PUT endpoint for user profile:  bc_obps/registration/api/user.py
    - Add endpoint tests: bc_obps/registration/tests/test_endpoints.py/class TestUserOperatorEndpoint
    - Modify client/e2e/auth/auth-setup.ts 
    - Modify client/e2e/auth/authentication.spec.ts 
  

## 🚀 Impact:
   - In `client/app/api/auth/[...nextauth]/route.ts` if authenticated user is NOT found in user table then value of JWT and session token property app_role="" and middleware  `client/middlewares/withAuthorization.tsx` routes user to Dashboard\Profile form. 
   - Completing the  `Dashboard\Profile` form will create a user in the user table and assign a default role depending on the user's identity provider (IDIR, Bceid)
   - Editing  `Dashboard\Profile` form will update editable information
   - API routes `bc_obps/registration/api/user.py` are tested using pytest in `bc_obps/registration/tests/test_endpoints.py\class TestUserOperatorEndpoint`
   -  Authenticated role routes are tested using Playwright `client/e2e/auth/authentication.spec.ts `
   -  ❗In `client/app/api/auth/[...nextauth]/route.ts` user_guid property removed from session token and accessible only from the NextAuth encrypted JWT for security purposes
   - The `user_guid` value can be obtained from NextAuth JWT using App Api `client/app/api/auth/token/route.ts`
   - In `client/app/utils/actions.ts` Authorization header sets `user_guid` using value obtained from `client/app/api/auth/token/route.ts`
 

## 📝 Notes:
-  After rebase, API routes POST tests FAIL with 400
   - Troubleshooting: using breakpoint() within the API endpoint enables variable inspection - magic!
   - Root cause: 'AppRole matching query does not exist' 
   - Possible Solutions: 
      - Similar to `bc_obps/registration/tests/test_models.py` add fixtures = [APP_ROLE_FIXTURE] to `bc_obps/registration/tests/test_endpoints.py` does not seem to resolve the issue possibly because "BC: (since) we've only used so far in the models, so it's probably not set up in the endpoint tests yet"
      - Adding code below suggested by SS caused error "RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable database access in this test error indicates that there's an attempt to access the database within a test, but the test environment is not set up to allow database access." 
```
@pytest.fixture(scope='class')
      def app_role_fixture():
Then :
@pytest.mark.usefixtures('app_role_fixture') line (above) test class definition
```

   - Modifying SS suggested code below resolved issue:
 ```
Background: Explicitly setting the scope='class' for the app_role_fixture might not be interacting well with the class-level database setup.
Since we already use pytest.mark.django_db at the module level modify the fixture code to the module level.

@pytest.fixture(scope='function')
def app_role_fixture():

    @pytest.mark.usefixtures('app_role_fixture')
    def test_create_user_profile_bceidbusiness(self):
```

## 🛠️ To Do:
- Perhaps a better flow is required for new user POST profile like a signout to signin re-direct but I had issues implementing this

##  🔬 Testing:

### API tests
1. Follow the [developer environment setup](https://github.com/bcgov/cas-registration/blob/develop/docs/developer-environment-setup.md#backend-environment-setup) to set up db, load fixtures and start the API server
2. Open terminal to run endpoint tests
```
cd bc_obps && make pythontests ARGS='registration/tests/test_endpoints.py'  
```
3. Results should be : 35 passed

### e2e tests

**Pre-reqs** 

1. In client folder create folder `client/playwright/.auth`
Upload files into  `client/playwright/.auth` from [1password](https://climateactionsecretariat.1password.ca/)
- OBPS FE Auth Session cas_analyst
- OBPS FE Auth Session cas_pending
4. Copy file `client/e2e/.env.local.example` to `client/e2e/.env.local`
5. Set  `client/e2e/.env.local` values as detailed in file `client/e2e/.env.local.example` 
6. Ensure the the example id used for "new user" in the e2e test is NOT created in the user table:
```
cd bc_obps && psql

 \c registration
You are now connected to database "registration" 
registration=# DELETE FROM erc.user where user_guid='c3cd84a8-e261-4814-93e1-5bd4a7ccd638';
```

1.  From terminal command, start the app development server:
 ```
cd client && yarn dev 
```  
2.  From terminal command, run Playwright e2e tests:
```
cd client && yarn e2e
```   
3. All tests should pass (24)

### App Tests:

**Create New User**

**Pre-reqs** 

1. Ensure the the example id used for "new user" in the e2e test is NOT created in the user table:
```
cd bc_obps && psql

 \c registration
registration=# DELETE FROM erc.user where user_guid='c3cd84a8-e261-4814-93e1-5bd4a7ccd638';
```

1. Ensure the API and App servers are running (as detailed above)
2. In a new anonymous web browser, navigate to `http://localhost:3000`
3. You should be directed to the unauthenticated landing page
![image](https://github.com/bcgov/cas-registration/assets/120038448/bd8166b1-4f19-4993-82dc-0b3340d625e7)
4. Click "Industry Operator Log In"
5. Log in with Bceid: bc-cas-dev-three, defined in [1password](https://climateactionsecretariat.1password.ca/)
6. You should be directed to `Dashboard\Profile` form with values in login name and email corresponding to the login ID details
![image](https://github.com/bcgov/cas-registration/assets/120038448/2aa518f3-cad7-46fa-a123-70548c6f1855)

7. Attempt to navigate to other routes e.g. http://localhost:3000/dashboard
8. You should be directed to `Dashboard\Profile` form
9. Complete the profile form and click "Submit"
10.  You should be logged out and re-directed to the unauthenticated landing page
11.  Log in with Bceid: bc-cas-dev-three
12. You should be directed to dashboard for industry user 
![image](https://github.com/bcgov/cas-registration/assets/120038448/f170fba2-c33c-4725-9233-f04b9b56b75f)

13. Click the login name in the right hand header
14. Profile information Submitted in step 9 should display
15. Update the profile form and click "Submit"
16. Changes should be successfully updated as indicated by the "Submit" to "Success" text in the button
17. Refresh the browser, changes should be reflected in the `Dashboard\Profile` form


**Optional Regression Tests:**
**User Dashboard Routing**

1. Ensure the API and App servers are running (as detailed above)
2. In a new anonymous web browser, navigate to `http://localhost:3000`
3. You should be directed to the unauthenticated landing page
4. Click "Program Administrator Log In"
5. You should be directed to IDIR login screen
6. Login using your IDIR account
7. Verify your dashboard reflects the app_role and/or existence of your IDIR ID defined in bc_obps/registration/fixtures/mock/user.json
7.1 Non existent (OR API server not running) " no role": Dashboard\User profile is displayed
7.2 Exists with "cas_pending": Pending message is displayed
7.3 Exists with "cas_admin": Cas admin dashboard navigation tiles are displayed
7.4 Exists with "industry_user": Industry user dashboard navigation tiles are displayed
8.  In an anonymous new web browser, navigate to `http://localhost:3000`
9. You should be directed to the anonymous landing page
10. Click "Industry Operator Log In"
11. Log in with Bceid: bc-cas-dev (defined 1password)
12. You should be directed to dashboard for industry user admin
13.  In an new anonymous web browser, navigate to `http://localhost:3000`
14. You should be directed to the unauthenticated landing page
15. Click "Industry Operator Log In"
16. Log in with Bceid: bc-cas-dev-secondary (defined 1password)
18. You should be directed to dashboard for industry user