### PR TITLE
Chore: update deployment yaml files

### DIFF
--- a/helm/cas-registration/templates/frontend/deployment.yaml
+++ b/helm/cas-registration/templates/frontend/deployment.yaml
@@ -40,15 +40,15 @@ spec:
             - name: KEYCLOAK_LOGIN_URL
               value: {{ .Values.frontend.auth.keycloakAuthUrl}}{{ .Values.frontend.auth.keycloakRealms }}
             - name: KEYCLOAK_LOGOUT_URL
-              value: {{ .Values.frontend.auth.keycloakAuthUrl}}{{ .Values.frontend.auth.keycloakRealms }}/logout
+              value: {{ .Values.frontend.auth.keycloakAuthUrl}}{{ .Values.frontend.auth.keycloakRealms }}{{ .Values.frontend.auth.keycloakOidc}}/logout
             - name: KEYCLOAK_TOKEN_URL
-              value: {{ .Values.frontend.auth.keycloakAuthUrl}}{{ .Values.frontend.auth.keycloakRealms }}/token
+              value: {{ .Values.frontend.auth.keycloakAuthUrl}}{{ .Values.frontend.auth.keycloakRealms }}{{ .Values.frontend.auth.keycloakOidc}}/token
             - name: NEXTAUTH_URL
               value: https://{{ .Values.frontend.route.host }}
             - name: SITEMINDER_LOGOUT_URL
               value: {{ .Values.frontend.auth.siteminderAuthUrl }}/clp-cgi/logoff.cgi
             - name: NEXT_PUBLIC_KEYCLOAK_LOGOUT_URL
-              value: {{ .Values.frontend.auth.siteminderAuthUrl }}/clp-cgi/logoff.cgi?retnow=1&returl={{ .Values.frontend.auth.keycloakAuthUrl}}{{ .Values.frontend.auth.keycloakRealms }}/logout
+              value: {{ .Values.frontend.auth.siteminderAuthUrl }}/clp-cgi/logoff.cgi?retnow=1&returl={{ .Values.frontend.auth.keycloakAuthUrl}}{{ .Values.frontend.auth.keycloakRealms }}{{ .Values.frontend.auth.keycloakOidc}}/logout
             - name: KEYCLOAK_CLIENT_ID
               value: {{ .Values.frontend.auth.keycloakClientId }}
             - name: NEXTAUTH_SECRET

--- a/helm/cas-registration/values.yaml
+++ b/helm/cas-registration/values.yaml
@@ -21,10 +21,10 @@ backend:
   resources:
     limits:
       cpu: 200m
-      memory: 256Mi
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
   autoscaling:
     enabled: false


### PR DESCRIPTION
Increases the backend deployment memory limits to allow for the newly implemented gunicorn workers to initialize
Updates the LOGOUT env vars to include the open-id protocol, this was missing & causing issues with our logout workflow.