### PR TITLE
fix: all user roles can navigate the multistep forms

### DIFF
--- a/client/app/components/form/MultiStepButtons.tsx
+++ b/client/app/components/form/MultiStepButtons.tsx
@@ -11,7 +11,6 @@ interface SubmitButtonProps {
   classNames?: string;
   step: number;
   steps: string[];
-  submitEveryStep?: boolean;
   allowBackNavigation?: boolean;
 }
 
@@ -22,13 +21,11 @@ const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
   steps,
   cancelUrl,
   classNames,
-  submitEveryStep,
   allowBackNavigation,
 }) => {
   const { pending } = useFormStatus();
   const isFinalStep = step === steps.length - 1;
   const isDisabled = disabled || pending;
-
   return (
     <div className={`flex w-full mt-8 justify-between ${classNames}`}>
       {cancelUrl && (
@@ -54,32 +51,24 @@ const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
               Back
             </Button>
           ))}
-        {!isFinalStep && !submitEveryStep && (
-          <Link href={`${baseUrl}/${step + 2}`}>
-            <Button variant="contained" type="button" disabled={isFinalStep}>
-              Next
-            </Button>
-          </Link>
-        )}
-        {isFinalStep && !submitEveryStep && (
+        {/* When the form is editable, the form should be submitted when navigating between steps */}
+        {!disabled && (
           <Button
             type="submit"
             aria-disabled={isDisabled}
             disabled={isDisabled}
             variant="contained"
           >
-            Submit
-          </Button>
-        )}
-        {submitEveryStep && (
-          <Button
-            type="submit"
-            aria-disabled={isDisabled}
-            disabled={isFinalStep && isDisabled}
-            variant="contained"
-          >
             {!isFinalStep ? "Next" : "Submit"}
           </Button>
+        )}
+        {/* When the form is not editable (e.g., IRC staff is reviewing an operation), the form should not be submitted when navigating between steps */}
+        {!isFinalStep && disabled && (
+          <Link href={`${baseUrl}/${step + 2}`}>
+            <Button variant="contained" type="button" disabled={isFinalStep}>
+              Next
+            </Button>
+          </Link>
         )}
       </div>
     </div>

--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -14,7 +14,6 @@ interface MultiStepFormProps {
   onSubmit: any;
   schema: any;
   showSubmissionStep?: boolean;
-  submitEveryStep?: boolean;
   allowBackNavigation?: boolean;
   uiSchema: any;
 }
@@ -28,7 +27,6 @@ const MultiStepFormBase = ({
   onSubmit,
   schema,
   showSubmissionStep,
-  submitEveryStep,
   allowBackNavigation,
   uiSchema,
 }: MultiStepFormProps) => {
@@ -61,7 +59,6 @@ const MultiStepFormBase = ({
           disabled={disabled}
           step={formSection}
           steps={formSectionList}
-          submitEveryStep={submitEveryStep}
           baseUrl={baseUrl}
           cancelUrl={cancelUrl}
           allowBackNavigation={allowBackNavigation}

--- a/client/app/components/form/OperationsForm.tsx
+++ b/client/app/components/form/OperationsForm.tsx
@@ -104,7 +104,6 @@ export default function OperationsForm({ formData, schema }: Props) {
           error={error}
           schema={schema}
           allowBackNavigation
-          submitEveryStep
           onSubmit={async (data: { formData?: any }) => {
             const method = isCreate ? "POST" : "PUT";
             const endpoint = isCreate

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -100,7 +100,6 @@ export default function UserOperatorMultiStepForm({
           disabled={isCasInternal || disabled}
           error={error}
           formData={formData}
-          submitEveryStep={!isCasInternal}
           onSubmit={submitHandler}
           uiSchema={userOperatorUiSchema}
         />


### PR DESCRIPTION
https://github.com/bcgov/cas-registration/issues/490

I manually tested submitting and viewing all the forms (except this currently broken one: https://github.com/bcgov/cas-registration/issues/491) since changing the multistep component affects a lot of the app.

Backend tests are failing because it's 2024 now. They're fixed in https://github.com/bcgov/cas-registration/pull/489 (and possibly other PRs) that will be merged in before this one, so they'll start passing once I rebase.