### PR TITLE
feat: View and manage user access requests as an Op/Org admin

### DIFF
--- a/bc_obps/registration/api/operator.py
+++ b/bc_obps/registration/api/operator.py
@@ -2,9 +2,9 @@ from typing import Optional
 from registration.utils import check_users_admin_request_eligibility
 from .api_base import router
 from django.shortcuts import get_object_or_404
-from registration.models import Operator
+from registration.models import Operator, UserOperator
 from ninja.responses import codes_4xx, codes_5xx
-from registration.schema import Message, OperatorOut
+from registration.schema import Message, OperatorOut, SelectUserOperatorStatus
 
 
 ##### GET #####
@@ -41,6 +41,12 @@ def get_operator(request, operator_id: int):
     except Exception as e:
         return 404, {"message": "No matching operator found"}
     return 200, operator
+
+
+@router.get("/operators/{operator_id}/user-operators", response=list[SelectUserOperatorStatus])
+def list_user_operators_status_of_operator(request, operator_id: int):
+    qs = UserOperator.objects.filter(operator=operator_id)
+    return qs
 
 
 ##### POST #####

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -280,6 +280,7 @@ def create_user_operator_contact(request, payload: UserOperatorContactIn):
 
 @router.put("/select-operator/user-operator/{user_id}/update-status")
 def update_user_operator_status(request, user_id: str):
+    current_admin_user = request.current_user
     payload = json.loads(request.body.decode())
     status = getattr(UserOperator.Statuses, payload.get("status").upper())
     user_operator = get_object_or_404(UserOperator, user=user_id)
@@ -287,6 +288,7 @@ def update_user_operator_status(request, user_id: str):
 
     if user_operator.status in [UserOperator.Statuses.APPROVED, UserOperator.Statuses.REJECTED]:
         user_operator.verified_at = datetime.now(pytz.utc)
+        user_operator.verified_by_id = current_admin_user
     if user_operator.status in [UserOperator.Statuses.PENDING]:
         user_operator.verified_at = None
         user_operator.verified_by_id = None

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -280,7 +280,7 @@ def create_user_operator_contact(request, payload: UserOperatorContactIn):
 
 @router.put("/select-operator/user-operator/{user_id}/update-status")
 def update_user_operator_status(request, user_id: str):
-    current_admin_user = request.current_user
+    current_admin_user: User = request.current_user
     payload = json.loads(request.body.decode())
     status = getattr(UserOperator.Statuses, payload.get("status").upper())
     user_operator = get_object_or_404(UserOperator, user=user_id)
@@ -288,7 +288,7 @@ def update_user_operator_status(request, user_id: str):
 
     if user_operator.status in [UserOperator.Statuses.APPROVED, UserOperator.Statuses.REJECTED]:
         user_operator.verified_at = datetime.now(pytz.utc)
-        user_operator.verified_by_id = current_admin_user
+        user_operator.verified_by_id = current_admin_user.user_guid
     if user_operator.status in [UserOperator.Statuses.PENDING]:
         user_operator.verified_at = None
         user_operator.verified_by_id = None

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -282,7 +282,7 @@ def create_user_operator_contact(request, payload: UserOperatorContactIn):
 def update_user_operator_status(request, user_operator_id: int):
     payload = json.loads(request.body.decode())
     status = getattr(UserOperator.Statuses, payload.get("status").upper())
-    user_operator = get_object_or_404(UserOperator, id=user_operator_id)
+    user_operator = get_object_or_404(UserOperator, user=user_id)
     user_operator.status = status
 
     if user_operator.status in [UserOperator.Statuses.APPROVED, UserOperator.Statuses.REJECTED]:

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -278,8 +278,8 @@ def create_user_operator_contact(request, payload: UserOperatorContactIn):
 ##### PUT #####
 
 
-@router.put("/select-operator/user-operator/{int:user_operator_id}/update-status")
-def update_user_operator_status(request, user_operator_id: int):
+@router.put("/select-operator/user-operator/{user_id}/update-status")
+def update_user_operator_status(request, user_id: str):
     payload = json.loads(request.body.decode())
     status = getattr(UserOperator.Statuses, payload.get("status").upper())
     user_operator = get_object_or_404(UserOperator, user=user_id)

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -68,10 +68,10 @@ def get_user_operator_admin_exists(request, operator_id: int):
     return 200, has_admin
 
 
-@router.get("/get-users-operators/{user_id}", response=List[SelectUserOperatorOperatorsOut])
-def get_user(request, user_id: str):
+@router.get("/get-current-users-operators", response=List[SelectUserOperatorOperatorsOut])
+def get_user(request):
     UserOperatorList = UserOperator.objects.filter(
-        user_id=user_id, role=UserOperator.Roles.ADMIN, status=UserOperator.Statuses.APPROVED
+        user_id=request.current_user.user_guid, role=UserOperator.Roles.ADMIN, status=UserOperator.Statuses.APPROVED
     )
     return UserOperatorList
 

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -10,6 +10,8 @@ from registration.schema import (
     UserOperatorContactIn,
     IsApprovedUserOperator,
 )
+from registration.schema.user_operator import SelectUserOperatorOperatorsOut
+from typing import List
 from .api_base import router
 from typing import Optional
 from django.shortcuts import get_object_or_404

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -66,6 +66,14 @@ def get_user_operator_admin_exists(request, operator_id: int):
     return 200, has_admin
 
 
