### PR TITLE
fix: prevent redirect on signout

### DIFF
--- a/client/app/components/navigation/Profile.tsx
+++ b/client/app/components/navigation/Profile.tsx
@@ -6,8 +6,8 @@ import { useEffect } from "react";
 // 🛠️ Function for nextauth and keycloak session logouts
 async function keycloakSessionLogOut() {
   try {
-    // call nextauth logout
-    await signOut();
+    // call nextauth logout preventing redirect
+    await signOut({ redirect: false });
     // redirect to Keycloak logout
     open(process.env.NEXT_PUBLIC_KEYCLOAK_LOGOUT_URL, "_self");
   } catch (err) {


### PR DESCRIPTION
WIP:

**Issue:** https://cas-reg-frontend-dev.apps.silver.devops.gov.bc.ca/ Log Out flow returns to `/home` instead of  the expected `xx/openid-connect/logout` page and SiteMinder-Keycloak logout is not completed (as seen in cookie values)
![image](https://github.com/bcgov/cas-registration/assets/120038448/cf488eb0-2958-4050-b95f-eb12c31c658a)


**Troubleshooting**
Locally, the SiteMinder-Keycloak logout page is displayed and  **seems** to initiate a complete SiteMinder-Keycloak logout (as seen in cookie values) allowing for multiple user login-logout-login.

![image](https://github.com/bcgov/cas-registration/assets/120038448/d0f6cce1-383b-433b-b7b9-1baffd89f51a)

Perhaps, the DEV server's redirect callback after SignOut overrides the navigation to the SiteMinder-Keycloak logout page.

**Possible Resolution**
Prevent any SignOut app callback redirect: `  await signOut({ redirect: false });`
