### PR TITLE
332 document exploration

### DIFF
--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -64,6 +64,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     'simple_history.middleware.HistoryRequestMiddleware',
+    "registration.middleware.file_upload_middleware.FileUploadMiddleware",
 ]
 
 ROOT_URLCONF = "bc_obps.urls"

--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -64,7 +64,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     'simple_history.middleware.HistoryRequestMiddleware',
-    "registration.middleware.file_upload_middleware.FileUploadMiddleware",
+    # "registration.middleware.file_upload_middleware.FileUploadMiddleware",
 ]
 
 ROOT_URLCONF = "bc_obps.urls"

--- a/bc_obps/registration/api/naics.py
+++ b/bc_obps/registration/api/naics.py
@@ -1,7 +1,8 @@
 from registration.decorators import authorize
 from .api_base import router
+from django.core.files.base import ContentFile
 from typing import List
-from registration.models import NaicsCode, AppRole, Document
+from registration.models import NaicsCode, AppRole, Document,  DocumentType
 from registration.schema import (
     NaicsCodeSchema,
 )
@@ -10,6 +11,11 @@ from ninja.files import UploadedFile
 from ninja import ModelSchema
 from ninja.responses import codes_4xx, codes_5xx
 from registration.schema import Message, OperatorOut, SelectUserOperatorStatus