+@router.get("/get-users-operators/{user_id}", response=List[SelectUserOperatorOperatorsOut])
+def get_user(request, user_id: str):
+    UserOperatorList = UserOperator.objects.filter(
+        user_id=user_id, role=UserOperator.Roles.ADMIN, status=UserOperator.Statuses.APPROVED
+    )
+    return UserOperatorList
+
+
 ##### POST #####
 
 

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from ninja import ModelSchema, Schema, Field
-from registration.models import Contact, User
+from registration.models import Contact, User, UserOperator
 from pydantic import Field
 
 
@@ -129,3 +129,13 @@ class SelectUserOperatorStatus(Schema):
 
     role: str
     status: str
+
+
+class SelectUserOperatorOperatorsOut(ModelSchema):
+    """
+    Schema for returning User's Business Operator
+    """
+
+    class Config:
+        model = UserOperator
+        model_fields = ["operator"]

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from ninja import ModelSchema, Schema
+from ninja import ModelSchema, Schema, Field
 from registration.models import Contact, User
 from pydantic import Field
 
@@ -115,3 +115,17 @@ class UserOperatorUserOut(ModelSchema):
     class Config:
         model = User
         model_fields = ["phone_number", "email"]
+
+
+class SelectUserOperatorStatus(Schema):
+    """
+    Schema for a User Operator model
+    """
+
+    first_name: str = Field(..., alias="user.first_name")
+    last_name: str = Field(..., alias="user.last_name")
+    position_title: str = Field(..., alias="user.position_title")
+    business_name: str = Field(..., alias="operator.legal_name")
+
+    role: str
+    status: str

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -1,4 +1,6 @@
 from typing import Optional
+import uuid
+from django.forms import UUIDField
 from ninja import ModelSchema, Schema, Field
 from registration.models import Contact, User, UserOperator
 from pydantic import Field
@@ -124,9 +126,10 @@ class SelectUserOperatorStatus(Schema):
 
     first_name: str = Field(..., alias="user.first_name")
     last_name: str = Field(..., alias="user.last_name")
+    email: str = Field(..., alias="user.email")
     position_title: str = Field(..., alias="user.position_title")
     business_name: str = Field(..., alias="operator.legal_name")
-
+    user_id: uuid.UUID = Field(..., alias="user.user_guid")
     role: str
     status: str
 

--- a/bc_obps/registration/tests/test_02_endpoints.py
+++ b/bc_obps/registration/tests/test_02_endpoints.py
@@ -624,7 +624,7 @@ class TestUserOperatorEndpoint:
         response = client.put(
             f"{base_endpoint}select-operator/user-operator/{user_operator.user_id}/update-status",
             content_type=content_type_json,
-            data={"status": "approved"},
+            data={"status": UserOperator.Statuses.APPROVED},
             HTTP_AUTHORIZATION=self.auth_header_dumps,
         )
 

--- a/bc_obps/registration/tests/test_02_endpoints.py
+++ b/bc_obps/registration/tests/test_02_endpoints.py
@@ -595,23 +595,25 @@ class TestUserOperatorEndpoint:
 
     def test_get_users_operators_list(self):
         operators = baker.make(Operator, _quantity=2)
-        user = baker.make(User)
         baker.make(
             UserOperator,
-            user=user,
+            user=self.user,
             operator=operators[0],
             role=UserOperator.Roles.ADMIN,
             status=UserOperator.Statuses.APPROVED,
         )
         baker.make(
             UserOperator,
-            user=user,
+            user=self.user,
             operator=operators[1],
             role=UserOperator.Roles.ADMIN,
             status=UserOperator.Statuses.APPROVED,
         )
 
-        response = client.get(f"{base_endpoint}get-users-operators/{user.user_guid}")
+        response = client.get(
+            f"{base_endpoint}get-current-users-operators",
+            HTTP_AUTHORIZATION=self.auth_header_dumps,
+        )
 
         assert len(json.loads(response.content)) == 2
 
@@ -635,6 +637,7 @@ class TestUserOperatorEndpoint:
 
         assert parsed_object.get("fields").get("status") == UserOperator.Statuses.APPROVED
         assert parsed_object.get("fields").get("verified_by") == str(self.user.user_guid)
+
 
 class TestUserEndpoint:
     endpoint = base_endpoint + "user"

--- a/bc_obps/registration/tests/test_02_endpoints.py
+++ b/bc_obps/registration/tests/test_02_endpoints.py
@@ -455,6 +455,24 @@ class TestOperatorsEndpoint:
         assert response.status_code == 404
         assert response.json() == {"message": "No matching operator found. Retry or add operator."}
 
+    def test_get_list_user_operators_status(self):
+        operator = baker.make(Operator)
+        user = baker.make(User)
+        userOperatorPrime = baker.make(
+            UserOperator,
+            user=user,
+            operator=operator,
+            role=UserOperator.Roles.ADMIN,
+            status=UserOperator.Statuses.APPROVED,
+        )
+        baker.make(UserOperator, operator=operator, _quantity=1)
+
+        response = client.get(
+            f"{self.endpoint}/{operator.id}/user-operators",
+        )
+
+        assert len(json.loads(response.content)) == 2
+
 
 class TestUserOperatorEndpoint:
     select_endpoint = base_endpoint + "select-operator"
@@ -575,6 +593,48 @@ class TestUserOperatorEndpoint:
         has_history_record = HistoricalUserOperator.objects.all()
         assert has_history_record.count() > 0, "History record was not created"
 
