### PR TITLE
fix: idir names entered into the db incorrectly

### DIFF
--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -3,6 +3,7 @@ import UserForm from "@/app/components/routes/profile/form/UserForm";
 import { UserProfileFormData } from "@/app/components/form/formDataTypes";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { IDP } from "@/app/types/types";
 
 // 🚀 API call: GET user's data
 async function getUserFormData(): Promise<
@@ -28,7 +29,8 @@ export default async function User() {
        * getServerSession requires passing the same object you would pass to NextAuth
        */
       const session = await getServerSession(authOptions);
-      const isIdir = session?.identity_provider === "idir";
+      const isIdir = session?.identity_provider === IDP.IDIR;
+
       // IDIR names come in the format "LASTNAME, FIRSTNAME" so we will split on the comma
       // and reverse so they don't go into the wrong fields
       const idirName = session?.user?.name?.split(", ").reverse();

--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -28,7 +28,13 @@ export default async function User() {
        * getServerSession requires passing the same object you would pass to NextAuth
        */
       const session = await getServerSession(authOptions);
-      const names = session?.user?.name?.split(" ");
+      const isIdir = session?.identity_provider === "idir";
+      // IDIR names come in the format "LASTNAME, FIRSTNAME" so we will split on the comma
+      // and reverse so they don't go into the wrong fields
+      const idirName = session?.user?.name?.split(", ").reverse();
+
+      const names = isIdir ? idirName : session?.user?.name?.split(" ");
+
       formData = {
         first_name: names?.[0] ?? "", // Use nullish coalescing here
         last_name: names?.[1] ?? "", // Use nullish coalescing here

--- a/client/app/types/types.ts
+++ b/client/app/types/types.ts
@@ -13,3 +13,8 @@ export enum Roles {
   INDUSTRY_USER = "industry_user",
   INDUSTRY_USER_ADMIN = "industry_user_admin",
 }
+
+export enum IDP {
+  IDIR = "idir",
+  BCEIDBUSINESS = "bceidbusiness",
+}


### PR DESCRIPTION
Fix for #422 

This seems like something that should be unified in SSO app though I imagine they'd risk breaking a bunch of projects if they changed it. IDIR user names come in the format `lastname, firstname` instead of `firstname lastname` like `BCeiD` users so I added some logic to fix it.