+from ninja import Schema
+import base64
+import io
+import json
+import re
 class DocumentOut(ModelSchema):
     """
     Schema for the Operator model
@@ -19,15 +25,38 @@ class DocumentOut(ModelSchema):
         model = Document
         model_fields = '__all__'
 
-@router.post("/upload", response={201: DocumentOut, codes_4xx: Message})
-async def create_document(request, file: UploadedFile = File(...)):
-    print('made it into the upload endpoint')
-    # i think is not actually the file
-    print('file',file)
-    data = file.read()
-    print('data',data)
-    breakpoint()
-    document = Document.objects.create(**data)
+# could use middleware for the transformation too? harder when it's part of a form
+class DocumentSchema(Schema):
+    boundary_map: str
+
+
+# @router.post("/upload", response={201: DocumentOut, codes_4xx: Message})
+# async def create_document(request, file: UploadedFile = File(...)):
+#     print('made it into the upload endpoint')
+#     # i think is not actually the file
+#     print('file',file)
+#     data = file.read()
+#     print('data',data)
+#     breakpoint()
+#     document = Document.objects.create(**data)
+
+
+#     return 201, document
+
+@router.post("/handle-file", response={201: DocumentOut, codes_4xx: Message})
+def create_document(request, payload: DocumentSchema):
+
+# for the real endpoint, we'll probably have to do some sort of loop because there can be multiple types of documents in each form
+
+    file_name =  re.search(r'name=([^;]+)', payload.boundary_map).group(1)
+    _, encoded_data = payload.boundary_map.split(',')
+
+    # Decode the base64-encoded data
+    file_data = base64.b64decode(encoded_data)
+    file = ContentFile(file_data, file_name)
+
+ 
+    document = Document.objects.create(file=file,  type=DocumentType.objects.get(name='boundary_map'), description='what was this meant to be? maybe it would make more sense to put the description in the DocumentType table?')
 
 
     return 201, document

--- a/bc_obps/registration/api/naics.py
+++ b/bc_obps/registration/api/naics.py
@@ -1,10 +1,37 @@
 from registration.decorators import authorize
 from .api_base import router
 from typing import List
-from registration.models import NaicsCode, AppRole
+from registration.models import NaicsCode, AppRole, Document
 from registration.schema import (
     NaicsCodeSchema,
 )
+from ninja import File
+from ninja.files import UploadedFile
+from ninja import ModelSchema
+from ninja.responses import codes_4xx, codes_5xx
+from registration.schema import Message, OperatorOut, SelectUserOperatorStatus
+class DocumentOut(ModelSchema):
+    """
+    Schema for the Operator model
+    """
+
+    class Config:
+        model = Document
+        model_fields = '__all__'
+
+@router.post("/upload", response={201: DocumentOut, codes_4xx: Message})
+async def create_document(request, file: UploadedFile = File(...)):
+    print('made it into the upload endpoint')
+    # i think is not actually the file
+    print('file',file)
+    data = file.read()
+    print('data',data)
+    breakpoint()
+    document = Document.objects.create(**data)
+
+
+    return 201, document
+
 
 ##### GET #####
 

--- a/bc_obps/registration/api/naics.py
+++ b/bc_obps/registration/api/naics.py
@@ -25,7 +25,7 @@ class DocumentOut(ModelSchema):
         model = Document
         model_fields = '__all__'
 
-# could use middleware for the transformation too? harder when it's part of a form
+
 class DocumentSchema(Schema):
     boundary_map: str
 

--- a/bc_obps/registration/api/naics.py
+++ b/bc_obps/registration/api/naics.py
@@ -2,7 +2,7 @@ from registration.decorators import authorize
 from .api_base import router
 from django.core.files.base import ContentFile
 from typing import List
-from registration.models import NaicsCode, AppRole, Document,  DocumentType
+from registration.models import NaicsCode, AppRole, Document, DocumentType
 from registration.schema import (
     NaicsCodeSchema,
 )
@@ -19,36 +19,28 @@ from ninja import NinjaAPI, File
 from ninja.files import UploadedFile
 import re
 import requests
-class DocumentOut(ModelSchema):
 
+
+class DocumentOut(ModelSchema):
 
     """
     Schema for the Operator model
     """
+
     boundary_map: str = None
 
-    # static method, start with resolve, name of field
     @staticmethod
     def resolve_boundary_map(obj: Document):
-        # if obj.file.file:
-        #     breakpoint()
-        #     file_content = obj.file.file
-        #     encoded_content = base64.b64encode(file_content).decode("utf-8")
-
-        #     return "data:application/pdf;base64," + encoded_content
-        
 
         response = requests.get(obj.file.url)
         if response.status_code == 200:
             # The file content is in response.content
             file_content = response.content
             encoded_content = base64.b64encode(file_content).decode("utf-8")
-            # data:image/jpeg;name=IMG-20231228-WA0000.jpg;base64 data:application/pdf;base64
-            var = "data:application/pdf;name=" + obj.file.name.split("/")[-1] + ";base64," + encoded_content
-            print(var)
-            return var
-        return 'i dont work yet'
-        
+            # on
+            return "data:application/pdf;name=" + obj.file.name.split("/")[-1] + ";base64," + encoded_content
+        return None
+
     class Config:
         model = Document
         model_fields = '__all__'
@@ -71,26 +63,32 @@ class DocumentSchema(Schema):
 
 #     return 201, document
 
+
 @router.get("/handle-file", response=DocumentOut)
 def get_file(request):
     qs = Document.objects.last()
     return qs
 
+
 @router.post("/handle-file", response={201: DocumentOut, codes_4xx: Message})
 def create_document(request, payload: DocumentSchema):
 
-# for the real endpoint, we'll probably have to do some sort of loop because there can be multiple types of documents in each form
+    # for the real endpoint, we'll probably have to do some sort of loop because there can be multiple types of documents in each form
 
-    file_name =  re.search(r'name=([^;]+)', payload.boundary_map).group(1)
+
+    # we could do this in a schema resolver too
+    file_name = re.search(r'name=([^;]+)', payload.boundary_map).group(1)
     _, encoded_data = payload.boundary_map.split(',')
 
     # Decode the base64-encoded data
     file_data = base64.b64decode(encoded_data)
     file = ContentFile(file_data, file_name)
 
- 
-    document = Document.objects.create(file=file,  type=DocumentType.objects.get(name='boundary_map'), description='what was this meant to be? maybe it would make more sense to put the description in the DocumentType table?')
-
+    document = Document.objects.create(
+        file=file,
+        type=DocumentType.objects.get(name='boundary_map'),
+        description='what was this meant to be? maybe it would make more sense to put the description in the DocumentType table?',
+    )
 
     return 201, document
 

--- a/bc_obps/registration/fixtures/mock/user.json
+++ b/bc_obps/registration/fixtures/mock/user.json
@@ -68,5 +68,19 @@
       "phone_number": "+16044015432",
       "app_role": "industry_user"
     }
+  },
+  {
+    "model": "registration.user",
+    "pk": 5,
+    "fields": {
+      "user_guid": "4da70f32-65fd-4137-87c1-111f2daba3dd",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "Bcgov",
+      "last_name": "Cas SECONDARY",
+      "position_title": "Code Monkey",
+      "email": "email@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "cas_admin"
+    }
   }
 ]

--- a/bc_obps/registration/middleware/file_upload_middleware.py
+++ b/bc_obps/registration/middleware/file_upload_middleware.py
@@ -1,0 +1,50 @@
+import base64
+import io
+import json
+from ninja import Router
+from ninja.errors import HttpError
+from django.core.files.base import ContentFile
+from ninja.files import UploadedFile
+from django.core.files.uploadedfile import InMemoryUploadedFile
+from tempfile import NamedTemporaryFile
+
+router = Router()
+
+class FileUploadMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        print('made it into the middleware')
+        # maybe better to check on if there's any sort of file (rjsf calles them boundary_map etc., how to deterine?)
+        if request.method == "POST" and request.path == "/api/registration/upload":
+
+            raw_data = request.body
+            decoded_data = json.loads(raw_data.decode('utf-8'))
+            data_url = decoded_data.get("file")
+
+            if data_url:
+                try:
+                    # Split the data URL to extract the base64-encoded data
+                    _, encoded_data = data_url.split(',')
+
+                    # Decode the base64-encoded data
+                    file_data = base64.b64decode(encoded_data)
+
+                    temp_file = NamedTemporaryFile(delete=False)
+                    temp_file.write(file_data)
+                    temp_file.flush()
+
+                    # Update request.FILES with the file--django docs: During file uploads, the actual file data is stored in request.FILES. Each entry in this dictionary is an UploadedFile object (or a subclass) – a wrapper around an uploaded file. You’ll usually use one of these methods to access the uploaded content:
+                    
+                    # (not sure how this would work with multiple files, name has to be 'file')
+                    request.FILES['file'] = UploadedFile(temp_file)
+                    
+                   
+                except Exception as e:
+                    raise HttpError(400, f"Error decoding Data URL: {str(e)}")
+
+        response = self.get_response(request)
+        return response
+
+

--- a/bc_obps/registration/middleware/file_upload_middleware.py
+++ b/bc_obps/registration/middleware/file_upload_middleware.py
@@ -1,50 +1,50 @@
-import base64
-import io
-import json
-from ninja import Router
-from ninja.errors import HttpError
-from django.core.files.base import ContentFile
-from ninja.files import UploadedFile
-from django.core.files.uploadedfile import InMemoryUploadedFile
-from tempfile import NamedTemporaryFile
+# import base64
+# import io
+# import json
+# from ninja import Router
+# from ninja.errors import HttpError
+# from django.core.files.base import ContentFile
+# from ninja.files import UploadedFile
+# from django.core.files.uploadedfile import InMemoryUploadedFile
+# from tempfile import NamedTemporaryFile
 
-router = Router()
+# router = Router()
 
-class FileUploadMiddleware:
-    def __init__(self, get_response):
-        self.get_response = get_response
+# class FileUploadMiddleware:
+#     def __init__(self, get_response):
+#         self.get_response = get_response
 
-    def __call__(self, request):
-        print('made it into the middleware')
-        # maybe better to check on if there's any sort of file (rjsf calles them boundary_map etc., how to deterine?)
-        if request.method == "POST" and request.path == "/api/registration/upload":
+#     def __call__(self, request):
+#         print('made it into the middleware')
+#         # maybe better to check on if there's any sort of file (rjsf calles them boundary_map etc., how to deterine?)
+#         if request.method == "POST" and request.path == "/api/registration/upload":
 
-            raw_data = request.body
-            decoded_data = json.loads(raw_data.decode('utf-8'))
-            data_url = decoded_data.get("file")
+#             raw_data = request.body
+#             decoded_data = json.loads(raw_data.decode('utf-8'))
+#             data_url = decoded_data.get("file")
 
-            if data_url:
-                try:
-                    # Split the data URL to extract the base64-encoded data
-                    _, encoded_data = data_url.split(',')
+#             if data_url:
+#                 try:
+#                     # Split the data URL to extract the base64-encoded data
+#                     _, encoded_data = data_url.split(',')
 
-                    # Decode the base64-encoded data
-                    file_data = base64.b64decode(encoded_data)
+#                     # Decode the base64-encoded data
+#                     file_data = base64.b64decode(encoded_data)
 
-                    temp_file = NamedTemporaryFile(delete=False)
-                    temp_file.write(file_data)
-                    temp_file.flush()
+#                     temp_file = NamedTemporaryFile(delete=False)
+#                     temp_file.write(file_data)
+#                     temp_file.flush()
 
-                    # Update request.FILES with the file--django docs: During file uploads, the actual file data is stored in request.FILES. Each entry in this dictionary is an UploadedFile object (or a subclass) – a wrapper around an uploaded file. You’ll usually use one of these methods to access the uploaded content:
+#                     # Update request.FILES with the file--django docs: During file uploads, the actual file data is stored in request.FILES. Each entry in this dictionary is an UploadedFile object (or a subclass) – a wrapper around an uploaded file. You’ll usually use one of these methods to access the uploaded content:
                     
-                    # (not sure how this would work with multiple files, name has to be 'file')
-                    request.FILES['file'] = UploadedFile(temp_file)
+#                     # (not sure how this would work with multiple files, name has to be 'file')
+#                     request.FILES['file'] = UploadedFile(temp_file)
                     
                    
-                except Exception as e:
-                    raise HttpError(400, f"Error decoding Data URL: {str(e)}")
+#                 except Exception as e:
+#                     raise HttpError(400, f"Error decoding Data URL: {str(e)}")
 
-        response = self.get_response(request)
-        return response
+#         response = self.get_response(request)
+#         return response
 
 

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -182,6 +182,8 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         )
         assert response.status_code == 401
 
+        # /select-operator/user-operator/operator/{user_operator_id}/update-status
+
     def test_get_user_operator_status(self):
         user_operator = baker.make(UserOperator, user_id=self.user.user_guid, status=UserOperator.Statuses.APPROVED)
         response = TestUtils.mock_get_with_auth_role(
@@ -234,6 +236,8 @@ class TestUserOperatorEndpoint(CommonTestSetup):
 
         assert parsed_object.get("fields").get("status") == UserOperator.Statuses.APPROVED
         assert parsed_object.get("fields").get("verified_by") == str(self.user.user_guid)
+
+        
 
     def test_request_admin_access_with_valid_payload(self):
         operator = baker.make(Operator)

--- a/client/app/(authenticated)/idir/cas_admin/brianna/formcomponent.tsx
+++ b/client/app/(authenticated)/idir/cas_admin/brianna/formcomponent.tsx
@@ -1,0 +1,64 @@
+"use client";
+import SelectOperatorRequestAccessConfirmPage from "@/app/components/routes/select-operator/request-access/confirm/Page";
+import { actionHandler } from "@/app/utils/actions";
+import Form from "@rjsf/core";
+import { customizeValidator } from "@rjsf/validator-ajv8";
+
+export default function BriannaForm({
+  params,
+  documents,
+}: {
+  readonly params: { id: number };
+  documents: any;
+}) {
+  console.log("documents", documents);
+  const customFormats = {
+    phone: /\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}$/,
+    "postal-code":
+      /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i,
+    bc_corporate_registry_number: "^[A-Za-z]{1,3}\\d{7}$",
+  };
+  const validator = customizeValidator({ customFormats });
+  return (
+    <Form
+      uiSchema={{
+        boundary_map: { "ui:options": { filePreview: true, accept: ".pdf" } },
+      }}
+      formData={{ boundary_map: documents.boundary_map }}
+      schema={{
+        title: "A registration form",
+        description: "A simple form example.",
+        type: "object",
+
+        properties: {
+          boundary_map: {
+            type: "string",
+            format: "data-url",
+            title: "Single file",
+          },
+          randomfield: {
+            type: "string",
+            title: "random extra field for testing what happens",
+          },
+        },
+      }}
+      validator={validator}
+      onSubmit={async (data) => {
+        console.log("data.formdata", data.formData);
+
+        const response = await actionHandler(
+          `registration/handle-file`,
+          "POST",
+          "",
+          // can't pass a File class to a server action so any dataURL transformation will have to happen middleware or backend
+          { body: JSON.stringify(data.formData) },
+        );
+
+        if (response.error) {
+          console.log("bad things happened");
+          return;
+        }
+      }}
+    />
+  );
+}

--- a/client/app/(authenticated)/idir/cas_admin/brianna/page.tsx
+++ b/client/app/(authenticated)/idir/cas_admin/brianna/page.tsx
@@ -4,19 +4,6 @@ import { actionHandler } from "@/app/utils/actions";
 import Form from "@rjsf/core";
 import { customizeValidator } from "@rjsf/validator-ajv8";
 
-function dataURLtoFile(dataurl: string, filename: string) {
-  console.log("dataurl", dataurl);
-  var arr = dataurl.split(","),
-    mime = arr[0].match(/:(.*?);/)[1],
-    bstr = atob(arr[arr.length - 1]),
-    n = bstr.length,
-    u8arr = new Uint8Array(n);
-  while (n--) {
-    u8arr[n] = bstr.charCodeAt(n);
-  }
-  return new File([u8arr], filename, { type: mime });
-}
-
 export default function Page({ params }: { readonly params: { id: number } }) {
   const customFormats = {
     phone: /\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}$/,
@@ -40,7 +27,7 @@ export default function Page({ params }: { readonly params: { id: number } }) {
           },
           randomfield: {
             type: "string",
-            title: "random filed",
+            title: "random extra field for testing what happens",
           },
         },
       }}
@@ -52,20 +39,9 @@ export default function Page({ params }: { readonly params: { id: number } }) {
           `registration/handle-file`,
           "POST",
           "",
-          // can't do this, can't pass a class to a server action
-          // b might need to write a new handler for files --oh nooooo, it's probably middleware
-          // dataURLtoFile(data.formData.file, "bri")
+          // can't pass a File class to a server action so any dataURL transformation will have to happen middleware or backend
           { body: JSON.stringify(data.formData) }
         );
-
-        // const response = await fetch(
-        //   `${process.env.API_URL}registration/upload`,
-        //   {
-        //     method: "POST",
-
-        //     body: data.formData,
-        //   }
-        // );
 
         if (response.error) {
           console.log("bad things happened");

--- a/client/app/(authenticated)/idir/cas_admin/brianna/page.tsx
+++ b/client/app/(authenticated)/idir/cas_admin/brianna/page.tsx
@@ -55,7 +55,7 @@ export default function Page({ params }: { readonly params: { id: number } }) {
           // can't do this, can't pass a class to a server action
           // b might need to write a new handler for files --oh nooooo, it's probably middleware
           // dataURLtoFile(data.formData.file, "bri")
-          { body: JSON.stringify(data.formData) }
+          { body: JSON.stringify(data.formData) },
         );
 
         // const response = await fetch(

--- a/client/app/(authenticated)/idir/cas_admin/brianna/page.tsx
+++ b/client/app/(authenticated)/idir/cas_admin/brianna/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+import SelectOperatorRequestAccessConfirmPage from "@/app/components/routes/select-operator/request-access/confirm/Page";
+import { actionHandler } from "@/app/utils/actions";
+import Form from "@rjsf/core";
+import { customizeValidator } from "@rjsf/validator-ajv8";
+
+function dataURLtoFile(dataurl: string, filename: string) {
+  console.log("dataurl", dataurl);
+  var arr = dataurl.split(","),
+    mime = arr[0].match(/:(.*?);/)[1],
+    bstr = atob(arr[arr.length - 1]),
+    n = bstr.length,
+    u8arr = new Uint8Array(n);
+  while (n--) {
+    u8arr[n] = bstr.charCodeAt(n);
+  }
+  return new File([u8arr], filename, { type: mime });
+}
+
+export default function Page({ params }: { readonly params: { id: number } }) {
+  const customFormats = {
+    phone: /\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}$/,
+    "postal-code":
+      /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i,
+    bc_corporate_registry_number: "^[A-Za-z]{1,3}\\d{7}$",
+  };
+  const validator = customizeValidator({ customFormats });
+  return (
+    <Form
+      schema={{
+        title: "A registration form",
+        description: "A simple form example.",
+        type: "object",
+
+        properties: {
+          file: {
+            type: "string",
+            format: "data-url",
+            title: "Single file",
+          },
+          randomfield: {
+            type: "string",
+            title: "random filed",
+          },
+        },
+      }}
+      validator={validator}
+      onSubmit={async (data) => {
+        console.log("data.formdata", data.formData);
+
+        const response = await actionHandler(
+          `registration/upload`,
+          "POST",
+          "",
+          // can't do this, can't pass a class to a server action
+          // b might need to write a new handler for files --oh nooooo, it's probably middleware
+          // dataURLtoFile(data.formData.file, "bri")
+          { body: JSON.stringify(data.formData) }
+        );
+
+        // const response = await fetch(
+        //   `${process.env.API_URL}registration/upload`,
+        //   {
+        //     method: "POST",
+
+        //     body: data.formData,
+        //   }
+        // );
+
+        if (response.error) {
+          console.log("bad things happened");
+          return;
+        }
+      }}
+    />
+  );
+}

--- a/client/app/(authenticated)/idir/cas_admin/brianna/page.tsx
+++ b/client/app/(authenticated)/idir/cas_admin/brianna/page.tsx
@@ -1,53 +1,20 @@
-"use client";
-import SelectOperatorRequestAccessConfirmPage from "@/app/components/routes/select-operator/request-access/confirm/Page";
 import { actionHandler } from "@/app/utils/actions";
-import Form from "@rjsf/core";
-import { customizeValidator } from "@rjsf/validator-ajv8";
+import BriannaForm from "./formcomponent";
 
-export default function Page({ params }: { readonly params: { id: number } }) {
-  const customFormats = {
-    phone: /\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}$/,
-    "postal-code":
-      /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i,
-    bc_corporate_registry_number: "^[A-Za-z]{1,3}\\d{7}$",
-  };
-  const validator = customizeValidator({ customFormats });
-  return (
-    <Form
-      schema={{
-        title: "A registration form",
-        description: "A simple form example.",
-        type: "object",
+export async function getDocuments() {
+  try {
+    return await actionHandler("registration/handle-file", "GET", "");
+  } catch (error) {
+    // Handle the error here or rethrow it to handle it at a higher level
+    throw error;
+  }
+}
 
-        properties: {
-          boundary_map: {
-            type: "string",
-            format: "data-url",
-            title: "Single file",
-          },
-          randomfield: {
-            type: "string",
-            title: "random extra field for testing what happens",
-          },
-        },
-      }}
-      validator={validator}
-      onSubmit={async (data) => {
-        console.log("data.formdata", data.formData);
-
-        const response = await actionHandler(
-          `registration/handle-file`,
-          "POST",
-          "",
-          // can't pass a File class to a server action so any dataURL transformation will have to happen middleware or backend
-          { body: JSON.stringify(data.formData) }
-        );
-
-        if (response.error) {
-          console.log("bad things happened");
-          return;
-        }
-      }}
-    />
-  );
+export default async function Page({
+  params,
+}: {
+  readonly params: { id: number };
+}) {
+  const documents = await getDocuments();
+  return <BriannaForm params={params} documents={documents} />;
 }

--- a/client/app/(authenticated)/idir/cas_admin/brianna/page.tsx
+++ b/client/app/(authenticated)/idir/cas_admin/brianna/page.tsx
@@ -33,7 +33,7 @@ export default function Page({ params }: { readonly params: { id: number } }) {
         type: "object",
 
         properties: {
-          file: {
+          boundary_map: {
             type: "string",
             format: "data-url",
             title: "Single file",
@@ -49,13 +49,13 @@ export default function Page({ params }: { readonly params: { id: number } }) {
         console.log("data.formdata", data.formData);
 
         const response = await actionHandler(
-          `registration/upload`,
+          `registration/handle-file`,
           "POST",
           "",
           // can't do this, can't pass a class to a server action
           // b might need to write a new handler for files --oh nooooo, it's probably middleware
           // dataURLtoFile(data.formData.file, "bri")
-          { body: JSON.stringify(data.formData) },
+          { body: JSON.stringify(data.formData) }
         );
 
         // const response = await fetch(


### PR DESCRIPTION
https://github.com/bcgov/cas-registration/issues/332

At this point, we can attach a file in a simple form, send it to the backend, and save it into the db and google bucket. We can also retrieve the file on the front-end and download it. Here's a loom of the exploration: https://www.loom.com/share/5e778beb18b64a73a92399614894653b

Learnings on file upload:
- the rjsf file widget stores a [dataurl](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) in the `formData`
- Django's `models.FileField` requires a file object. When you Document.objects.create(file=the ContentFile I made from the dataurl), django will put the file into the google bucket
- I decided to do the dataurl-to-file conversion in the endpoint and django ninja schemas. In this POC the form is very simple, but in the real app we're going to have multiple files in each form as well as form data, so the backend ~seems to be the most flexible. (I played with middleware but with full form data it would be a lot more complicated, and I'm not sure I successfully transformed the file anyway)

To test this PR:
- add GS_BUCKET_NAME and GOOGLE_APPLICATION_CREDENTIALS to your env (see 1password_
**To mimic an industry user:**
- login to the app with your idir
- navigate to `http://localhost:3000/brianna`
- upload a file and submit the form (doesn't matter if you fill out the extra random field)
- psql into the db and see that your file is in the Document table
- go into google storage and see that your file is in the bucket
**To mimic an IRC user who is reviewing the form:**
- go back to the form in the browser and refresh. your file is still there and you can 
