### PR TITLE
fix: re-enable pagination on mui datagrid

### DIFF
--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -118,7 +118,9 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
         rows={rows}
         columns={customColumns}
         showCellVerticalBorder
-        hideFooter
+        initialState={{
+          pagination: { paginationModel: { pageSize: 20 } },
+        }}
         // Set the row height to "auto" so that the row height will adjust to the content
         getRowHeight={() => "auto"}
         slots={{
@@ -127,9 +129,6 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
           columnUnsortedIcon: SortIcon,
         }}
         sx={{
-          "& .MuiSvgIcon-root": {
-            color: "white",
-          },
           "& .MuiDataGrid-columnHeaderDraggableContainer": {
             minWidth: "100%",
           },
@@ -158,6 +157,10 @@ const DataGrid: React.FC<Props> = ({ rows, columns, cntxt }) => {
           },
           "& .MuiDataGrid-columnHeaderTitleContainer": {
             justifyContent: "space-between",
+            "& .MuiSvgIcon-root": {
+              // Make the sort icon white in the title containers
+              color: "white",
+            },
           },
           "& .MuiDataGrid-columnHeaderTitleContainerContent": {
             flex: 1,


### PR DESCRIPTION
Fix for #765 

Follow up tech debt issue to support server side pagination: #782 

Show the footer again and enable pagination even if it's not in the design:
<img width="1360" alt="Screenshot 2024-01-30 at 11 17 30 AM" src="https://github.com/bcgov/cas-registration/assets/14259474/87b0605c-ec79-48ef-b221-1ec7dc3665cf">


Re-enables pagination and sets page size to 20 as discussed at standup. If you want to actually test the pagination you will have to somehow get over 20 records (Operators or Operations) in the database. I just ran my load testing PR for a few mins which created hundreds.

<img width="767" alt="Screenshot 2024-01-30 at 10 50 52 AM" src="https://github.com/bcgov/cas-registration/assets/14259474/0e9ecd72-49a7-48ad-a098-c15bb3ce951e">

