### PR TITLE
fix: handle form state externally to prevent data loss on error

### DIFF
--- a/client/app/components/form/FormBase.tsx
+++ b/client/app/components/form/FormBase.tsx
@@ -1,9 +1,10 @@
 import defaultTheme from "./defaultTheme";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { customizeValidator } from "@rjsf/validator-ajv8";
 import { FormProps, withTheme, ThemeProps } from "@rjsf/core";
 import { customTransformErrors } from "@/app/utils/customTransformErrors";
 import { RJSFValidationError } from "@rjsf/utils";
+import { IChangeEvent } from "@rjsf/core";
 
 const customFormats = {
   phone: /\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}$/,
@@ -35,13 +36,21 @@ interface FormPropsWithTheme<T> extends Omit<FormProps<T>, "validator"> {
 const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
   const { theme, formData, omitExtraData } = props;
   const Form = useMemo(() => withTheme(theme ?? defaultTheme), [theme]);
+  const [formState, setFormState] = useState(formData ?? {});
+
+  // Handling form state externally as RJSF was resetting the form data on submission and
+  // creating buggy behaviour if there was an API error and the user attempted to resubmit
+  const handleChange = (e: IChangeEvent) => {
+    setFormState(e.formData);
+  };
 
   return (
     <Form
       {...props}
-      formData={formData ?? {}}
+      formData={formState}
       noHtml5Validate
       omitExtraData={omitExtraData ?? true}
+      onChange={handleChange}
       showErrorList={false}
       transformErrors={transformErrors}
       validator={validator}

--- a/client/app/components/form/FormBase.tsx
+++ b/client/app/components/form/FormBase.tsx
@@ -31,16 +31,18 @@ const validator = customizeValidator({ customFormats });
 interface FormPropsWithTheme<T> extends Omit<FormProps<T>, "validator"> {
   theme?: ThemeProps;
   validator?: any;
+  setErrorReset?: (error: undefined) => void;
 }
 
 const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
-  const { theme, formData, omitExtraData } = props;
+  const { theme, formData, omitExtraData, setErrorReset } = props;
   const Form = useMemo(() => withTheme(theme ?? defaultTheme), [theme]);
   const [formState, setFormState] = useState(formData ?? {});
 
   // Handling form state externally as RJSF was resetting the form data on submission and
   // creating buggy behaviour if there was an API error and the user attempted to resubmit
   const handleChange = (e: IChangeEvent) => {
+    if (setErrorReset) setErrorReset(undefined);
     setFormState(e.formData);
   };
 

--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -13,6 +13,7 @@ interface MultiStepFormProps {
   formData?: any;
   onSubmit: any;
   schema: any;
+  setErrorReset?: (error: undefined) => void;
   showSubmissionStep?: boolean;
   allowBackNavigation?: boolean;
   uiSchema: any;
@@ -26,6 +27,7 @@ const MultiStepFormBase = ({
   formData,
   onSubmit,
   schema,
+  setErrorReset,
   showSubmissionStep,
   allowBackNavigation,
   uiSchema,
@@ -53,6 +55,7 @@ const MultiStepFormBase = ({
         readonly={disabled}
         onSubmit={onSubmit}
         formData={formData}
+        setErrorReset={setErrorReset}
       >
         {error && <Alert severity="error">{error}</Alert>}
         <MultiStepButtons

--- a/client/app/components/form/OperationsForm.tsx
+++ b/client/app/components/form/OperationsForm.tsx
@@ -88,6 +88,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
           baseUrl={`/dashboard/operations/${operationId}`}
           cancelUrl="/dashboard/operations"
           formData={transformedFormData}
+          setErrorReset={setError}
           disabled={
             session?.user.app_role?.includes("cas") ||
             formData?.status === Status.PENDING

--- a/client/app/components/form/UserOperatorContactForm.tsx
+++ b/client/app/components/form/UserOperatorContactForm.tsx
@@ -27,7 +27,7 @@ export default function UserOperatorContactForm({
   const { push, back } = useRouter();
   const params = useParams();
   const searchParams = useSearchParams();
-  const [errorList, setErrorList] = useState([] as any[]);
+  const [error, setError] = useState(undefined);
 
   const submitHandler = async (data: { formData?: UserOperatorFormData }) => {
     const newFormData = {
@@ -56,7 +56,7 @@ export default function UserOperatorContactForm({
         );
 
     if (response.error) {
-      setErrorList([{ message: response.error }]);
+      setError(response.error);
       return;
     }
 
@@ -72,13 +72,9 @@ export default function UserOperatorContactForm({
       formData={formData}
       onSubmit={submitHandler}
       uiSchema={userOperatorUiSchema}
+      setErrorReset={setError}
     >
-      {errorList.length > 0 &&
-        errorList.map((e: any) => (
-          <Alert key={e.message} severity="error">
-            {e.message}
-          </Alert>
-        ))}
+      {error && <Alert severity="error">{error}</Alert>}
       <div className={"flex my-8 justify-between"}>
         <Button variant="outlined" onClick={() => back()}>
           Cancel

--- a/client/app/components/form/UserOperatorContactForm.tsx
+++ b/client/app/components/form/UserOperatorContactForm.tsx
@@ -28,16 +28,11 @@ export default function UserOperatorContactForm({
   const params = useParams();
   const searchParams = useSearchParams();
   const [errorList, setErrorList] = useState([] as any[]);
-  const [formState, setFormState] = useState(formData);
 
   const submitHandler = async (data: { formData?: UserOperatorFormData }) => {
     const newFormData = {
-      ...formState,
       ...data.formData,
     } as UserOperatorFormData;
-
-    // to prevent resetting the form state when errors occur
-    setFormState(newFormData);
 
     // add user operator id to form data if it exists (to be used in senior officer creation)
     newFormData.user_operator_id =
@@ -74,7 +69,7 @@ export default function UserOperatorContactForm({
     <FormBase
       schema={schema}
       readonly={readonly}
-      formData={formState}
+      formData={formData}
       onSubmit={submitHandler}
       uiSchema={userOperatorUiSchema}
     >

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -51,7 +51,7 @@ export default function UserOperatorMultiStepForm({
       `/dashboard/select-operator/user-operator/create/${params?.formSection}`,
       {
         body: JSON.stringify(newFormData),
-      }
+      },
     );
 
     if (response.error) {
@@ -61,7 +61,7 @@ export default function UserOperatorMultiStepForm({
 
     if (isFinalStep) {
       push(
-        `/dashboard/select-operator/received/add-operator/${response.operator_id}`
+        `/dashboard/select-operator/received/add-operator/${response.operator_id}`,
       );
       return;
     }
@@ -69,7 +69,7 @@ export default function UserOperatorMultiStepForm({
     push(
       `/dashboard/select-operator/user-operator/create/${
         formSection + 2
-      }?user-operator-id=${response.user_operator_id}`
+      }?user-operator-id=${response.user_operator_id}`,
     );
   }; // If the user is an approved cas internal user or if no operator exists show the entire multistep form
   const isCasInternal =
@@ -107,6 +107,7 @@ export default function UserOperatorMultiStepForm({
           schema={schema}
           disabled={isCasInternal ?? disabled}
           error={error}
+          setErrorReset={setError}
           formData={formData}
           onSubmit={submitHandler}
           uiSchema={userOperatorUiSchema}

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -27,7 +27,6 @@ export default function UserOperatorMultiStepForm({
   const params = useParams();
   const searchParams = useSearchParams();
   const [error, setError] = useState(undefined);
-  const [formState, setFormState] = useState(formData);
   const formSection = parseInt(params?.formSection as string) - 1;
   const formSectionList = Object.keys(schema.properties as RJSFSchema);
   const isFinalStep = formSection === formSectionList.length - 1;
@@ -36,11 +35,8 @@ export default function UserOperatorMultiStepForm({
     searchParams.get("user-operator-id") || (params?.id as string);
   const submitHandler = async (data: { formData?: UserOperatorFormData }) => {
     const newFormData = {
-      ...formState,
       ...data.formData,
     } as UserOperatorFormData;
-    // to prevent resetting the form state when errors occur
-    setFormState(newFormData);
 
     // add user operator id to form data if it exists (to be used in senior officer creation)
     if (userOperatorId) newFormData.user_operator_id = userOperatorId;
@@ -55,7 +51,7 @@ export default function UserOperatorMultiStepForm({
       `/dashboard/select-operator/user-operator/create/${params?.formSection}`,
       {
         body: JSON.stringify(newFormData),
-      },
+      }
     );
 
     if (response.error) {
@@ -65,7 +61,7 @@ export default function UserOperatorMultiStepForm({
 
     if (isFinalStep) {
       push(
-        `/dashboard/select-operator/received/add-operator/${response.operator_id}`,
+        `/dashboard/select-operator/received/add-operator/${response.operator_id}`
       );
       return;
     }
@@ -73,7 +69,7 @@ export default function UserOperatorMultiStepForm({
     push(
       `/dashboard/select-operator/user-operator/create/${
         formSection + 2
-      }?user-operator-id=${response.user_operator_id}`,
+      }?user-operator-id=${response.user_operator_id}`
     );
   }; // If the user is an approved cas internal user or if no operator exists show the entire multistep form
   const isCasInternal =


### PR DESCRIPTION
Fixes #528 

More explanation and steps to reproduce the bug/check that it's fixed in the issue. I couldn't find anything in RJSF form props that looked like it would handle this: 

https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/form-props/

The easy fix is handling form state externally though let me know if you have other ideas!