### PR TITLE
556 disable form buttons on submit

### DIFF
--- a/client/app/components/form/MultiStepButtons.tsx
+++ b/client/app/components/form/MultiStepButtons.tsx
@@ -6,26 +6,29 @@ import Link from "next/link";
 
 interface SubmitButtonProps {
   baseUrl: string;
-  disabled?: boolean;
   cancelUrl: string;
   classNames?: string;
+  disabled?: boolean;
+  isSubmitting: boolean;
   step: number;
   steps: string[];
   allowBackNavigation?: boolean;
 }
 
 const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
+  allowBackNavigation,
   baseUrl,
-  disabled,
-  step,
-  steps,
   cancelUrl,
   classNames,
-  allowBackNavigation,
+  disabled,
+  isSubmitting,
+  step,
+  steps,
 }) => {
   const { pending } = useFormStatus();
   const isFinalStep = step === steps.length - 1;
-  const isDisabled = disabled || pending;
+  const isDisabled = disabled || pending || isSubmitting;
+
   return (
     <div className={`flex w-full mt-8 justify-between ${classNames}`}>
       {cancelUrl && (
@@ -65,7 +68,11 @@ const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
         {/* When the form is not editable (e.g., IRC staff is reviewing an operation), the form should not be submitted when navigating between steps */}
         {!isFinalStep && disabled && (
           <Link href={`${baseUrl}/${step + 2}`}>
-            <Button variant="contained" type="button" disabled={isFinalStep}>
+            <Button
+              variant="contained"
+              type="button"
+              disabled={isFinalStep || isSubmitting}
+            >
               Next
             </Button>
           </Link>

--- a/client/app/components/form/MultiStepButtons.tsx
+++ b/client/app/components/form/MultiStepButtons.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@mui/material";
-import { useFormStatus } from "react-dom";
 import Link from "next/link";
 
 interface SubmitButtonProps {
@@ -25,9 +24,8 @@ const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
   step,
   steps,
 }) => {
-  const { pending } = useFormStatus();
   const isFinalStep = step === steps.length - 1;
-  const isDisabled = disabled || pending || isSubmitting;
+  const isDisabled = disabled || isSubmitting;
 
   return (
     <div className={`flex w-full mt-8 justify-between ${classNames}`}>

--- a/client/app/components/form/MultiStepButtons.tsx
+++ b/client/app/components/form/MultiStepButtons.tsx
@@ -55,18 +55,8 @@ const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
             </Button>
           ))}
         {/* When the form is editable, the form should be submitted when navigating between steps */}
-        {!disabled && (
-          <Button
-            type="submit"
-            aria-disabled={isDisabled}
-            disabled={isDisabled}
-            variant="contained"
-          >
-            {!isFinalStep ? "Next" : "Submit"}
-          </Button>
-        )}
         {/* When the form is not editable (e.g., IRC staff is reviewing an operation), the form should not be submitted when navigating between steps */}
-        {!isFinalStep && disabled && (
+        {!isFinalStep && disabled ? (
           <Link href={`${baseUrl}/${step + 2}`}>
             <Button
               variant="contained"
@@ -76,6 +66,15 @@ const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
               Next
             </Button>
           </Link>
+        ) : (
+          <Button
+            type="submit"
+            aria-disabled={isDisabled}
+            disabled={isDisabled}
+            variant="contained"
+          >
+            {!isFinalStep ? "Next" : "Submit"}
+          </Button>
         )}
       </div>
     </div>

--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -48,10 +48,13 @@ const MultiStepFormBase = ({
     ? [...mapSectionTitles, "Submission"]
     : mapSectionTitles;
 
+  // Set isSubmitting to true to disable submit buttons and prevent multiple form submissions
   const submitHandler = async (data: any) => {
     setIsSubmitting(true);
     const response = await onSubmit(data);
 
+    // If there is an error, set isSubmitting to false to re-enable submit buttons
+    // and allow user to attempt to re-submit the form
     if (response?.error) {
       setIsSubmitting(false);
     }

--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { useParams } from "next/navigation";
 import { RJSFSchema } from "@rjsf/utils";
 import { Alert } from "@mui/material";
@@ -32,6 +35,7 @@ const MultiStepFormBase = ({
   allowBackNavigation,
   uiSchema,
 }: MultiStepFormProps) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const params = useParams();
   const formSection = parseInt(params?.formSection as string) - 1;
 
@@ -44,6 +48,14 @@ const MultiStepFormBase = ({
     ? [...mapSectionTitles, "Submission"]
     : mapSectionTitles;
 
+  const submitHandler = async (data: any) => {
+    setIsSubmitting(true);
+    await onSubmit(data);
+    setIsSubmitting(false);
+  };
+
+  const isDisabled = disabled || isSubmitting;
+
   return (
     <>
       <MultiStepHeader step={formSection} steps={formSectionTitles} />
@@ -51,15 +63,16 @@ const MultiStepFormBase = ({
         className="[&>div>fieldset]:min-h-[40vh]"
         schema={schema.properties[formSectionList[formSection]] as RJSFSchema}
         uiSchema={uiSchema}
-        disabled={disabled}
-        readonly={disabled}
-        onSubmit={onSubmit}
+        disabled={isDisabled}
+        readonly={isDisabled}
+        onSubmit={submitHandler}
         formData={formData}
         setErrorReset={setErrorReset}
       >
         {error && <Alert severity="error">{error}</Alert>}
         <MultiStepButtons
-          disabled={disabled}
+          disabled={isDisabled}
+          isSubmitting={isSubmitting}
           step={formSection}
           steps={formSectionList}
           baseUrl={baseUrl}

--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -50,8 +50,11 @@ const MultiStepFormBase = ({
 
   const submitHandler = async (data: any) => {
     setIsSubmitting(true);
-    await onSubmit(data);
-    setIsSubmitting(false);
+    const response = await onSubmit(data);
+
+    if (response?.error) {
+      setIsSubmitting(false);
+    }
   };
 
   const isDisabled = disabled || isSubmitting;

--- a/client/app/components/form/OperationsForm.tsx
+++ b/client/app/components/form/OperationsForm.tsx
@@ -110,7 +110,9 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
 
             if (response.error) {
               setError(response.error);
-              return;
+              // return error so MultiStepFormBase can re-enable the submit button
+              // so user can attempt to submit again
+              return { error: response.error };
             }
 
             router.replace(`/dashboard/operations/${operation}/${formSection}`);

--- a/client/app/components/form/OperationsForm.tsx
+++ b/client/app/components/form/OperationsForm.tsx
@@ -111,7 +111,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
             if (response.error) {
               setError(response.error);
               // return error so MultiStepFormBase can re-enable the submit button
-              // so user can attempt to submit again
+              // and user can attempt to submit again
               return { error: response.error };
             }
 

--- a/client/app/components/form/SubmitButton.tsx
+++ b/client/app/components/form/SubmitButton.tsx
@@ -18,6 +18,7 @@ const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
       variant="contained"
       type="submit"
       aria-disabled={disabled || pending}
+      disabled={disabled || pending}
     >
       {label}
     </Button>

--- a/client/app/components/form/SubmitButton.tsx
+++ b/client/app/components/form/SubmitButton.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@mui/material";
-import { useFormStatus } from "react-dom";
 
 interface SubmitButtonProps {
   label: string;
@@ -12,13 +11,12 @@ const SubmitButton: React.FunctionComponent<SubmitButtonProps> = ({
   label,
   disabled,
 }) => {
-  const { pending } = useFormStatus();
   return (
     <Button
       variant="contained"
       type="submit"
-      aria-disabled={disabled || pending}
-      disabled={disabled || pending}
+      aria-disabled={disabled}
+      disabled={disabled}
     >
       {label}
     </Button>

--- a/client/app/components/form/UserOperatorContactForm.tsx
+++ b/client/app/components/form/UserOperatorContactForm.tsx
@@ -28,8 +28,10 @@ export default function UserOperatorContactForm({
   const params = useParams();
   const searchParams = useSearchParams();
   const [error, setError] = useState(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const submitHandler = async (data: { formData?: UserOperatorFormData }) => {
+    setIsSubmitting(true);
     const newFormData = {
       ...data.formData,
     } as UserOperatorFormData;
@@ -57,6 +59,7 @@ export default function UserOperatorContactForm({
 
     if (response.error) {
       setError(response.error);
+      setIsSubmitting(false);
       return;
     }
 
@@ -79,7 +82,7 @@ export default function UserOperatorContactForm({
         <Button variant="outlined" onClick={() => back()}>
           Cancel
         </Button>
-        <SubmitButton label="Submit" />
+        <SubmitButton disabled={isSubmitting} label="Submit" />
       </div>
     </FormBase>
   );

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -56,7 +56,9 @@ export default function UserOperatorMultiStepForm({
 
     if (response.error) {
       setError(response.error);
-      return;
+      // return error so MultiStepFormBase can re-enable the submit button
+      // so user can attempt to submit again
+      return { error: response.error };
     }
 
     if (isFinalStep) {

--- a/client/app/components/form/UserOperatorMultiStepForm.tsx
+++ b/client/app/components/form/UserOperatorMultiStepForm.tsx
@@ -57,7 +57,7 @@ export default function UserOperatorMultiStepForm({
     if (response.error) {
       setError(response.error);
       // return error so MultiStepFormBase can re-enable the submit button
-      // so user can attempt to submit again
+      // and user can attempt to submit again
       return { error: response.error };
     }
 


### PR DESCRIPTION
Implements #556

This disabled the form buttons on submit in forms that use the `MultistepFormBase` as well as the single `UserOperatorContactForm`.

If there is an error during form submission we reenable the submit buttons.