### PR TITLE
316 rjsf url email validation

### DIFF
--- a/client/app/components/form/FormBase.tsx
+++ b/client/app/components/form/FormBase.tsx
@@ -18,7 +18,7 @@ const customFormatsErrorMessages = {
   "postal-code": "Format should be A1A 1A1",
   phone: "Format should be ###-###-####",
   email: "Please enter a valid email address, e.g. mail@example.com",
-  website: "Please enter a valid website, e.g. www.website.com",
+  uri: "Please enter a valid website link, e.g. http://www.website.com, https://www.website.com",
 };
 
 const transformErrors = (errors: RJSFValidationError[]) => {

--- a/client/app/components/form/FormBase.tsx
+++ b/client/app/components/form/FormBase.tsx
@@ -16,7 +16,7 @@ const customFormatsErrorMessages = {
   bc_corporate_registry_number:
     "BC Corporate Registry number should be 1-3 letters followed by 7 digits",
   "postal-code": "Format should be A1A 1A1",
-  phone: "Format should be ###-###-####",
+  phone: "Format should be ### ### ####",
   email: "Please enter a valid email address, e.g. mail@example.com",
   uri: "Please enter a valid website link, e.g. http://www.website.com, https://www.website.com",
 };

--- a/client/app/components/form/FormBase.tsx
+++ b/client/app/components/form/FormBase.tsx
@@ -42,10 +42,9 @@ const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
       formData={formData ?? {}}
       noHtml5Validate
       omitExtraData={omitExtraData ?? true}
-      // set showErrorList to false after PR 316 is in
-      showErrorList={"top"}
-      validator={validator}
+      showErrorList={false}
       transformErrors={transformErrors}
+      validator={validator}
     />
   );
 };

