### PR TITLE
Fix/fixtures do not load

### DIFF
--- a/bc_obps/registration/api/api_base.py
+++ b/bc_obps/registration/api/api_base.py
@@ -15,11 +15,7 @@ def setup(request):
     if settings.ENVIRONMENT == "develop":
         try:
             call_command('truncate_all_tables')
-            call_command(
-                'loaddata',
-                glob(os.path.join(BASE_DIR, 'registration/fixtures/mock/*.json')),
-                glob(os.path.join(BASE_DIR, 'registration/fixtures/real/*.json')),
-            )
+            call_command('load_fixtures')
             return HttpResponse("Test setup complete.", status=200)
         except Exception as e:
             return HttpResponse(f"Test setup failed. Reason:{e}", status=500)

--- a/bc_obps/registration/api/api_base.py
+++ b/bc_obps/registration/api/api_base.py
@@ -1,3 +1,6 @@
+from glob import glob
+import os
+from bc_obps.settings import BASE_DIR
 from ninja import Router
 from django.core.management import call_command
 from django.conf import settings
@@ -12,7 +15,7 @@ def setup(request):
     if settings.ENVIRONMENT == "develop":
         try:
             call_command('truncate_all_tables')
-            call_command('load_fixtures')
+            call_command('loaddata', glob(os.path.join(BASE_DIR,'registration/fixtures/mock/*.json')), glob(os.path.join(BASE_DIR,'registration/fixtures/real/*.json')))
             return HttpResponse("Test setup complete.", status=200)
         except Exception as e:
             return HttpResponse(f"Test setup failed. Reason:{e}", status=500)

--- a/bc_obps/registration/api/api_base.py
+++ b/bc_obps/registration/api/api_base.py
@@ -15,7 +15,11 @@ def setup(request):
     if settings.ENVIRONMENT == "develop":
         try:
             call_command('truncate_all_tables')
-            call_command('loaddata', glob(os.path.join(BASE_DIR,'registration/fixtures/mock/*.json')), glob(os.path.join(BASE_DIR,'registration/fixtures/real/*.json')))
+            call_command(
+                'loaddata',
+                glob(os.path.join(BASE_DIR, 'registration/fixtures/mock/*.json')),
+                glob(os.path.join(BASE_DIR, 'registration/fixtures/real/*.json')),
+            )
             return HttpResponse("Test setup complete.", status=200)
         except Exception as e:
             return HttpResponse(f"Test setup failed. Reason:{e}", status=500)

--- a/bc_obps/registration/api/api_base.py
+++ b/bc_obps/registration/api/api_base.py
@@ -1,6 +1,3 @@
-from glob import glob
-import os
-from bc_obps.settings import BASE_DIR
 from ninja import Router
 from django.core.management import call_command
 from django.conf import settings

--- a/bc_obps/registration/management/commands/load_fixtures.py
+++ b/bc_obps/registration/management/commands/load_fixtures.py
@@ -7,5 +7,5 @@ class Command(BaseCommand):
     help = 'Load all fixtures in app directories'
 
     def handle(self, *args, **kwargs):
-        cmd_args = list(pathlib.Path().glob('./registration/fixtures/*'))
+        cmd_args = list(pathlib.Path().glob('./registration/fixtures/*/*.json'))
         call_command('loaddata', *cmd_args)

--- a/bc_obps/registration/management/commands/truncate_all_tables.py
+++ b/bc_obps/registration/management/commands/truncate_all_tables.py
@@ -7,7 +7,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         with connection.cursor() as cursor:
-            cursor.execute("SELECT tablename FROM pg_tables WHERE schemaname in 'erc, erc_history';")
+            cursor.execute("SELECT tablename FROM pg_tables WHERE schemaname in ('erc, erc_history');")
             for row in cursor.fetchall():
                 table_name = row[0]
                 # Use Django's query building to create a safe parameterized query

--- a/bc_obps/registration/management/commands/truncate_all_tables.py
+++ b/bc_obps/registration/management/commands/truncate_all_tables.py
@@ -7,7 +7,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         with connection.cursor() as cursor:
-            cursor.execute("SELECT tablename FROM pg_tables WHERE schemaname = 'erc';")
+            cursor.execute("SELECT tablename FROM pg_tables WHERE schemaname in 'erc, erc_history';")
             for row in cursor.fetchall():
                 table_name = row[0]
                 # Use Django's query building to create a safe parameterized query

--- a/helm/cas-registration/templates/backend/deployment.yaml
+++ b/helm/cas-registration/templates/backend/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: {{ .Release.Name }}-backend
-          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.sourceRepoImageTag | default .Values.backend.image.tag }}"
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.defaultImageTag | default .Values.backend.image.tag }}"
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
           env:
             - name: DJANGO_SECRET_KEY

--- a/helm/cas-registration/templates/frontend/deployment.yaml
+++ b/helm/cas-registration/templates/frontend/deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "cas-registration.fullname" . }}-nextauth
                   key: nextauth-secret
-          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.sourceRepoImageTag | default .Values.frontend.image.tag }}"
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.defaultImageTag | default .Values.frontend.image.tag }}"
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.frontend.service.port }}


### PR DESCRIPTION
After splitting the fixtures into the subdirectories 'mock' and 'real', call_command('load_fixtures') was broken because it's only looking for fixtures directly in the fixtures/ directory. 

The fix: ~Updated the call_command to use 'loaddata' instead of 'load_fixtures' and passed a set of glob patterns to read all fixtures in the subdirectories.~ Updated the pathing in the load_fixtures.py function