### PR TITLE
chore: backend is only available from within the cluster

### DIFF
--- a/helm/cas-registration/templates/backend/deployment.yaml
+++ b/helm/cas-registration/templates/backend/deployment.yaml
@@ -55,7 +55,7 @@ spec:
                 key: host
                 name: cas-obps-postgres-pguser-registration
           - name: ALLOWED_HOSTS
-            value: {{ .Values.backend.route.host }}
+            value: '*'
         name: {{ .Release.Name }}-backend-reset-migrations
         image: "{{ .Values.backend.image.repository }}:{{ .Values.defaultImageTag | default .Values.backend.image.tag }}"
         imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
@@ -103,7 +103,7 @@ spec:
                   key: host
                   name: cas-obps-postgres-pguser-registration
             - name: ALLOWED_HOSTS
-              value: {{ .Values.backend.route.host }}
+              value: '*'
             - name: GS_BUCKET_NAME
               valueFrom:
                 secretKeyRef:

--- a/helm/cas-registration/templates/backend/route.yaml
+++ b/helm/cas-registration/templates/backend/route.yaml
@@ -1,4 +1,4 @@
-{{- if not (hasSuffix "-prod" .Release.Namespace)}}
+{{- if (.Values.backend.deployRoute)}}
 
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/helm/cas-registration/templates/frontend/deployment.yaml
+++ b/helm/cas-registration/templates/frontend/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - name: {{ template "cas-registration.fullname" . }}-frontend
           env:
             - name: API_URL
-              value: {{ .Values.frontend.apiUrl }}
+              value: http://{{ include "cas-registration.fullname" . }}-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.backend.service.port }}/api/
             - name: KEYCLOAK_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/helm/cas-registration/values-dev.yaml
+++ b/helm/cas-registration/values-dev.yaml
@@ -10,6 +10,8 @@ backend:
 
   environment: develop
 
+  deployRoute: true
+
 frontend:
   replicaCount: 1
 
@@ -18,8 +20,6 @@ frontend:
 
   route:
     host: cas-reg-frontend-dev.apps.silver.devops.gov.bc.ca
-
-  apiUrl: https://cas-reg-backend-dev.apps.silver.devops.gov.bc.ca/api/
 
   environment: develop
 

--- a/helm/cas-registration/values-prod.yaml
+++ b/helm/cas-registration/values-prod.yaml
@@ -19,8 +19,6 @@ frontend:
   route:
     host: cas-reg-frontend-dev.apps.silver.devops.gov.bc.ca
 
-  apiUrl: https://cas-reg-backend-dev.apps.silver.devops.gov.bc.ca/api/
-
   environment: production
 
   auth:

--- a/helm/cas-registration/values-test.yaml
+++ b/helm/cas-registration/values-test.yaml
@@ -19,8 +19,6 @@ frontend:
   route:
     host: cas-reg-frontend-test.apps.silver.devops.gov.bc.ca
 
-  apiUrl: https://cas-reg-backend-test.apps.silver.devops.gov.bc.ca/api/
-
   environment: test
 
   auth:

--- a/helm/cas-registration/values.yaml
+++ b/helm/cas-registration/values.yaml
@@ -11,6 +11,8 @@ backend:
     # Overrides the image tag whose default is the chart appVersion.
     tag: "latest"
 
+  deployRoute: false
+
   service:
     type: ClusterIP
     port: 8000


### PR DESCRIPTION
Directs the frontend to hit the backend service which is only accessible from within the cluster instead of a route.
No backend route is created in test/prod.
A route is still created in the develop environment in case we want to explore anything in django admin & to allow our dev data setup job to complete.