### PR TITLE
chore: await signout() on logout button click

### DIFF
--- a/client/app/components/navigation/Profile.tsx
+++ b/client/app/components/navigation/Profile.tsx
@@ -28,8 +28,8 @@ export default function Profile({ name }: { readonly name: string }) {
           color="inherit"
           variant="text"
           className="text-lg"
-          onClick={() => {
-            signOut({
+          onClick={async () => {
+            await signOut({
               callbackUrl: process.env.NEXT_PUBLIC_KEYCLOAK_LOGOUT_URL,
             });
           }}


### PR DESCRIPTION
signout() call needs to be awaited, otherwise it redirects too fast & doesn't sign out