### PR TITLE
Fix: 447 save correct user names

### DIFF
--- a/client/app/api/auth/[...nextauth]/route.ts
+++ b/client/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,5 @@
 import NextAuth, { NextAuthOptions } from "next-auth";
-import KeycloakProvider, { KeycloakProfile } from "next-auth/providers/keycloak";
+import KeycloakProvider, {KeycloakProfile} from "next-auth/providers/keycloak";
 import { Errors, IDP, Roles } from "@/app/utils/enums";
 import { actionHandler } from "@/app/utils/actions";
 
@@ -42,8 +42,8 @@ export const authOptions: NextAuthOptions = {
     async jwt({ token, account, profile }) {
       try {
         if (profile) {
-          token.given_name = profile.given_name;
-          token.family_name = profile.family_name;
+          token.given_name = (profile as KeycloakProfile).given_name;
+          token.family_name = (profile as KeycloakProfile).family_name;
         }
         //📌  Provider account (only available on sign in)
         if (account) {

--- a/client/app/api/auth/[...nextauth]/route.ts
+++ b/client/app/api/auth/[...nextauth]/route.ts
@@ -18,6 +18,12 @@ export const authOptions: NextAuthOptions = {
       clientId: `${process.env.KEYCLOAK_CLIENT_ID}`,
       clientSecret: `${process.env.KEYCLOAK_CLIENT_SECRET}`,
       issuer: `${process.env.KEYCLOAK_LOGIN_URL}`,
+      profile(profile) {
+        return {
+          ...profile,
+          id: profile.sub
+        };
+      },
     }),
   ],
   //https://next-auth.js.org/configuration/pages
@@ -33,8 +39,12 @@ export const authOptions: NextAuthOptions = {
      * @return {object}            JSON Web Token that will be saved
      */
     // 👇️ called whenever a JSON Web Token is created/updated
-    async jwt({ token, account }) {
+    async jwt({ token, account, profile }) {
       try {
+        if (profile) {
+          token.given_name = profile.given_name;
+          token.family_name = profile.family_name;
+        }
         //📌  Provider account (only available on sign in)
         if (account) {
           // ✨  On a new sessions, you can add information to the next-auth created token...
@@ -166,6 +176,8 @@ export const authOptions: NextAuthOptions = {
         identity_provider: token.identity_provider,
         user: {
           ...session.user,
+          given_name: token.given_name,
+          family_name: token.family_name,
           app_role: token.app_role,
         },
       };

--- a/client/app/api/auth/[...nextauth]/route.ts
+++ b/client/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,5 @@
 import NextAuth, { NextAuthOptions } from "next-auth";
-import KeycloakProvider from "next-auth/providers/keycloak";
+import KeycloakProvider, { KeycloakProfile } from "next-auth/providers/keycloak";
 import { Errors, IDP, Roles } from "@/app/utils/enums";
 import { actionHandler } from "@/app/utils/actions";
 
@@ -18,7 +18,7 @@ export const authOptions: NextAuthOptions = {
       clientId: `${process.env.KEYCLOAK_CLIENT_ID}`,
       clientSecret: `${process.env.KEYCLOAK_CLIENT_SECRET}`,
       issuer: `${process.env.KEYCLOAK_LOGIN_URL}`,
-      profile(profile) {
+      profile(profile: KeycloakProfile) {
         return {
           ...profile,
           id: profile.sub

--- a/client/app/api/auth/[...nextauth]/route.ts
+++ b/client/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,7 @@
 import NextAuth, { NextAuthOptions } from "next-auth";
-import KeycloakProvider, {KeycloakProfile} from "next-auth/providers/keycloak";
+import KeycloakProvider, {
+  KeycloakProfile,
+} from "next-auth/providers/keycloak";
 import { Errors, IDP, Roles } from "@/app/utils/enums";
 import { actionHandler } from "@/app/utils/actions";
 
@@ -21,7 +23,7 @@ export const authOptions: NextAuthOptions = {
       profile(profile: KeycloakProfile) {
         return {
           ...profile,
-          id: profile.sub
+          id: profile.sub,
         };
       },
     }),

--- a/client/app/components/navigation/Session.tsx
+++ b/client/app/components/navigation/Session.tsx
@@ -1,12 +1,15 @@
 import Login from "@/app/components/navigation/Login";
 import Profile from "@/app/components/navigation/Profile";
 import { useSession } from "next-auth/react";
+import { getUserFullName } from "@/app/utils/getUserFullName";
 
 // 🏗️ Component to manage session based navigation
 export default function Session() {
   // 👤 Use NextAuth.js hook to get information about the user's session
   //  Destructuring assignment from data property of the object returned by useSession()
   const { data: session, status } = useSession();
+
+  const profileName = getUserFullName(session);
 
   if (status === "loading") {
     //👇️ Handle loading state (e.g., show a loading spinner).
@@ -17,6 +20,6 @@ export default function Session() {
   } else {
     //👇️ Handle authenticated state (e.g., display user information).
     // You can access the user session data through the 'session' variable.
-    return <Profile name={session?.user?.name || ""} />;
+    return <Profile name={profileName} />;
   }
 }

--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -29,10 +29,14 @@ export default async function User() {
        * getServerSession requires passing the same object you would pass to NextAuth
        */
       const session = await getServerSession(authOptions);
+      const isIdir = session?.identity_provider === IDP.IDIR;
+      // IDIR users have a given_name and a family_name attribute in the jwt, so we can use that in the case of idir
+      // BCeID users use the name attribute and we split on the space if there is one
+      const names = isIdir ? [session?.user?.given_name, session?.user?.family_name] : session?.user?.name?.split(" ");
 
       formData = {
-        first_name: session?.user?.given_name ?? "", // Use nullish coalescing here
-        last_name: session?.user?.family_name ?? "", // Use nullish coalescing here
+        first_name: names?.[0] ?? "", // Use nullish coalescing here
+        last_name: names?.[1] ?? "", // Use nullish coalescing here
         email: session?.user?.email || "",
         phone_number: "",
         position_title: "",

--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -4,6 +4,7 @@ import { UserProfileFormData } from "@/app/components/form/formDataTypes";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { IDP } from "@/app/utils/enums";
+import { getUserFullName } from "@/app/utils/getUserFullName";
 
 // 🚀 API call: GET user's data
 async function getUserFormData(): Promise<
@@ -32,9 +33,7 @@ export default async function User() {
       const isIdir = session?.identity_provider === IDP.IDIR;
       // IDIR users have a given_name and a family_name attribute in the jwt, so we can use that in the case of idir
       // BCeID users use the name attribute and we split on the space if there is one
-      const names = isIdir
-        ? [session?.user?.given_name, session?.user?.family_name]
-        : session?.user?.name?.split(" ");
+      const names = getUserFullName(session)?.split(" ");
 
       formData = {
         first_name: names?.[0] ?? "", // Use nullish coalescing here

--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -3,7 +3,6 @@ import UserForm from "@/app/components/routes/profile/form/UserForm";
 import { UserProfileFormData } from "@/app/components/form/formDataTypes";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
-import { IDP } from "@/app/utils/enums";
 import { getUserFullName } from "@/app/utils/getUserFullName";
 
 // 🚀 API call: GET user's data

--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -29,17 +29,10 @@ export default async function User() {
        * getServerSession requires passing the same object you would pass to NextAuth
        */
       const session = await getServerSession(authOptions);
-      const isIdir = session?.identity_provider === IDP.IDIR;
-
-      // IDIR names come in the format "LASTNAME, FIRSTNAME" so we will split on the comma
-      // and reverse so they don't go into the wrong fields
-      const idirName = session?.user?.name?.split(", ").reverse();
-
-      const names = isIdir ? idirName : session?.user?.name?.split(" ");
 
       formData = {
-        first_name: names?.[0] ?? "", // Use nullish coalescing here
-        last_name: names?.[1] ?? "", // Use nullish coalescing here
+        first_name: session?.user?.given_name ?? "", // Use nullish coalescing here
+        last_name: session?.user?.family_name ?? "", // Use nullish coalescing here
         email: session?.user?.email || "",
         phone_number: "",
         position_title: "",

--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -30,9 +30,6 @@ export default async function User() {
        * getServerSession requires passing the same object you would pass to NextAuth
        */
       const session = await getServerSession(authOptions);
-      const isIdir = session?.identity_provider === IDP.IDIR;
-      // IDIR users have a given_name and a family_name attribute in the jwt, so we can use that in the case of idir
-      // BCeID users use the name attribute and we split on the space if there is one
       const names = getUserFullName(session)?.split(" ");
 
       formData = {

--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -32,7 +32,9 @@ export default async function User() {
       const isIdir = session?.identity_provider === IDP.IDIR;
       // IDIR users have a given_name and a family_name attribute in the jwt, so we can use that in the case of idir
       // BCeID users use the name attribute and we split on the space if there is one
-      const names = isIdir ? [session?.user?.given_name, session?.user?.family_name] : session?.user?.name?.split(" ");
+      const names = isIdir
+        ? [session?.user?.given_name, session?.user?.family_name]
+        : session?.user?.name?.split(" ");
 
       formData = {
         first_name: names?.[0] ?? "", // Use nullish coalescing here

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -7,6 +7,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { actionHandler } from "@/app/utils/actions";
 import { Status } from "@/app/utils/enums";
+import { getUserFullName } from "@/app/utils/getUserFullName";
 
 const getUserOperatorStatus = async () => {
   try {
@@ -22,7 +23,7 @@ const getUserOperatorStatus = async () => {
 
 export default async function MyOperatorPage() {
   const session = await getServerSession(authOptions);
-  const userName = session?.user?.name?.split(" ")?.[0];
+  const userName = getUserFullName(session);
   const { status } = await getUserOperatorStatus();
   if (status === Status.PENDING.toLowerCase()) {
     return <div>Your request is pending.</div>;

--- a/client/app/types/next-auth.d.ts
+++ b/client/app/types/next-auth.d.ts
@@ -18,6 +18,8 @@ declare module "next-auth/jwt" {
     identity_provider: string | undefined;
     error?: string;
     app_role?: string;
+    given_name?: string;
+    family_name?: string;
   }
 }
 
@@ -28,6 +30,8 @@ declare module "next-auth" {
     user: {
       user_guid: string | undefined;
       app_role?: string;
+      given_name?: string;
+      family_name?: string;
     } & DefaultSession["user"];
   }
 }

--- a/client/app/utils/getUserFullName.ts
+++ b/client/app/utils/getUserFullName.ts
@@ -1,7 +1,7 @@
 import { Session } from 'next-auth';
 
 export const getUserFullName = (
-  session: Session
+  session?: Session | null
 ) => {
 
   const givenName = session?.user?.given_name;

--- a/client/app/utils/getUserFullName.ts
+++ b/client/app/utils/getUserFullName.ts
@@ -1,20 +1,13 @@
-import { Session } from 'next-auth';
+import { Session } from "next-auth";
 
-export const getUserFullName = (
-  session?: Session | null
-) => {
-
+export const getUserFullName = (session?: Session | null) => {
   const givenName = session?.user?.given_name;
   const familyName = session?.user?.family_name;
   let userFullName;
-  if (givenName && familyName)
-    userFullName = givenName.concat(' ', familyName);
-  else if (givenName && !familyName)
-    userFullName = givenName;
-  else if (!givenName && familyName)
-    userFullName = familyName;
-  else
-    userFullName = session?.user?.name || "";
+  if (givenName && familyName) userFullName = givenName.concat(" ", familyName);
+  else if (givenName && !familyName) userFullName = givenName;
+  else if (!givenName && familyName) userFullName = familyName;
+  else userFullName = session?.user?.name || "";
 
-  return userFullName
+  return userFullName;
 };

--- a/client/app/utils/getUserFullName.ts
+++ b/client/app/utils/getUserFullName.ts
@@ -1,0 +1,20 @@
+import { Session } from 'next-auth';
+
+export const getUserFullName = (
+  session: Session
+) => {
+
+  const givenName = session?.user?.given_name;
+  const familyName = session?.user?.family_name;
+  let userFullName;
+  if (givenName && familyName)
+    userFullName = givenName.concat(' ', familyName);
+  else if (givenName && !familyName)
+    userFullName = givenName;
+  else if (!givenName && familyName)
+    userFullName = familyName;
+  else
+    userFullName = session?.user?.name || "";
+
+  return userFullName
+};


### PR DESCRIPTION
Fixes the issue where ministry codes were being added to the user data by parsing the given_name and family_name attributes from the jwt and using those for IDIR users.
I still had to use the .name attribute in some places for the bceid users as it appears that both the given_name and family_name end up in the given_name attribute of the jwt for these users.