### PR TITLE
chore: update OUT schemas to allow for newly nullable fields

### DIFF
--- a/bc_obps/registration/schema/multiple_operator.py
+++ b/bc_obps/registration/schema/multiple_operator.py
@@ -17,7 +17,7 @@ class MultipleOperatorOut(ModelSchema):
     )
     mo_business_structure: str = Field(..., alias="business_structure")
     mo_website: Optional[str] = Field(None, alias="website")
-    mo_percentage_ownership: float = Field(None, alias="percentage_ownership")
+    mo_percentage_ownership: Optional[float] = Field(None, alias="percentage_ownership")
     mo_physical_street_address: str = Field(..., alias="physical_address.street_address")
     mo_physical_municipality: str = Field(..., alias="physical_address.municipality")
     mo_physical_province: str = Field(..., alias="physical_address.province")

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -69,7 +69,7 @@ class OperationUpdateIn(ModelSchema):
 class OperationOut(ModelSchema):
     # handling aliases and optional fields
     operator_id: int = Field(..., alias="operator.id")
-    naics_code_id: int = Field(..., alias="naics_code.id")
+    naics_code_id: int = Field(None, alias="naics_code.id")
     bcghg_id: Optional[str] = None
     opt_in: Optional[bool] = None
     verified_at: Optional[date] = None

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -69,7 +69,7 @@ class OperationUpdateIn(ModelSchema):
 class OperationOut(ModelSchema):
     # handling aliases and optional fields
     operator_id: int = Field(..., alias="operator.id")
-    naics_code_id: int = Field(None, alias="naics_code.id")
+    naics_code_id: Optional[int] = Field(None, alias="naics_code.id")
     bcghg_id: Optional[str] = None
     opt_in: Optional[bool] = None
     verified_at: Optional[date] = None

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -46,17 +46,17 @@ class UserOperatorOut(ModelSchema):
     trade_name: Optional[str] = Field("", alias="operator.trade_name")
     cra_business_number: Optional[int] = Field(None, alias="operator.cra_business_number")
     bc_corporate_registry_number: str = Field(
-        ..., regex=BC_CORPORATE_REGISTRY_REGEX, alias="operator.bc_corporate_registry_number"
+        None, regex=BC_CORPORATE_REGISTRY_REGEX, alias="operator.bc_corporate_registry_number"
     )
-    business_structure: str = Field(..., alias="operator.business_structure.name")
-    physical_street_address: str = Field(..., alias="operator.physical_address.street_address")
-    physical_municipality: str = Field(..., alias="operator.physical_address.municipality")
-    physical_province: str = Field(..., alias="operator.physical_address.province")
-    physical_postal_code: str = Field(..., alias="operator.physical_address.postal_code")
-    mailing_street_address: str = Field(..., alias="operator.mailing_address.street_address")
-    mailing_municipality: str = Field(..., alias="operator.mailing_address.municipality")
-    mailing_province: str = Field(..., alias="operator.mailing_address.province")
-    mailing_postal_code: str = Field(..., alias="operator.mailing_address.postal_code")
+    business_structure: str = Field(None, alias="operator.business_structure.name")
+    physical_street_address: str = Field(None, alias="operator.physical_address.street_address")
+    physical_municipality: str = Field(None, alias="operator.physical_address.municipality")
+    physical_province: str = Field(None, alias="operator.physical_address.province")
+    physical_postal_code: str = Field(None, alias="operator.physical_address.postal_code")
+    mailing_street_address: str = Field(None, alias="operator.mailing_address.street_address")
+    mailing_municipality: str = Field(None, alias="operator.mailing_address.municipality")
+    mailing_province: str = Field(None, alias="operator.mailing_address.province")
+    mailing_postal_code: str = Field(None, alias="operator.mailing_address.postal_code")
     website: Optional[str] = Field("", alias="operator.website")
     is_senior_officer: bool
     mailing_address_same_as_physical: bool

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -45,18 +45,18 @@ class UserOperatorOut(ModelSchema):
     legal_name: str = Field(..., alias="operator.legal_name")
     trade_name: Optional[str] = Field("", alias="operator.trade_name")
     cra_business_number: Optional[int] = Field(None, alias="operator.cra_business_number")
-    bc_corporate_registry_number: str = Field(
+    bc_corporate_registry_number: Optional[str] = Field(
         None, regex=BC_CORPORATE_REGISTRY_REGEX, alias="operator.bc_corporate_registry_number"
     )
-    business_structure: str = Field(None, alias="operator.business_structure.name")
-    physical_street_address: str = Field(None, alias="operator.physical_address.street_address")
-    physical_municipality: str = Field(None, alias="operator.physical_address.municipality")
-    physical_province: str = Field(None, alias="operator.physical_address.province")
-    physical_postal_code: str = Field(None, alias="operator.physical_address.postal_code")
-    mailing_street_address: str = Field(None, alias="operator.mailing_address.street_address")
-    mailing_municipality: str = Field(None, alias="operator.mailing_address.municipality")
-    mailing_province: str = Field(None, alias="operator.mailing_address.province")
-    mailing_postal_code: str = Field(None, alias="operator.mailing_address.postal_code")
+    business_structure: Optional[str] = Field(None, alias="operator.business_structure.name")
+    physical_street_address: Optional[str] = Field(None, alias="operator.physical_address.street_address")
+    physical_municipality: Optional[str] = Field(None, alias="operator.physical_address.municipality")
+    physical_province: Optional[str] = Field(None, alias="operator.physical_address.province")
+    physical_postal_code: Optional[str] = Field(None, alias="operator.physical_address.postal_code")
+    mailing_street_address: Optional[str] = Field(None, alias="operator.mailing_address.street_address")
+    mailing_municipality: Optional[str] = Field(None, alias="operator.mailing_address.municipality")
+    mailing_province: Optional[str] = Field(None, alias="operator.mailing_address.province")
+    mailing_postal_code: Optional[str] = Field(None, alias="operator.mailing_address.postal_code")
     website: Optional[str] = Field("", alias="operator.website")
     is_senior_officer: bool
     mailing_address_same_as_physical: bool


### PR DESCRIPTION
Some fields were made to be nullable in #616, these fields need a `None` default set in their OUT schemas so that requests for this information do not error out when that nullable data is null.