### PR TITLE
Task/edit operation wo status reset/706

### DIFF
--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -250,6 +250,7 @@ def update_operation(request, operation_id: int, submit: str, save_contact: str,
             "bcghg_id",
             "opt_in",
             "operation_has_multiple_operators",
+            "status",
         }
     )
 
@@ -262,13 +263,10 @@ def update_operation(request, operation_id: int, submit: str, save_contact: str,
             - if operation.status was already "Approved", it should remain Approved and the submission date should not be altered
             - if operation.status was "Changes Requested", it should switch to Pending
             - if operation.status was "Declined", it should switch to Pending
+            - if operation.status was "Not Started", it should switch to Pending
             - if operation.status was "Pending", it should remain as Pending
         """
-        if operation.status in [
-            Operation.Statuses.CHANGES_REQUESTED,
-            Operation.Statuses.DECLINED,
-            Operation.Statuses.PENDING,
-        ]:
+        if operation.status is not Operation.Statuses.APPROVED:
             operation.status = Operation.Statuses.PENDING
             operation.submission_date = datetime.now(pytz.utc)
 
@@ -279,6 +277,9 @@ def update_operation(request, operation_id: int, submit: str, save_contact: str,
 
     operation.save()
     operation.set_create_or_update(modifier=user)
+
+    print("partway through - operation in db:")
+    print(operation.__dict__)
 
     if payload.operation_has_multiple_operators:
         create_or_update_multiple_operators(payload.multiple_operators_array, operation, user)

--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -241,6 +241,9 @@ def update_operation(request, operation_id: int, submit: str, save_contact: str,
             operation.point_of_contact = external_poc
 
     # updating only a subset of fields (using all fields would overwrite the existing ones)
+    print("\n\npayload: ", payload.__dict__)
+    print("\n\n")
+
     payload_dict: dict = payload.dict(
         include={
             "name",

--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -184,7 +184,7 @@ def create_operation(request, payload: OperationCreateIn):
 
 @router.put("/operations/{operation_id}", response={200: OperationUpdateOut, codes_4xx: Message})
 @authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
-def update_operation(request, operation_id: int, submit: str, save_contact: str, payload: OperationUpdateIn):
+def update_operation(request, operation_id: int, submit: str, form_section: int, payload: OperationUpdateIn):
     user: User = request.current_user
     user_operator = UserOperator.objects.filter(user_id=user.user_guid).first()
     # if there's no user_operator or operator, then the user hasn't requested access to the operator
@@ -207,7 +207,27 @@ def update_operation(request, operation_id: int, submit: str, save_contact: str,
 
     point_of_contact_id = payload.point_of_contact_id or None
 
-    if save_contact == "true":
+    # the frontend includes default values, which are being sent in the payload to the backend. We need to know
+    # whether the data being received in the payload is what the user has actually viewed, so we separate this
+    # by form_section (the paginated form in the UI)
+    if form_section == 1:
+        data_fields = [
+            'name',
+            'type',
+            'naics_code_id',
+            'swrs_facility_id',
+            'bcghg_id',
+            'opt_in',
+        ]
+        payload_dict: dict = {}
+        for attr in data_fields:
+            if hasattr(payload, attr):
+                payload_dict[attr] = getattr(payload, attr)
+        for attr, value in payload_dict.items():
+            setattr(operation, attr, value)
+        operation.regulated_products.set(payload.regulated_products)
+        operation.save(update_fields=list(payload_dict.keys()))
+    elif form_section == 2:
         is_external_point_of_contact = payload.is_external_point_of_contact
 
         if is_external_point_of_contact is False:  # the point of contact is the user
@@ -239,23 +259,7 @@ def update_operation(request, operation_id: int, submit: str, save_contact: str,
             )
             external_poc.set_create_or_update(modifier=user)
             operation.point_of_contact = external_poc
-
-    # updating only a subset of fields (using all fields would overwrite the existing ones)
-    # TODO: review the use of payload_dict. I'm suspicious of this logic....
-    payload_dict: dict = payload.dict(
-        include={
-            "name",
-            "type",
-            "previous_year_attributable_emissions",
-            "swrs_facility_id",
-            "bcghg_id",
-            "opt_in",
-            "operation_has_multiple_operators",
-        }
-    )
-
-    for attr, value in payload_dict.items():
-        setattr(operation, attr, value)
+        operation.save(update_fields=['point_of_contact'])
 
     if submit == "true":
         """
@@ -272,15 +276,7 @@ def update_operation(request, operation_id: int, submit: str, save_contact: str,
             operation.submission_date = datetime.now(pytz.utc)
             operation.save(update_fields=['status', 'submission_date'])
 
-    operation.save(update_fields=list(payload_dict.keys()))
     operation.set_create_or_update(modifier=user)
-
-    if payload.operation_has_multiple_operators:
-        create_or_update_multiple_operators(payload.multiple_operators_array, operation, user)
-    else:  # if the operation doesn't have multiple operators anymore, archive all existing ones
-        operation_multiple_operators = MultipleOperator.objects.filter(operation_id=operation.id)
-        for operator in operation_multiple_operators:
-            operator.set_archive(modifier=user)
 
     if payload.statutory_declaration:
         operation.documents.filter(type=DocumentType.objects.get(name="signed_statutory_declaration")).delete()

--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -211,18 +211,16 @@ def update_operation(request, operation_id: int, submit: str, form_section: int,
     # whether the data being received in the payload is what the user has actually viewed, so we separate this
     # by form_section (the paginated form in the UI)
     if form_section == 1:
-        data_fields = [
-            'name',
-            'type',
-            'naics_code_id',
-            'swrs_facility_id',
-            'bcghg_id',
-            'opt_in',
-        ]
-        payload_dict: dict = {}
-        for attr in data_fields:
-            if hasattr(payload, attr):
-                payload_dict[attr] = getattr(payload, attr)
+        payload_dict: dict = payload.dict(
+            include={
+                'name',
+                'type',
+                'naics_code_id',
+                'swrs_facility_id',
+                'bcghg_id',
+                'opt_in',
+            }
+        )
         for attr, value in payload_dict.items():
             setattr(operation, attr, value)
         operation.regulated_products.set(payload.regulated_products)
@@ -271,7 +269,7 @@ def update_operation(request, operation_id: int, submit: str, form_section: int,
             - if operation.status was "Not Started", it should switch to Pending
             - if operation.status was "Pending", it should remain as Pending
         """
-        if Operation.Statuses(operation.status) is not Operation.Statuses.APPROVED:
+        if operation.status != Operation.Statuses.APPROVED:
             operation.status = Operation.Statuses.PENDING
             operation.submission_date = datetime.now(pytz.utc)
             operation.save(update_fields=['status', 'submission_date'])

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -49,20 +49,15 @@ class OperationUpdateIn(ModelSchema):
     position_title: Optional[str] = None
     email: Optional[str] = None
     phone_number: Optional[str] = None
+    regulated_products: Optional[List[int]] = []
+    reporting_activities: Optional[List[int]] = []
     # external point of contact details
     external_point_of_contact_first_name: Optional[str] = None
     external_point_of_contact_last_name: Optional[str] = None
     external_point_of_contact_position_title: Optional[str] = None
     external_point_of_contact_email: Optional[str] = None
     external_point_of_contact_phone_number: Optional[str] = None
-    # shared point of contact details
-    street_address: Optional[str] = None
-    municipality: Optional[str] = None
-    province: Optional[str] = None
-    postal_code: Optional[str] = None
     is_external_point_of_contact: Optional[bool] = None
-    operation_has_multiple_operators: Optional[bool] = False
-    multiple_operators_array: Optional[list] = None
     statutory_declaration: Optional[str] = None
 
     @validator("statutory_declaration")

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -42,7 +42,6 @@ class OperationUpdateOut(Schema):
 class OperationUpdateIn(ModelSchema):
     # Converting types
     first_name: Optional[str] = None
-    point_of_contact_id: Optional[int] = None
     last_name: Optional[str] = None
     position_title: Optional[str] = None
     email: Optional[str] = None

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -41,16 +41,12 @@ class OperationUpdateOut(Schema):
 
 class OperationUpdateIn(ModelSchema):
     # Converting types
-    verified_at: Optional[date] = None
-    # point of contact details
-    point_of_contact_id: Optional[int] = None
     first_name: Optional[str] = None
+    point_of_contact_id: Optional[int] = None
     last_name: Optional[str] = None
     position_title: Optional[str] = None
     email: Optional[str] = None
     phone_number: Optional[str] = None
-    regulated_products: Optional[List[int]] = []
-    reporting_activities: Optional[List[int]] = []
     # external point of contact details
     external_point_of_contact_first_name: Optional[str] = None
     external_point_of_contact_last_name: Optional[str] = None
@@ -68,14 +64,7 @@ class OperationUpdateIn(ModelSchema):
 
     class Config:
         model = Operation
-        model_exclude = [
-            "id",  # need to exclude id since it's auto generated and we don't want to pass it in
-            "documents",  # excluding documents because they are handled by individual form fields
-            *AUDIT_FIELDS,
-            "status",
-            "submission_date",
-        ]
-
+        model_fields = ['operator', 'name', 'type', 'naics_code', 'opt_in', 'point_of_contact', 'regulated_products']
         allow_population_by_field_name = True
 
 

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -77,6 +77,8 @@ class OperationUpdateIn(ModelSchema):
             "id",  # need to exclude id since it's auto generated and we don't want to pass it in
             "documents",  # excluding documents because they are handled by individual form fields
             *AUDIT_FIELDS,
+            "status",
+            "submission_date",
         ]
 
         allow_population_by_field_name = True

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -115,7 +115,7 @@ class TestOperationsEndpoint(CommonTestSetup):
                 role,
                 content_type_json,
                 mock_operation.json(),
-                self.endpoint + "/" + str(operation.id) + "?submit=false&save_contact=false",
+                self.endpoint + "/" + str(operation.id) + "?submit=false&form_section=1",
             )
             assert response.status_code == 401
 
@@ -233,71 +233,72 @@ class TestOperationsEndpoint(CommonTestSetup):
         )
         assert post_response.status_code == 201
 
-    def test_post_new_operation_with_multiple_operators(self):
-        naics_code = baker.make(NaicsCode)
-        contact = baker.make(Contact)
-        regulated_products = baker.make(RegulatedProduct, _quantity=2)
-        reporting_activities = baker.make(ReportingActivity, _quantity=2)
-        operator = operator_baker()
-        mock_operation = OperationCreateIn(
-            name='Springfield Nuclear Power Plant',
-            type='Single Facility Operation',
-            naics_code_id=naics_code.id,
-            operation_has_multiple_operators=True,
-            multiple_operators_array=[
-                {
-                    "mo_legal_name": "test",
-                    "mo_trade_name": "test",
-                    "mo_cra_business_number": 123,
-                    "mo_bc_corporate_registry_number": 'abc1234567',
-                    "mo_business_structure": "BC Corporation",
-                    "mo_website": "https://www.test-mo.com",
-                    "mo_physical_street_address": "test",
-                    "mo_physical_municipality": "test",
-                    "mo_physical_province": "BC",
-                    "mo_physical_postal_code": "V1V 1V1",
-                    "mo_mailing_address_same_as_physical": True,
-                    "mo_mailing_street_address": "test",
-                    "mo_mailing_municipality": "test",
-                    "mo_mailing_province": "BC",
-                    "mo_mailing_postal_code": "V1V 1V1",
-                },
-                {
-                    "mo_legal_name": "test2",
-                    "mo_trade_name": "test2",
-                    "mo_cra_business_number": 123,
-                    "mo_bc_corporate_registry_number": 'wer1234567',
-                    "mo_business_structure": "BC Corporation",
-                    "mo_physical_street_address": "test",
-                    "mo_physical_municipality": "test",
-                    "mo_physical_province": "BC",
-                    "mo_physical_postal_code": "V1V 1V1",
-                    "mo_mailing_address_same_as_physical": True,
-                    "mo_mailing_street_address": "test",
-                    "mo_mailing_municipality": "test",
-                    "mo_mailing_province": "BC",
-                    "mo_mailing_postal_code": "V1V 1V1",
-                },
-            ],
-            reporting_activities=reporting_activities,
-            regulated_products=regulated_products,
-            contacts=[contact.id],
-            operator_id=operator.id,
-        )
-        post_response = TestUtils.mock_post_with_auth_role(
-            self, 'industry_user', content_type_json, mock_operation.json()
-        )
-        assert post_response.status_code == 201
-        assert post_response.json().get('id') is not None
-        baker.make(
-            UserOperator, user_id=self.user.user_guid, status=UserOperator.Statuses.APPROVED, operator_id=operator.id
-        )
-        get_response = TestUtils.mock_get_with_auth_role(self, 'industry_user').json()[0]
-        assert (
-            'operation_has_multiple_operators' in get_response
-            and get_response['operation_has_multiple_operators'] == True
-        )
-        assert 'multiple_operators_array' in get_response and len(get_response['multiple_operators_array']) == 2
+    # commenting out this unit test for now because multiple_operators are not included in MVP
+    # def test_post_new_operation_with_multiple_operators(self):
+    #     naics_code = baker.make(NaicsCode)
+    #     contact = baker.make(Contact)
+    #     regulated_products = baker.make(RegulatedProduct, _quantity=2)
+    #     # reporting_activities = baker.make(ReportingActivity, _quantity=2)
+    #     operator = operator_baker()
+    #     mock_operation = OperationCreateIn(
+    #         name='Springfield Nuclear Power Plant',
+    #         type='Single Facility Operation',
+    #         naics_code_id=naics_code.id,
+    #         # operation_has_multiple_operators=True,
+    #         # multiple_operators_array=[
+    #         #     {
+    #         #         "mo_legal_name": "test",
+    #         #         "mo_trade_name": "test",
+    #         #         "mo_cra_business_number": 123,
+    #         #         "mo_bc_corporate_registry_number": 'abc1234567',
+    #         #         "mo_business_structure": "BC Corporation",
+    #         #         "mo_website": "https://www.test-mo.com",
+    #         #         "mo_physical_street_address": "test",
+    #         #         "mo_physical_municipality": "test",
+    #         #         "mo_physical_province": "BC",
+    #         #         "mo_physical_postal_code": "V1V 1V1",
+    #         #         "mo_mailing_address_same_as_physical": True,
+    #         #         "mo_mailing_street_address": "test",
+    #         #         "mo_mailing_municipality": "test",
+    #         #         "mo_mailing_province": "BC",
+    #         #         "mo_mailing_postal_code": "V1V 1V1",
+    #         #     },
+    #         #     {
+    #         #         "mo_legal_name": "test2",
+    #         #         "mo_trade_name": "test2",
+    #         #         "mo_cra_business_number": 123,
+    #         #         "mo_bc_corporate_registry_number": 'wer1234567',
+    #         #         "mo_business_structure": "BC Corporation",
+    #         #         "mo_physical_street_address": "test",
+    #         #         "mo_physical_municipality": "test",
+    #         #         "mo_physical_province": "BC",
+    #         #         "mo_physical_postal_code": "V1V 1V1",
+    #         #         "mo_mailing_address_same_as_physical": True,
+    #         #         "mo_mailing_street_address": "test",
+    #         #         "mo_mailing_municipality": "test",
+    #         #         "mo_mailing_province": "BC",
+    #         #         "mo_mailing_postal_code": "V1V 1V1",
+    #         #     },
+    #         # ],
+    #         # reporting_activities=reporting_activities,
+    #         regulated_products=regulated_products,
+    #         contacts=[contact.id],
+    #         operator_id=operator.id,
+    #     )
+    #     post_response = TestUtils.mock_post_with_auth_role(
+    #         self, 'industry_user', content_type_json, mock_operation.json()
+    #     )
+    #     assert post_response.status_code == 201
+    #     assert post_response.json().get('id') is not None
+    #     baker.make(
+    #         UserOperator, user_id=self.user.user_guid, status=UserOperator.Statuses.APPROVED, operator_id=operator.id
+    #     )
+    #     get_response = TestUtils.mock_get_with_auth_role(self, 'industry_user').json()[0]
+    #     assert (
+    #         'operation_has_multiple_operators' in get_response
+    #         and get_response['operation_has_multiple_operators'] == True
+    #     )
+    #     assert 'multiple_operators_array' in get_response and len(get_response['multiple_operators_array']) == 2
 
     def test_post_new_malformed_operation(self):
         response = TestUtils.mock_post_with_auth_role(
@@ -328,7 +329,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             type='Type 1',
             operator_id=operator.id,
             regulated_products=[],
-            reporting_activities=[],
+            # reporting_activities=[],
         )
         post_response = TestUtils.mock_post_with_auth_role(
             self, "industry_user", content_type_json, data=new_operation.json()
@@ -473,7 +474,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             payload.json(),
-            self.endpoint + "/" + str(operation.id) + "?submit=false&save_contact=false",
+            self.endpoint + "/" + str(operation.id) + "?submit=false&form_section=1",
         )
         assert response.status_code == 200
         assert response.json() == {"name": "New name"}
@@ -502,7 +503,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             payload.json(),
-            self.endpoint + "/" + str(operation.id) + "?submit=true&save_contact=false",
+            self.endpoint + "/" + str(operation.id) + "?submit=true&form_section=1",
         )
 
         assert response.status_code == 200
@@ -521,7 +522,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             {"garbage": "i am bad data"},
-            self.endpoint + "/" + str(operation.id) + "?submit=false&save_contact=false",
+            self.endpoint + "/" + str(operation.id) + "?submit=false&form_section=1",
         )
 
         assert response.status_code == 422
@@ -539,7 +540,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             point_of_contact_id=contact2.id,
             type='Single Facility Operation',
             naics_code_id=operation.naics_code_id,
-            reporting_activities=[],
+            # reporting_activities=[],
             regulated_products=[],
             operation_has_multiple_operators=False,
             point_of_contact=contact2.id,
@@ -561,7 +562,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             update.json(),
-            self.endpoint + '/' + str(operation.id) + "?submit=true&save_contact=true",
+            self.endpoint + '/' + str(operation.id) + "?submit=true&form_section=2",
         )
         assert put_response.status_code == 200
 
@@ -581,7 +582,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             name='Springfield Nuclear Power Plant',
             type='Single Facility Operation',
             naics_code_id=operation.naics_code_id,
-            reporting_activities=[],
+            # reporting_activities=[],
             regulated_products=[],
             operation_has_multiple_operators=False,
             documents=[],
@@ -608,7 +609,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             update.json(),
-            self.endpoint + '/' + str(operation.id) + "?submit=true&save_contact=true",
+            self.endpoint + '/' + str(operation.id) + "?submit=true&form_section=2",
         )
         assert put_response.status_code == 200
 
@@ -644,8 +645,8 @@ class TestOperationsEndpoint(CommonTestSetup):
             naics_code_id=operation.naics_code_id,
             operator_id=operator.id,
             documents=[],
-            regulated_products=[],
-            reporting_activities=[],
+            # regulated_products=[],
+            # reporting_activities=[],
         )
 
         TestUtils.authorize_current_user_as_operator_user(self, operator)
@@ -654,7 +655,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             update.json(),
-            self.endpoint + '/' + str(operation.id) + "?submit=true&save_contact=false",
+            self.endpoint + '/' + str(operation.id) + "?submit=true&form_section=1",
         )
         assert put_response.status_code == 200
         assert Operation.objects.count() == 1
@@ -679,7 +680,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             naics_code_id=operation.naics_code_id,
             documents=[],
             regulated_products=[],
-            reporting_activities=[],
+            # reporting_activities=[],
         )
 
         TestUtils.authorize_current_user_as_operator_user(self, operator)
@@ -688,7 +689,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             update.json(),
-            self.endpoint + '/' + str(operation.id) + "?submit=true&save_contact=false",
+            self.endpoint + '/' + str(operation.id) + "?submit=true&form_section=1",
         )
         assert put_response.status_code == 200
         assert Operation.objects.count() == 1
@@ -714,7 +715,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             naics_code_id=operation.naics_code_id,
             documents=[],
             regulated_products=[],
-            reporting_activities=[],
+            # reporting_activities=[],
         )
         TestUtils.authorize_current_user_as_operator_user(self, operator)
         put_response = TestUtils.mock_put_with_auth_role(
@@ -722,7 +723,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             update.json(),
-            self.endpoint + '/' + str(operation.id) + "?submit=true&save_contact=false",
+            self.endpoint + '/' + str(operation.id) + "?submit=true&form_section=1",
         )
 
         assert put_response.status_code == 200
@@ -751,7 +752,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             naics_code_id=operation.naics_code_id,
             documents=[],
             regulated_products=[],
-            reporting_activities=[],
+            # reporting_activities=[],
         )
         TestUtils.authorize_current_user_as_operator_user(self, operator)
         put_response = TestUtils.mock_put_with_auth_role(
@@ -759,7 +760,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             update.json(),
-            self.endpoint + '/' + str(operation.id) + "?submit=true&save_contact=false",
+            self.endpoint + '/' + str(operation.id) + "?submit=true&form_section=1",
         )
 
         assert put_response.status_code == 200
@@ -781,14 +782,15 @@ class TestOperationsEndpoint(CommonTestSetup):
         operation.submission_date = fake_timestamp_from_past
         operation.save(update_fields=['status', 'operator_id', 'submission_date'])
 
+        regulated_product = baker.make(RegulatedProduct)
         update = OperationUpdateIn(
             name='Declined Operation Name',
             type='Type',
             operator_id=operator.id,
             naics_code_id=operation.naics_code_id,
             documents=[],
-            regulated_products=[],
-            reporting_activities=[],
+            regulated_products=[regulated_product.id],
+            # reporting_activities=[],
         )
         TestUtils.authorize_current_user_as_operator_user(self, operator)
         put_response = TestUtils.mock_put_with_auth_role(
@@ -796,7 +798,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             update.json(),
-            self.endpoint + '/' + str(operation.id) + "?submit=true&save_contact=false",
+            self.endpoint + '/' + str(operation.id) + "?submit=true&form_section=1",
         )
 
         assert put_response.status_code == 200
@@ -809,3 +811,66 @@ class TestOperationsEndpoint(CommonTestSetup):
         # assert that operation's submission_date has been updated to the current time (approximately)
         assert retrieved_operation.submission_date - datetime.now(timezone.utc) < timedelta(seconds=10)
         assert retrieved_operation.status == Operation.Statuses.PENDING
+
+    def test_put_operation_one_form_section_at_a_time(self):
+        # test setup
+        operator = operator_baker()
+        operation = operation_baker()
+        operation.operator_id = operator.id
+        operation.save(update_fields=['operator_id'])
+        TestUtils.authorize_current_user_as_operator_user(self, operator)
+
+        # update fields visible in section 1 of form (on frontend)
+        update_from_form_section_1 = OperationUpdateIn(
+            name='New and Improved Legal Name',
+            type='Type A',
+            operator_id=operator.id,
+            documents=[],
+            regulated_products=[],
+            naics_code_id=operation.naics_code_id
+            # reporting_activities=[1],
+        )
+        put_response_1 = TestUtils.mock_put_with_auth_role(
+            self,
+            'industry_user',
+            content_type_json,
+            update_from_form_section_1.json(),
+            self.endpoint + '/' + str(operation.id) + "?submit=false&form_section=1",
+        )
+        assert put_response_1.status_code == 200
+        assert Operation.objects.count() == 1
+        retrieved_op = Operation.objects.first()
+        assert retrieved_op.name == 'New and Improved Legal Name'
+        assert retrieved_op.type == 'Type A'
+
+        # update fields visible in section 2 of form
+        update_from_form_section_2 = OperationUpdateIn(
+            name='This name should not be changed',
+            type='bad type',
+            operator_id=operator.id,
+            naics_code_id=operation.naics_code_id,
+            regulated_products=[],
+            # reporting_activities=[],
+            is_external_point_of_contact=True,
+            external_point_of_contact_first_name='Bart',
+            external_point_of_contact_last_name='Simpson',
+            external_point_of_contact_position_title='Scoundrel',
+            external_point_of_contact_email='bart@email.com',
+            external_point_of_contact_phone_number='+17787777777',
+        )
+        put_response_2 = TestUtils.mock_put_with_auth_role(
+            self,
+            'industry_user',
+            content_type_json,
+            update_from_form_section_2.json(),
+            self.endpoint + '/' + str(operation.id) + "?submit=false&form_section=2",
+        )
+        assert put_response_2.status_code == 200
+        assert Operation.objects.count() == 1
+        retrieved_op = Operation.objects.first()
+        # should be 2 contacts - the original Contact created by baker for the operation, and the updated "Bart" contact
+        assert Contact.objects.count() == 2
+        contact = Contact.objects.last()
+        assert contact.first_name == 'Bart'
+        assert retrieved_op.point_of_contact_id == contact.id
+        assert retrieved_op.name == 'New and Improved Legal Name'

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -671,6 +671,8 @@ class TestOperationsEndpoint(CommonTestSetup):
             submission_date=fake_timestamp_from_past,
         )
 
+        operation.save()
+
         print(operation.__dict__)
 
         update = OperationUpdateIn(

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -459,9 +459,6 @@ class TestOperationsEndpoint(CommonTestSetup):
         payload = TestUtils.mock_OperationUpdateIn()
         operation = operation_baker(payload.operator)
 
-        operation.operator_id = operator.id
-        operation.save(update_fields=['operator_id'])
-
         # approve the user
         baker.make(
             UserOperator,

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -530,16 +530,17 @@ class TestOperationsEndpoint(CommonTestSetup):
         contact2 = baker.make(Contact, email=contact1.email)
         operator = operator_baker()
         operation = operation_baker(operator.id)
+        operation.point_of_contact = contact2
+        operation.save(update_fields=['point_of_contact'])
 
         update = OperationUpdateIn(
             name='Springfield Nuclear Power Plant',
             # this updates the existing contact (contact2)
-            point_of_contact_id=contact2.id,
             type='Single Facility Operation',
             naics_code_id=operation.naics_code_id,
             # reporting_activities=[],
             regulated_products=[],
-            operation_has_multiple_operators=False,
+            # operation_has_multiple_operators=False,
             operator_id=operator.id,
             is_external_point_of_contact=False,
             street_address='19 Evergreen Terrace',
@@ -580,7 +581,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             naics_code_id=operation.naics_code_id,
             # reporting_activities=[],
             regulated_products=[],
-            operation_has_multiple_operators=False,
+            # operation_has_multiple_operators=False,
             documents=[],
             operator_id=operator.id,
             is_external_point_of_contact=True,
@@ -609,9 +610,9 @@ class TestOperationsEndpoint(CommonTestSetup):
         )
         assert put_response.status_code == 200
 
-        # expect 2 Contacts in the database -- the first_contact, and the external_point_of_contact
-        assert Contact.objects.count() == 2
+        # expect 1 Contact in the database -- we are updating the existing point_of_contact
         contacts = Contact.objects.all()
+        assert contacts.count() == 1
         assert first_contact in contacts
         # assert that external_point_of_contact is one of the Contacts in the database
         bart_contact = None
@@ -865,8 +866,8 @@ class TestOperationsEndpoint(CommonTestSetup):
         assert put_response_2.status_code == 200
         assert Operation.objects.count() == 1
         retrieved_op = Operation.objects.first()
-        # should be 2 contacts - the original Contact created by baker for the operation, and the updated "Bart" contact
-        assert Contact.objects.count() == 2
+        # should be 1 contacts - we updated the existing point_of_contact
+        assert Contact.objects.count() == 1
         assert retrieved_op.point_of_contact.first_name == 'Bart'
-        assert retrieved_op.point_of_contact_id != original_contact_id
+        assert retrieved_op.point_of_contact_id == original_contact_id
         assert retrieved_op.name == 'New and Improved Legal Name'

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -688,7 +688,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             update.json(),
-            self.endpoint + '/' + str(operation.id) + "?submit=true",
+            self.endpoint + '/' + str(operation.id) + "?submit=true&save_contact=false",
         )
         assert put_response.status_code == 200
         assert Operation.objects.count() == 1
@@ -722,7 +722,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             update.json(),
-            self.endpoint + '/' + str(operation.id) + "?submit=true",
+            self.endpoint + '/' + str(operation.id) + "?submit=true&save_contact=false",
         )
 
         assert put_response.status_code == 200
@@ -759,7 +759,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             update.json(),
-            self.endpoint + '/' + str(operation.id) + "?submit=true",
+            self.endpoint + '/' + str(operation.id) + "?submit=true&save_contact=false",
         )
 
         assert put_response.status_code == 200
@@ -796,7 +796,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             'industry_user',
             content_type_json,
             update.json(),
-            self.endpoint + '/' + str(operation.id) + "?submit=true",
+            self.endpoint + '/' + str(operation.id) + "?submit=true&save_contact=false",
         )
 
         assert put_response.status_code == 200

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -540,7 +540,6 @@ class TestOperationsEndpoint(CommonTestSetup):
             # reporting_activities=[],
             regulated_products=[],
             operation_has_multiple_operators=False,
-            point_of_contact=contact2.id,
             operator_id=operator.id,
             is_external_point_of_contact=False,
             street_address='19 Evergreen Terrace',
@@ -642,7 +641,7 @@ class TestOperationsEndpoint(CommonTestSetup):
             naics_code_id=operation.naics_code_id,
             operator_id=operator.id,
             documents=[],
-            # regulated_products=[],
+            regulated_products=[],
             # reporting_activities=[],
         )
 
@@ -816,6 +815,7 @@ class TestOperationsEndpoint(CommonTestSetup):
         operation.operator_id = operator.id
         operation.save(update_fields=['operator_id'])
         TestUtils.authorize_current_user_as_operator_user(self, operator)
+        original_contact_id = operation.point_of_contact.id
 
         # update fields visible in section 1 of form (on frontend)
         update_from_form_section_1 = OperationUpdateIn(
@@ -867,7 +867,6 @@ class TestOperationsEndpoint(CommonTestSetup):
         retrieved_op = Operation.objects.first()
         # should be 2 contacts - the original Contact created by baker for the operation, and the updated "Bart" contact
         assert Contact.objects.count() == 2
-        contact = Contact.objects.last()
-        assert contact.first_name == 'Bart'
-        assert retrieved_op.point_of_contact_id == contact.id
+        assert retrieved_op.point_of_contact.first_name == 'Bart'
+        assert retrieved_op.point_of_contact_id != original_contact_id
         assert retrieved_op.name == 'New and Improved Legal Name'

--- a/bc_obps/registration/tests/utils/helpers.py
+++ b/bc_obps/registration/tests/utils/helpers.py
@@ -87,10 +87,8 @@ class TestUtils:
         naics_code = baker.make(NaicsCode, naics_code=123456, naics_description='desc')
         point_of_contact = baker.make(Contact)
         operator = operator_baker()
-        activity = baker.make(ReportingActivity)
         product = baker.make(RegulatedProduct)
         operation = operation_baker()
-        operation.reporting_activities.set([activity.id])
         operation.regulated_products.set([product.id])
 
         return OperationUpdateIn(
@@ -98,14 +96,6 @@ class TestUtils:
             point_of_contact_id=point_of_contact.id,
             type="Single Facility Operation",
             naics_code_id=naics_code.id,
-            reporting_activities=[activity.id],
-            physical_street_address="19 Evergreen Terrace",
-            physical_municipality="Springfield",
-            physical_province="BC",
-            physical_postal_code="V1V 1V1",
-            legal_land_description="It's legal",
-            latitude=90,
-            longitude=-120,
             regulated_products=[product.id],
             point_of_contact=point_of_contact.id,
             operator_id=operator.id,
@@ -114,11 +104,6 @@ class TestUtils:
             last_name="Simpson",
             email="homer@email.com",
             phone_number="+17787777777",
-            street_address="19 Evergreen Terrace",
-            position_title="Nuclear Safety Inspector",
-            municipality="Springfield",
-            province="BC",
-            postal_code="V1V 1V1",
         )
 
     @staticmethod

--- a/client/app/components/form/OperationsForm.tsx
+++ b/client/app/components/form/OperationsForm.tsx
@@ -81,9 +81,7 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
             const method = isCreate ? "POST" : "PUT";
             const endpoint = isCreate
               ? "registration/operations"
-              : `registration/operations/${formData?.id}?submit=${isFinalStep}&save_contact=${
-                  formSection === 2
-                }`;
+              : `registration/operations/${formData?.id}?submit=${isFinalStep}&form_section=${formSection}`;
             const pathToRevalidate = isCreate
               ? "dashboard/operations"
               : `dashboard/operations/${formData?.id}`;


### PR DESCRIPTION
Card: [706](https://github.com/bcgov/cas-registration/issues/706)

Original purpose of card was to ensure that operations that are already Approved don't have their status reset to "Pending" when an edit is made (PUT request sent for the operation). This PR addresses that and some other issues:

- deletes/comments out Operation fields that are no longer required for MVP (such as multiple_operators, reporting_activities, addresses, etc.)
- fixes logic on the PUT endpoint for operations. We weren't saving some of the fields being sent to the backend correctly. There's still room for improvement on this IMO - it gets ugly because part of the payload being sent via the PUT request is actually default values from the frontend, which is why I introduced the `form_section` param on the endpoint so that we're only saving the parts of data in the payload that will come from the form section the user is on. Confusing? Yup. 