### PR TITLE
285 disable form pending status

### DIFF
--- a/client/app/components/form/OperationsForm.tsx
+++ b/client/app/components/form/OperationsForm.tsx
@@ -61,6 +61,12 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
   const isNotFinalStep = formSection !== formSectionList.length;
   const isFinalStep = formSection === formSectionList.length;
 
+  const isCasInternal =
+    session?.user.app_role?.includes("cas") &&
+    !session?.user.app_role?.includes("pending");
+
+  const isFormStatusPending = formData?.status === Status.PENDING;
+
   return (
     <>
       {operationName ? (
@@ -89,10 +95,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
           cancelUrl="/dashboard/operations"
           formData={transformedFormData}
           setErrorReset={setError}
-          disabled={
-            session?.user.app_role?.includes("cas") ||
-            formData?.status === Status.PENDING
-          }
+          disabled={isCasInternal || isFormStatusPending}
           error={error}
           schema={schema}
           allowBackNavigation
@@ -109,7 +112,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
             const responseOpId = await actionHandler(
               "registration/user-operator-operator-id",
               "GET",
-              "",
+              ""
             );
             if (responseOpId.error) {
               setError(responseOpId.error);
@@ -130,7 +133,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
               pathToRevalidate,
               {
                 body: JSON.stringify(body),
-              },
+              }
             );
 
             const operation = response?.id || operationId;
@@ -143,7 +146,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
             router.replace(`/dashboard/operations/${operation}/${formSection}`);
             if (isNotFinalStep) {
               router.push(
-                `/dashboard/operations/${operation}/${formSection + 1}`,
+                `/dashboard/operations/${operation}/${formSection + 1}`
               );
               return;
             }

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -10,7 +10,7 @@ import UserOperatorReview from "@/app/components/routes/access-requests/form/Use
 import MultiStepFormBase from "@/app/components/form/MultiStepFormBase";
 import { UserOperatorFormData } from "@/app/components/form/formDataTypes";
 import Note from "../datagrid/Note";
-import { Status } from "@/app/types/types";
+import { Status } from "@/app/utils/enums";
 
 interface UserOperatorFormProps {
   readonly schema: RJSFSchema;

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -10,15 +10,14 @@ import UserOperatorReview from "@/app/components/routes/access-requests/form/Use
 import MultiStepFormBase from "@/app/components/form/MultiStepFormBase";
 import { UserOperatorFormData } from "@/app/components/form/formDataTypes";
 import Note from "../datagrid/Note";
+import { Status } from "@/app/types/types";
 
 interface UserOperatorFormProps {
   readonly schema: RJSFSchema;
   readonly formData: Partial<UserOperatorFormData>;
-  readonly disabled?: boolean;
 }
 
 export default function UserOperatorMultiStepForm({
-  disabled,
   schema,
   formData,
 }: UserOperatorFormProps) {
@@ -51,7 +50,7 @@ export default function UserOperatorMultiStepForm({
       `/dashboard/select-operator/user-operator/create/${params?.formSection}`,
       {
         body: JSON.stringify(newFormData),
-      },
+      }
     );
 
     if (response.error) {
@@ -61,7 +60,7 @@ export default function UserOperatorMultiStepForm({
 
     if (isFinalStep) {
       push(
-        `/dashboard/select-operator/received/add-operator/${response.operator_id}`,
+        `/dashboard/select-operator/received/add-operator/${response.operator_id}`
       );
       return;
     }
@@ -69,12 +68,17 @@ export default function UserOperatorMultiStepForm({
     push(
       `/dashboard/select-operator/user-operator/create/${
         formSection + 2
-      }?user-operator-id=${response.user_operator_id}`,
+      }?user-operator-id=${response.user_operator_id}`
     );
-  }; // If the user is an approved cas internal user or if no operator exists show the entire multistep form
+  };
+
   const isCasInternal =
     session?.user.app_role?.includes("cas") &&
     !session?.user.app_role?.includes("pending");
+
+  const isFormStatusPending = formData?.status === Status.PENDING;
+
+  // If the user is an approved cas internal user or if no operator exists show the entire multistep form
   if (isCasInternal || !userOperatorId || formSection) {
     return (
       <>
@@ -105,7 +109,7 @@ export default function UserOperatorMultiStepForm({
               : "/dashboard/select-operator"
           }
           schema={schema}
-          disabled={isCasInternal ?? disabled}
+          disabled={isCasInternal || isFormStatusPending}
           error={error}
           setErrorReset={setError}
           formData={formData}

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -24,6 +24,7 @@ export default async function MyOperatorPage() {
   const session = await getServerSession(authOptions);
   const userName = session?.user?.name?.split(" ")?.[0];
   const { status } = await getUserOperatorStatus();
+
   if (status === Status.PENDING.toLowerCase()) {
     return <div>Your request is pending.</div>;
   }


### PR DESCRIPTION
Edit: waiting until #441 is complete so we can easily test disabled pending status for industry users

Implements #285 

The requirements in the ticket look more complex than it is, I believe as of now we just need to disable the form for CAS admin that doesn't have `cas_pending` as role and also for anyone if the form status is pending.

To whoever reviews this I don't think we need to add disabled state to the single page `UserOperatorForm`. I believe that when that form is submitted and viewed again as an industry user (once #441 is complete) or as a CAS admin/analyst then they will view the multistep form. 

Let me know if I am missing something and I will update that form as well!
