### PR TITLE
604 add doc upload page

### DIFF
--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -11,6 +11,8 @@ import MultiStepButtons from "./MultiStepButtons";
 interface MultiStepFormProps {
   baseUrl: string;
   cancelUrl: string;
+  // Optional array to override the default header titles
+  customHeaderTitles?: string[];
   error?: any;
   disabled?: boolean;
   formData?: any;
@@ -25,6 +27,7 @@ interface MultiStepFormProps {
 const MultiStepFormBase = ({
   baseUrl,
   cancelUrl,
+  customHeaderTitles,
   disabled,
   error,
   formData,
@@ -61,10 +64,14 @@ const MultiStepFormBase = ({
   };
 
   const isDisabled = disabled || isSubmitting;
+  const isCustomTitles = customHeaderTitles && customHeaderTitles.length > 0;
 
   return (
     <>
-      <MultiStepHeader step={formSection} steps={formSectionTitles} />
+      <MultiStepHeader
+        step={formSection}
+        steps={isCustomTitles ? customHeaderTitles : formSectionTitles}
+      />
       <FormBase
         className="[&>div>fieldset]:min-h-[40vh]"
         schema={schema.properties[formSectionList[formSection]] as RJSFSchema}

--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -66,6 +66,15 @@ const MultiStepFormBase = ({
   const isDisabled = disabled || isSubmitting;
   const isCustomTitles = customHeaderTitles && customHeaderTitles.length > 0;
 
+  if (
+    isCustomTitles &&
+    formSectionTitles.length !== customHeaderTitles.length
+  ) {
+    throw new Error(
+      "The number of custom header titles must match the number of form sections",
+    );
+  }
+
   return (
     <>
       <MultiStepHeader

--- a/client/app/components/form/MultiStepFormBase.tsx
+++ b/client/app/components/form/MultiStepFormBase.tsx
@@ -12,7 +12,7 @@ interface MultiStepFormProps {
   baseUrl: string;
   cancelUrl: string;
   // Optional array to override the default header titles
-  customHeaderTitles?: string[];
+  customStepNames?: string[];
   error?: any;
   disabled?: boolean;
   formData?: any;
@@ -27,7 +27,7 @@ interface MultiStepFormProps {
 const MultiStepFormBase = ({
   baseUrl,
   cancelUrl,
-  customHeaderTitles,
+  customStepNames,
   disabled,
   error,
   formData,
@@ -64,11 +64,11 @@ const MultiStepFormBase = ({
   };
 
   const isDisabled = disabled || isSubmitting;
-  const isCustomTitles = customHeaderTitles && customHeaderTitles.length > 0;
+  const isCustomStepNames = customStepNames && customStepNames.length > 0;
 
   if (
-    isCustomTitles &&
-    formSectionTitles.length !== customHeaderTitles.length
+    isCustomStepNames &&
+    formSectionTitles.length !== customStepNames.length
   ) {
     throw new Error(
       "The number of custom header titles must match the number of form sections",
@@ -79,7 +79,7 @@ const MultiStepFormBase = ({
     <>
       <MultiStepHeader
         step={formSection}
-        steps={isCustomTitles ? customHeaderTitles : formSectionTitles}
+        steps={isCustomStepNames ? customStepNames : formSectionTitles}
       />
       <FormBase
         className="[&>div>fieldset]:min-h-[40vh]"

--- a/client/app/components/form/MultiStepHeader.tsx
+++ b/client/app/components/form/MultiStepHeader.tsx
@@ -4,6 +4,9 @@ interface MultiStepHeaderProps {
 }
 
 const MultiStepHeader = ({ step, steps }: MultiStepHeaderProps) => {
+  // Reduce the width of the title if there are more than 2 steps
+  // so it will break onto a new line
+  const titleWidth = steps.length > 2 ? "lg:w-36" : "";
   return (
     <div className="block md:flex flex-row mt-10 mb-6 justify-between w-full">
       {steps.map((s, i) => {
@@ -23,7 +26,8 @@ const MultiStepHeader = ({ step, steps }: MultiStepHeaderProps) => {
             >
               {i + 1}
             </div>
-            <div className={`ml-4 h-min `}>{steps[i]}</div>
+            <div className={`ml-4 h-min w-full ${titleWidth}`}>{steps[i]}</div>
+
             {!isLastStep && (
               <div className="hidden lg:block mx-4 grow">
                 <hr className="border-black" />

--- a/client/app/components/form/MultiStepHeader.tsx
+++ b/client/app/components/form/MultiStepHeader.tsx
@@ -26,7 +26,7 @@ const MultiStepHeader = ({ step, steps }: MultiStepHeaderProps) => {
             >
               {i + 1}
             </div>
-            <div className={`ml-4 h-min w-full ${titleWidth}`}>{steps[i]}</div>
+            <div className={`ml-4 h-min ${titleWidth}`}>{steps[i]}</div>
 
             {!isLastStep && (
               <div className="hidden lg:block mx-4 grow">

--- a/client/app/components/form/OperationsForm.tsx
+++ b/client/app/components/form/OperationsForm.tsx
@@ -60,8 +60,8 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
         <MultiStepFormBase
           baseUrl={`/dashboard/operations/${operationId}`}
           cancelUrl="/dashboard/operations"
-          // Add custom titles since "Statutory Declaration" is truncated from the
-          // title that is in the schema
+          // Add custom titles since "Statutory Declaration" is different than the
+          // title in the schema "Statutory Declaration and Disclaimer"
           customHeaderTitles={[
             "Operation General Information",
             "Application Lead",

--- a/client/app/components/form/OperationsForm.tsx
+++ b/client/app/components/form/OperationsForm.tsx
@@ -62,7 +62,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
           cancelUrl="/dashboard/operations"
           // Add custom titles since "Statutory Declaration" is different than the
           // title in the schema "Statutory Declaration and Disclaimer"
-          customHeaderTitles={[
+          customStepNames={[
             "Operation General Information",
             "Application Lead",
             "Statutory Declaration",

--- a/client/app/components/form/OperationsForm.tsx
+++ b/client/app/components/form/OperationsForm.tsx
@@ -60,6 +60,13 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
         <MultiStepFormBase
           baseUrl={`/dashboard/operations/${operationId}`}
           cancelUrl="/dashboard/operations"
+          // Add custom titles since "Statutory Declaration" is truncated from the
+          // title that is in the schema
+          customHeaderTitles={[
+            "Operation General Information",
+            "Application Lead",
+            "Statutory Declaration",
+          ]}
           formData={formData}
           setErrorReset={setError}
           disabled={

--- a/client/app/components/form/defaultTheme.ts
+++ b/client/app/components/form/defaultTheme.ts
@@ -1,8 +1,13 @@
 import { ThemeProps, getDefaultRegistry } from "@rjsf/core";
 import * as widgets from "./widgets";
 import InlineFieldTemplate from "@/app/styles/rjsf/InlineFieldTemplate";
+import TitleFieldTemplate from "@/app/styles/rjsf/TitleFieldTemplate";
 
-const { fields, widgets: defaultWidgets } = getDefaultRegistry();
+const {
+  fields,
+  templates: defaultTemplates,
+  widgets: defaultWidgets,
+} = getDefaultRegistry();
 
 const formTheme: ThemeProps = {
   fields: {
@@ -13,8 +18,9 @@ const formTheme: ThemeProps = {
     ...widgets,
   },
   templates: {
-    ...getDefaultRegistry().templates,
+    ...defaultTemplates,
     FieldTemplate: InlineFieldTemplate,
+    TitleFieldTemplate,
   },
 };
 

--- a/client/app/components/form/titles/operationsTitles.tsx
+++ b/client/app/components/form/titles/operationsTitles.tsx
@@ -1,3 +1,22 @@
+export const StatutoryDeclarationDisclaimerTitle = (
+  <>
+    <b>Please note:</b>
+    <br />
+    <ul className="mt-0">
+      <li>
+        Information in this application will be shared with the Minister of
+        Finance and the name of the Operator and BORO ID may be disclosed [for
+        the purposes of administering the Carbon Tax Act][fuel
+        suppliers][publicly].
+      </li>
+      <li>
+        The Operator is responsible for determining their eligibility for an
+        exemption under the Carbon Tax Act.
+      </li>
+    </ul>
+  </>
+);
+
 export const StatutoryDeclarationUploadFieldTitle = (
   // Uncomment and replace the URL with the correct one when the template is ready in #645
   // <>

--- a/client/app/components/form/titles/operationsTitles.tsx
+++ b/client/app/components/form/titles/operationsTitles.tsx
@@ -1,5 +1,5 @@
 export const StatutoryDeclarationUploadFieldTitle = (
-  // Uncomment and replace the URL with the correct one when the template is ready
+  // Uncomment and replace the URL with the correct one when the template is ready in #645
   // <>
   //   Statutory Declaration
   //   <br />

--- a/client/app/components/form/titles/operationsTitles.tsx
+++ b/client/app/components/form/titles/operationsTitles.tsx
@@ -1,0 +1,12 @@
+export const StatutoryDeclarationTitle = (
+  // Uncomment and replace the URL with the correct one when the template is ready
+  // <>
+  //   Statutory Declaration
+  //   <br />
+  //   <span className="font-normal">
+  //     (Download <a href="TEMPLATE DOWNLOAD URL HERE">template</a>)
+  //   </span>
+  // </>
+  // Delete this line when the template is ready
+  <>Statutory Declaration</>
+);

--- a/client/app/components/form/titles/operationsTitles.tsx
+++ b/client/app/components/form/titles/operationsTitles.tsx
@@ -5,9 +5,7 @@ export const StatutoryDeclarationDisclaimerTitle = (
     <ul className="mt-0">
       <li>
         Information in this application will be shared with the Minister of
-        Finance and the name of the Operator and BORO ID may be disclosed [for
-        the purposes of administering the Carbon Tax Act][fuel
-        suppliers][publicly].
+        Finance and the name of the Operator and BORO ID may be disclosed.
       </li>
       <li>
         The Operator is responsible for determining their eligibility for an

--- a/client/app/components/form/titles/operationsTitles.tsx
+++ b/client/app/components/form/titles/operationsTitles.tsx
@@ -16,14 +16,11 @@ export const StatutoryDeclarationDisclaimerTitle = (
 );
 
 export const StatutoryDeclarationUploadFieldTitle = (
-  // Uncomment and replace the URL with the correct one when the template is ready in #645
-  // <>
-  //   Statutory Declaration
-  //   <br />
-  //   <span className="font-normal">
-  //     (Download <a href="TEMPLATE DOWNLOAD URL HERE">template</a>)
-  //   </span>
-  // </>
-  // Delete this line when the template is ready
-  <>Statutory Declaration</>
+  <>
+    Statutory Declaration
+    <br />
+    <span className="font-normal">
+      (Download <a href="TEMPLATE DOWNLOAD URL HERE">template</a>)
+    </span>
+  </>
 );

--- a/client/app/components/form/titles/operationsTitles.tsx
+++ b/client/app/components/form/titles/operationsTitles.tsx
@@ -1,4 +1,4 @@
-export const StatutoryDeclarationTitle = (
+export const StatutoryDeclarationUploadFieldTitle = (
   // Uncomment and replace the URL with the correct one when the template is ready
   // <>
   //   Statutory Declaration

--- a/client/app/styles/rjsf/FieldTemplate.tsx
+++ b/client/app/styles/rjsf/FieldTemplate.tsx
@@ -16,7 +16,11 @@ function FieldTemplate({
   const isLabel = uiSchema?.["ui:options"]?.label !== false;
 
   return (
-    <div style={style} className={`w-full ${classNames}`}>
+    <div
+      style={style}
+      // hide duplicate title <legend>
+      className={`w-full [&>fieldset>legend]:hidden ${classNames} `}
+    >
       {isLabel && label && (
         <label htmlFor={id} className="inline-block">
           {label}

--- a/client/app/styles/rjsf/FieldTemplate.tsx
+++ b/client/app/styles/rjsf/FieldTemplate.tsx
@@ -16,11 +16,7 @@ function FieldTemplate({
   const isLabel = uiSchema?.["ui:options"]?.label !== false;
 
   return (
-    <div
-      style={style}
-      // hide duplicate title <legend>
-      className={`w-full [&>fieldset>legend]:hidden ${classNames} `}
-    >
+    <div style={style} className={`w-full ${classNames} `}>
       {isLabel && label && (
         <label htmlFor={id} className="inline-block">
           {label}

--- a/client/app/styles/rjsf/InlineFieldTemplate.tsx
+++ b/client/app/styles/rjsf/InlineFieldTemplate.tsx
@@ -37,7 +37,10 @@ function InlineFieldTemplate({
   const error = rawErrors && rawErrors[0];
 
   // UI Schema options
-  const isLabel = uiSchema?.["ui:options"]?.label !== false;
+  const options = uiSchema?.["ui:options"] || {};
+  const jsxTitle = options?.jsxTitle as any;
+  const fieldLabel = jsxTitle ?? label;
+  const isLabel = options?.label !== false && fieldLabel;
 
   return (
     <Grid
@@ -55,10 +58,10 @@ function InlineFieldTemplate({
       }}
       className={classNames}
     >
-      {isLabel && label && (
+      {isLabel && (
         <Grid item xs={12} md={3} className="w-10">
           <label htmlFor={id} className="font-bold">
-            {label}
+            {fieldLabel}
             {required ? "*" : null}
           </label>
         </Grid>

--- a/client/app/styles/rjsf/InlineFieldTemplate.tsx
+++ b/client/app/styles/rjsf/InlineFieldTemplate.tsx
@@ -38,9 +38,7 @@ function InlineFieldTemplate({
 
   // UI Schema options
   const options = uiSchema?.["ui:options"] || {};
-  const jsxTitle = options?.jsxTitle as any;
-  const fieldLabel = jsxTitle ?? label;
-  const isLabel = options?.label !== false && fieldLabel;
+  const isLabel = options?.label !== false;
 
   return (
     <Grid
@@ -61,7 +59,7 @@ function InlineFieldTemplate({
       {isLabel && (
         <Grid item xs={12} md={3} className="w-10">
           <label htmlFor={id} className="font-bold">
-            {fieldLabel}
+            {label}
             {required ? "*" : null}
           </label>
         </Grid>

--- a/client/app/styles/rjsf/TitleFieldTemplate.tsx
+++ b/client/app/styles/rjsf/TitleFieldTemplate.tsx
@@ -1,0 +1,7 @@
+const TitleFieldTemplate = () => {
+  // RJSF isn't giving us access to 'ui:options' or 'ui:classNames' for customization
+  // so we're just going to return an empty fragment and handle the title in the field template
+  return <></>;
+};
+
+export default TitleFieldTemplate;

--- a/client/app/styles/rjsf/TitleOnlyFieldTemplate.tsx
+++ b/client/app/styles/rjsf/TitleOnlyFieldTemplate.tsx
@@ -6,14 +6,10 @@ function TitleOnlyFieldTemplate({
   id,
   style,
   label,
-  uiSchema,
 }: FieldTemplateProps) {
-  const options = uiSchema?.["ui:options"] || {};
-  const jsxTitle = options?.jsxTitle as any;
-
   return (
     <div style={style} className={`w-full my-8 ${classNames}`} id={id}>
-      {jsxTitle || label}
+      {label}
     </div>
   );
 }

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -415,12 +415,27 @@ const operationPage2: RJSFSchema = {
   ],
 };
 
+const operationPage3: RJSFSchema = {
+  type: "object",
+  title: "Statutory Declaration and Disclaimer",
+  // Uncomment this once documents are implemented
+  /*   required: ["statutory_declaration"], */
+  properties: {
+    statutory_declaration: {
+      type: "string",
+      title: "Are you the application lead?",
+      format: "data-url",
+    },
+  },
+};
+
 export const operationSchema: RJSFSchema = {
   type: "object",
   title: "Operation",
   properties: {
     operationPage1,
     operationPage2,
+    operationPage3,
   },
 };
 
@@ -471,10 +486,10 @@ export const operationUiSchema = {
     "mo_mailing_province",
     "mo_mailing_postal_code",
     "Would you like to add an exemption ID application lead?",
+    "statutory_declaration",
   ],
   "ui:FieldTemplate": FieldTemplate,
   "ui:classNames": "form-heading-label",
-  "ui:options": { label: false },
   id: {
     "ui:widget": "hidden",
   },

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -608,14 +608,10 @@ export const operationUiSchema = {
   },
   statutory_declaration_disclaimer_section: {
     "ui:FieldTemplate": TitleOnlyFieldTemplate,
-    "ui:options": {
-      jsxTitle: StatutoryDeclarationDisclaimerTitle,
-    },
+    "ui:title": StatutoryDeclarationDisclaimerTitle,
   },
   statutory_declaration: {
     "ui:widget": "FileWidget",
-    "ui:options": {
-      jsxTitle: StatutoryDeclarationUploadFieldTitle,
-    },
+    "ui:title": StatutoryDeclarationUploadFieldTitle,
   },
 };

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -7,7 +7,10 @@ import {
   OperatorMailingAddressTitle,
   OperatorPhysicalAddressTitle,
 } from "@/app/components/form/titles/userOperatorTitles";
-import { StatutoryDeclarationUploadFieldTitle } from "@/app/components/form/titles/operationsTitles";
+import {
+  StatutoryDeclarationDisclaimerTitle,
+  StatutoryDeclarationUploadFieldTitle,
+} from "@/app/components/form/titles/operationsTitles";
 
 const subheading = {
   "ui:classNames": "text-bc-bg-blue text-start text-lg",
@@ -422,6 +425,12 @@ const operationPage3: RJSFSchema = {
   // Uncomment this once documents are implemented
   /*   required: ["statutory_declaration"], */
   properties: {
+    statutory_declaration_disclaimer_section: {
+      //Not an actual field in the db - this is just to make the form look like the wireframes
+      title: "Statutory Declaration and Disclaimer",
+      type: "object",
+      readOnly: true,
+    },
     statutory_declaration: {
       type: "string",
       title: "Statutory Declaration",
@@ -487,6 +496,7 @@ export const operationUiSchema = {
     "mo_mailing_province",
     "mo_mailing_postal_code",
     "Would you like to add an exemption ID application lead?",
+    "statutory_declaration_disclaimer_section",
     "statutory_declaration",
   ],
   "ui:FieldTemplate": FieldTemplate,
@@ -596,6 +606,12 @@ export const operationUiSchema = {
   },
   external_lead_email: {
     "ui:widget": "EmailWidget",
+  },
+  statutory_declaration_disclaimer_section: {
+    "ui:FieldTemplate": TitleOnlyFieldTemplate,
+    "ui:options": {
+      jsxTitle: StatutoryDeclarationDisclaimerTitle,
+    },
   },
   statutory_declaration: {
     "ui:widget": "FileWidget",

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -7,7 +7,7 @@ import {
   OperatorMailingAddressTitle,
   OperatorPhysicalAddressTitle,
 } from "@/app/components/form/titles/userOperatorTitles";
-import { StatutoryDeclarationTitle } from "@/app/components/form/titles/operationsTitles";
+import { StatutoryDeclarationUploadFieldTitle } from "@/app/components/form/titles/operationsTitles";
 
 const subheading = {
   "ui:classNames": "text-bc-bg-blue text-start text-lg",
@@ -424,7 +424,7 @@ const operationPage3: RJSFSchema = {
   properties: {
     statutory_declaration: {
       type: "string",
-      title: "Are you the application lead?",
+      title: "Statutory Declaration",
       format: "data-url",
     },
   },
@@ -600,7 +600,7 @@ export const operationUiSchema = {
   statutory_declaration: {
     "ui:widget": "FileWidget",
     "ui:options": {
-      jsxTitle: StatutoryDeclarationTitle,
+      jsxTitle: StatutoryDeclarationUploadFieldTitle,
     },
   },
 };

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -550,9 +550,7 @@ export const operationUiSchema = {
     items: {
       mo_physical_address_section: {
         ...subheading,
-        "ui:options": {
-          jsxTitle: OperatorPhysicalAddressTitle,
-        },
+        "ui:title": OperatorPhysicalAddressTitle,
       },
       mo_percentage_ownership: {
         "ui:options": {
@@ -574,9 +572,7 @@ export const operationUiSchema = {
       },
       mo_mailing_address_section: {
         ...subheading,
-        "ui:options": {
-          jsxTitle: OperatorMailingAddressTitle,
-        },
+        "ui:title": OperatorMailingAddressTitle,
       },
       mo_physical_postal_code: {
         "ui:widget": "PostalCodeWidget",

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -7,6 +7,7 @@ import {
   OperatorMailingAddressTitle,
   OperatorPhysicalAddressTitle,
 } from "@/app/components/form/titles/userOperatorTitles";
+import { StatutoryDeclarationTitle } from "@/app/components/form/titles/operationsTitles";
 
 const subheading = {
   "ui:classNames": "text-bc-bg-blue text-start text-lg",
@@ -595,5 +596,11 @@ export const operationUiSchema = {
   },
   external_lead_email: {
     "ui:widget": "EmailWidget",
+  },
+  statutory_declaration: {
+    "ui:widget": "FileWidget",
+    "ui:options": {
+      jsxTitle: StatutoryDeclarationTitle,
+    },
   },
 };

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -422,8 +422,7 @@ const operationPage2: RJSFSchema = {
 const operationPage3: RJSFSchema = {
   type: "object",
   title: "Statutory Declaration and Disclaimer",
-  // Uncomment this once documents are implemented
-  /*   required: ["statutory_declaration"], */
+  required: ["statutory_declaration"],
   properties: {
     statutory_declaration_disclaimer_section: {
       //Not an actual field in the db - this is just to make the form look like the wireframes

--- a/client/app/utils/jsonSchema/userOperator.ts
+++ b/client/app/utils/jsonSchema/userOperator.ts
@@ -453,9 +453,7 @@ export const userOperatorUiSchema = {
   },
   senior_officer_section: {
     ...subheading,
-    "ui:options": {
-      jsxTitle: SeniorOfficerTitle,
-    },
+    "ui:title": SeniorOfficerTitle,
   },
   so_email: {
     "ui:widget": "EmailWidget",
@@ -472,15 +470,11 @@ export const userOperatorUiSchema = {
   // OPERATOR INFO SECTION
   mailing_address_section: {
     ...subheading,
-    "ui:options": {
-      jsxTitle: OperatorMailingAddressTitle,
-    },
+    "ui:title": OperatorMailingAddressTitle,
   },
   physical_address_section: {
     ...subheading,
-    "ui:options": {
-      jsxTitle: OperatorPhysicalAddressTitle,
-    },
+    "ui:title": OperatorPhysicalAddressTitle,
   },
   mailing_address_same_as_physical: {
     "ui:widget": "RadioWidget",
@@ -525,9 +519,7 @@ export const userOperatorUiSchema = {
     items: {
       po_physical_address_section: {
         ...subheading,
-        "ui:options": {
-          jsxTitle: ParentCompanyPhysicalAddressTitle,
-        },
+        "ui:title": ParentCompanyPhysicalAddressTitle,
       },
       po_mailing_address_same_as_physical: {
         "ui:widget": "RadioWidget",
@@ -546,9 +538,7 @@ export const userOperatorUiSchema = {
       },
       po_mailing_address_section: {
         ...subheading,
-        "ui:options": {
-          jsxTitle: ParentCompanyMailingAddressTitle,
-        },
+        "ui:title": ParentCompanyMailingAddressTitle,
       },
       po_physical_postal_code: {
         "ui:widget": "PostalCodeWidget",

--- a/client/app/utils/jsonSchema/userOperator.ts
+++ b/client/app/utils/jsonSchema/userOperator.ts
@@ -1,7 +1,6 @@
 import { RJSFSchema } from "@rjsf/utils";
 import provinceOptions from "@/app/data/provinces.json";
 import FieldTemplate from "@/app/styles/rjsf/FieldTemplate";
-import GroupTitleFieldTemplate from "@/app/styles/rjsf/GroupTitleFieldTemplate";
 import TitleOnlyFieldTemplate from "@/app/styles/rjsf/TitleOnlyFieldTemplate";
 import {
   OperatorMailingAddressTitle,
@@ -438,10 +437,6 @@ export const userOperatorUiSchema = {
   ],
   "ui:FieldTemplate": FieldTemplate,
   "ui:classNames": "form-heading-label",
-  "ui:TitleFieldTemplate": GroupTitleFieldTemplate,
-  "ui:options": {
-    label: false,
-  },
   // CONTACT INFO SECTION
   email: {
     "ui:widget": "EmailWidget",


### PR DESCRIPTION
Implements #604 

Also fixes missing form headers on both Operations and User Operator forms
<img width="1433" alt="Screenshot 2024-01-19 at 11 33 39 AM" src="https://github.com/bcgov/cas-registration/assets/14259474/c660dbf6-7887-4d2d-84be-9425b2a34363">

Took me awhile to think of a good way to have different titles in the `MultiStepHeader` than what is in the form header (Statutory Declaration instead of the full `Statutory Declaration and Disclaimer`. I have added a `customHeaderTitles` option to the `MultiStepFormBase` that takes an array of strings and uses that for the titles instead of pulling from the form schema. 

I added a custom `jsxTitle` for the upload field itself since the design has bold text over a link to a download for the template. It's mostly commented out until we are given a link to the template download for the `statutory_declaration` field though it's styled and should be ready to go. I've created a follow up ticket as a reminder #645 

<img width="723" alt="Screenshot 2024-01-19 at 10 24 17 AM" src="https://github.com/bcgov/cas-registration/assets/14259474/56e2eb79-a73b-42e6-8375-03e04da62d1b">