+    def test_get_users_operators_list(self):
+        operators = baker.make(Operator, _quantity=2)
+        user = baker.make(User)
+        baker.make(
+            UserOperator,
+            user=user,
+            operator=operators[0],
+            role=UserOperator.Roles.ADMIN,
+            status=UserOperator.Statuses.APPROVED,
+        )
+        baker.make(
+            UserOperator,
+            user=user,
+            operator=operators[1],
+            role=UserOperator.Roles.ADMIN,
+            status=UserOperator.Statuses.APPROVED,
+        )
+
+        response = client.get(f"{base_endpoint}get-users-operators/{user.user_guid}")
+
+        assert len(json.loads(response.content)) == 2
+
+    def test_put_update_user_status(self):
+        user = baker.make(User)
+        user_operator = baker.make(UserOperator, status=UserOperator.Statuses.PENDING, user_id=user.user_guid)
+
+        response = client.put(
+            f"{base_endpoint}select-operator/user-operator/{user_operator.user_id}/update-status",
+            content_type=content_type_json,
+            data={"status": "approved"},
+            HTTP_AUTHORIZATION=self.auth_header_dumps,
+        )
+
+        assert response.status_code == 200
+
+        response_content = json.loads(response.content.decode("utf-8"))
+        parsed_list = json.loads(response_content)
+        # the put_response content is returned as a list but there's only ever one object in the list
+        parsed_object = parsed_list[0]
+
+        assert parsed_object.get("fields").get("status") == UserOperator.Statuses.APPROVED
+        assert parsed_object.get("fields").get("verified_by") == str(self.user.user_guid)
 
 class TestUserEndpoint:
     endpoint = base_endpoint + "user"

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -5,6 +5,7 @@ import { actionHandler } from "@/app/utils/actions";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { ChangeUserOperatorStatusColumnCell } from "@/app/components/datagrid/ChangeUserOperatorStatusColumnCell";
+import { statusStyle } from "@/app/components/datagrid/userPageHelpers";
 
 type BusinessUserOperator = {
   operator: string;
@@ -72,22 +73,29 @@ export default async function Page() {
   }
 
   const columns = [
-    { field: "id", headerName: "User ID" },
-    { field: "name", headerName: "Name" },
-    { field: "email", headerName: "Email" },
-    { field: "business", headerName: "BCeID Business" },
-    { field: "userRole", headerName: "User Role" },
-    { field: "status", headerName: "Status" },
+    { field: "id", headerName: "User ID", flex: 2 },
+    { field: "name", headerName: "Name", flex: 2 },
+    { field: "email", headerName: "Email", flex: 6 },
+    { field: "business", headerName: "BCeID Business", flex: 6 },
+    { field: "userRole", headerName: "User Role", flex: 4 },
+    {
+      field: "status",
+      headerName: "Status",
+      flex: 3,
+      renderCell: statusStyle,
+    },
     {
       field: "actions",
       headerName: "Actions",
+      sortable: false,
       renderCell: ChangeUserOperatorStatusColumnCell,
+      flex: 4,
     },
   ];
 
   const statusRows: GridRowsProp = userOperatorStatuses.map((uOS) => ({
     id: uOS.user_id,
-    name: `${uOS.first_name} ${uOS.last_name}`,
+    name: `${uOS.first_name} ${uOS.last_name.slice(0, 1)}`,
     email: uOS.email,
     business: uOS.business_name,
     userRole: uOS.role,

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -55,16 +55,12 @@ const statusStringToEnum = (status: string): Status => {
   switch (status.toUpperCase()) {
     case "MYSELF":
       return Status.MYSELF;
-      break;
     case "APPROVED":
       return Status.APPROVED;
-      break;
     case "REJECTED":
       return Status.REJECTED;
-      break;
     case "PENDING":
       return Status.PENDING;
-      break;
     case "DRAFT":
     default:
       return Status.DRAFT;

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -1,4 +1,4 @@
-import { GridRowsProp } from "@mui/x-data-grid";
+import { GridColDef, GridRowsProp } from "@mui/x-data-grid";
 import DataGrid from "@/app/components/datagrid/DataGrid";
 
 import { actionHandler } from "@/app/utils/actions";
@@ -74,7 +74,7 @@ export default async function Page() {
     userOperatorStatuses[selfIndex].status = "myself";
   }
 
-  const columns = [
+  const columns: GridColDef[] = [
     {
       field: "id",
       headerName: "User ID",
@@ -136,7 +136,6 @@ export default async function Page() {
     business: uOS.business_name,
     userRole: uOS.role,
     status: uOS.status,
-    actions: "todo: Approve/Reject func",
   }));
 
   return (

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -4,6 +4,7 @@ import DataGrid from "@/app/components/datagrid/DataGrid";
 import { actionHandler } from "@/app/utils/actions";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { ChangeUserOperatorStatusColumnCell } from "@/app/components/datagrid/ChangeUserOperatorStatusColumnCell";
 
 type BusinessUserOperator = {
   operator: string;
@@ -73,7 +74,11 @@ export default async function Page() {
     { field: "business", headerName: "BCeID Business" },
     { field: "userRole", headerName: "User Role" },
     { field: "status", headerName: "Status" },
-    { field: "actions", headerName: "Actions" },
+    {
+      field: "actions",
+      headerName: "Actions",
+      renderCell: ChangeUserOperatorStatusColumnCell,
+    },
   ];
 
   const statusRows: GridRowsProp = userOperatorStatuses.map((uOS) => ({

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -1,3 +1,25 @@
-export default function Page() {
-  return <h1>TO DO: Users Page</h1>;
+import { actionHandler } from "@/app/utils/actions";
+
+// 🛠️ Function to fetch userOperators
+async function getUserOperatorsForOperator() {
+  try {
+    return await actionHandler(
+      "registration/operators/2/user-operators",
+      "GET",
+      "/dashboard/users",
+    );
+  } catch (error) {
+    throw error;
+  }
+}
+
+export default async function Page() {
+  const raw = await getUserOperatorsForOperator();
+
+  return (
+    <>
+      <h1>TO DO: Users Page</h1>
+      <pre>{JSON.stringify(raw, null, 2)}</pre>
+    </>
+  );
 }

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -65,31 +65,67 @@ export default async function Page() {
           getUserOperatorsForOperator(associatedOperator.operator),
         ),
       )
-    )
-      .flat()
-      .filter(
-        (userOperator) => !(userOperator.user_id.replace(/-/g, "") === uid),
-      );
+    ).flat();
+
+    // 🤳Identify current admin user in the list
+    const selfIndex = userOperatorStatuses.findIndex(
+      (userOperator) => userOperator.user_id.replace(/-/g, "") === uid,
+    );
+    userOperatorStatuses[selfIndex].status = "myself";
   }
 
   const columns = [
-    { field: "id", headerName: "User ID", flex: 2 },
-    { field: "name", headerName: "Name", flex: 2 },
-    { field: "email", headerName: "Email", flex: 6 },
-    { field: "business", headerName: "BCeID Business", flex: 6 },
-    { field: "userRole", headerName: "User Role", flex: 4 },
+    {
+      field: "id",
+      headerName: "User ID",
+      flex: 2,
+      align: "center",
+      headerAlign: "center",
+    },
+    {
+      field: "name",
+      headerName: "Name",
+      flex: 2,
+      align: "center",
+      headerAlign: "center",
+    },
+    {
+      field: "email",
+      headerName: "Email",
+      flex: 6,
+      align: "center",
+      headerAlign: "center",
+    },
+    {
+      field: "business",
+      headerName: "BCeID Business",
+      flex: 6,
+      align: "center",
+      headerAlign: "center",
+    },
+    {
+      field: "userRole",
+      headerName: "User Role",
+      flex: 4,
+      align: "center",
+      headerAlign: "center",
+    },
     {
       field: "status",
       headerName: "Status",
       flex: 3,
       renderCell: statusStyle,
+      align: "center",
+      headerAlign: "center",
     },
     {
       field: "actions",
       headerName: "Actions",
       sortable: false,
       renderCell: ChangeUserOperatorStatusColumnCell,
-      flex: 4,
+      flex: 6,
+      align: "center",
+      headerAlign: "center",
     },
   ];
 

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -64,7 +64,11 @@ export default async function Page() {
           getUserOperatorsForOperator(associatedOperator.operator),
         ),
       )
-    ).flat();
+    )
+      .flat()
+      .filter(
+        (userOperator) => !(userOperator.user_id.replace(/-/g, "") === uid),
+      );
   }
 
   const columns = [

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -1,3 +1,6 @@
+import { GridRowsProp } from "@mui/x-data-grid";
+import DataGrid from "@/app/components/datagrid/DataGrid";
+
 import { actionHandler } from "@/app/utils/actions";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
@@ -63,12 +66,29 @@ export default async function Page() {
     ).flat();
   }
 
+  const columns = [
+    { field: "id", headerName: "User ID" },
+    { field: "name", headerName: "Name" },
+    { field: "email", headerName: "Email" },
+    { field: "business", headerName: "BCeID Business" },
+    { field: "userRole", headerName: "User Role" },
+    { field: "status", headerName: "Status" },
+    { field: "actions", headerName: "Actions" },
+  ];
+
+  const statusRows: GridRowsProp = userOperatorStatuses.map((uOS) => ({
+    id: uOS.user_id,
+    name: `${uOS.first_name} ${uOS.last_name}`,
+    email: uOS.email,
+    business: uOS.business_name,
+    userRole: uOS.role,
+    status: uOS.status,
+    actions: "todo: Approve/Reject func",
+  }));
+
   return (
     <>
-      <h1>TO DO: Users Page</h1>
-      <pre>
-        {userOperatorStatuses && JSON.stringify(userOperatorStatuses, null, 2)}
-      </pre>
+      <DataGrid rows={statusRows} columns={columns} cntxt="userOperators" />
     </>
   );
 }

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -1,7 +1,7 @@
 import { GridColDef, GridRowsProp } from "@mui/x-data-grid";
 import DataGrid from "@/app/components/datagrid/DataGrid";
 
-import { actionHandler, getCurrentUserGuid } from "@/app/utils/actions";
+import { actionHandler, getToken } from "@/app/utils/actions";
 import { ChangeUserOperatorStatusColumnCell } from "@/app/components/datagrid/ChangeUserOperatorStatusColumnCell";
 import { statusStyle } from "@/app/components/datagrid/userPageHelpers";
 import { Status } from "@/app/types/types";
@@ -72,7 +72,8 @@ export default async function Page() {
   const approvedOperators = await getAdminsApprovedUserOperators();
 
   if (approvedOperators) {
-    const uid = await getCurrentUserGuid();
+    const token = await getToken();
+    const uid = token?.user_guid ?? "";
     userOperatorStatuses = (
       await Promise.all(
         approvedOperators.flatMap((associatedOperator) =>

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -7,10 +7,12 @@ type BusinessUserOperator = {
 };
 
 interface UserOperatorStatus {
+  user_id: string;
   first_name: string;
   last_name: string;
   position_title: string;
   business_name: string;
+  email: string;
   role: string;
   status: string;
 }

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -159,7 +159,7 @@ export default async function Page() {
 
   return (
     <>
-      <DataGrid rows={statusRows} columns={columns} cntxt="userOperators" />
+      <DataGrid rows={statusRows} columns={columns} />
     </>
   );
 }

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -1,10 +1,42 @@
 import { actionHandler } from "@/app/utils/actions";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+
+type BusinessUserOperator = {
+  operator: string;
+};
+
+interface UserOperatorStatus {
+  first_name: string;
+  last_name: string;
+  position_title: string;
+  business_name: string;
+  role: string;
+  status: string;
+}
 
 // 🛠️ Function to fetch userOperators
-async function getUserOperatorsForOperator() {
+async function getUserOperatorsForOperator(
+  operator_id: string,
+): Promise<UserOperatorStatus[]> {
   try {
     return await actionHandler(
-      "registration/operators/2/user-operators",
+      `registration/operators/${operator_id}/user-operators`,
+      "GET",
+      "/dashboard/users",
+    );
+  } catch (error) {
+    throw error;
+  }
+}
+
+// 🛠️ Function to fetch a user's approved UserOperators, returning the business id as `obj.operator`
+async function getAdminsApprovedUserOperators(
+  user_guid: string,
+): Promise<BusinessUserOperator[]> {
+  try {
+    return await actionHandler(
+      `registration/get-users-operators/${user_guid}`,
       "GET",
       "/dashboard/users",
     );
@@ -14,12 +46,27 @@ async function getUserOperatorsForOperator() {
 }
 
 export default async function Page() {
-  const raw = await getUserOperatorsForOperator();
+  const session = await getServerSession(authOptions);
+  let userOperatorStatuses: UserOperatorStatus[] = [];
+
+  if (session?.user.user_guid) {
+    const uid = session.user.user_guid;
+    const approvedOperator = await getAdminsApprovedUserOperators(uid);
+    userOperatorStatuses = (
+      await Promise.all(
+        approvedOperator.flatMap((associatedOperator) =>
+          getUserOperatorsForOperator(associatedOperator.operator),
+        ),
+      )
+    ).flat();
+  }
 
   return (
     <>
       <h1>TO DO: Users Page</h1>
-      <pre>{JSON.stringify(raw, null, 2)}</pre>
+      <pre>
+        {userOperatorStatuses && JSON.stringify(userOperatorStatuses, null, 2)}
+      </pre>
     </>
   );
 }

--- a/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
+++ b/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { GridRenderCellParams } from "@mui/x-data-grid/models/params/gridCellParams";
+import Button from "@mui/material/Button";
+type UserOperatorStatus = "draft" | "pending" | "approved" | "rejected";
+
+interface ButtonRenderCellParams extends GridRenderCellParams {
+  row: {
+    id: string;
+    name: string;
+    email: string;
+    business: string;
+    userRole: string;
+    status: UserOperatorStatus;
+    actions: string;
+  };
+}
+
+export async function ChangeUserOperatorStatusColumnCell(
+  params: ButtonRenderCellParams,
+) {
+  const userOperatorStatus = params.row.status;
+
+  const buttonsToShow = (status: UserOperatorStatus): string[] => {
+    if (status.toLowerCase() === "pending") {
+      return ["Approve", "Deny"];
+    } else if (
+      status.toLowerCase() === "approved" ||
+      status.toLowerCase() === "rejected"
+    ) {
+      return ["Undo"];
+    }
+    return [];
+  };
+
+  return (
+    <>
+      {buttonsToShow(userOperatorStatus).map((item, index) => (
+        <Button variant="outlined" key={index}>
+          {item}
+        </Button>
+      ))}
+    </>
+  );
+}

--- a/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
+++ b/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
@@ -7,16 +7,10 @@ import ThumbUpIcon from "@mui/icons-material/ThumbUp";
 import DoNotDisturbIcon from "@mui/icons-material/DoNotDisturb";
 import { ReactNode } from "react";
 import { Stack } from "@mui/system";
-
-type UserOperatorStatus =
-  | "draft"
-  | "pending"
-  | "approved"
-  | "rejected"
-  | "myself";
+import { Status } from "@/app/types/types";
 
 interface UserOperatorStatusAction {
-  statusTo: UserOperatorStatus;
+  statusTo: Status;
   title: string;
   color: ButtonOwnProps["color"];
   icon?: ReactNode;
@@ -29,14 +23,14 @@ interface ButtonRenderCellParams extends GridRenderCellParams {
     email: string;
     business: string;
     userRole: string;
-    status: UserOperatorStatus;
+    status: Status;
     actions: string;
   };
 }
 
 const handleUpdateStatus = async (
   userOperatorId: string,
-  statusUpdate: UserOperatorStatus,
+  statusUpdate: Status,
 ) => {
   try {
     return await actionHandler(
@@ -60,33 +54,28 @@ export async function ChangeUserOperatorStatusColumnCell(
   const userOperatorStatus = params.row.status;
   const userOperatorId = params.row.id;
 
-  const buttonsToShow = (
-    status: UserOperatorStatus,
-  ): UserOperatorStatusAction[] => {
-    if (status.toLowerCase() === "myself") {
+  const buttonsToShow = (status: Status): UserOperatorStatusAction[] => {
+    if (status === Status.MYSELF) {
       return [];
-    } else if (status.toLowerCase() === "pending") {
+    } else if (status === Status.PENDING) {
       return [
         {
-          statusTo: "approved",
+          statusTo: Status.APPROVED,
           title: "Approve",
           color: "success",
           icon: <ThumbUpIcon />,
         },
         {
-          statusTo: "rejected",
+          statusTo: Status.REJECTED,
           title: "Deny",
           color: "error",
           icon: <DoNotDisturbIcon />,
         },
       ];
-    } else if (
-      status.toLowerCase() === "approved" ||
-      status.toLowerCase() === "rejected"
-    ) {
+    } else if (status === Status.APPROVED || status === Status.REJECTED) {
       return [
         {
-          statusTo: "pending",
+          statusTo: Status.PENDING,
           title: "Undo",
           color: "primary",
         },

--- a/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
+++ b/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
@@ -1,14 +1,25 @@
 "use client";
 
 import { GridRenderCellParams } from "@mui/x-data-grid/models/params/gridCellParams";
-import Button from "@mui/material/Button";
+import Button, { ButtonOwnProps } from "@mui/material/Button";
 import { actionHandler } from "@/app/utils/actions";
+import ThumbUpIcon from "@mui/icons-material/ThumbUp";
+import DoNotDisturbIcon from "@mui/icons-material/DoNotDisturb";
+import { ReactNode } from "react";
+import { Stack } from "@mui/system";
 
-type UserOperatorStatus = "draft" | "pending" | "approved" | "rejected";
+type UserOperatorStatus =
+  | "draft"
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "myself";
 
 interface UserOperatorStatusAction {
   statusTo: UserOperatorStatus;
   title: string;
+  color: ButtonOwnProps["color"];
+  icon?: ReactNode;
 }
 
 interface ButtonRenderCellParams extends GridRenderCellParams {
@@ -52,33 +63,53 @@ export async function ChangeUserOperatorStatusColumnCell(
   const buttonsToShow = (
     status: UserOperatorStatus,
   ): UserOperatorStatusAction[] => {
-    if (status.toLowerCase() === "pending") {
+    if (status.toLowerCase() === "myself") {
+      return [];
+    } else if (status.toLowerCase() === "pending") {
       return [
-        { statusTo: "approved", title: "Approve" },
-        { statusTo: "rejected", title: "Deny" },
+        {
+          statusTo: "approved",
+          title: "Approve",
+          color: "success",
+          icon: <ThumbUpIcon />,
+        },
+        {
+          statusTo: "rejected",
+          title: "Deny",
+          color: "error",
+          icon: <DoNotDisturbIcon />,
+        },
       ];
     } else if (
       status.toLowerCase() === "approved" ||
       status.toLowerCase() === "rejected"
     ) {
-      return [{ statusTo: "pending", title: "Undo" }];
+      return [
+        {
+          statusTo: "pending",
+          title: "Undo",
+          color: "primary",
+        },
+      ];
     }
     return [];
   };
 
   return (
-    <>
+    <Stack direction="row" spacing={1}>
       {buttonsToShow(userOperatorStatus).map((item, index) => (
         <Button
-          variant="outlined"
+          variant={item.title === "Undo" ? "text" : "outlined"}
           key={index}
           onClick={async () =>
             handleUpdateStatus(userOperatorId, item.statusTo)
           }
+          color={item.color}
+          endIcon={item.icon}
         >
           {item.title}
         </Button>
       ))}
-    </>
+    </Stack>
   );
 }

--- a/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
+++ b/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
@@ -2,7 +2,14 @@
 
 import { GridRenderCellParams } from "@mui/x-data-grid/models/params/gridCellParams";
 import Button from "@mui/material/Button";
+import { actionHandler } from "@/app/utils/actions";
+
 type UserOperatorStatus = "draft" | "pending" | "approved" | "rejected";
+
+interface UserOperatorStatusAction {
+  statusTo: UserOperatorStatus;
+  title: string;
+}
 
 interface ButtonRenderCellParams extends GridRenderCellParams {
   row: {
@@ -16,19 +23,45 @@ interface ButtonRenderCellParams extends GridRenderCellParams {
   };
 }
 
+const handleUpdateStatus = async (
+  userOperatorId: string,
+  statusUpdate: UserOperatorStatus,
+) => {
+  try {
+    return await actionHandler(
+      `registration/select-operator/user-operator/${userOperatorId}/update-status`,
+      "PUT",
+      "/dashboard/users",
+      {
+        body: JSON.stringify({
+          status: statusUpdate,
+        }),
+      },
+    );
+  } catch (error) {
+    throw error;
+  }
+};
+
 export async function ChangeUserOperatorStatusColumnCell(
   params: ButtonRenderCellParams,
 ) {
   const userOperatorStatus = params.row.status;
+  const userOperatorId = params.row.id;
 
-  const buttonsToShow = (status: UserOperatorStatus): string[] => {
+  const buttonsToShow = (
+    status: UserOperatorStatus,
+  ): UserOperatorStatusAction[] => {
     if (status.toLowerCase() === "pending") {
-      return ["Approve", "Deny"];
+      return [
+        { statusTo: "approved", title: "Approve" },
+        { statusTo: "rejected", title: "Deny" },
+      ];
     } else if (
       status.toLowerCase() === "approved" ||
       status.toLowerCase() === "rejected"
     ) {
-      return ["Undo"];
+      return [{ statusTo: "pending", title: "Undo" }];
     }
     return [];
   };
@@ -36,8 +69,14 @@ export async function ChangeUserOperatorStatusColumnCell(
   return (
     <>
       {buttonsToShow(userOperatorStatus).map((item, index) => (
-        <Button variant="outlined" key={index}>
-          {item}
+        <Button
+          variant="outlined"
+          key={index}
+          onClick={async () =>
+            handleUpdateStatus(userOperatorId, item.statusTo)
+          }
+        >
+          {item.title}
         </Button>
       ))}
     </>

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -12,7 +12,7 @@ import { Button } from "@mui/material";
 interface Props {
   rows: GridRowsProp;
   columns: GridColDef[];
-  cntxt: string;
+  cntxt?: string;
 }
 
 const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {

--- a/client/app/components/datagrid/userPageHelpers.tsx
+++ b/client/app/components/datagrid/userPageHelpers.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Button, ButtonOwnProps } from "@mui/material";
+import { GridValueGetterParams } from "@mui/x-data-grid";
+
+export const statusStyle = (params: GridValueGetterParams) => {
+  const colorMap = new Map<string, ButtonOwnProps["color"]>([
+    ["myself", "primary"],
+    ["pending", "primary"],
+    ["approved", "success"],
+    ["rejected", "error"],
+  ]);
+
+  const statusColor = colorMap.get(params.value) || "primary";
+
+  return (
+    <Button variant="outlined" color={statusColor} sx={{ borderRadius: 32 }}>
+      {params.value}
+    </Button>
+  );
+};

--- a/client/app/components/datagrid/userPageHelpers.tsx
+++ b/client/app/components/datagrid/userPageHelpers.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { Chip, ChipOwnProps } from "@mui/material";
-import { GridValueGetterParams } from "@mui/x-data-grid";
+import { GridRenderCellParams } from "@mui/x-data-grid";
 
 const capitalizeFirstLetter = (label: string) =>
   label.charAt(0).toUpperCase() + label.slice(1);
 
-export const statusStyle = (params: GridValueGetterParams) => {
+export const statusStyle = (params: GridRenderCellParams) => {
   const colorMap = new Map<string, ChipOwnProps["color"]>([
     ["myself", "primary"],
     ["pending", "primary"],

--- a/client/app/components/datagrid/userPageHelpers.tsx
+++ b/client/app/components/datagrid/userPageHelpers.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { Button, ButtonOwnProps } from "@mui/material";
+import { Chip, ChipOwnProps } from "@mui/material";
 import { GridValueGetterParams } from "@mui/x-data-grid";
 
+const capitalizeFirstLetter = (label: string) =>
+  label.charAt(0).toUpperCase() + label.slice(1);
+
 export const statusStyle = (params: GridValueGetterParams) => {
-  const colorMap = new Map<string, ButtonOwnProps["color"]>([
+  const colorMap = new Map<string, ChipOwnProps["color"]>([
     ["myself", "primary"],
     ["pending", "primary"],
     ["approved", "success"],
@@ -14,8 +17,11 @@ export const statusStyle = (params: GridValueGetterParams) => {
   const statusColor = colorMap.get(params.value) || "primary";
 
   return (
-    <Button variant="outlined" color={statusColor} sx={{ borderRadius: 32 }}>
-      {params.value}
-    </Button>
+    <Chip
+      label={capitalizeFirstLetter(params.value)}
+      variant="outlined"
+      color={statusColor}
+      sx={{ mx: "auto", width: 90 }}
+    ></Chip>
   );
 };

--- a/client/app/components/datagrid/userPageHelpers.tsx
+++ b/client/app/components/datagrid/userPageHelpers.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Status } from "@/app/types/types";
 import { Chip, ChipOwnProps } from "@mui/material";
 import { GridRenderCellParams } from "@mui/x-data-grid";
 
@@ -8,10 +9,10 @@ const capitalizeFirstLetter = (label: string) =>
 
 export const statusStyle = (params: GridRenderCellParams) => {
   const colorMap = new Map<string, ChipOwnProps["color"]>([
-    ["myself", "primary"],
-    ["pending", "primary"],
-    ["approved", "success"],
-    ["rejected", "error"],
+    [Status.MYSELF, "primary"],
+    [Status.PENDING, "primary"],
+    [Status.APPROVED, "success"],
+    [Status.REJECTED, "error"],
   ]);
 
   const statusColor = colorMap.get(params.value) || "primary";

--- a/client/app/types/types.ts
+++ b/client/app/types/types.ts
@@ -1,4 +1,5 @@
 export enum Status {
+  MYSELF = "Myself",
   APPROVED = "Approved",
   REJECTED = "Rejected",
   PENDING = "Pending",

--- a/client/app/utils/actions.ts
+++ b/client/app/utils/actions.ts
@@ -10,7 +10,7 @@ import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 
 // 🔒 App API route to get the encrypted JWT
-async function getToken() {
+export async function getToken() {
   try {
     const res = await fetch(`${process.env.NEXTAUTH_URL}/api/auth/token`, {
       method: "GET",
@@ -100,36 +100,6 @@ export async function actionHandler(
       console.error(`An unknown error occurred while fetching ${endpoint}`);
       return {
         error: `An unknown error occurred while fetching ${endpoint}`,
-      };
-    }
-  }
-}
-
-/**
- * Returns the user's GUID for comparison purposes.
- * @returns A Promise that resolves to the string equalling the user's GUID.
- */
-export async function getCurrentUserGuid() {
-  try {
-    // 🔒 Get the encrypted JWT
-    const token = await getToken();
-    // get the user_guid from the JWT
-    return token?.user_guid ?? "";
-  } catch (error: unknown) {
-    // Handle any errors, including network issues
-    if (error instanceof Error) {
-      // eslint-disable-next-line no-console
-      return {
-        // eslint-disable-next-line no-console
-        error: `An error occurred while fetching current users GUID: ${error.message}`,
-      };
-    } else {
-      // eslint-disable-next-line no-console
-      console.error(
-        `An unknown error occurred while fetching current users GUID`,
-      );
-      return {
-        error: `An unknown error occurred while fetching current users GUID`,
       };
     }
   }

--- a/client/app/utils/actions.ts
+++ b/client/app/utils/actions.ts
@@ -104,3 +104,33 @@ export async function actionHandler(
     }
   }
 }
+
+/**
+ * Returns the user's GUID for comparison purposes.
+ * @returns A Promise that resolves to the string equalling the user's GUID.
+ */
+export async function getCurrentUserGuid() {
+  try {
+    // 🔒 Get the encrypted JWT
+    const token = await getToken();
+    // get the user_guid from the JWT
+    return token?.user_guid ?? "";
+  } catch (error: unknown) {
+    // Handle any errors, including network issues
+    if (error instanceof Error) {
+      // eslint-disable-next-line no-console
+      return {
+        // eslint-disable-next-line no-console
+        error: `An error occurred while fetching current users GUID: ${error.message}`,
+      };
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(
+        `An unknown error occurred while fetching current users GUID`,
+      );
+      return {
+        error: `An unknown error occurred while fetching current users GUID`,
+      };
+    }
+  }
+}

--- a/client/app/utils/users/adminUserOperators.ts
+++ b/client/app/utils/users/adminUserOperators.ts
@@ -1,0 +1,78 @@
+import { Status } from "@/app/types/types";
+import { actionHandler, getToken } from "@/app/utils/actions";
+
+export interface UserOperatorStatus {
+  user_id: string;
+  first_name: string;
+  last_name: string;
+  position_title: string;
+  business_name: string;
+  email: string;
+  role: string;
+  status: string | Status;
+}
+
+type UserOperator = {
+  operator: string;
+};
+
+// 🛠️ Function to fetch a user's approved UserOperators, returning the business id as `obj.operator`
+async function getAdminsApprovedUserOperators(): Promise<UserOperator[]> {
+  try {
+    return await actionHandler(
+      `registration/get-current-users-operators`,
+      "GET",
+      "/dashboard/users",
+    );
+  } catch (error) {
+    throw error;
+  }
+}
+
+// 🛠️ Function to fetch userOperators
+async function getUserOperatorsForOperator(
+  operator_id: string,
+): Promise<UserOperatorStatus[]> {
+  try {
+    return await actionHandler(
+      `registration/operators/${operator_id}/user-operators`,
+      "GET",
+      "/dashboard/users",
+    );
+  } catch (error) {
+    throw error;
+  }
+}
+
+// 🛠️ Function to fetch approved operators for admins, processes the associated user operators, and updates their statuses.
+export async function processAdminUserOperators(): Promise<
+  UserOperatorStatus[]
+> {
+  let userOperatorStatuses: UserOperatorStatus[] = [];
+  const approvedOperators = await getAdminsApprovedUserOperators();
+  if (approvedOperators) {
+    const token = await getToken();
+    const uid = token?.user_guid ?? "";
+    userOperatorStatuses = (
+      await Promise.all(
+        approvedOperators.flatMap((associatedOperator) =>
+          getUserOperatorsForOperator(associatedOperator.operator),
+        ),
+      )
+    )
+      .flat()
+      .map((uo) => {
+        uo.status = uo.status
+          ? Status[uo.status.toUpperCase() as keyof typeof Status]
+          : Status.DRAFT;
+        return uo;
+      });
+
+    // 🤳Identify current admin user in the list
+    const selfIndex = userOperatorStatuses.findIndex(
+      (userOperator) => userOperator.user_id.replace(/-/g, "") === uid,
+    );
+    userOperatorStatuses[selfIndex].status = Status.MYSELF;
+  }
+  return userOperatorStatuses;
+}


### PR DESCRIPTION
Addresses [#28](https://app.zenhub.com/workspaces/team-moose-sprint-board-60d216175a2689000ec774d0/issues/gh/bcgov/cas-registration/28). Adds backend API and frontend interface for an Organization Admin to view, approve/deny user access requests.

## Changes 🚧

- Add GET endpoint to retrieve all user access request statuses for a particular Operator `/operators/{operator_id}/user-operators`.
- Add GET endpoint to retrieve all of a user's associated Operators `/get-users-operators/{user_id}`.
- Add PUT endpoint to change access request status of a UserOperator `/select-operator/user-operator/{user_id}/update-status`.
- Add page for `/dashboard/users` for External Admin.
  - Lists all users for External Admin's Operators and their access request statuses.
  - Ability to Approve/Deny/Undo (set to pending) user acceses requests.
 
## To test 🔬

Spin up the front and backend
Login using `Business BCeID development environment` account from 1Pass in your local environment 
Navigate to `/dashboard/users`. You should see a list of users with various statuses. 
- The user with the _Myself_ status should have no actions available
- The user with the _Pending_ status should have the Approve and Deny actions
- A user that is _Approved_ or _Denied_ should have the Undo action

## Notes📝 
Out of scope of this ticket was the ability to change the User's Role, but this functionality is part of the Wireframes. 