### PR TITLE
469 make operator table match wireframe

### DIFF
--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -5,7 +5,7 @@ import {
   UserOperatorStatus,
 } from "@/app/utils/users/adminUserOperators";
 import { ChangeUserOperatorStatusColumnCell } from "@/app/components/datagrid/ChangeUserOperatorStatusColumnCell";
-import { statusStyle } from "@/app/components/datagrid/userPageHelpers";
+import { statusStyle } from "@/app/components/datagrid/helpers";
 
 export default async function Page() {
   const userOperatorStatuses: UserOperatorStatus[] =

--- a/client/app/(authenticated)/idir/cas_admin/dashboard/operators/page.tsx
+++ b/client/app/(authenticated)/idir/cas_admin/dashboard/operators/page.tsx
@@ -1,19 +1,11 @@
 import { Suspense } from "react";
 import AccessRequests from "@/app/components/routes/access-requests/AccessRequests";
 import Loading from "@/app/components/loading/SkeletonGrid";
-import Note from "@/app/components/datagrid/Note";
 
 export default function Page() {
   return (
-    <>
-      <Note
-        message="Once “Approved”, the user will have access to their
-      operator dashboard with full admin permissions, and can grant access and
-      designate permissions to other Business BCeID holders there."
-      />
-      <Suspense fallback={<Loading />}>
-        <AccessRequests />
-      </Suspense>
-    </>
+    <Suspense fallback={<Loading />}>
+      <AccessRequests />
+    </Suspense>
   );
 }

--- a/client/app/(authenticated)/idir/cas_analyst/dashboard/operators/page.tsx
+++ b/client/app/(authenticated)/idir/cas_analyst/dashboard/operators/page.tsx
@@ -1,19 +1,11 @@
 import { Suspense } from "react";
 import AccessRequests from "@/app/components/routes/access-requests/AccessRequests";
 import Loading from "@/app/components/loading/SkeletonGrid";
-import Note from "@/app/components/datagrid/Note";
 
 export default function Page() {
   return (
-    <>
-      <Note
-        message="Once “Approved”, the user will have access to their
-        operator dashboard with full admin permissions, and can grant access and
-        designate permissions to other Business BCeID holders there."
-      />
-      <Suspense fallback={<Loading />}>
-        <AccessRequests />
-      </Suspense>
-    </>
+    <Suspense fallback={<Loading />}>
+      <AccessRequests />
+    </Suspense>
   );
 }

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -117,6 +117,7 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
       <MuiGrid
         rows={rows}
         columns={customColumns}
+        showCellVerticalBorder
         components={{
           ColumnSortedAscendingIcon: AscendingIcon,
           ColumnSortedDescendingIcon: DescendingIcon,

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -8,6 +8,7 @@ import {
 } from "@mui/x-data-grid";
 import Link from "next/link";
 import { Button } from "@mui/material";
+import { BC_GOV_BACKGROUND_COLOR_BLUE } from "@/app/styles/colors";
 
 interface Props {
   rows: GridRowsProp;
@@ -76,7 +77,36 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
 
   return (
     <div style={{ height: "auto", width: "100%" }}>
-      <MuiGrid rows={rows} columns={customColumns} disableVirtualization />
+      <MuiGrid
+        rows={rows}
+        columns={customColumns}
+        sx={{
+          "& .MuiSvgIcon-root": {
+            color: "white",
+          },
+          "& .MuiDataGrid-columnHeader": {
+            border: "1px white solid",
+            borderBottom: "none",
+            borderTop: "none",
+            color: "white",
+            backgroundColor: BC_GOV_BACKGROUND_COLOR_BLUE,
+            fontWeight: "bold",
+          },
+          "& .MuiDataGrid-columnHeader:first-child": {
+            borderLeft: "none",
+          },
+          "& .MuiDataGrid-columnHeader:last-child": {
+            borderRight: "none",
+          },
+          "& .MuiDataGrid-columnHeaderTitle": {
+            fontWeight: "bold",
+          },
+          "& .MuiDataGrid-columnSeparator": {
+            display: "none",
+          },
+        }}
+        disableVirtualization
+      />
     </div>
   );
 };

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -68,7 +68,7 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
                 <div>
                   {/* 🔗 Add reg or details link */}
                   <Link href={`operations/${params.row.id}/1`}>
-                    <Button variant="contained">
+                    <Button variant="contained" className="text-bc-links-color">
                       {params.row.status === "Not Registered"
                         ? "Start Registration"
                         : "View Details"}
@@ -92,8 +92,11 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
               renderCell: (params: GridRenderCellParams) => (
                 <div>
                   {/* Link to the first page of the multistep form for a specific user-operator. The '1' represents the first formSection of the form. */}
-                  <Link href={`operators/user-operator/${params.row.id}/1`}>
-                    <Button variant="contained">View Details</Button>
+                  <Link
+                    className="no-underline text-bc-link-blue"
+                    href={`operators/user-operator/${params.row.id}/1`}
+                  >
+                    View Details
                   </Link>
                 </div>
               ),

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -140,7 +140,9 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
             fontWeight: "bold",
             justifyContent: "center",
           },
-
+          "& .MuiDataGrid-columnHeaders": {
+            backgroundColor: BC_GOV_BACKGROUND_COLOR_BLUE,
+          },
           "& .MuiDataGrid-columnHeader:first-child": {
             borderLeft: "none",
           },

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -118,6 +118,7 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
         rows={rows}
         columns={customColumns}
         showCellVerticalBorder
+        hideFooter
         components={{
           ColumnSortedAscendingIcon: AscendingIcon,
           ColumnSortedDescendingIcon: DescendingIcon,

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -16,6 +16,40 @@ interface Props {
   cntxt?: string;
 }
 
+interface SortIconProps {
+  topFill?: string;
+  bottomFill?: string;
+}
+
+const SortIcon = ({ topFill, bottomFill }: SortIconProps) => {
+  return (
+    <svg
+      width="10"
+      height="15"
+      viewBox="0 0 10 15"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9.32714 5.86914L0.672861 5.86914C0.0741596 5.86914 -0.225192 5.12087 0.198608 4.68235L4.52407 0.203175C4.78642 -0.0682907 5.21358 -0.0682907 5.47593 0.203175L9.80139 4.68235C10.2252 5.12087 9.92584 5.86914 9.32714 5.86914Z"
+        fill={topFill || "white"}
+      />
+      <path
+        d="M0.672861 9.13086H9.32714C9.92584 9.13086 10.2252 9.87913 9.80139 10.3176L5.47593 14.7968C5.21358 15.0683 4.78642 15.0683 4.52407 14.7968L0.198608 10.3176C-0.225193 9.87913 0.0741586 9.13086 0.672861 9.13086Z"
+        fill={bottomFill || "white"}
+      />
+    </svg>
+  );
+};
+
+const AscendingIcon = () => {
+  return <SortIcon topFill="grey" bottomFill="white" />;
+};
+
+const DescendingIcon = () => {
+  return <SortIcon topFill="white" bottomFill="grey" />;
+};
+
 const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
   // 📚  Define a state variable to store columns
   const [customColumns, setCustomColumns] = useState<GridColDef[]>(columns);
@@ -80,12 +114,17 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
       <MuiGrid
         rows={rows}
         columns={customColumns}
+        components={{
+          ColumnSortedAscendingIcon: AscendingIcon,
+          ColumnSortedDescendingIcon: DescendingIcon,
+          ColumnUnsortedIcon: SortIcon,
+        }}
         sx={{
           "& .MuiSvgIcon-root": {
             color: "white",
           },
           "& .MuiDataGrid-columnHeaderDraggableContainer": {
-            flex: 0,
+            minWidth: "100%",
           },
           "& .MuiDataGrid-columnHeader": {
             border: "1px white solid",
@@ -103,11 +142,19 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
           "& .MuiDataGrid-columnHeader:last-child": {
             borderRight: "none",
           },
+          "& .MuiDataGrid-columnHeaderTitleContainer": {
+            justifyContent: "space-between",
+          },
+          "& .MuiDataGrid-columnHeaderTitleContainerContent": {
+            flex: 1,
+          },
           "& .MuiDataGrid-columnHeaderTitle": {
             fontWeight: "bold",
             whiteSpace: "pre-line",
             lineHeight: "normal",
             textAlign: "center",
+            width: "100%",
+            minWidth: "100%",
           },
           "& .MuiDataGrid-columnSeparator": {
             display: "none",
@@ -115,6 +162,17 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
           "& .MuiDataGrid-cell": {
             justifyContent: "center",
             textAlign: "center",
+          },
+          ".MuiDataGrid-iconButtonContainer": {
+            visibility: "visible !important",
+            minWidth: "20px",
+          },
+          "& .MuiDataGrid-sortIcon": {
+            opacity: "inherit !important",
+          },
+          // We may want tor eenable this functionality though it's not in the design
+          ".MuiDataGrid-menuIcon": {
+            display: "none",
           },
         }}
         disableVirtualization

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -174,7 +174,8 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
           "& .MuiDataGrid-sortIcon": {
             opacity: "inherit !important",
           },
-          // We may want tor eenable this functionality though it's not in the design
+          // This hides the 3 dots menu that had additional options for each row
+          // We may want to renable this menu though it's not in the design
           ".MuiDataGrid-menuIcon": {
             display: "none",
           },

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -84,6 +84,9 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
           "& .MuiSvgIcon-root": {
             color: "white",
           },
+          "& .MuiDataGrid-columnHeaderDraggableContainer": {
+            flex: 0,
+          },
           "& .MuiDataGrid-columnHeader": {
             border: "1px white solid",
             borderBottom: "none",
@@ -91,7 +94,9 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
             color: "white",
             backgroundColor: BC_GOV_BACKGROUND_COLOR_BLUE,
             fontWeight: "bold",
+            justifyContent: "center",
           },
+
           "& .MuiDataGrid-columnHeader:first-child": {
             borderLeft: "none",
           },
@@ -100,9 +105,16 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
           },
           "& .MuiDataGrid-columnHeaderTitle": {
             fontWeight: "bold",
+            whiteSpace: "pre-line",
+            lineHeight: "normal",
+            textAlign: "center",
           },
           "& .MuiDataGrid-columnSeparator": {
             display: "none",
+          },
+          "& .MuiDataGrid-cell": {
+            justifyContent: "center",
+            textAlign: "center",
           },
         }}
         disableVirtualization

--- a/client/app/components/datagrid/Note.tsx
+++ b/client/app/components/datagrid/Note.tsx
@@ -2,12 +2,13 @@ export const registrationRequestNote =
   "Once “Approved”, the operation will be registered for the B.C. Output-Based Pricing System and exempted from the carbon tax.";
 
 interface Props {
+  classNames?: string;
   message: string;
 }
 
-const Note = ({ message }: Props) => {
+const Note = ({ classNames, message }: Props) => {
   return (
-    <div>
+    <div className={classNames}>
       <strong>Note: </strong>
       {message}
     </div>

--- a/client/app/components/datagrid/helpers.tsx
+++ b/client/app/components/datagrid/helpers.tsx
@@ -4,9 +4,6 @@ import { Status } from "@/app/utils/enums";
 import { Chip, ChipOwnProps } from "@mui/material";
 import { GridRenderCellParams } from "@mui/x-data-grid";
 
-const capitalizeFirstLetter = (label: string) =>
-  label.charAt(0).toUpperCase() + label.slice(1);
-
 export const statusStyle = (params: GridRenderCellParams) => {
   const colorMap = new Map<string, ChipOwnProps["color"]>([
     [Status.MYSELF, "primary"],
@@ -19,10 +16,10 @@ export const statusStyle = (params: GridRenderCellParams) => {
 
   return (
     <Chip
-      label={capitalizeFirstLetter(params.value)}
+      label={params.value}
       variant="outlined"
       color={statusColor}
-      sx={{ mx: "auto", width: 90 }}
+      sx={{ width: 90 }}
     ></Chip>
   );
 };

--- a/client/app/components/routes/access-requests/AccessRequests.tsx
+++ b/client/app/components/routes/access-requests/AccessRequests.tsx
@@ -62,22 +62,27 @@ export default async function AccessRequests() {
         cntxt="user-operators"
         rows={rows}
         columns={[
-          { field: "id", headerName: "Request ID", width: 150 },
-          { field: "first_name", headerName: "First Name", width: 150 },
-          { field: "last_name", headerName: "Last Name", width: 150 },
+          {
+            field: "id",
+            headerName: "Request\n ID",
+            width: 100,
+            headerClassName: "table-heading",
+          },
+          { field: "first_name", headerName: "First\n Name", width: 180 },
+          { field: "last_name", headerName: "Last\n Name", width: 180 },
           { field: "email", headerName: "Email", width: 300 },
-          { field: "legal_name", headerName: "Operator", width: 300 },
+          { field: "legal_name", headerName: "Operator", width: 380 },
           {
             field: "status",
             headerName: "Status",
-            width: 150,
+            width: 130,
             renderCell: statusStyle,
           },
           {
             field: "action",
             headerName: "Action",
             sortable: false,
-            width: 200,
+            width: 140,
           },
         ]}
       />

--- a/client/app/components/routes/access-requests/AccessRequests.tsx
+++ b/client/app/components/routes/access-requests/AccessRequests.tsx
@@ -66,7 +66,6 @@ export default async function AccessRequests() {
             field: "id",
             headerName: "Request\n ID",
             width: 100,
-            headerClassName: "table-heading",
           },
           { field: "first_name", headerName: "First\n Name", width: 180 },
           { field: "last_name", headerName: "Last\n Name", width: 180 },

--- a/client/app/components/routes/access-requests/AccessRequests.tsx
+++ b/client/app/components/routes/access-requests/AccessRequests.tsx
@@ -1,8 +1,10 @@
 import { GridRowsProp } from "@mui/x-data-grid";
+import Note from "@/app/components/datagrid/Note";
 
 import { actionHandler } from "@/app/utils/actions";
 import DataGrid from "@/app/components/datagrid/DataGrid";
 import { UserOperator } from "./types";
+import { statusStyle } from "@/app/components/datagrid/helpers";
 
 // 🛠️ Function to fetch user-operators
 async function getUserOperators() {
@@ -50,6 +52,12 @@ export default async function AccessRequests() {
   // Render the DataGrid component
   return (
     <>
+      <Note
+        classNames="mb-4 mt-6"
+        message="Once “Approved”, the user will have access to their
+      operator dashboard with full admin permissions, and can grant access and
+      designate permissions to other Business BCeID holders there."
+      />
       <DataGrid
         cntxt="user-operators"
         rows={rows}
@@ -59,7 +67,12 @@ export default async function AccessRequests() {
           { field: "last_name", headerName: "Last Name", width: 150 },
           { field: "email", headerName: "Email", width: 300 },
           { field: "legal_name", headerName: "Operator", width: 300 },
-          { field: "status", headerName: "Status", width: 150 },
+          {
+            field: "status",
+            headerName: "Status",
+            width: 150,
+            renderCell: statusStyle,
+          },
           {
             field: "action",
             headerName: "Action",

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -89,7 +89,8 @@ export default async function Operations() {
             field: "action",
             headerName: "Action",
             sortable: false,
-            width: 200,
+            // Temporary width, will be reduced in follow up PR #468 operations table
+            width: 500,
           },
         ]}
       />


### PR DESCRIPTION
Implements #469 

Acceptance criteria 1: I wrote a comment in the issue explaining that after a discussion it was decided to leave the `Request ID` column in for now and perhaps revisit post MVP.

Acceptance criteria 2: Admittedly I went far past the scope of this as it just said to add the status pill if it was easy. I started to make some improvements and got a bit carried away though I think it was worth spending a few hours on and looks very close to what is in the Figma designs. The `Datagrid` is now styled so the work will carry over to the `Operations` table style update.

The `Operations` table looks slightly weird due to this update, the `Action` column is still oversized though looks a bit off since the content is centered like the design. I'm working on the Operations table issue right now so it will look better soon.

<img width="1440" alt="Screenshot 2024-01-16 at 1 50 53 PM" src="https://github.com/bcgov/cas-registration/assets/14259474/fcc78495-7e31-4123-827c-e304fffb13dd">


