### PR TITLE
refactor: change new operation '0' param to 'create'

### DIFF
--- a/client/app/components/form/OperationsForm.tsx
+++ b/client/app/components/form/OperationsForm.tsx
@@ -29,7 +29,7 @@ export default function OperationsForm({ formData, schema }: Props) {
   const params = useParams();
   const formSection = parseInt(params?.formSection as string);
   const operationId = params?.operation;
-  const isCreate = params?.operation === "0";
+  const isCreate = params?.operation === "create";
 
   const isApplicationLeadExternal =
     userEmail !== formData?.application_lead?.email;

--- a/client/app/components/navigation/Bread.tsx
+++ b/client/app/components/navigation/Bread.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { ReactNode } from "react";
-import { usePathname } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import Breadcrumbs from "@mui/material/Breadcrumbs/Breadcrumbs";
@@ -35,7 +35,6 @@ function isValidLink(segment: string): boolean {
     "confirm",
     "received",
     "user-operator",
-    "create",
     "add-operator",
     "request-access",
   ];
@@ -86,9 +85,15 @@ export default function Bread({
 }: TBreadCrumbProps) {
   // 🛸 Routing: use the `usePathname` hook from next/navigation to access the current route information
   const paths = usePathname();
-
+  // 🔍 useParams, returns an object containing the current route's filled in dynamic parameters
+  // The properties name is the segment's name, i.e. formSection
+  const params = useParams();
   // 🔗 Links: We split the route path into segments and map over them to generate breadcrumb links.
   const pathNames = paths.split("/").filter((path) => path);
+  // 🧹 Check if params contain formSection and remove the last index if true
+  if (params && params.formSection) {
+    pathNames.pop();
+  }
 
   return (
     <Box

--- a/client/app/components/routes/operations/Page.tsx
+++ b/client/app/components/routes/operations/Page.tsx
@@ -21,7 +21,7 @@ export default async function OperationsPage() {
       <h1>Operations List</h1>
       {/* Conditionally render the button based on user's role */}
       {role === Roles.INDUSTRY_USER_ADMIN && (
-        <Link href={"/dashboard/operations/0/1"}>
+        <Link href={"/dashboard/operations/create/1"}>
           <Button variant="contained">Add Operation</Button>
         </Link>
       )}

--- a/client/app/components/routes/operations/form/Operation.tsx
+++ b/client/app/components/routes/operations/form/Operation.tsx
@@ -135,7 +135,8 @@ export default async function Operation({ numRow }: { numRow?: number }) {
 
   let operation: any;
 
-  if (numRow) {
+  // Check that numRow is a number so we don't try to fetch an operation with a string eg: "create"
+  if (numRow && !isNaN(Number(numRow))) {
     operation = await getOperation(numRow);
   }
 

--- a/client/app/components/routes/operations/form/OperationReview.tsx
+++ b/client/app/components/routes/operations/form/OperationReview.tsx
@@ -36,6 +36,8 @@ const OperationReview = ({ operation }: Props) => {
     return response;
   };
 
+  if (!operation) return null;
+
   return (
     <Review
       approvedMessage="You have approved the request for carbon tax exemption."


### PR DESCRIPTION
Small PR to fix using `0` as the query param value for creating a new operation form back to `create`. 

Shon and I decided to fix this as part of the breadcrumb work. 