### PR TITLE
fix: allow custom redirect

### DIFF
--- a/client/app/api/auth/[...nextauth]/route.ts
+++ b/client/app/api/auth/[...nextauth]/route.ts
@@ -70,7 +70,7 @@ export const authOptions: NextAuthOptions = {
           // 🚀 API call: Get user app_role by user_guid from user table
           const responseRole = await actionHandler(
             `registration/user-app-role/${token.user_guid}`,
-            "GET"
+            "GET",
           );
           if (responseRole?.role_name) {
             // user found in table, assign role to token (note: all industry users have the same app role of `industry_user`, and their permissions are further defined by their role in the UserOperator model)
@@ -81,7 +81,7 @@ export const authOptions: NextAuthOptions = {
                 // 🚀 API call: check if user is admin approved
                 const responseAdmin = await actionHandler(
                   `registration/is-approved-admin-user-operator/${token.user_guid}`,
-                  "GET"
+                  "GET",
                 );
                 if (responseAdmin?.approved) {
                   token.app_role = "industry_user_admin"; // note: industry_user_admin a front-end only role. In the db, all industry users have an industry_user app_role, and their permissions are further defined by UserOperator.role

--- a/client/app/api/auth/[...nextauth]/route.ts
+++ b/client/app/api/auth/[...nextauth]/route.ts
@@ -70,7 +70,7 @@ export const authOptions: NextAuthOptions = {
           // 🚀 API call: Get user app_role by user_guid from user table
           const responseRole = await actionHandler(
             `registration/user-app-role/${token.user_guid}`,
-            "GET",
+            "GET"
           );
           if (responseRole?.role_name) {
             // user found in table, assign role to token (note: all industry users have the same app role of `industry_user`, and their permissions are further defined by their role in the UserOperator model)
@@ -81,7 +81,7 @@ export const authOptions: NextAuthOptions = {
                 // 🚀 API call: check if user is admin approved
                 const responseAdmin = await actionHandler(
                   `registration/is-approved-admin-user-operator/${token.user_guid}`,
-                  "GET",
+                  "GET"
                 );
                 if (responseAdmin?.approved) {
                   token.app_role = "industry_user_admin"; // note: industry_user_admin a front-end only role. In the db, all industry users have an industry_user app_role, and their permissions are further defined by UserOperator.role
@@ -182,6 +182,18 @@ export const authOptions: NextAuthOptions = {
           app_role: token.app_role,
         },
       };
+    },
+    // 👇️ called anytime the user is redirected to a callback URL (e.g. on signin or signout).
+    // by default only URLs on the same URL as the site are allowed, you can use the redirect callback to customise that behaviour.
+    async redirect({ url, baseUrl }) {
+      // Allows relative callback URLs
+      if (url.startsWith("/")) return `${baseUrl}${url}`;
+      // Allows callback URLs on the same origin
+      else if (new URL(url).origin === baseUrl) return url;
+      // 🛸 Allow callbacks to identity server
+      else if (new URL(url).origin === process.env.SITEMINDER_AUTH_URL)
+        return url;
+      return baseUrl;
     },
   },
 };

--- a/client/app/components/navigation/Profile.tsx
+++ b/client/app/components/navigation/Profile.tsx
@@ -3,18 +3,6 @@ import Link from "@mui/material/Link";
 import { signIn, signOut, useSession } from "next-auth/react";
 import { useEffect } from "react";
 
-// 🛠️ Function for nextauth and keycloak session logouts
-async function keycloakSessionLogOut() {
-  try {
-    // call nextauth logout preventing redirect
-    await signOut({ redirect: false });
-    // redirect to Keycloak logout
-    open(process.env.NEXT_PUBLIC_KEYCLOAK_LOGOUT_URL, "_self");
-  } catch (err) {
-    console.error(err);
-  }
-}
-
 export default function Profile({ name }: { readonly name: string }) {
   /* use the NextAuth useSession hook to get session data, and if a specific error condition is met,
      triggers a forced sign-in using the "keycloak" provider to potentially resolve the error related to refreshing access tokens.*/
@@ -41,8 +29,9 @@ export default function Profile({ name }: { readonly name: string }) {
           variant="text"
           className="text-lg"
           onClick={() => {
-            //keycloak logout then nextauth logout
-            keycloakSessionLogOut();
+            signOut({
+              callbackUrl: process.env.NEXT_PUBLIC_KEYCLOAK_LOGOUT_URL,
+            });
           }}
         >
           Log Out


### PR DESCRIPTION
WIP:

**Issue:** https://cas-reg-frontend-dev.apps.silver.devops.gov.bc.ca/ Log Out flow stays on same page instead of  the expected `xx/openid-connect/logout` page and SiteMinder-Keycloak logout is not completed (as seen in cookie values)
![image](https://github.com/bcgov/cas-registration/assets/120038448/fbd2fcb0-2f77-449a-93a0-9fa87febca90)

**Troubleshooting**
Potentially, the open function fails to set the location href  because it is being prevented by security ensuring the window is in  "active interaction" state (activating or focusing a browser window in response to a user gesture).


**Possible Resolution**
Remove dependency on window.open and leverage nextauth signOut function's callbackUrl parameter in combination with customising nextauth route.ts redirect function to allow callbacks to the identity server.
