### PR TITLE
fix: user profile empty string values not triggering form validation

### DIFF
--- a/client/app/components/form/formDataTypes.ts
+++ b/client/app/components/form/formDataTypes.ts
@@ -57,6 +57,7 @@ export interface UserOperatorFormData extends UserFormData {
   is_new: boolean;
   operator_id: number;
 }
+
 export interface UserProfileFormData {
   first_name: string;
   last_name: string;
@@ -65,6 +66,16 @@ export interface UserProfileFormData {
   phone_number: string;
   app_role?: { role_name: string };
 }
+
+export interface UserProfilePartialFormData {
+  first_name?: string;
+  last_name?: string;
+  position_title?: string;
+  email?: string;
+  phone_number?: string;
+  app_role?: { role_name: string };
+}
+
 export interface SelectOperatorFormData {
   search_type: string;
   legal_name?: string;

--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -32,11 +32,9 @@ export default async function User() {
       const names = getUserFullName(session)?.split(" ");
 
       formData = {
-        first_name: names?.[0] ?? "", // Use nullish coalescing here
-        last_name: names?.[1] ?? "", // Use nullish coalescing here
-        email: session?.user?.email || "",
-        phone_number: "",
-        position_title: "",
+        first_name: names?.[0],
+        last_name: names?.[1],
+        email: session?.user?.email,
       };
     } else {
       return (

--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -1,6 +1,9 @@
 import { actionHandler } from "@/app/utils/actions";
 import UserForm from "@/app/components/routes/profile/form/UserForm";
-import { UserProfileFormData } from "@/app/components/form/formDataTypes";
+import {
+  UserProfileFormData,
+  UserProfilePartialFormData,
+} from "@/app/components/form/formDataTypes";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { getUserFullName } from "@/app/utils/getUserFullName";
@@ -18,7 +21,7 @@ export default async function User() {
   // determines POST or PUT based on formData.error.includes("404")
   let isCreate = false;
   // get user's data
-  let formData: UserProfileFormData | { error: string } =
+  let formData: UserProfilePartialFormData | { error: string } =
     await getUserFormData();
   if ("error" in formData) {
     if (formData.error.includes("404")) {
@@ -34,7 +37,7 @@ export default async function User() {
       formData = {
         first_name: names?.[0],
         last_name: names?.[1],
-        email: session?.user?.email,
+        email: session?.user?.email ?? undefined,
       };
     } else {
       return (

--- a/client/app/components/routes/profile/form/UserForm.tsx
+++ b/client/app/components/routes/profile/form/UserForm.tsx
@@ -4,7 +4,10 @@ import FormBase from "@/app/components/form/FormBase";
 import { Alert } from "@mui/material";
 import SubmitButton from "@/app/components/form/SubmitButton";
 import { actionHandler } from "@/app/utils/actions";
-import { UserProfileFormData } from "@/app/components/form/formDataTypes";
+import {
+  UserProfileFormData,
+  UserProfilePartialFormData,
+} from "@/app/components/form/formDataTypes";
 import { userSchema, userUiSchema } from "@/app/utils/jsonSchema/user";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
@@ -12,7 +15,7 @@ import { useRouter } from "next/navigation";
 // 📐 Interface: expected properties and their types for UserForm component
 
 interface Props {
-  formData?: UserProfileFormData;
+  formData?: UserProfilePartialFormData;
   isCreate: boolean;
 }
 // 🏗️ Client side component: dashboard\profile


### PR DESCRIPTION
Fix for #550 

This was caused since an empty string still counts as a string in JSON Schema. I have created a `UserProfilePartialFormData` type to be used when we won't have all of the user profile form data and kept the original `UserProfileFormData` type for when it all needs to be there.