### PR TITLE
chore: show access logs in stdout

### DIFF
--- a/bc_obps/Dockerfile
+++ b/bc_obps/Dockerfile
@@ -49,4 +49,4 @@ EXPOSE 8000
 # Install project dependencies using Poetry
 RUN poetry install --without dev
 USER ${USER_ID}
-CMD ["/usr/bin/env", "bash", "-c", "poetry run python manage.py collectstatic --noinput && poetry run python manage.py migrate && poetry run gunicorn bc_obps.wsgi:application --timeout 200 --workers 8 --bind '0.0.0.0:8000'"]
+CMD ["/usr/bin/env", "bash", "-c", "poetry run python manage.py collectstatic --noinput && poetry run python manage.py migrate && poetry run gunicorn --access-logfile - bc_obps.wsgi:application --timeout 200 --workers 8 --bind '0.0.0.0:8000'"]


### PR DESCRIPTION
Since switching to gunicorn, no logs have been appearing in the openshift stdout logging. This flag should fix that