### PR TITLE
441 - As an IO user, when I click the My Operator tile, I see the appropriate page depending on my status

### DIFF
--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -358,7 +358,6 @@ def create_user_operator_contact(request, payload: UserOperatorContactIn):
     except Exception as e:
         return 400, {"message": str(e)}
 
-    # TODO: approved status may have to be changed to pending if the user is not an admin
     if user_operator_instance.status != UserOperator.Statuses.APPROVED:
         user_operator_instance.status = UserOperator.Statuses.PENDING
     user_operator_instance.save(

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -75,6 +75,7 @@ def save_operator(payload: any, operator_instance: UserOperatorOperatorIn, user:
             "physical_address_id",
             "mailing_address_id",
             "website",
+            "business_structure",
         ]
         created_or_updated_operator_instance: Operator = update_model_instance(
             operator_instance, operator_related_fields, payload.dict()

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -44,7 +44,7 @@ from django.forms import model_to_dict
 
 
 # Function to save operator data to reuse in POST/PUT methods
-def save_operator(payload: any, operator_instance: Operator, user: User):
+def save_operator(payload: any, operator_instance: UserOperatorOperatorIn, user: User):
     # rollback the transaction if any of the following fails (mostly to prevent orphaned addresses)
     with transaction.atomic():
         # create physical address record

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -347,6 +347,7 @@ def create_operator_and_user_operator(request, payload: UserOperatorOperatorIn):
 def create_user_operator_contact(request, payload: UserOperatorContactIn):
     try:
         user_operator_instance: UserOperator = get_object_or_404(UserOperator, id=payload.user_operator_id)
+        operator: Operator = user_operator_instance.operator
         user: User = request.current_user
         is_senior_officer: bool = payload.is_senior_officer
 
@@ -392,7 +393,9 @@ def create_user_operator_contact(request, payload: UserOperatorContactIn):
     except Exception as e:
         return 400, {"message": str(e)}
 
-    user_operator_instance.status = UserOperator.Statuses.PENDING
+    # TODO: approved status may have to be changed to pending if the user is not an admin
+    if user_operator_instance.status != UserOperator.Statuses.APPROVED:
+        user_operator_instance.status = UserOperator.Statuses.PENDING
     user_operator_instance.save(
         update_fields=["status"],
     )

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -422,13 +422,6 @@ def check_status(status: str):
 @router.put("/user-operator/operator/{int:user_operator_id}", response={200: RequestAccessOut, codes_4xx: Message})
 def update_operator_and_user_operator(request, payload: UserOperatorOperatorIn, user_operator_id: int):
     user: User = request.current_user
-    raise_401_if_role_not_authorized(
-        request,
-        [
-            "industry_user",
-            "industry_user_admin",
-        ],
-    )
     try:
         operator_instance: Operator = get_object_or_404(Operator, id=user_operator_id)
 
@@ -445,7 +438,6 @@ def update_operator_and_user_operator(request, payload: UserOperatorOperatorIn, 
 
 @router.put("/user-operator/contact", response={200: SelectOperatorIn, codes_4xx: Message})
 def create_user_operator_contact(request, payload: UserOperatorContactIn):
-    raise_401_if_role_not_authorized(request, ["industry_user", "industry_user_admin"])
     try:
         user_operator_instance: UserOperator = get_object_or_404(UserOperator, id=payload.user_operator_id)
         operator: Operator = user_operator_instance.operator

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -137,6 +137,41 @@ def save_operator(payload: any, operator_instance: Operator, user: User):
             return 200, {"user_operator_id": user_operator.id}
 
 
+# Function to create/update Operator instance data to reuse in POST/PUT methods
+def create_operator_data(operator_instance: Operator, payload_dict: dict):
+    # Consolidate mailing address if indicated
+    if payload_dict.get("mailing_address_same_as_physical"):
+        payload_dict.update(
+            {
+                "mailing_street_address": payload_dict["physical_street_address"],
+                "mailing_municipality": payload_dict["physical_municipality"],
+                "mailing_province": payload_dict["physical_province"],
+                "mailing_postal_code": payload_dict["physical_postal_code"],
+            }
+        )
+
+    # fields to update on the Operator model
+    operator_related_fields = [
+        "legal_name",
+        "trade_name",
+        "physical_street_address",
+        "physical_municipality",
+        "physical_province",
+        "physical_postal_code",
+        "mailing_street_address",
+        "mailing_municipality",
+        "mailing_province",
+        "mailing_postal_code",
+        "website",
+    ]
+
+    created_operator_instance: Operator = update_model_instance(
+        operator_instance, operator_related_fields, payload_dict
+    )
+
+    return created_operator_instance
+
+
 ##### GET #####
 @router.get("/user-operator-status-from-user", response={200: UserOperatorStatus, codes_4xx: Message})
 @authorize(["industry_user"], UserOperator.get_all_industry_user_operator_roles())

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -412,7 +412,8 @@ def update_operator_and_user_operator(request, payload: UserOperatorOperatorIn, 
         return 400, {"message": str(e)}
 
 
-@router.put("/select-operator/user-operator/{user_guid}/update-status")
+##### PUT #####
+@router.put("/select-operator/user-operator/update-status", response={200: UserOperatorOut, codes_4xx: Message})
 @authorize(AppRole.get_all_authorized_app_roles(), ["admin"])
 def update_user_operator_status(request, payload: UserOperatorStatusUpdate):
     current_user: User = request.current_user  # irc user or industry user admin

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -131,8 +131,7 @@ def save_operator(payload: any, operator_instance: UserOperatorOperatorIn, user:
             operator=created_or_updated_operator_instance,
             role=UserOperator.Roles.ADMIN,
         )
-        if created:
-            user_operator.set_create_or_update(modifier=user)
+        user_operator.set_create_or_update(modifier=user)
         return 200, {"user_operator_id": user_operator.id}
 
 

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -164,7 +164,6 @@ def create_operator_data(operator_instance: Operator, payload_dict: dict):
         "mailing_postal_code",
         "website",
     ]
-
     created_operator_instance: Operator = update_model_instance(
         operator_instance, operator_related_fields, payload_dict
     )
@@ -421,12 +420,15 @@ def check_status(status: str):
     return False
 
 
-# this endpoint is for updating the status of a user
-@router.put("/user-operator/operator/{int:user_operator_id}", response={200: RequestAccessOut, codes_4xx: Message})
-def update_operator_and_user_operator(request, payload: UserOperatorOperatorIn, user_operator_id: int):
+
+@router.put(
+    "/user-operator/operator/{int:user_operator_operator_id}", response={200: RequestAccessOut, codes_4xx: Message}
+)
+@authorize(AppRole.get_industry_roles())
+def update_operator_and_user_operator(request, payload: UserOperatorOperatorIn, user_operator_operator_id: int):
     user: User = request.current_user
     try:
-        operator_instance: Operator = get_object_or_404(Operator, id=user_operator_id)
+        operator_instance: Operator = get_object_or_404(Operator, id=user_operator_operator_id)
 
         # save operator data
         save_operator(payload, operator_instance, user)

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -137,40 +137,6 @@ def save_operator(payload: any, operator_instance: Operator, user: User):
             return 200, {"user_operator_id": user_operator.id}
 
 
-# Function to create/update Operator instance data to reuse in POST/PUT methods
-def create_operator_data(operator_instance: Operator, payload_dict: dict):
-    # Consolidate mailing address if indicated
-    if payload_dict.get("mailing_address_same_as_physical"):
-        payload_dict.update(
-            {
-                "mailing_street_address": payload_dict["physical_street_address"],
-                "mailing_municipality": payload_dict["physical_municipality"],
-                "mailing_province": payload_dict["physical_province"],
-                "mailing_postal_code": payload_dict["physical_postal_code"],
-            }
-        )
-
-    # fields to update on the Operator model
-    operator_related_fields = [
-        "legal_name",
-        "trade_name",
-        "physical_street_address",
-        "physical_municipality",
-        "physical_province",
-        "physical_postal_code",
-        "mailing_street_address",
-        "mailing_municipality",
-        "mailing_province",
-        "mailing_postal_code",
-        "website",
-    ]
-    created_operator_instance: Operator = update_model_instance(
-        operator_instance, operator_related_fields, payload_dict
-    )
-
-    return created_operator_instance
-
-
 ##### GET #####
 @router.get("/user-operator-status-from-user", response={200: UserOperatorStatus, codes_4xx: Message})
 @authorize(["industry_user"], UserOperator.get_all_industry_user_operator_roles())

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -36,7 +36,6 @@ from registration.utils import (
     check_users_admin_request_eligibility,
     check_access_request_matches_business_guid,
     get_an_operators_approved_users,
-    raise_401_if_role_not_authorized,
 )
 from ninja.responses import codes_4xx
 from datetime import datetime
@@ -396,11 +395,10 @@ def check_status(status: str):
     return False
 
 
-
 @router.put(
     "/user-operator/operator/{int:user_operator_operator_id}", response={200: RequestAccessOut, codes_4xx: Message}
 )
-@authorize(AppRole.get_industry_roles())
+@authorize(["industry_user"], UserOperator.get_all_industry_user_operator_roles())
 def update_operator_and_user_operator(request, payload: UserOperatorOperatorIn, user_operator_operator_id: int):
     user: User = request.current_user
     try:

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -137,6 +137,18 @@ def save_operator(payload: any, operator_instance: Operator, user: User):
             return 200, {"user_operator_id": user_operator.id}
 
 
+# Function to get or create a UserOperator instance to reuse in POST/PUT methods
+def get_or_create_user_operator(user: User, operator: Operator):
+    user_operator, created = UserOperator.objects.get_or_create(
+        user=user,
+        operator=operator,
+        role=UserOperator.Roles.ADMIN,
+    )
+    if created:
+        user_operator.set_create_or_update(modifier=user)
+    return user_operator
+
+
 ##### GET #####
 @router.get("/user-operator-status-from-user", response={200: UserOperatorStatus, codes_4xx: Message})
 @authorize(["industry_user"], UserOperator.get_all_industry_user_operator_roles())

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -165,6 +165,15 @@ def is_approved_admin_user_operator(request, user_guid: str):
     return 200, {"approved": approved_user_operator}
 
 
+@router.get("/user-operator-operator-id", response={200: UserOperatorOperatorIdOut, codes_4xx: Message})
+@authorize(["industry_user"], UserOperator.get_all_industry_user_operator_roles())
+def get_user_operator_operator_id(request):
+    user_operator = get_object_or_404(
+        UserOperator, user_id=request.current_user.user_guid, status=UserOperator.Statuses.APPROVED
+    )
+    return 200, {"operator_id": user_operator.operator_id}
+
+
 @router.get(
     "/select-operator/user-operator/{int:user_operator_id}",
     response=UserOperatorOut,

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -663,7 +663,7 @@ class TestUserOperatorEndpoint(CommonTestSetup):
             so_phone_number="+16044015432",
             street_address="123 Main St",
             trade_name="Operator 2 Trade Name",
-            website="http://www.example2.com",
+            website="https://www.example2.com",
         )
         put_response = TestUtils.mock_put_with_auth_role(
             self,

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -208,12 +208,25 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         assert response.status_code == 401
 
         # user-operator/operator/{user_operator_operator_id}
-        mock_data = TestUtils.mock_UserOperatorOperatorIn()
+
+        mock_payload = {
+            "legal_name": "Operation 1 Legal Name",
+            "cra_business_number": 987654321,
+            "bc_corporate_registry_number": "abc1234321",
+            "business_structure": BusinessStructure.objects.first().pk,
+            "physical_street_address": "test physical street address",
+            "physical_municipality": "test physical municipality",
+            "physical_province": "test physical province",
+            "physical_postal_code": "test physical postal code",
+            "mailing_address_same_as_physical": True,
+            "operator_has_parent_operators": False,
+            "parent_operators_array": [],
+        }
         response = TestUtils.mock_put_with_auth_role(
             self,
             'cas_pending',
             content_type_json,
-            mock_data.json(),
+            mock_payload,
             f"{base_endpoint}user-operator/operator/1",
         )
         assert response.status_code == 401
@@ -221,7 +234,7 @@ class TestUserOperatorEndpoint(CommonTestSetup):
             self,
             'cas_analyst',
             content_type_json,
-            mock_data.json(),
+            mock_payload,
             f"{base_endpoint}user-operator/operator/1",
         )
         assert response.status_code == 401
@@ -229,7 +242,7 @@ class TestUserOperatorEndpoint(CommonTestSetup):
             self,
             'cas_admin',
             content_type_json,
-            mock_data.json(),
+            mock_payload,
             f"{base_endpoint}user-operator/operator/1",
         )
         assert response.status_code == 401
@@ -632,44 +645,33 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         # Assert that the parent operator 1 and 2 have the correct operator index
         assert parent_operators[0].operator_index == 1
         assert parent_operators[1].operator_index == 2
+
     def test_put_user_operator_operator(self):
         operator = baker.make(Operator, bc_corporate_registry_number="abc1234567")
-        business_structure = baker.make(BusinessStructure, name='BC Corporation')
-        mock_operation = UserOperatorOperatorIn(
-            bc_corporate_registry_number="abc1234567",
-            business_structure=business_structure.name,
-            cra_business_number=987654321,
-            email="email@email.com",
-            first_name="Bcgov",
-            is_senior_officer=False,
-            last_name="Cas",
-            legal_name="Operator 2 Legal Name",
-            mailing_address_same_as_physical=False,
-            mailing_municipality="City",
-            mailing_postal_code="A1B 2C3",
-            mailing_province="ON",
-            mailing_street_address="123 Main St",
-            municipality="Cityville",
-            operator_has_parent_company=False,
-            phone_number="+16044015432",
-            physical_municipality="Village",
-            physical_postal_code="M2N 3P4",
-            physical_province="BC",
-            physical_street_address="789 Oak St",
-            position_title="Senior Officer2123",
-            postal_code="A1B 2C3",
-            province="ON",
-            so_email="email@email.com",
-            so_phone_number="+16044015432",
-            street_address="123 Main St",
-            trade_name="Operator 2 Trade Name",
-            website="https://www.example2.com",
-        )
+        baker.make(BusinessStructure, name='BC Corporation')
+
+        mock_payload = {
+            "legal_name": "Put Operator Legal Name",
+            "cra_business_number": 963852741,
+            "bc_corporate_registry_number": "abc1234321",
+            "business_structure": BusinessStructure.objects.first().pk,
+            "physical_street_address": "test physical street address",
+            "physical_municipality": "test physical municipality",
+            "physical_province": "BC",
+            "physical_postal_code": "H0H0H0",
+            "mailing_address_same_as_physical": False,
+            "mailing_street_address": "test mailing street address",
+            "mailing_municipality": "test mailing municipality",
+            "mailing_province": "BC",
+            "mailing_postal_code": "V0V0V0",
+            "operator_has_parent_operators": True,
+            "parent_operators_array": [],
+        }
         put_response = TestUtils.mock_put_with_auth_role(
             self,
             'industry_user',
             content_type_json,
-            mock_operation.json(),
+            mock_payload,
             f"{base_endpoint}user-operator/operator/{operator.id}",
         )
 

--- a/client/app/(authenticated)/bceidbusiness/industry_user/dashboard/select-operator/(request-access)/user-operator/[id]/[formSection]/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user/dashboard/select-operator/(request-access)/user-operator/[id]/[formSection]/page.tsx
@@ -3,7 +3,7 @@ import SelectOperatorRequestAccessReceivedUserOperatorPage from "@/app/component
 export default async function Page({
   params,
 }: {
-  readonly params?: Readonly<{ id: number }>;
+  readonly params?: Readonly<{ id: number | string; formSection: number }>;
 }) {
   return (
     <SelectOperatorRequestAccessReceivedUserOperatorPage params={params} />

--- a/client/app/(authenticated)/bceidbusiness/industry_user/dashboard/select-operator/(request-access)/user-operator/create/[formSection]/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user/dashboard/select-operator/(request-access)/user-operator/create/[formSection]/page.tsx
@@ -1,5 +1,0 @@
-import SelectOperatorRequestAccessReceivedUserOperatorPage from "@/app/components/routes/select-operator/request-access/user-operator/Page";
-
-export default async function Page() {
-  return <SelectOperatorRequestAccessReceivedUserOperatorPage />;
-}

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/select-operator/(request-access)/user-operator/[id]/[formSection]/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/select-operator/(request-access)/user-operator/[id]/[formSection]/page.tsx
@@ -3,7 +3,7 @@ import SelectOperatorRequestAccessReceivedUserOperatorPage from "@/app/component
 export default async function Page({
   params,
 }: {
-  readonly params?: Readonly<{ id: number }>;
+  readonly params?: Readonly<{ id: number | string; formSection: number }>;
 }) {
   return (
     <SelectOperatorRequestAccessReceivedUserOperatorPage params={params} />

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/select-operator/(request-access)/user-operator/create/[formSection]/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/select-operator/(request-access)/user-operator/create/[formSection]/page.tsx
@@ -1,5 +1,0 @@
-import SelectOperatorRequestAccessReceivedUserOperatorPage from "@/app/components/routes/select-operator/request-access/user-operator/Page";
-
-export default async function Page() {
-  return <SelectOperatorRequestAccessReceivedUserOperatorPage />;
-}

--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import { RJSFSchema } from "@rjsf/utils";
 import { Alert } from "@mui/material";
 import FormBase from "./FormBase";
@@ -40,11 +40,14 @@ const MultiStepFormBase = ({
 }: MultiStepFormProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const params = useParams();
-  const formSection = parseInt(params?.formSection as string) - 1;
+  const formSection =
+    parseInt(useSearchParams().get("form-section") as string) ||
+    parseInt(params?.formSection as string);
+  const formSectionIndex = formSection - 1;
 
   const formSectionList = Object.keys(schema.properties as any);
   const mapSectionTitles = formSectionList.map(
-    (section) => schema.properties[section].title,
+    (section) => schema.properties[section].title
   );
 
   const formSectionTitles = showSubmissionStep
@@ -71,7 +74,7 @@ const MultiStepFormBase = ({
     formSectionTitles.length !== customStepNames.length
   ) {
     throw new Error(
-      "The number of custom header titles must match the number of form sections",
+      "The number of custom header titles must match the number of form sections"
     );
   }
 
@@ -83,7 +86,9 @@ const MultiStepFormBase = ({
       />
       <FormBase
         className="[&>div>fieldset]:min-h-[40vh]"
-        schema={schema.properties[formSectionList[formSection]] as RJSFSchema}
+        schema={
+          schema.properties[formSectionList[formSectionIndex]] as RJSFSchema
+        }
         uiSchema={uiSchema}
         disabled={isDisabled}
         readonly={isDisabled}
@@ -95,7 +100,7 @@ const MultiStepFormBase = ({
         <MultiStepButtons
           disabled={isDisabled}
           isSubmitting={isSubmitting}
-          step={formSection}
+          step={formSectionIndex}
           steps={formSectionList}
           baseUrl={baseUrl}
           cancelUrl={cancelUrl}

--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
+import { Button } from "@mui/material";
 import { RJSFSchema } from "@rjsf/utils";
 import { Alert } from "@mui/material";
 import FormBase from "./FormBase";
@@ -9,6 +10,8 @@ import MultiStepHeader from "./MultiStepHeader";
 import MultiStepButtons from "./MultiStepButtons";
 
 interface MultiStepFormProps {
+  allowBackNavigation?: boolean;
+  allowEdit?: boolean;
   baseUrl: string;
   cancelUrl: string;
   // Optional array to override the default header titles
@@ -20,11 +23,12 @@ interface MultiStepFormProps {
   schema: any;
   setErrorReset?: (error: undefined) => void;
   showSubmissionStep?: boolean;
-  allowBackNavigation?: boolean;
   uiSchema: any;
 }
 
 const MultiStepFormBase = ({
+  allowBackNavigation,
+  allowEdit = false,
   baseUrl,
   cancelUrl,
   customStepNames,
@@ -35,10 +39,11 @@ const MultiStepFormBase = ({
   schema,
   setErrorReset,
   showSubmissionStep,
-  allowBackNavigation,
   uiSchema,
 }: MultiStepFormProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isEditMode, setIsEditMode] = useState(false);
+
   const params = useParams();
   const formSection =
     parseInt(useSearchParams().get("form-section") as string) ||
@@ -66,7 +71,12 @@ const MultiStepFormBase = ({
     }
   };
 
-  const isDisabled = disabled || isSubmitting;
+  const isDisabled = (disabled && !isEditMode) || isSubmitting;
+
+  const handleEditClick = () => {
+    setIsEditMode(true);
+  };
+
   const isCustomStepNames = customStepNames && customStepNames.length > 0;
 
   if (
@@ -80,8 +90,20 @@ const MultiStepFormBase = ({
 
   return (
     <>
+      {allowEdit && (
+        <div className="w-full flex justify-end">
+          <Button
+            variant="contained"
+            color="primary"
+            disabled={isEditMode}
+            onClick={handleEditClick}
+          >
+            Edit information
+          </Button>
+        </div>
+      )}
       <MultiStepHeader
-        step={formSection}
+        step={formSectionIndex}
         steps={isCustomStepNames ? customStepNames : formSectionTitles}
       />
       <FormBase

--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useParams, useSearchParams } from "next/navigation";
+import { useParams } from "next/navigation";
 import { Button } from "@mui/material";
 import { RJSFSchema } from "@rjsf/utils";
 import { Alert } from "@mui/material";
@@ -45,9 +45,7 @@ const MultiStepFormBase = ({
   const [isEditMode, setIsEditMode] = useState(false);
 
   const params = useParams();
-  const formSection =
-    parseInt(useSearchParams().get("form-section") as string) ||
-    parseInt(params?.formSection as string);
+  const formSection = parseInt(params?.formSection as string);
   const formSectionIndex = formSection - 1;
 
   const formSectionList = Object.keys(schema.properties as any);

--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -50,7 +50,7 @@ const MultiStepFormBase = ({
 
   const formSectionList = Object.keys(schema.properties as any);
   const mapSectionTitles = formSectionList.map(
-    (section) => schema.properties[section].title
+    (section) => schema.properties[section].title,
   );
 
   const formSectionTitles = showSubmissionStep

--- a/client/app/components/form/OperationsForm.tsx
+++ b/client/app/components/form/OperationsForm.tsx
@@ -34,6 +34,12 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
   const isNotFinalStep = formSection !== formSectionList.length;
   const isFinalStep = formSection === formSectionList.length;
 
+  const isCasInternal =
+    session?.user.app_role?.includes("cas") &&
+    !session?.user.app_role?.includes("pending");
+
+  const isFormStatusPending = formData?.status === Status.PENDING;
+
   return (
     <>
       {operationName ? (
@@ -67,10 +73,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
           ]}
           formData={formData}
           setErrorReset={setError}
-          disabled={
-            session?.user.app_role?.includes("cas") ||
-            formData?.status === Status.PENDING
-          }
+          disabled={isCasInternal || isFormStatusPending}
           error={error}
           schema={schema}
           allowBackNavigation
@@ -87,7 +90,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
             const responseOpId = await actionHandler(
               "registration/user-operator-operator-id",
               "GET",
-              "",
+              ""
             );
             if (responseOpId.error) {
               setError(responseOpId.error);
@@ -108,7 +111,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
               pathToRevalidate,
               {
                 body: JSON.stringify(body),
-              },
+              }
             );
 
             const operation = response?.id || operationId;
@@ -123,7 +126,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
             router.replace(`/dashboard/operations/${operation}/${formSection}`);
             if (isNotFinalStep) {
               router.push(
-                `/dashboard/operations/${operation}/${formSection + 1}`,
+                `/dashboard/operations/${operation}/${formSection + 1}`
               );
               return;
             }

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -53,11 +53,11 @@ export default function UserOperatorMultiStepForm({
     if (userOperatorId) newFormData.user_operator_id = userOperatorId;
 
     const apiUrl = `registration/user-operator/${
-      isFinalStep && isCreate ? "contact" : "operator"
+      isFinalStep ? "contact" : "operator"
     }`;
 
     const response = await actionHandler(
-      apiUrl,
+      `${apiUrl}${!isCreate && !isFinalStep ? `/${userOperatorId}` : ""}`,
       isCreate ? "POST" : "PUT",
       `/dashboard/select-operator/user-operator/create/${params?.formSection}`,
       {

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -9,8 +9,12 @@ import { useSession } from "next-auth/react";
 import UserOperatorReview from "@/app/components/routes/access-requests/form/UserOperatorReview";
 import MultiStepFormBase from "@/app/components/form/MultiStepFormBase";
 import { UserOperatorFormData } from "@/app/components/form/formDataTypes";
+<<<<<<< HEAD
 import Note from "../datagrid/Note";
 import { Status } from "@/app/types/types";
+=======
+import { Status } from "@/app/utils/enums";
+>>>>>>> 149a9d22 (fix: status enum import)
 
 interface UserOperatorFormProps {
   readonly schema: RJSFSchema;
@@ -108,19 +112,11 @@ export default function UserOperatorMultiStepForm({
         )}
         <MultiStepFormBase
           baseUrl={`/dashboard/operators/user-operator/${userOperatorId}`}
-<<<<<<< HEAD
           cancelUrl={
             isCasInternal
               ? "/dashboard/operators"
               : "/dashboard/select-operator"
           }
-=======
-          // TODO: change cancelUrl for industry user depending on if they are creating or editing an operator
-          // as in #441 they will be taken directly to the form view if they have already created an operator
-          cancelUrl={`/dashboard/${
-            isCasInternal ? "operators" : "select-operator"
-          }`}
->>>>>>> 008665cc (refactor: operation form disabled logic)
           schema={schema}
           disabled={isCasInternal || isFormStatusPending}
           error={error}

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -108,11 +108,19 @@ export default function UserOperatorMultiStepForm({
         )}
         <MultiStepFormBase
           baseUrl={`/dashboard/operators/user-operator/${userOperatorId}`}
+<<<<<<< HEAD
           cancelUrl={
             isCasInternal
               ? "/dashboard/operators"
               : "/dashboard/select-operator"
           }
+=======
+          // TODO: change cancelUrl for industry user depending on if they are creating or editing an operator
+          // as in #441 they will be taken directly to the form view if they have already created an operator
+          cancelUrl={`/dashboard/${
+            isCasInternal ? "operators" : "select-operator"
+          }`}
+>>>>>>> 008665cc (refactor: operation form disabled logic)
           schema={schema}
           disabled={isCasInternal || isFormStatusPending}
           error={error}

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -58,7 +58,7 @@ export default function UserOperatorMultiStepForm({
 
     const response = await actionHandler(
       `${apiUrl}${!isCreate && !isFinalStep ? `/${userOperatorId}` : ""}`,
-      isCreate ? "POST" : "PUT",
+      isCreate || isFinalStep ? "POST" : "PUT",
       `/dashboard/select-operator/user-operator/create/${params?.formSection}`,
       {
         body: JSON.stringify(newFormData),

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -59,7 +59,7 @@ export default function UserOperatorMultiStepForm({
     const response = await actionHandler(
       `${apiUrl}${!isCreate && !isFinalStep ? `/${userOperatorId}` : ""}`,
       isCreate || isFinalStep ? "POST" : "PUT",
-      `/dashboard/select-operator/user-operator/create/${params?.formSection}`,
+      "",
       {
         body: JSON.stringify(newFormData),
       }

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -78,6 +78,7 @@ export default function UserOperatorMultiStepForm({
       );
       return;
     }
+
     return push(
       `/dashboard/select-operator/user-operator/${
         isCreate ? "create" : userOperatorId

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -59,12 +59,12 @@ export default function UserOperatorMultiStepForm({
     }`;
 
     const response = await actionHandler(
-      `${apiUrl}${isCreate && isFinalStep ? "" : `/${userOperatorId}`}`,
+      `${apiUrl}${!isCreate && !isFinalStep ? `/${userOperatorId}` : ""}`,
       isCreate || isFinalStep ? "POST" : "PUT",
       "",
       {
         body: JSON.stringify(newFormData),
-      }
+      },
     );
 
     if (response.error) {
@@ -76,7 +76,7 @@ export default function UserOperatorMultiStepForm({
 
     if (isFinalStep) {
       push(
-        `/dashboard/select-operator/received/add-operator/${response.operator_id}`
+        `/dashboard/select-operator/received/add-operator/${response.operator_id}`,
       );
       return;
     }
@@ -88,7 +88,7 @@ export default function UserOperatorMultiStepForm({
         isCreate ? "create" : userOperatorId
       }/${formSection + 1}${
         isCreate ? `?user-operator-id=${response.user_operator_id}` : ""
-      }`
+      }`,
     );
   };
 

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -42,15 +42,17 @@ export default function UserOperatorMultiStepForm({
   const formSectionList = Object.keys(schema.properties as RJSFSchema);
   const isFinalStep = formSectionIndex === formSectionList.length - 1;
 
-  const userOperatorId =
-    searchParams.get("user-operator-id") || (params?.id as string);
+  const userOperatorId = params?.id as string;
+
+  const userOperatorIdParam = searchParams?.get("user-operator-id");
   const submitHandler = async (data: { formData?: UserOperatorFormData }) => {
     const newFormData = {
       ...data.formData,
     } as UserOperatorFormData;
 
     // add user operator id to form data if it exists (to be used in senior officer creation)
-    if (userOperatorId) newFormData.user_operator_id = userOperatorId;
+    if (userOperatorId)
+      newFormData.user_operator_id = userOperatorIdParam || userOperatorId;
 
     const apiUrl = `registration/user-operator/${
       isFinalStep ? "contact" : "operator"
@@ -79,10 +81,14 @@ export default function UserOperatorMultiStepForm({
       return;
     }
 
+    // continue to use user-operator-id search param for create route since database will error if sending a user operator id
+    // in the /[id] route as the user doesn't exist yet
     return push(
       `/dashboard/select-operator/user-operator/${
         isCreate ? "create" : userOperatorId
-      }/${formSection + 1}`
+      }/${formSection + 1}${
+        isCreate ? `?user-operator-id=${response.user_operator_id}` : ""
+      }`
     );
   };
 

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -92,6 +92,7 @@ export default function UserOperatorMultiStepForm({
   const isFormStatusDisabled =
     formData?.status === Status.PENDING || formData?.status === Status.APPROVED;
 
+  const operatorRoute = isCasInternal ? "operators" : "select-operator";
   // If the user is an approved cas internal user or if no operator exists show the entire multistep form
   if (isCasInternal || !userOperatorId || formSection) {
     return (
@@ -126,7 +127,7 @@ export default function UserOperatorMultiStepForm({
           }
           allowEdit={isFormStatusDisabled && !isCasInternal}
           allowBackNavigation
-          baseUrl={`/dashboard/select-operator/user-operator/${
+          baseUrl={`/dashboard/${operatorRoute}/user-operator/${
             isCreate ? "create" : userOperatorId
           }`}
           schema={schema}

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -59,7 +59,7 @@ export default function UserOperatorMultiStepForm({
     }`;
 
     const response = await actionHandler(
-      `${apiUrl}${!isCreate && !isFinalStep ? `/${userOperatorId}` : ""}`,
+      `${apiUrl}${isCreate && isFinalStep ? "" : `/${userOperatorId}`}`,
       isCreate || isFinalStep ? "POST" : "PUT",
       "",
       {

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -9,12 +9,8 @@ import { useSession } from "next-auth/react";
 import UserOperatorReview from "@/app/components/routes/access-requests/form/UserOperatorReview";
 import MultiStepFormBase from "@/app/components/form/MultiStepFormBase";
 import { UserOperatorFormData } from "@/app/components/form/formDataTypes";
-<<<<<<< HEAD
 import Note from "../datagrid/Note";
-import { Status } from "@/app/types/types";
-=======
 import { Status } from "@/app/utils/enums";
->>>>>>> 149a9d22 (fix: status enum import)
 
 interface UserOperatorFormProps {
   readonly schema: RJSFSchema;
@@ -30,9 +26,15 @@ export default function UserOperatorMultiStepForm({
   const params = useParams();
   const searchParams = useSearchParams();
   const [error, setError] = useState(undefined);
-  const formSection = parseInt(params?.formSection as string) - 1;
+
+  const formSection =
+    parseInt(params?.formSection as string) ||
+    parseInt(searchParams.get("form-section") as string);
+
+  const formSectionIndex = formSection - 1;
+
   const formSectionList = Object.keys(schema.properties as RJSFSchema);
-  const isFinalStep = formSection === formSectionList.length - 1;
+  const isFinalStep = formSectionIndex === formSectionList.length - 1;
 
   const userOperatorId =
     searchParams.get("user-operator-id") || (params?.id as string);
@@ -73,7 +75,7 @@ export default function UserOperatorMultiStepForm({
 
     push(
       `/dashboard/select-operator/user-operator/create/${
-        formSection + 2
+        formSection + 1
       }?user-operator-id=${response.user_operator_id}`
     );
   };

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -52,7 +52,7 @@ export default function UserOperatorMultiStepForm({
 
     // add user operator id to form data if it exists (to be used in senior officer creation)
     if (userOperatorId)
-      newFormData.user_operator_id = userOperatorIdParam || userOperatorId;
+      newFormData.user_operator_id = userOperatorIdParam ?? userOperatorId;
 
     const apiUrl = `registration/user-operator/${
       isFinalStep ? "contact" : "operator"

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -119,12 +119,12 @@ export default function UserOperatorMultiStepForm({
           />
         )}
         <MultiStepFormBase
-          allowEdit={isFormStatusDisabled}
           cancelUrl={
             isCasInternal
               ? "/dashboard/operators"
               : "/dashboard/select-operator"
           }
+          allowEdit={isFormStatusDisabled && !isCasInternal}
           allowBackNavigation
           baseUrl={`/dashboard/select-operator/user-operator/${
             isCreate ? "create" : userOperatorId

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -29,7 +29,7 @@ export default function UserOperatorMultiStepForm({
 
   const formSection =
     parseInt(params?.formSection as string) ||
-    parseInt(searchParams.get("formSection") as string);
+    parseInt(searchParams.get("form-section") as string);
 
   const formSectionIndex = formSection - 1;
 
@@ -84,7 +84,8 @@ export default function UserOperatorMultiStepForm({
     session?.user.app_role?.includes("cas") &&
     !session?.user.app_role?.includes("pending");
 
-  const isFormStatusPending = formData?.status === Status.PENDING;
+  const isFormStatusDisabled =
+    formData?.status === Status.PENDING || formData?.status === Status.APPROVED;
 
   // If the user is an approved cas internal user or if no operator exists show the entire multistep form
   if (isCasInternal || !userOperatorId || formSection) {
@@ -113,6 +114,7 @@ export default function UserOperatorMultiStepForm({
           />
         )}
         <MultiStepFormBase
+          allowEdit={isFormStatusDisabled}
           baseUrl={`/dashboard/operators/user-operator/${userOperatorId}`}
           cancelUrl={
             isCasInternal
@@ -120,7 +122,7 @@ export default function UserOperatorMultiStepForm({
               : "/dashboard/select-operator"
           }
           schema={schema}
-          disabled={isCasInternal || isFormStatusPending}
+          disabled={isCasInternal || isFormStatusDisabled}
           error={error}
           setErrorReset={setError}
           formData={formData}

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -61,7 +61,9 @@ export default function UserOperatorMultiStepForm({
     const response = await actionHandler(
       `${apiUrl}${!isCreate && !isFinalStep ? `/${userOperatorId}` : ""}`,
       isCreate || isFinalStep ? "POST" : "PUT",
-      "",
+      `/dashboard/select-operator/user-operator/${
+        isCreate ? "create" : userOperatorId
+      }/${formSection}`,
       {
         body: JSON.stringify(newFormData),
       },

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -10,15 +10,14 @@ import UserOperatorReview from "@/app/components/routes/access-requests/form/Use
 import MultiStepFormBase from "@/app/components/form/MultiStepFormBase";
 import { UserOperatorFormData } from "@/app/components/form/formDataTypes";
 import Note from "../datagrid/Note";
+import { Status } from "@/app/types/types";
 
 interface UserOperatorFormProps {
   readonly schema: RJSFSchema;
   readonly formData: Partial<UserOperatorFormData>;
-  readonly disabled?: boolean;
 }
 
 export default function UserOperatorMultiStepForm({
-  disabled,
   schema,
   formData,
 }: UserOperatorFormProps) {
@@ -51,7 +50,7 @@ export default function UserOperatorMultiStepForm({
       `/dashboard/select-operator/user-operator/create/${params?.formSection}`,
       {
         body: JSON.stringify(newFormData),
-      },
+      }
     );
 
     if (response.error) {
@@ -63,7 +62,7 @@ export default function UserOperatorMultiStepForm({
 
     if (isFinalStep) {
       push(
-        `/dashboard/select-operator/received/add-operator/${response.operator_id}`,
+        `/dashboard/select-operator/received/add-operator/${response.operator_id}`
       );
       return;
     }
@@ -71,12 +70,17 @@ export default function UserOperatorMultiStepForm({
     push(
       `/dashboard/select-operator/user-operator/create/${
         formSection + 2
-      }?user-operator-id=${response.user_operator_id}`,
+      }?user-operator-id=${response.user_operator_id}`
     );
-  }; // If the user is an approved cas internal user or if no operator exists show the entire multistep form
+  };
+
   const isCasInternal =
     session?.user.app_role?.includes("cas") &&
     !session?.user.app_role?.includes("pending");
+
+  const isFormStatusPending = formData?.status === Status.PENDING;
+
+  // If the user is an approved cas internal user or if no operator exists show the entire multistep form
   if (isCasInternal || !userOperatorId || formSection) {
     return (
       <>
@@ -110,7 +114,7 @@ export default function UserOperatorMultiStepForm({
               : "/dashboard/select-operator"
           }
           schema={schema}
-          disabled={isCasInternal ?? disabled}
+          disabled={isCasInternal || isFormStatusPending}
           error={error}
           setErrorReset={setError}
           formData={formData}

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -29,7 +29,7 @@ export default function UserOperatorMultiStepForm({
 
   const formSection =
     parseInt(params?.formSection as string) ||
-    parseInt(searchParams.get("form-section") as string);
+    parseInt(searchParams.get("formSection") as string);
 
   const formSectionIndex = formSection - 1;
 

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -47,9 +47,7 @@ export default async function MyOperatorPage() {
     status === Status.PENDING || status === Status.APPROVED;
 
   if (isRedirectToForm) {
-    redirect(
-      `/dashboard/select-operator/user-operator/${userOperatorId}?form-section=1`
-    );
+    redirect(`/dashboard/select-operator/user-operator/${userOperatorId}/1`);
   }
 
   return (

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { redirect } from "next/navigation";
 import Loading from "@/app/components/loading/SkeletonField";
 import SelectOperator from "@/app/components/routes/select-operator/form/SelectOperator";
 import { BC_GOV_LINKS_COLOR } from "@/app/styles/colors";
@@ -14,7 +15,19 @@ const getUserOperatorStatus = async () => {
     return await actionHandler(
       `registration/user-operator-status-from-user`,
       "GET",
-      "",
+      ""
+    );
+  } catch (error) {
+    throw error;
+  }
+};
+
+const getUserOperatorId = async () => {
+  try {
+    return await actionHandler(
+      `registration/user-operator-operator-id`,
+      "GET",
+      ""
     );
   } catch (error) {
     throw error;
@@ -24,10 +37,18 @@ const getUserOperatorStatus = async () => {
 export default async function MyOperatorPage() {
   const session = await getServerSession(authOptions);
   const userName = getUserFullName(session);
+
+  const userOperatorIdResponse = await getUserOperatorId();
+  const userOperatorId = userOperatorIdResponse?.operator_id;
+
   const { status } = await getUserOperatorStatus();
-  if (status === Status.PENDING) {
-    return <div>Your request is pending.</div>;
+
+  const isRedirectToForm =
+    status === Status.PENDING || status === Status.APPROVED;
+  if (isRedirectToForm) {
+    redirect(`/dashboard/select-operator/user-operator/${userOperatorId}`);
   }
+
   return (
     <>
       {/* Streaming to render UI parts in a client incrementally, as soon as possible */}

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -45,9 +45,10 @@ export default async function MyOperatorPage() {
 
   const isRedirectToForm =
     status === Status.PENDING || status === Status.APPROVED;
+
   if (isRedirectToForm) {
     redirect(
-      `/dashboard/select-operator/user-operator/${userOperatorId}?form-section=1`,
+      `/dashboard/select-operator/user-operator/${userOperatorId}?form-section=1`
     );
   }
 

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -46,7 +46,9 @@ export default async function MyOperatorPage() {
   const isRedirectToForm =
     status === Status.PENDING || status === Status.APPROVED;
   if (isRedirectToForm) {
-    redirect(`/dashboard/select-operator/user-operator/${userOperatorId}`);
+    redirect(
+      `/dashboard/select-operator/user-operator/${userOperatorId}?form-section=1`,
+    );
   }
 
   return (

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -44,7 +44,7 @@ export default async function MyOperatorPage() {
   const { status } = await getUserOperatorStatus();
 
   const isRedirectToForm =
-    status === Status.PENDING || status === Status.APPROVED;
+    status === Status.APPROVED || status === Status.PENDING;
 
   if (isRedirectToForm) {
     redirect(`/dashboard/select-operator/user-operator/${userOperatorId}/1`);

--- a/client/app/components/routes/select-operator/form/UserOperator.tsx
+++ b/client/app/components/routes/select-operator/form/UserOperator.tsx
@@ -18,7 +18,7 @@ async function getCurrentUser() {
   return actionHandler(
     `registration/user`,
     "GET",
-    `/dashboard/select-operator/user-operator`,
+    `/dashboard/select-operator/user-operator`
   );
 }
 
@@ -26,22 +26,22 @@ async function getBusinessStructures() {
   return actionHandler(
     `registration/business_structures`,
     "GET",
-    `/dashboard/select-operator/user-operator`,
+    `/dashboard/select-operator/user-operator`
   );
 }
 
-export async function getUserOperatorFormData(id: number | string | undefined) {
-  if (!id || id === "request-access") return {};
+export async function getUserOperatorFormData(id: number | string) {
+  if (!id || isNaN(Number(id))) return {};
   return actionHandler(
     `registration/select-operator/user-operator/${id}`,
     "GET",
-    `/user-operator/${id}`,
+    `/user-operator/${id}`
   );
 }
 
 // To populate the options for the business structure select field
 const createUserOperatorSchema = (
-  businessStructureList: { id: string; label: string }[],
+  businessStructureList: { id: string; label: string }[]
 ): RJSFSchema => {
   const localSchema = JSON.parse(JSON.stringify(userOperatorSchema));
 
@@ -51,7 +51,7 @@ const createUserOperatorSchema = (
       title: businessStructure.label,
       enum: [businessStructure.id],
       value: businessStructure.id,
-    }),
+    })
   );
 
   // for operator
@@ -94,7 +94,7 @@ export default async function UserOperator({
     (businessStructure: BusinessStructure) => ({
       id: businessStructure.name,
       label: businessStructure.name,
-    }),
+    })
   );
 
   const formData = {

--- a/client/app/components/routes/select-operator/form/UserOperator.tsx
+++ b/client/app/components/routes/select-operator/form/UserOperator.tsx
@@ -70,7 +70,7 @@ const createUserOperatorSchema = (
 export default async function UserOperator({
   params,
 }: Readonly<{
-  params: { id: number | string; readonly?: boolean };
+  params?: { id?: number | string; readonly?: boolean };
 }>) {
   const serverError = <div>Server Error. Please try again later.</div>;
   const userOperatorId = params?.id;
@@ -81,7 +81,7 @@ export default async function UserOperator({
     await getCurrentUser();
 
   const userOperatorData: UserOperatorFormData | { error: string } =
-    await getUserOperatorFormData(userOperatorId);
+    await getUserOperatorFormData(userOperatorId as string | number);
 
   if (
     "error" in userData ||

--- a/client/app/components/routes/select-operator/form/UserOperator.tsx
+++ b/client/app/components/routes/select-operator/form/UserOperator.tsx
@@ -18,7 +18,7 @@ async function getCurrentUser() {
   return actionHandler(
     `registration/user`,
     "GET",
-    `/dashboard/select-operator/user-operator`
+    `/dashboard/select-operator/user-operator`,
   );
 }
 
@@ -26,7 +26,7 @@ async function getBusinessStructures() {
   return actionHandler(
     `registration/business_structures`,
     "GET",
-    `/dashboard/select-operator/user-operator`
+    `/dashboard/select-operator/user-operator`,
   );
 }
 
@@ -35,13 +35,13 @@ export async function getUserOperatorFormData(id: number | string) {
   return actionHandler(
     `registration/select-operator/user-operator/${id}`,
     "GET",
-    `/user-operator/${id}`
+    `/user-operator/${id}`,
   );
 }
 
 // To populate the options for the business structure select field
 const createUserOperatorSchema = (
-  businessStructureList: { id: string; label: string }[]
+  businessStructureList: { id: string; label: string }[],
 ): RJSFSchema => {
   const localSchema = JSON.parse(JSON.stringify(userOperatorSchema));
 
@@ -51,7 +51,7 @@ const createUserOperatorSchema = (
       title: businessStructure.label,
       enum: [businessStructure.id],
       value: businessStructure.id,
-    })
+    }),
   );
 
   // for operator
@@ -94,7 +94,7 @@ export default async function UserOperator({
     (businessStructure: BusinessStructure) => ({
       id: businessStructure.name,
       label: businessStructure.name,
-    })
+    }),
   );
 
   const formData = {

--- a/client/app/components/routes/select-operator/form/UserOperator.tsx
+++ b/client/app/components/routes/select-operator/form/UserOperator.tsx
@@ -70,7 +70,7 @@ const createUserOperatorSchema = (
 export default async function UserOperator({
   params,
 }: Readonly<{
-  params?: { id?: number | string; readonly?: boolean };
+  params: { id: number | string; readonly?: boolean };
 }>) {
   const serverError = <div>Server Error. Please try again later.</div>;
   const userOperatorId = params?.id;

--- a/client/app/components/routes/select-operator/request-access/user-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/request-access/user-operator/Page.tsx
@@ -5,7 +5,7 @@ import UserOperator from "@/app/components/routes/select-operator/form/UserOpera
 export default async function SelectOperatorRequestAccessReceivedUserOperatorPage({
   params,
 }: {
-  readonly params?: Readonly<{ id?: number | string }>;
+  readonly params?: Readonly<{ id: number | string; formSection: number }>;
 }) {
   return (
     <Suspense fallback={<Loading />}>


### PR DESCRIPTION
Implements #441

To easily test this log in as industry user using `bc-cas-dev` account which is approved. When you click on the `My Operator` tile you will be redirected to the multistep user operator form which now has an `Edit information` button at the top.

This also refactored the user operator multistep form to use the `/[id]/[formSection]` dynamic routes just like the operations form. This was needed as all the conditional route logic was getting too complex and this simplified it a lot.

`NOTE:` as it wasn't a requirement of this ticket I didn't redirect `PENDING` status to the form as it requires far more work than I suspected as a lot of our API routes surrounding this only allows `APPROVED` users to fetch data. I will discuss this at standup on monday and possibly do it as part of #285.

