### PR TITLE
419 senior officer checkbox has no text

### DIFF
--- a/client/app/components/form/widgets/CheckboxWidget.tsx
+++ b/client/app/components/form/widgets/CheckboxWidget.tsx
@@ -9,17 +9,20 @@ const CheckboxWidget: React.FC<WidgetProps> = ({
   value,
   required,
 }) => (
-  <Checkbox
-    id={id}
-    checked={typeof value === "undefined" ? false : value}
-    value={value}
-    required={required}
-    aria-label={label}
-    disabled={disabled}
-    onChange={(event: { target: { checked: any } }) =>
-      onChange(event.target.checked)
-    }
-  />
+  <div className="flex items-center">
+    <label className="font-bold mr-4">{label}</label>
+    <Checkbox
+      id={id}
+      checked={typeof value === "undefined" ? false : value}
+      value={value}
+      required={required}
+      aria-label={label}
+      disabled={disabled}
+      onChange={(event: { target: { checked: any } }) =>
+        onChange(event.target.checked)
+      }
+    />
+  </div>
 );
 
 export default CheckboxWidget;

--- a/client/app/components/form/widgets/CheckboxWidget.tsx
+++ b/client/app/components/form/widgets/CheckboxWidget.tsx
@@ -1,0 +1,25 @@
+import { WidgetProps } from "@rjsf/utils/lib/types";
+import Checkbox from "@mui/material/Checkbox";
+
+const CheckboxWidget: React.FC<WidgetProps> = ({
+  disabled,
+  id,
+  onChange,
+  label,
+  value,
+  required,
+}) => (
+  <Checkbox
+    id={id}
+    checked={typeof value === "undefined" ? false : value}
+    value={value}
+    required={required}
+    aria-label={label}
+    disabled={disabled}
+    onChange={(event: { target: { checked: any } }) =>
+      onChange(event.target.checked)
+    }
+  />
+);
+
+export default CheckboxWidget;

--- a/client/app/components/form/widgets/index.ts
+++ b/client/app/components/form/widgets/index.ts
@@ -1,3 +1,4 @@
+export { default as CheckboxWidget } from "./CheckboxWidget";
 export { default as ComboBox } from "./ComboBox";
 export { default as EmailWidget } from "./EmailWidget";
 export { default as FileWidget } from "./FileWidget";

--- a/client/app/utils/jsonSchema/userOperator.ts
+++ b/client/app/utils/jsonSchema/userOperator.ts
@@ -445,9 +445,7 @@ export const userOperatorUiSchema = {
     "ui:widget": "EmailWidget",
   },
   is_senior_officer: {
-    "ui:options": {
-      label: false,
-    },
+    "ui:widget": "CheckboxWidget",
   },
   senior_officer_section: {
     ...subheading,

--- a/client/app/utils/jsonSchema/userOperator.ts
+++ b/client/app/utils/jsonSchema/userOperator.ts
@@ -446,6 +446,9 @@ export const userOperatorUiSchema = {
   },
   is_senior_officer: {
     "ui:widget": "CheckboxWidget",
+    "ui:options": {
+      label: false,
+    },
   },
   senior_officer_section: {
     ...subheading,

--- a/docs/rjsf-forms.md
+++ b/docs/rjsf-forms.md
@@ -110,3 +110,18 @@ To enable validation of the postal code widget the format must be set to `format
     title: 'Postal codefield'
   }
 ```
+
+### Checkbox widget
+
+A checkbox widget for `boolean` type fields. Set the `ui:widget` to `CheckboxWidget` in the fields `uiSchema`
+
+To ensure the label doesn't display twice using the default `InlineFieldTemplate` set `label: false` in `ui:options`.
+
+```
+checkbox_field {
+  "ui:widget": "CheckboxWidget",
+  "ui:options": {
+      label: false,
+  }
+}
+```


### PR DESCRIPTION
Implements #419 

Created a MUI checkbox widget so the styling would match the rest of our widgets. `label: false` now just hides the label in the `InlineFieldTemplate` instead of both the widget and the template.