--- a/client/app/styles/rjsf/InlineFieldTemplate.tsx
+++ b/client/app/styles/rjsf/InlineFieldTemplate.tsx
@@ -35,7 +35,6 @@ function InlineFieldTemplate({
 
   const isErrors = rawErrors && rawErrors.length > 0;
   const error = rawErrors && rawErrors[0];
-  console.log(error);
 
   // UI Schema options
   const isLabel = uiSchema?.["ui:options"]?.label !== false;

--- a/client/app/styles/rjsf/InlineFieldTemplate.tsx
+++ b/client/app/styles/rjsf/InlineFieldTemplate.tsx
@@ -3,8 +3,9 @@
 import Grid from "@mui/material/Grid";
 import { FieldTemplateProps } from "@rjsf/utils";
 
-export const AlertIcon = () => (
+export const AlertIcon = ({ classNames }) => (
   <svg
+    className={classNames}
     width="26"
     height="26"
     viewBox="0 0 26 26"
@@ -33,6 +34,8 @@ function InlineFieldTemplate({
   if (isHidden) return null;
 
   const isErrors = rawErrors && rawErrors.length > 0;
+  const error = rawErrors && rawErrors[0];
+  console.log(error);
 
   // UI Schema options
   const isLabel = uiSchema?.["ui:options"]?.label !== false;
@@ -73,15 +76,27 @@ function InlineFieldTemplate({
         }}
       >
         {children}
-        {isErrors && (
-          <div
-            className="text-red-500 absolute right-[-40px] pt-2"
-            role="alert"
-          >
-            <AlertIcon />
-          </div>
-        )}
       </Grid>
+      {isErrors && (
+        <Grid
+          item
+          xs={12}
+          md={4}
+          role="alert"
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            color: "error.main",
+            marginLeft: {
+              xs: "0",
+              md: "16px",
+            },
+          }}
+        >
+          <AlertIcon classNames="hidden md:block mr-2" />
+          <span>{error}</span>
+        </Grid>
+      )}
 
       {description}
       {help}

--- a/client/app/styles/rjsf/InlineFieldTemplate.tsx
+++ b/client/app/styles/rjsf/InlineFieldTemplate.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Grid from "@mui/material/Grid";
+import Box from "@mui/material/Box";
 import { FieldTemplateProps } from "@rjsf/utils";
 
-export const AlertIcon = ({ classNames }) => (
+export const AlertIcon = () => (
   <svg
-    className={classNames}
     width="26"
     height="26"
     viewBox="0 0 26 26"
@@ -45,12 +45,12 @@ function InlineFieldTemplate({
       sx={{
         marginBottom: {
           xs: "16px",
-          sm: "8px",
+          md: "8px",
         },
         display: "flex",
         alignItems: {
           xs: "flex-start",
-          sm: "center",
+          md: "center",
         },
       }}
       className={classNames}
@@ -92,7 +92,17 @@ function InlineFieldTemplate({
             },
           }}
         >
-          <AlertIcon classNames="hidden md:block mr-4" />
+          <Box
+            sx={{
+              display: {
+                xs: "none",
+                md: "block",
+              },
+              marginRight: "12px",
+            }}
+          >
+            <AlertIcon />
+          </Box>
           <span>{error}</span>
         </Grid>
       )}

--- a/client/app/styles/rjsf/InlineFieldTemplate.tsx
+++ b/client/app/styles/rjsf/InlineFieldTemplate.tsx
@@ -93,7 +93,7 @@ function InlineFieldTemplate({
             },
           }}
         >
-          <AlertIcon classNames="hidden md:block mr-2" />
+          <AlertIcon classNames="hidden md:block mr-4" />
           <span>{error}</span>
         </Grid>
       )}

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -459,9 +459,7 @@ export const operationUiSchema = {
     "ui:widget": "RadioWidget",
   },
   is_application_lead_external: {
-    "Would you like to add an exemption ID application lead?": {
-      "ui:widget": "RadioWidget",
-    },
+    "ui:widget": "RadioWidget",
   },
   opt_in: {
     "ui:widget": "RadioWidget",

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -198,7 +198,7 @@ const operationPage1: RJSFSchema = {
                 mo_website: {
                   type: "string",
                   title: "Website (optional)",
-                  format: "url",
+                  format: "uri",
                 },
                 mo_percentage_ownership: {
                   type: "number",

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -198,6 +198,7 @@ const operationPage1: RJSFSchema = {
                 mo_website: {
                   type: "string",
                   title: "Website (optional)",
+                  format: "url",
                 },
                 mo_percentage_ownership: {
                   type: "number",
@@ -361,6 +362,7 @@ const operationPage2: RJSFSchema = {
           email: {
             type: "string",
             title: "Email Address",
+            format: "email",
           },
           phone_number: {
             type: "string",

--- a/client/app/utils/jsonSchema/userOperator.ts
+++ b/client/app/utils/jsonSchema/userOperator.ts
@@ -47,7 +47,7 @@ const userOperatorPage1: RJSFSchema = {
       title: "Business Structure",
       anyOf: [],
     },
-    website: { type: "string", title: "Website (optional)" },
+    website: { type: "string", title: "Website (optional)", format: "url" },
     operator_has_parent_company: {
       title: "Does the operator have a parent company?",
       type: "boolean",
@@ -137,7 +137,7 @@ const userOperatorPage1: RJSFSchema = {
             title: "Business Structure",
             anyOf: [],
           },
-          pc_website: { type: "string", title: "Website" },
+          pc_website: { type: "string", title: "Website", format: "url" },
           percentage_owned_by_parent_company: {
             type: "number",
             title: "Percentage of ownership of operator (%)",
@@ -338,6 +338,7 @@ export const userOperatorPage2: RJSFSchema = {
           so_email: {
             type: "string",
             title: "Email Address",
+            format: "email",
             default: "",
           },
           so_phone_number: {
@@ -355,6 +356,7 @@ export const userOperatorPage2: RJSFSchema = {
           email: {
             type: "string",
             title: "Email Address",
+            format: "email",
             readOnly: true,
           },
           phone_number: {

--- a/client/app/utils/jsonSchema/userOperator.ts
+++ b/client/app/utils/jsonSchema/userOperator.ts
@@ -47,7 +47,7 @@ const userOperatorPage1: RJSFSchema = {
       title: "Business Structure",
       anyOf: [],
     },
-    website: { type: "string", title: "Website (optional)", format: "url" },
+    website: { type: "string", title: "Website (optional)", format: "uri" },
     operator_has_parent_company: {
       title: "Does the operator have a parent company?",
       type: "boolean",
@@ -137,7 +137,7 @@ const userOperatorPage1: RJSFSchema = {
             title: "Business Structure",
             anyOf: [],
           },
-          pc_website: { type: "string", title: "Website", format: "url" },
+          pc_website: { type: "string", title: "Website", format: "uri" },
           percentage_owned_by_parent_company: {
             type: "number",
             title: "Percentage of ownership of operator (%)",

--- a/docs/rjsf-forms.md
+++ b/docs/rjsf-forms.md
@@ -99,3 +99,11 @@ To enable validation of the postal code widget the format must be set to `format
     title: 'Postal codefield'
   }
 ```
+
+## Custom validation with formats
+
+- `url` - accepts a URL with or without `http://`, `https://` or `www`
+- `email` - built in RJSF format to verify an email address is valid
+- `postal-code` - accepts a Canadian postal code in `A1A 1A1
+` format
+- `phone` - accepts a phone number in `+11234567890` format

--- a/docs/rjsf-forms.md
+++ b/docs/rjsf-forms.md
@@ -29,7 +29,18 @@ Then, in the form schema, add `format: <customFormats key`> to the relevant fiel
 bc_corporate_registry_number: { type: "string", title: "title", format: "bc_corporate_registry_number" }
 ```
 
-See below for validation of specific widgets.
+#### List of formats
+
+##### Custom
+
+- `phone` - Canadian/US formatted phone number: `+12345678901`
+- `bc_corporate_registry_number` - 3 letters, 7 numbers: `abc1234567`
+- `postal-code` - Canadian postal code format: A1A 1A1
+
+##### RJSF defaults
+
+- `uri` - URL format: http://www.website.com, https://www.website.com
+- `email` - Standard email format: email@address.com
 
 ## Custom widgets
 
@@ -99,11 +110,3 @@ To enable validation of the postal code widget the format must be set to `format
     title: 'Postal codefield'
   }
 ```
-
-## Custom validation with formats
-
-- `url` - accepts a URL with or without `http://`, `https://` or `www`
-- `email` - built in RJSF format to verify an email address is valid
-- `postal-code` - accepts a Canadian postal code in `A1A 1A1
-` format
-- `phone` - accepts a phone number in `+11234567890` format


### PR DESCRIPTION
Implements #316 

We were going to use a custom validator for URLs since the RJSF `uri` format is strict and requires `https://` though Nan said that's okay for now and to just updated the error messaging.
