### PR TITLE
782 mui datagrid serverside pagination

### DIFF
--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -123,7 +123,7 @@ def list_operations(request, page: int = 1, sort_field: str = "created_at", sort
             .order_by(f"{sort_direction}{sort_field}")
         )
         paginator = Paginator(qs, 20)
-        return 200, OperationListOut(
+        return 200, OperationPaginatedOut(
             data=[OperationOut.from_orm(operation) for operation in paginator.page(page).object_list],
             row_count=paginator.count,
         )
@@ -142,7 +142,7 @@ def list_operations(request, page: int = 1, sort_field: str = "created_at", sort
         .only(*OperationListOut.Config.model_fields, "operator__legal_name", "bc_obps_regulated_operation__id")
     )
     paginator = Paginator(operators_operations, 20)
-    return 200, OperationListOut(
+    return 200, OperationPaginatedOut(
         data=[OperationOut.from_orm(operation) for operation in paginator.page(page).object_list],
         row_count=paginator.count,
     )

--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -123,8 +123,7 @@ def list_operations(request, page: int = 1):
         )
         paginator = Paginator(qs, 20)
         return 200, OperationListOut(
-            operation_list=[OperationOut.from_orm(operation) for operation in paginator.page(page).object_list],
-            total_pages=paginator.num_pages,
+            data=[OperationOut.from_orm(operation) for operation in paginator.page(page).object_list],
             row_count=paginator.count,
         )
     # Industry users can only see their companies' operations (if there's no user_operator or operator, then the user hasn't requested access to the operator)
@@ -144,7 +143,6 @@ def list_operations(request, page: int = 1):
     paginator = Paginator(operators_operations, 20)
     return 200, {
         "data": paginator.page(page).object_list,
-        "total_pages": paginator.num_pages,
         "row_count": paginator.count,
     }
 

--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from django.core.exceptions import ValidationError
 import pytz
 from typing import List, Union
+from typing import List
+from django.core.paginator import Paginator
 from registration.models import (
     AppRole,
     MultipleOperator,
@@ -24,6 +26,7 @@ from registration.models import (
 from registration.schema import (
     OperationCreateIn,
     OperationUpdateIn,
+    OperationListOut,
     OperationOut,
     OperationCreateOut,
     OperationUpdateOut,
@@ -106,9 +109,9 @@ def create_or_update_multiple_operators(
 ##### GET #####
 
 
-@router.get("/operations", response={200: List[OperationListOut], codes_4xx: Message})
+@router.get("/operations", response={200: OperationListOut, codes_4xx: Message})
 @authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
-def list_operations(request):
+def list_operations(request, page: int = 1):
     user: User = request.current_user
     # IRC users can see all operations except ones that are not started yet
     if user.is_irc_user():
@@ -117,7 +120,12 @@ def list_operations(request):
             .exclude(status=Operation.Statuses.NOT_STARTED)
             .only(*OperationListOut.Config.model_fields, "operator__legal_name", "bc_obps_regulated_operation__id")
         )
-        return 200, qs
+        paginator = Paginator(qs, 20)
+        return 200, OperationListOut(
+            operation_list=[OperationOut.from_orm(operation) for operation in paginator.page(page).object_list],
+            total_pages=paginator.num_pages,
+            row_count=paginator.count,
+        )
     # Industry users can only see their companies' operations (if there's no user_operator or operator, then the user hasn't requested access to the operator)
     user_operator = UserOperator.objects.filter(user_id=user.user_guid).only("operator_id").first()
     if not user_operator:
@@ -132,8 +140,12 @@ def list_operations(request):
         .order_by("-created_at")
         .only(*OperationListOut.Config.model_fields, "operator__legal_name", "bc_obps_regulated_operation__id")
     )
-
-    return 200, operators_operations
+    paginator = Paginator(operators_operations, 20)
+    return 200, {
+        "operation_list": paginator.page(page).object_list,
+        "total_pages": paginator.num_pages,
+        "row_count": paginator.count,
+    }
 
 
 @router.get(

--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -113,9 +113,9 @@ def create_or_update_multiple_operators(
 @authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
 def list_operations(request, page: int = 1, sort_field: str = "created_at", sort_order: str = "desc"):
     user: User = request.current_user
+    sort_direction = "-" if sort_order == "desc" else ""
     # IRC users can see all operations except ones that are not started yet
     if user.is_irc_user():
-        sort_direction = "-" if sort_order == "desc" else ""
         qs = (
             Operation.objects.select_related("operator", "bc_obps_regulated_operation")
             .exclude(status=Operation.Statuses.NOT_STARTED)
@@ -138,7 +138,7 @@ def list_operations(request, page: int = 1, sort_field: str = "created_at", sort
     operators_operations = (
         Operation.objects.select_related("operator", "bc_obps_regulated_operation")
         .filter(operator_id=user_operator.operator_id)
-        .order_by("-created_at")
+        .order_by(f"{sort_direction}{sort_field}")
         .only(*OperationListOut.Config.model_fields, "operator__legal_name", "bc_obps_regulated_operation__id")
     )
     paginator = Paginator(operators_operations, 20)

--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -27,6 +27,7 @@ from registration.schema import (
     OperationCreateIn,
     OperationUpdateIn,
     OperationPaginatedOut,
+    OperationListOut,
     OperationOut,
     OperationCreateOut,
     OperationUpdateOut,
@@ -123,8 +124,9 @@ def list_operations(request, page: int = 1, sort_field: str = "created_at", sort
             .order_by(f"{sort_direction}{sort_field}")
         )
         paginator = Paginator(qs, 20)
+
         return 200, OperationPaginatedOut(
-            data=[OperationOut.from_orm(operation) for operation in paginator.page(page).object_list],
+            data=[OperationListOut.from_orm(operation) for operation in paginator.page(page).object_list],
             row_count=paginator.count,
         )
     # Industry users can only see their companies' operations (if there's no user_operator or operator, then the user hasn't requested access to the operator)
@@ -143,7 +145,7 @@ def list_operations(request, page: int = 1, sort_field: str = "created_at", sort
     )
     paginator = Paginator(operators_operations, 20)
     return 200, OperationPaginatedOut(
-        data=[OperationOut.from_orm(operation) for operation in paginator.page(page).object_list],
+        data=[OperationListOut.from_orm(operation) for operation in paginator.page(page).object_list],
         row_count=paginator.count,
     )
 

--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -1,4 +1,4 @@
-from registration.constants import UNAUTHORIZED_MESSAGE
+from registration.constants import PAGE_SIZE, UNAUTHORIZED_MESSAGE
 from django.db import transaction
 from registration.decorators import authorize
 from .api_base import router
@@ -123,7 +123,7 @@ def list_operations(request, page: int = 1, sort_field: str = "created_at", sort
             .only(*OperationListOut.Config.model_fields, "operator__legal_name", "bc_obps_regulated_operation__id")
             .order_by(f"{sort_direction}{sort_field}")
         )
-        paginator = Paginator(qs, 20)
+        paginator = Paginator(qs, PAGE_SIZE)
 
         return 200, OperationPaginatedOut(
             data=[OperationListOut.from_orm(operation) for operation in paginator.page(page).object_list],
@@ -143,7 +143,7 @@ def list_operations(request, page: int = 1, sort_field: str = "created_at", sort
         .order_by(f"{sort_direction}{sort_field}")
         .only(*OperationListOut.Config.model_fields, "operator__legal_name", "bc_obps_regulated_operation__id")
     )
-    paginator = Paginator(operators_operations, 20)
+    paginator = Paginator(operators_operations, PAGE_SIZE)
     return 200, OperationPaginatedOut(
         data=[OperationListOut.from_orm(operation) for operation in paginator.page(page).object_list],
         row_count=paginator.count,

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -221,7 +221,6 @@ def get_user(request):
 
 @router.get("/user-operators", response=UserOperatorPaginatedOut)
 @authorize(AppRole.get_authorized_irc_roles())
-
 def list_user_operators(request, page: int = 1, sort_field: str = "created_at", sort_order: str = "desc"):
     sort_direction = "-" if sort_order == "desc" else ""
 
@@ -234,10 +233,12 @@ def list_user_operators(request, page: int = 1, sort_field: str = "created_at", 
         sort_field = f"user__{sort_field}"
     if sort_field == "legal_name":
         sort_field = "operator__legal_name"
-        
-    qs = UserOperator.objects.select_related("operator", "user").only(
-        "id", "status", "user__last_name", "user__first_name", "user__email", "operator__legal_name"
-    ).order_by(f"{sort_direction}{sort_field}")
+
+    qs = (
+        UserOperator.objects.select_related("operator", "user")
+        .only("id", "status", "user__last_name", "user__first_name", "user__email", "operator__legal_name")
+        .order_by(f"{sort_direction}{sort_field}")
+    )
     paginator = Paginator(qs, PAGE_SIZE)
     user_operator_list = []
 

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -18,8 +18,6 @@ from registration.schema import (
     RequestAccessOut,
     IsApprovedUserOperator,
     UserOperatorIdOut,
-    UserOperatorOperatorIdOut,
-    UserOperatorStatus,
     UserOperatorStatusUpdate,
     ExternalDashboardUsersTileData,
     PendingUserOperatorOut,
@@ -43,6 +41,7 @@ from registration.models import (
 from ninja.responses import codes_4xx
 from datetime import datetime
 from django.forms import model_to_dict
+from registration.constants import PAGE_SIZE
 
 
 # Function to save operator data to reuse in POST/PUT methods
@@ -235,10 +234,11 @@ def list_user_operators(request, page: int = 1, sort_field: str = "created_at", 
         sort_field = f"user__{sort_field}"
     if sort_field == "legal_name":
         sort_field = "operator__legal_name"
+        
     qs = UserOperator.objects.select_related("operator", "user").only(
         "id", "status", "user__last_name", "user__first_name", "user__email", "operator__legal_name"
     ).order_by(f"{sort_direction}{sort_field}")
-    paginator = Paginator(qs, 20)
+    paginator = Paginator(qs, PAGE_SIZE)
     user_operator_list = []
 
     paginator = Paginator(qs, 20)

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -265,7 +265,6 @@ def list_user_operators(request, page: int = 1):
         )
     return 200, UserOperatorPaginatedOut(
         data=user_operator_list,
-        total_pages=paginator.num_pages,
         row_count=paginator.count,
     )
 

--- a/bc_obps/registration/constants.py
+++ b/bc_obps/registration/constants.py
@@ -16,3 +16,5 @@ BC_CORPORATE_REGISTRY_REGEX_MESSAGE = "BC Corporate Registry Number should be 1-
 BORO_ID_REGEX = r"^\d{2}-\d{4}$"
 
 USER_CACHE_PREFIX = "user_cache_"
+
+PAGE_SIZE = 20

--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -62,5 +62,316 @@
       "regulated_products": [],
       "status": "Approved"
     }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 1,
+      "documents": [],
+      "submission_date": "2024-01-13T15:28:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 5",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990001",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 1,
+      "documents": [],
+      "submission_date": "2024-01-14T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 6",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990000",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 1,
+      "documents": [],
+      "submission_date": "2024-01-15T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 7",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990006",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 1,
+      "documents": [],
+      "submission_date": "2024-01-16T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 8",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990007",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 1,
+      "documents": [],
+      "submission_date": "2024-01-17T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 9",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990008",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 1,
+      "documents": [],
+      "submission_date": "2024-01-18T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 10",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990009",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 1,
+      "documents": [],
+      "submission_date": "2024-01-19T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 11",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990010",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 1,
+      "documents": [],
+      "submission_date": "2024-01-20T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 12",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990011",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 1,
+      "documents": [],
+      "submission_date": "2024-01-21T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 13",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990012",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 2,
+      "documents": [],
+      "submission_date": "2024-01-22T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 14",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990013",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 2,
+      "documents": [],
+      "submission_date": "2024-01-23T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 15",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990014",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 2,
+      "documents": [],
+      "submission_date": "2024-01-24T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 16",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990015",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 2,
+      "documents": [],
+      "submission_date": "2024-01-25T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 17",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990016",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 2,
+      "documents": [],
+      "submission_date": "2024-01-26T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 18",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990017",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 2,
+      "documents": [],
+      "submission_date": "2024-01-27T15:27:00.000Z",
+      "point_of_contact": 1,
+      "name": "Operation 19",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990018",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 2,
+      "documents": [],
+      "submission_date": "2024-01-28T15:27:00.000Z",
+      "name": "Operation 20",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990019",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 2,
+      "documents": [],
+      "name": "Operation 21",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990020",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 2,
+      "documents": [],
+      "name": "Operation 22",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990021",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 2,
+      "documents": [],
+      "name": "Operation 23",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990022",
+      "regulated_products": [],
+      "status": "Pending"
+    }
+  },
+  {
+    "model": "registration.operation",
+    "fields": {
+      "operator": 2,
+      "documents": [],
+      "name": "Operation 24",
+      "type": "Single Facility Operation",
+      "naics_code": 21,
+      "opt_in": false,
+      "bcghg_id": "23219990023",
+      "regulated_products": [],
+      "status": "Pending"
+    }
   }
 ]

--- a/bc_obps/registration/fixtures/mock/user.json
+++ b/bc_obps/registration/fixtures/mock/user.json
@@ -82,5 +82,327 @@
       "phone_number": "+16044015432",
       "app_role": "industry_user"
     }
+  },
+  {
+    "model": "registration.user",
+    "pk": 6,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000003",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "3",
+      "position_title": "Code Monkey",
+      "email": "test1@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000004",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "4",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000005",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "5",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000006",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "6",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000007",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "7",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000008",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "8",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000009",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "9",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000010",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "10",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000011",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "11",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000012",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "12",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000013",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "10",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000013",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "10",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000014",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "14",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000015",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "15",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000016",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "16",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000017",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "17",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000018",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "18",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000019",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "19",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000020",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "20",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000021",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "21",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000022",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "22",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000023",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "23",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
+  },
+  {
+    "model": "registration.user",
+    "pk": 7,
+    "fields": {
+      "user_guid": "00000000-0000-0000-0000-000000000024",
+      "business_guid": "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+      "first_name": "User",
+      "last_name": "24",
+      "position_title": "Code Monkey",
+      "email": "test2@email.com",
+      "phone_number": "+16044015432",
+      "app_role": "industry_user"
+    }
   }
 ]

--- a/bc_obps/registration/fixtures/mock/userOperator.json
+++ b/bc_obps/registration/fixtures/mock/userOperator.json
@@ -29,7 +29,7 @@
     "fields": {
       "user": "279c80cf57814c28872740a133d17c0d",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -41,7 +41,7 @@
     "fields": {
       "user": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       "operator": 3,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -53,7 +53,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000002",
       "operator": 3,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -65,7 +65,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000003",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -77,7 +77,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000004",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -89,7 +89,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000005",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -101,7 +101,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000006",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -113,7 +113,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000007",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -125,7 +125,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000008",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -137,7 +137,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000009",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -149,7 +149,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000010",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -161,7 +161,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000011",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -173,7 +173,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000012",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -185,7 +185,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000013",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -197,7 +197,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000014",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -209,7 +209,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000015",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -221,7 +221,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000016",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -233,7 +233,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000017",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -245,7 +245,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000018",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -257,7 +257,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000019",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -269,7 +269,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000020",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -281,7 +281,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000021",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -293,7 +293,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000022",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -305,7 +305,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000023",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null
@@ -317,7 +317,7 @@
     "fields": {
       "user": "00000000-0000-0000-0000-000000000024",
       "operator": 2,
-      "role": "reporter",
+      "role": "admin",
       "status": "Pending",
       "verified_at": null,
       "verified_by": null

--- a/bc_obps/registration/fixtures/mock/userOperator.json
+++ b/bc_obps/registration/fixtures/mock/userOperator.json
@@ -64,7 +64,7 @@
     "pk": 6,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000003",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -76,7 +76,7 @@
     "pk": 7,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000004",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -88,7 +88,7 @@
     "pk": 8,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000005",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -100,7 +100,7 @@
     "pk": 9,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000006",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -112,7 +112,7 @@
     "pk": 10,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000007",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -124,7 +124,7 @@
     "pk": 11,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000008",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -136,7 +136,7 @@
     "pk": 12,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000009",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -148,7 +148,7 @@
     "pk": 13,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000010",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -160,7 +160,7 @@
     "pk": 14,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000011",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -172,7 +172,7 @@
     "pk": 15,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000012",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -184,7 +184,7 @@
     "pk": 16,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000013",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -196,7 +196,7 @@
     "pk": 17,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000014",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -208,7 +208,7 @@
     "pk": 18,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000015",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -220,7 +220,7 @@
     "pk": 19,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000016",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -232,7 +232,7 @@
     "pk": 20,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000017",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -244,7 +244,7 @@
     "pk": 21,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000018",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -256,7 +256,7 @@
     "pk": 22,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000019",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -268,7 +268,7 @@
     "pk": 23,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000020",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -280,7 +280,7 @@
     "pk": 24,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000021",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -292,7 +292,7 @@
     "pk": 25,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000022",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -304,7 +304,7 @@
     "pk": 26,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000023",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,
@@ -316,7 +316,7 @@
     "pk": 27,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000024",
-      "operator": 3,
+      "operator": 2,
       "role": "reporter",
       "status": "Pending",
       "verified_at": null,

--- a/bc_obps/registration/fixtures/mock/userOperator.json
+++ b/bc_obps/registration/fixtures/mock/userOperator.json
@@ -46,5 +46,281 @@
       "verified_at": null,
       "verified_by": null
     }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 5,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000002",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 6,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000003",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 7,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000004",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 8,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000005",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 9,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000006",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 10,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000007",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 11,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000008",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 12,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000009",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 13,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000010",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 14,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000011",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 15,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000012",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 16,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000013",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 17,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000014",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 18,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000015",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 19,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000016",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 20,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000017",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 21,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000018",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 22,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000019",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 23,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000020",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 24,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000021",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 25,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000022",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 26,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000023",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.useroperator",
+    "pk": 27,
+    "fields": {
+      "user": "00000000-0000-0000-0000-000000000024",
+      "operator": 3,
+      "role": "reporter",
+      "status": "Pending",
+      "verified_at": null,
+      "verified_by": null
+    }
   }
 ]

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -132,11 +132,8 @@ class OperationUpdateStatusOut(ModelSchema):
     class Config:
         model = Operation
         model_fields = ["id"]
-        
-class OperationListOut(Schema):
-    operation_list: List[OperationOut]
-    total_pages: int
-    
+
+
 class OperationPaginatedOut(Schema):
     data: List[OperationListOut]
     row_count: int

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -140,4 +140,3 @@ class OperationListOut(Schema):
 class OperationPaginatedOut(Schema):
     data: List[OperationOut]
     row_count: int
-    total_pages: int

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -136,4 +136,8 @@ class OperationUpdateStatusOut(ModelSchema):
 class OperationListOut(Schema):
     operation_list: List[OperationOut]
     total_pages: int
+    
+class OperationPaginatedOut(Schema):
+    data: List[OperationOut]
     row_count: int
+    total_pages: int

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -138,5 +138,5 @@ class OperationListOut(Schema):
     total_pages: int
     
 class OperationPaginatedOut(Schema):
-    data: List[OperationOut]
+    data: List[OperationListOut]
     row_count: int

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 from registration.schema.operator import OperatorForOperationOut
 from registration.utils import file_to_data_url, data_url_to_file
 from ninja import Field, ModelSchema, Schema
@@ -132,3 +132,8 @@ class OperationUpdateStatusOut(ModelSchema):
     class Config:
         model = Operation
         model_fields = ["id"]
+        
+class OperationListOut(Schema):
+    operation_list: List[OperationOut]
+    total_pages: int
+    row_count: int

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -159,5 +159,5 @@ class UserOperatorListOut(Schema):
 
 
 class UserOperatorPaginatedOut(Schema):
-    row_count: int
     data: List[UserOperatorListOut]
+    row_count: int

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -156,3 +156,9 @@ class UserOperatorListOut(Schema):
     last_name: str
     email: str
     legal_name: str
+
+
+class UserOperatorPaginatedOut(Schema):
+    row_count: int
+    total_pages: int
+    data: List[UserOperatorListOut]

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -160,5 +160,4 @@ class UserOperatorListOut(Schema):
 
 class UserOperatorPaginatedOut(Schema):
     row_count: int
-    total_pages: int
     data: List[UserOperatorListOut]

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -17,6 +17,7 @@ from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 
 pytestmark = pytest.mark.django_db
 from registration.tests.utils.bakers import document_baker, operation_baker, operator_baker, user_operator_baker
+from registration.constants import PAGE_SIZE
 
 # initialize the APIClient app
 client = Client()
@@ -201,11 +202,11 @@ class TestOperationsEndpoint(CommonTestSetup):
         response = TestUtils.mock_get_with_auth_role(self, "cas_admin")
         assert response.status_code == 200
         response_data = response.json().get('data')
-        assert len(response_data) == 20
+        assert len(response_data) == PAGE_SIZE
         response = TestUtils.mock_get_with_auth_role(self, "cas_analyst")
         assert response.status_code == 200
         response_data = response.json().get('data')
-        assert len(response_data) == 20
+        assert len(response_data) == PAGE_SIZE
         # industry users can only see their own company's operations, and only if they're approved
         baker.make(
             UserOperator, user_id=self.user.user_guid, status=UserOperator.Statuses.APPROVED, operator_id=operator1.id
@@ -213,7 +214,7 @@ class TestOperationsEndpoint(CommonTestSetup):
         response = TestUtils.mock_get_with_auth_role(self, "industry_user")
         assert response.status_code == 200
         response_data = response.json().get('data')
-        assert len(response_data) == 20
+        assert len(response_data) == PAGE_SIZE
 
     def test_operations_endpoint_get_method_paginated(self):
         operator1 = operator_baker()
@@ -230,7 +231,7 @@ class TestOperationsEndpoint(CommonTestSetup):
         response_data = response.json().get('data')
         # save the id of the first paginated response item
         page_1_response_id = response_data[0].get('id')
-        assert len(response_data) == 20
+        assert len(response_data) == PAGE_SIZE
         # Get the page 2 response
         response = TestUtils.mock_get_with_auth_role(
             self, "cas_admin", self.endpoint + "?page=2&sort_field=created_at&sort_order=desc"
@@ -239,7 +240,7 @@ class TestOperationsEndpoint(CommonTestSetup):
         response_data = response.json().get('data')
         # save the id of the first paginated response item
         page_2_response_id = response_data[0].get('id')
-        assert len(response_data) == 20
+        assert len(response_data) == PAGE_SIZE
         # assert that the first item in the page 1 response is not the same as the first item in the page 2 response
         assert page_1_response_id != page_2_response_id
 
@@ -251,7 +252,7 @@ class TestOperationsEndpoint(CommonTestSetup):
         response_data = response.json().get('data')
         # save the id of the first paginated response item
         page_2_response_id_reverse = response_data[0].get('id')
-        assert len(response_data) == 20
+        assert len(response_data) == PAGE_SIZE
         # assert that the first item in the page 2 response is not the same as the first item in the page 2 response with reversed order
         assert page_2_response_id != page_2_response_id_reverse
 

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -222,8 +222,9 @@ class TestOperationsEndpoint(CommonTestSetup):
         assert post_response.json().get('name') == "Springfield Nuclear Power Plant"
         assert post_response.json().get('id') is not None
         # check that the default status of pending was applied
-        get_response = TestUtils.mock_get_with_auth_role(self, "industry_user").json()[0]
-        assert 'status' in get_response and get_response['status'] == 'Not Started'
+        get_response = TestUtils.mock_get_with_auth_role(self, "industry_user").json()
+        get_response_data = get_response.get('data')[0]
+        assert 'status' in get_response_data and get_response_data['status'] == 'Not Started'
         post_response = TestUtils.mock_post_with_auth_role(
             self, "industry_user", content_type_json, mock_operation.json(), endpoint=None
         )

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -243,6 +243,18 @@ class TestOperationsEndpoint(CommonTestSetup):
         # assert that the first item in the page 1 response is not the same as the first item in the page 2 response
         assert page_1_response_id != page_2_response_id
 
+        # Get the page 2 response but with a different sort order
+        response = TestUtils.mock_get_with_auth_role(
+            self, "cas_admin", self.endpoint + "?page=2&sort_field=created_at&sort_order=asc"
+        )
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        # save the id of the first paginated response item
+        page_2_response_id_reverse = response_data[0].get('id')
+        assert len(response_data) == 20
+        # assert that the first item in the page 2 response is not the same as the first item in the page 2 response with reversed order
+        assert page_2_response_id != page_2_response_id_reverse
+
     # POST
     def test_authorized_roles_can_post_new_operation(self):
         operator = operator_baker()

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -14,6 +14,7 @@ from registration.models import (
 )
 from registration.tests.utils.bakers import operator_baker, user_operator_baker
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
+from registration.constants import PAGE_SIZE
 
 pytestmark = pytest.mark.django_db
 
@@ -240,7 +241,7 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         response_data = response.json().get('data')
         # save the id of the first paginated response item
         page_1_response_id = response_data[0].get('id')
-        assert len(response_data) == 20
+        assert len(response_data) == PAGE_SIZE
         # Get the page 2 response
         response = TestUtils.mock_get_with_auth_role(
             self, "cas_admin", f"{base_endpoint}user-operators?page=2&sort_field=created_at&sort_order=desc"
@@ -249,7 +250,7 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         response_data = response.json().get('data')
         # save the id of the first paginated response item
         page_2_response_id = response_data[0].get('id')
-        assert len(response_data) == 20
+        assert len(response_data) == PAGE_SIZE
         # assert that the first item in the page 1 response is not the same as the first item in the page 2 response
         assert page_1_response_id != page_2_response_id
 
@@ -261,7 +262,7 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         response_data = response.json().get('data')
         # save the id of the first paginated response item
         page_2_response_id_reverse = response_data[0].get('id')
-        assert len(response_data) == 20
+        assert len(response_data) == PAGE_SIZE
         # assert that the first item in the page 2 response is not the same as the first item in the page 2 response with reversed order
         assert page_2_response_id != page_2_response_id_reverse
 

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -225,6 +225,46 @@ class TestUserOperatorEndpoint(CommonTestSetup):
 
         assert len(json.loads(response.content)) == 1
 
+    def test_get_user_operators_paginated(self):
+        baker.make(
+            UserOperator,
+            user=self.user,
+            operator=operator_baker(),
+            role=UserOperator.Roles.ADMIN,
+            status=UserOperator.Statuses.APPROVED,
+            _quantity=60,
+        )
+
+        response = TestUtils.mock_get_with_auth_role(self, 'cas_admin', f"{base_endpoint}user-operators")
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        # save the id of the first paginated response item
+        page_1_response_id = response_data[0].get('id')
+        assert len(response_data) == 20
+        # Get the page 2 response
+        response = TestUtils.mock_get_with_auth_role(
+            self, "cas_admin", f"{base_endpoint}user-operators?page=2&sort_field=created_at&sort_order=desc"
+        )
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        # save the id of the first paginated response item
+        page_2_response_id = response_data[0].get('id')
+        assert len(response_data) == 20
+        # assert that the first item in the page 1 response is not the same as the first item in the page 2 response
+        assert page_1_response_id != page_2_response_id
+
+        # Get page 2 again but with different sort order
+        response = TestUtils.mock_get_with_auth_role(
+            self, "cas_admin", f"{base_endpoint}user-operators?page=2&sort_field=created_at&sort_order=asc"
+        )
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        # save the id of the first paginated response item
+        page_2_response_id_reverse = response_data[0].get('id')
+        assert len(response_data) == 20
+        # assert that the first item in the page 2 response is not the same as the first item in the page 2 response with reversed order
+        assert page_2_response_id != page_2_response_id_reverse
+
     def test_user_operator_put_update_user_status(self):
         user = baker.make(User)
         user_operator = user_operator_baker()

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -1,5 +1,5 @@
 import { GridColDef, GridRowsProp } from "@mui/x-data-grid";
-import OperatorDataGrid from "@/app/components/datagrid/OperatorDataGrid";
+import DataGrid from "@/app/components/datagrid/DataGrid";
 import {
   ExternalDashboardUsersTile,
   processExternalDashboardUsersTileData,
@@ -74,5 +74,5 @@ export default async function Page() {
     status: uOS.status,
   }));
 
-  return <OperatorDataGrid rows={statusRows} columns={columns} />;
+  return <DataGrid rows={statusRows} columns={columns} />;
 }

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -1,5 +1,5 @@
 import { GridColDef, GridRowsProp } from "@mui/x-data-grid";
-import DataGrid from "@/app/components/datagrid/DataGrid";
+import OperatorDataGrid from "@/app/components/datagrid/OperatorDataGrid";
 import {
   ExternalDashboardUsersTile,
   processExternalDashboardUsersTileData,
@@ -64,6 +64,7 @@ export default async function Page() {
       headerAlign: "center",
     },
   ];
+
   const statusRows: GridRowsProp = userOperatorStatuses.map((uOS) => ({
     id: uOS.user.user_guid,
     name: `${uOS.user.first_name} ${uOS.user.last_name.slice(0, 1)}`,
@@ -73,5 +74,5 @@ export default async function Page() {
     status: uOS.status,
   }));
 
-  return <DataGrid rows={statusRows} columns={columns} />;
+  return <OperatorDataGrid rows={statusRows} columns={columns} />;
 }

--- a/client/app/(authenticated)/idir/cas_admin/dashboard/operators/page.tsx
+++ b/client/app/(authenticated)/idir/cas_admin/dashboard/operators/page.tsx
@@ -1,11 +1,3 @@
-import { Suspense } from "react";
-import AccessRequests from "@/app/components/routes/access-requests/AccessRequests";
-import Loading from "@/app/components/loading/SkeletonGrid";
+import OperatorsPage from "@/app/components/routes/operators/OperatorsPage";
 
-export default function Page() {
-  return (
-    <Suspense fallback={<Loading />}>
-      <AccessRequests />
-    </Suspense>
-  );
-}
+export default OperatorsPage;

--- a/client/app/(authenticated)/idir/cas_analyst/dashboard/operators/page.tsx
+++ b/client/app/(authenticated)/idir/cas_analyst/dashboard/operators/page.tsx
@@ -1,11 +1,3 @@
-import { Suspense } from "react";
-import AccessRequests from "@/app/components/routes/access-requests/AccessRequests";
-import Loading from "@/app/components/loading/SkeletonGrid";
+import OperatorsPage from "@/app/components/routes/operators/OperatorsPage";
 
-export default function Page() {
-  return (
-    <Suspense fallback={<Loading />}>
-      <AccessRequests />
-    </Suspense>
-  );
-}
+export default OperatorsPage;

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -109,9 +109,10 @@ const DataGrid: React.FC<Props> = ({
         rowCount={rowCount}
         showCellVerticalBorder
         initialState={{
-          pagination: { paginationModel: { pageSize: 20 } },
+          pagination: { paginationModel: { pageSize: PAGE_SIZE } },
         }}
         pagination
+        pageSizeOptions={[PAGE_SIZE]}
         sortingMode={paginationMode}
         paginationMode={paginationMode}
         onPaginationModelChange={setPaginationModel}

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -8,6 +8,7 @@ import {
   GridSortItem,
 } from "@mui/x-data-grid";
 import { BC_GOV_BACKGROUND_COLOR_BLUE } from "@/app/styles/colors";
+import Pagination from "@/app/components/datagrid/Pagination";
 
 interface Props {
   fetchPageData?: (
@@ -121,6 +122,7 @@ const DataGrid: React.FC<Props> = ({
           columnSortedAscendingIcon: AscendingIcon,
           columnSortedDescendingIcon: DescendingIcon,
           columnUnsortedIcon: SortIcon,
+          pagination: Pagination,
         }}
         sx={{
           "& .MuiDataGrid-columnHeaderDraggableContainer": {

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -15,6 +15,7 @@ interface Props {
   rows: GridRowsProp;
   rowCount?: number;
   columns: GridColDef[];
+  paginationMode?: "client" | "server";
 }
 
 interface SortIconProps {
@@ -54,10 +55,11 @@ const DescendingIcon = () => {
 const PAGE_SIZE = 20;
 
 const DataGrid: React.FC<Props> = ({
+  columns,
   fetchPageData,
+  paginationMode = "client",
   rows: initialRows,
   rowCount,
-  columns,
 }) => {
   const [rows, setRows] = useState(initialRows ?? []);
   const [loading, setLoading] = useState(false);
@@ -99,8 +101,8 @@ const DataGrid: React.FC<Props> = ({
           pagination: { paginationModel: { pageSize: 20 } },
         }}
         pagination
-        sortingMode="server"
-        paginationMode="server"
+        sortingMode={paginationMode}
+        paginationMode={paginationMode}
         onPaginationModelChange={setPaginationModel}
         onSortModelChange={setSortModel}
         // Set the row height to "auto" so that the row height will adjust to the content

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -1,22 +1,16 @@
 "use client";
-import { useEffect, useState } from "react";
+
 import {
   DataGrid as MuiGrid,
   GridRowsProp,
   GridColDef,
-  GridRenderCellParams,
 } from "@mui/x-data-grid";
-import Link from "next/link";
 import { BC_GOV_BACKGROUND_COLOR_BLUE } from "@/app/styles/colors";
 import { Session } from "next-auth";
 
 interface Props {
   rows: GridRowsProp;
   columns: GridColDef[];
-  cntxt?: string;
-  // Optionally pass the server session to the component
-  // Since directly using client session can be a bit slow to load
-  session?: Session | null;
 }
 
 interface SortIconProps {
@@ -53,79 +47,12 @@ const DescendingIcon = () => {
   return <SortIcon topFill="white" bottomFill="grey" />;
 };
 
-const DataGrid: React.FC<Props> = ({ rows, columns, cntxt, session }) => {
-  // 📚  Define a state variable to store columns
-  const [customColumns, setCustomColumns] = useState<GridColDef[]>(columns);
-
-  const isIndustryUser = session?.user.app_role?.includes("industry");
-
-  useEffect(() => {
-    // 🔍 Props passed from Server Components—for example client/app/operations/page.tsx—must be serializable
-    // Handling non-serializable column functions here...
-    switch (cntxt) {
-      case "operations":
-        // 📚 Define a custom renderCell function for the 'action' column
-        const updatedColumnsOperations = columns.map((column) => {
-          if (column.field === "action") {
-            return {
-              ...column,
-              renderCell: (params: GridRenderCellParams) => (
-                <div>
-                  {/* 🔗 Add reg or details link */}
-                  <Link
-                    className="no-underline text-bc-link-blue whitespace-normal"
-                    // Indutry users view multistep form, internal users view single page details route
-                    href={`operations/${params.row.id}${
-                      isIndustryUser ? "/1" : ""
-                    }`}
-                  >
-                    {params.row.status === "Not Started"
-                      ? "Start Application"
-                      : "View Details"}
-                  </Link>
-                </div>
-              ),
-            };
-          }
-          return column;
-        });
-        //  🔄 Use updatedColumns for rendering the DataGrid
-        setCustomColumns(updatedColumnsOperations);
-        break;
-      case "user-operators":
-        // 📚 Define a custom renderCell function for the 'action' column
-        const updatedColumnsUserOperators = columns.map((column) => {
-          if (column.field === "action") {
-            return {
-              ...column,
-              renderCell: (params: GridRenderCellParams) => (
-                <div>
-                  {/* Link to the first page of the multistep form for a specific user-operator. The '1' represents the first formSection of the form. */}
-                  <Link
-                    className="no-underline text-bc-link-blue"
-                    href={`operators/user-operator/${params.row.id}/1`}
-                  >
-                    View Details
-                  </Link>
-                </div>
-              ),
-            };
-          }
-          return column;
-        });
-        //  🔄 Use updatedColumns for rendering the DataGrid
-        setCustomColumns(updatedColumnsUserOperators);
-        break;
-      default:
-        break;
-    }
-  }, [columns, cntxt]);
-
+const DataGrid: React.FC<Props> = ({ rows, columns }) => {
   return (
     <div style={{ height: "auto", width: "100%" }}>
       <MuiGrid
         rows={rows}
-        columns={customColumns}
+        columns={columns}
         showCellVerticalBorder
         initialState={{
           pagination: { paginationModel: { pageSize: 20 } },

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -8,7 +8,6 @@ import {
   GridSortItem,
 } from "@mui/x-data-grid";
 import { BC_GOV_BACKGROUND_COLOR_BLUE } from "@/app/styles/colors";
-import { Session } from "next-auth";
 
 interface Props {
   fetchPageData?: (
@@ -80,7 +79,7 @@ const DataGrid: React.FC<Props> = ({
 
   useEffect(() => {
     const sortModelField = sortModel[0]?.field ?? "created_at";
-    const sortModelDirection = sortModel[0]?.sort ?? "asc";
+    const sortModelOrder = sortModel[0]?.sort ?? "asc";
     // Don't fetch data if the component is not mounted
     // Since we will grab the first page using the server side props
     if (!isComponentMounted || !fetchPageData) return;
@@ -90,13 +89,13 @@ const DataGrid: React.FC<Props> = ({
       const pageData = await fetchPageData(
         paginationModel.page + 1,
         sortModelField,
-        sortModelDirection,
+        sortModelOrder,
       );
       setRows(pageData);
     };
 
     fetchData().then(() => setLoading(false));
-  }, [isComponentMounted, paginationModel, sortModel]);
+  }, [paginationModel, sortModel]);
 
   return (
     <div style={{ height: "auto", width: "100%" }}>

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -79,7 +79,8 @@ const DataGrid: React.FC<Props> = ({
 
   useEffect(() => {
     const sortModelField = sortModel[0]?.field ?? "created_at";
-    const sortModelOrder = sortModel[0]?.sort ?? "asc";
+    const sortModelOrder = sortModel[0]?.sort ?? "desc";
+
     // Don't fetch data if the component is not mounted
     // Since we will grab the first page using the server side props
     if (!isComponentMounted || !fetchPageData) return;
@@ -95,6 +96,7 @@ const DataGrid: React.FC<Props> = ({
     };
 
     fetchData().then(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [paginationModel, sortModel]);
 
   return (

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -11,7 +11,11 @@ import { BC_GOV_BACKGROUND_COLOR_BLUE } from "@/app/styles/colors";
 import { Session } from "next-auth";
 
 interface Props {
-  fetchPageData?: (page: number) => Promise<any>;
+  fetchPageData?: (
+    page: number,
+    sortField?: string,
+    sortOrder?: string,
+  ) => Promise<any>;
   rows: GridRowsProp;
   rowCount?: number;
   columns: GridColDef[];
@@ -68,7 +72,6 @@ const DataGrid: React.FC<Props> = ({
     page: 0,
     pageSize: PAGE_SIZE,
   });
-
   const [sortModel, setSortModel] = useState([] as GridSortItem[]);
 
   useEffect(() => {
@@ -76,13 +79,19 @@ const DataGrid: React.FC<Props> = ({
   }, []);
 
   useEffect(() => {
+    const sortModelField = sortModel[0]?.field ?? "created_at";
+    const sortModelDirection = sortModel[0]?.sort ?? "asc";
     // Don't fetch data if the component is not mounted
     // Since we will grab the first page using the server side props
     if (!isComponentMounted || !fetchPageData) return;
     setLoading(true);
     const fetchData = async () => {
       // fetch data from server
-      const pageData = await fetchPageData(paginationModel.page + 1);
+      const pageData = await fetchPageData(
+        paginationModel.page + 1,
+        sortModelField,
+        sortModelDirection,
+      );
       setRows(pageData);
     };
 

--- a/client/app/components/datagrid/DataGrid.tsx
+++ b/client/app/components/datagrid/DataGrid.tsx
@@ -11,7 +11,7 @@ import { BC_GOV_BACKGROUND_COLOR_BLUE } from "@/app/styles/colors";
 import { Session } from "next-auth";
 
 interface Props {
-  fetchPageData: (page: number) => Promise<any>;
+  fetchPageData?: (page: number) => Promise<any>;
   rows: GridRowsProp;
   rowCount?: number;
   columns: GridColDef[];
@@ -76,7 +76,7 @@ const DataGrid: React.FC<Props> = ({
   useEffect(() => {
     // Don't fetch data if the component is not mounted
     // Since we will grab the first page using the server side props
-    if (!isComponentMounted) return;
+    if (!isComponentMounted || !fetchPageData) return;
     setLoading(true);
     const fetchData = async () => {
       // fetch data from server

--- a/client/app/components/datagrid/OperationDataGrid.tsx
+++ b/client/app/components/datagrid/OperationDataGrid.tsx
@@ -8,8 +8,8 @@ import { formatOperationRows } from "@/app/components/routes/operations/Operatio
 
 const fetchOperationPageData = async (
   page: number,
-  sortField: string,
-  sortDirection: string,
+  sortField?: string,
+  sortDirection?: string,
 ) => {
   try {
     // fetch data from server

--- a/client/app/components/datagrid/OperationDataGrid.tsx
+++ b/client/app/components/datagrid/OperationDataGrid.tsx
@@ -14,7 +14,7 @@ const fetchOperationPageData = async (page: number) => {
       "GET",
       "",
     );
-    return formatOperationRows(pageData.operation_list);
+    return formatOperationRows(pageData.data);
   } catch (error) {
     throw error;
   }
@@ -53,10 +53,11 @@ const OperationDataGrid = ({
 
   return (
     <DataGrid
+      columns={updatedColumnsOperations}
       fetchPageData={fetchOperationPageData}
+      paginationMode="server"
       rows={rows}
       rowCount={rowCount}
-      columns={updatedColumnsOperations}
     />
   );
 };

--- a/client/app/components/datagrid/OperationDataGrid.tsx
+++ b/client/app/components/datagrid/OperationDataGrid.tsx
@@ -6,11 +6,15 @@ import { GridRenderCellParams } from "@mui/x-data-grid";
 import { actionHandler } from "@/app/utils/actions";
 import { formatOperationRows } from "@/app/components/routes/operations/Operations";
 
-const fetchOperationPageData = async (page: number) => {
+const fetchOperationPageData = async (
+  page: number,
+  sortField: string,
+  sortDirection: string,
+) => {
   try {
     // fetch data from server
     const pageData = await actionHandler(
-      `registration/operations?page=${page}`,
+      `registration/operations?page=${page}&sort_field=${sortField}&sort_direction=${sortDirection}`,
       "GET",
       "",
     );

--- a/client/app/components/datagrid/OperationDataGrid.tsx
+++ b/client/app/components/datagrid/OperationDataGrid.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import DataGrid from "./DataGrid";
+import Link from "next/link";
+import { GridRenderCellParams } from "@mui/x-data-grid";
+
+const OperationDataGrid = ({
+  rows,
+  columns,
+}: {
+  rows: any[];
+  columns: any[];
+}) => {
+  const updatedColumnsOperations = columns.map((column) => {
+    if (column.field === "action") {
+      return {
+        ...column,
+        renderCell: (params: GridRenderCellParams) => (
+          <div>
+            {/* 🔗 Add reg or details link */}
+            <Link
+              className="no-underline text-bc-link-blue whitespace-normal"
+              href={`operations/${params.row.id}/1`}
+            >
+              {params.row.status === "Not Started"
+                ? "Start Application"
+                : "View Details"}
+            </Link>
+          </div>
+        ),
+      };
+    }
+    return column;
+  });
+
+  return <DataGrid rows={rows} columns={updatedColumnsOperations} />;
+};
+
+export default OperationDataGrid;

--- a/client/app/components/datagrid/OperationDataGrid.tsx
+++ b/client/app/components/datagrid/OperationDataGrid.tsx
@@ -3,13 +3,31 @@
 import DataGrid from "./DataGrid";
 import Link from "next/link";
 import { GridRenderCellParams } from "@mui/x-data-grid";
+import { actionHandler } from "@/app/utils/actions";
+import { formatOperationRows } from "@/app/components/routes/operations/Operations";
+
+const fetchOperationPageData = async (page: number) => {
+  try {
+    // fetch data from server
+    const pageData = await actionHandler(
+      `registration/operations?page=${page}`,
+      "GET",
+      "",
+    );
+    return formatOperationRows(pageData.operation_list);
+  } catch (error) {
+    throw error;
+  }
+};
 
 const OperationDataGrid = ({
   rows,
+  rowCount,
   columns,
 }: {
   rows: any[];
   columns: any[];
+  rowCount: number;
 }) => {
   const updatedColumnsOperations = columns.map((column) => {
     if (column.field === "action") {
@@ -33,7 +51,14 @@ const OperationDataGrid = ({
     return column;
   });
 
-  return <DataGrid rows={rows} columns={updatedColumnsOperations} />;
+  return (
+    <DataGrid
+      fetchPageData={fetchOperationPageData}
+      rows={rows}
+      rowCount={rowCount}
+      columns={updatedColumnsOperations}
+    />
+  );
 };
 
 export default OperationDataGrid;

--- a/client/app/components/datagrid/OperationDataGrid.tsx
+++ b/client/app/components/datagrid/OperationDataGrid.tsx
@@ -9,12 +9,12 @@ import { formatOperationRows } from "@/app/components/routes/operations/Operatio
 const fetchOperationPageData = async (
   page: number,
   sortField?: string,
-  sortDirection?: string,
+  sortOrder?: string,
 ) => {
   try {
     // fetch data from server
     const pageData = await actionHandler(
-      `registration/operations?page=${page}&sort_field=${sortField}&sort_direction=${sortDirection}`,
+      `registration/operations?page=${page}&sort_field=${sortField}&sort_order=${sortOrder}`,
       "GET",
       "",
     );

--- a/client/app/components/datagrid/OperatorDataGrid.tsx
+++ b/client/app/components/datagrid/OperatorDataGrid.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import DataGrid from "./DataGrid";
+import Link from "next/link";
+import { GridRenderCellParams } from "@mui/x-data-grid";
+
+const OperatorDataGrid = ({
+  rows,
+  columns,
+}: {
+  rows: any[];
+  columns: any[];
+}) => {
+  const updatedColumnsUserOperators = columns.map((column) => {
+    if (column.field === "action") {
+      return {
+        ...column,
+        renderCell: (params: GridRenderCellParams) => (
+          <div>
+            {/* Link to the first page of the multistep form for a specific user-operator. The '1' represents the first formSection of the form. */}
+            <Link
+              className="no-underline text-bc-link-blue"
+              href={`operators/user-operator/${params.row.id}/1`}
+            >
+              View Details
+            </Link>
+          </div>
+        ),
+      };
+    }
+    return column;
+  });
+
+  return <DataGrid rows={rows} columns={updatedColumnsUserOperators} />;
+};
+
+export default OperatorDataGrid;

--- a/client/app/components/datagrid/OperatorDataGrid.tsx
+++ b/client/app/components/datagrid/OperatorDataGrid.tsx
@@ -9,12 +9,12 @@ import { formatUserOperatorRows } from "@/app/components/routes/access-requests/
 const fetchUserOperatorPageData = async (
   page: number,
   sortField?: string,
-  sortDirection?: string,
+  sortOrder?: string,
 ) => {
   try {
     // fetch data from server
     const pageData = await actionHandler(
-      `registration/user-operators?page=${page}&sort_field=${sortField}&sort_direction=${sortDirection}`,
+      `registration/user-operators?page=${page}&sort_field=${sortField}&sort_order=${sortOrder}`,
       "GET",
       "",
     );

--- a/client/app/components/datagrid/OperatorDataGrid.tsx
+++ b/client/app/components/datagrid/OperatorDataGrid.tsx
@@ -31,7 +31,13 @@ const OperatorDataGrid = ({
     return column;
   });
 
-  return <DataGrid rows={rows} columns={updatedColumnsUserOperators} />;
+  return (
+    <DataGrid
+      columns={updatedColumnsUserOperators}
+      paginationMode="server"
+      rows={rows}
+    />
+  );
 };
 
 export default OperatorDataGrid;

--- a/client/app/components/datagrid/OperatorDataGrid.tsx
+++ b/client/app/components/datagrid/OperatorDataGrid.tsx
@@ -1,14 +1,32 @@
 "use client";
 
 import DataGrid from "./DataGrid";
+import { actionHandler } from "@/app/utils/actions";
 import Link from "next/link";
 import { GridRenderCellParams } from "@mui/x-data-grid";
+import { formatUserOperatorRows } from "@/app/components/routes/access-requests/AccessRequests";
+
+const fetchUserOperatorPageData = async (page: number) => {
+  try {
+    // fetch data from server
+    const pageData = await actionHandler(
+      `registration/user-operators?page=${page}`,
+      "GET",
+      "",
+    );
+    return formatUserOperatorRows(pageData.data);
+  } catch (error) {
+    throw error;
+  }
+};
 
 const OperatorDataGrid = ({
   rows,
+  rowCount,
   columns,
 }: {
   rows: any[];
+  rowCount: number;
   columns: any[];
 }) => {
   const updatedColumnsUserOperators = columns.map((column) => {
@@ -34,8 +52,10 @@ const OperatorDataGrid = ({
   return (
     <DataGrid
       columns={updatedColumnsUserOperators}
+      fetchPageData={fetchUserOperatorPageData}
       paginationMode="server"
       rows={rows}
+      rowCount={rowCount}
     />
   );
 };

--- a/client/app/components/datagrid/OperatorDataGrid.tsx
+++ b/client/app/components/datagrid/OperatorDataGrid.tsx
@@ -6,11 +6,15 @@ import Link from "next/link";
 import { GridRenderCellParams } from "@mui/x-data-grid";
 import { formatUserOperatorRows } from "@/app/components/routes/access-requests/AccessRequests";
 
-const fetchUserOperatorPageData = async (page: number) => {
+const fetchUserOperatorPageData = async (
+  page: number,
+  sortField?: string,
+  sortDirection?: string,
+) => {
   try {
     // fetch data from server
     const pageData = await actionHandler(
-      `registration/user-operators?page=${page}`,
+      `registration/user-operators?page=${page}&sort_field=${sortField}&sort_direction=${sortDirection}`,
       "GET",
       "",
     );

--- a/client/app/components/datagrid/Pagination.tsx
+++ b/client/app/components/datagrid/Pagination.tsx
@@ -1,0 +1,56 @@
+import {
+  gridPageSizeSelector,
+  GridPagination,
+  useGridApiContext,
+  useGridSelector,
+  gridFilteredTopLevelRowCountSelector,
+  useGridRootProps,
+} from "@mui/x-data-grid";
+import MuiPagination from "@mui/material/Pagination";
+import { TablePaginationProps } from "@mui/material/TablePagination";
+
+const getPageCount = (rowCount: number, pageSize: number): number => {
+  if (pageSize > 0 && rowCount > 0) {
+    return Math.ceil(rowCount / pageSize);
+  }
+
+  return 0;
+};
+
+// This is a custom pagination component that is used to override the default pagination component
+// It adds numbered pagination buttons to the default pagination component
+const Pagination = ({
+  page,
+  onPageChange,
+  className,
+}: Pick<TablePaginationProps, "page" | "onPageChange" | "className">) => {
+  const apiRef = useGridApiContext();
+  const pageSize = useGridSelector(apiRef, gridPageSizeSelector);
+  const visibleTopLevelRowCount = useGridSelector(
+    apiRef,
+    gridFilteredTopLevelRowCountSelector,
+  );
+  const rootProps = useGridRootProps();
+  const pageCount = getPageCount(
+    rootProps.rowCount ?? visibleTopLevelRowCount,
+    pageSize,
+  );
+
+  return (
+    <MuiPagination
+      color="primary"
+      className={className}
+      count={pageCount}
+      page={page + 1}
+      onChange={(event, newPage) => {
+        onPageChange(event as any, newPage - 1);
+      }}
+    />
+  );
+};
+
+const CustomPagination = (props: any) => {
+  return <GridPagination ActionsComponent={Pagination} {...props} />;
+};
+
+export default CustomPagination;

--- a/client/app/components/routes/access-requests/AccessRequests.tsx
+++ b/client/app/components/routes/access-requests/AccessRequests.tsx
@@ -1,24 +1,10 @@
+"use client";
+
 import { GridRowsProp } from "@mui/x-data-grid";
 import Note from "@/app/components/datagrid/Note";
-
-import { actionHandler } from "@/app/utils/actions";
 import OperatorDataGrid from "@/app/components/datagrid/OperatorDataGrid";
 import { UserOperatorPaginated } from "./types";
 import { statusStyle } from "@/app/components/datagrid/helpers";
-
-// 🛠️ Function to fetch user-operators
-async function getUserOperators() {
-  try {
-    return await actionHandler(
-      "registration/user-operators?page=1",
-      "GET",
-      "/dashboard/operators",
-    );
-  } catch (error) {
-    // Handle the error here or rethrow it to handle it at a higher level
-    throw error;
-  }
-}
 
 export const formatUserOperatorRows = (rows: GridRowsProp) => {
   return rows.map(
@@ -36,9 +22,11 @@ export const formatUserOperatorRows = (rows: GridRowsProp) => {
 };
 
 // 🧩 Main component
-export default async function AccessRequests() {
-  // Fetch userOperator data
-  const userOperators: UserOperatorPaginated = await getUserOperators();
+const AccessRequests = ({
+  userOperators,
+}: {
+  userOperators: UserOperatorPaginated;
+}) => {
   if (!userOperators) {
     return <div>No access requests yet.</div>;
   }
@@ -88,4 +76,6 @@ export default async function AccessRequests() {
       />
     </>
   );
-}
+};
+
+export default AccessRequests;

--- a/client/app/components/routes/access-requests/AccessRequests.tsx
+++ b/client/app/components/routes/access-requests/AccessRequests.tsx
@@ -3,14 +3,14 @@ import Note from "@/app/components/datagrid/Note";
 
 import { actionHandler } from "@/app/utils/actions";
 import OperatorDataGrid from "@/app/components/datagrid/OperatorDataGrid";
-import { UserOperator } from "./types";
+import { UserOperatorPaginated } from "./types";
 import { statusStyle } from "@/app/components/datagrid/helpers";
 
 // 🛠️ Function to fetch user-operators
 async function getUserOperators() {
   try {
     return await actionHandler(
-      "registration/user-operators",
+      "registration/user-operators?page=1",
       "GET",
       "/dashboard/operators",
     );
@@ -20,30 +20,30 @@ async function getUserOperators() {
   }
 }
 
+export const formatUserOperatorRows = (rows: GridRowsProp) => {
+  return rows.map(
+    ({ id, status, first_name, last_name, email, legal_name }) => {
+      return {
+        id,
+        status,
+        first_name,
+        last_name,
+        email,
+        legal_name,
+      };
+    },
+  );
+};
+
 // 🧩 Main component
 export default async function AccessRequests() {
   // Fetch userOperator data
-  const userOperators: [UserOperator] = await getUserOperators();
+  const userOperators: UserOperatorPaginated = await getUserOperators();
   if (!userOperators) {
     return <div>No access requests yet.</div>;
   }
-
-  // Transform the fetched data into rows for the DataGrid component
-  const rows: GridRowsProp =
-    userOperators.length > 0
-      ? userOperators.map(
-          ({ id, status, first_name, last_name, email, legal_name }) => {
-            return {
-              id,
-              status,
-              first_name,
-              last_name,
-              email,
-              legal_name,
-            };
-          },
-        )
-      : [];
+  const { row_count: rowCount } = userOperators;
+  const rows = formatUserOperatorRows(userOperators.data);
 
   // Render the DataGrid component
   return (
@@ -54,6 +54,7 @@ export default async function AccessRequests() {
       />
       <OperatorDataGrid
         rows={rows}
+        rowCount={rowCount}
         columns={[
           {
             field: "id",

--- a/client/app/components/routes/access-requests/AccessRequests.tsx
+++ b/client/app/components/routes/access-requests/AccessRequests.tsx
@@ -2,7 +2,7 @@ import { GridRowsProp } from "@mui/x-data-grid";
 import Note from "@/app/components/datagrid/Note";
 
 import { actionHandler } from "@/app/utils/actions";
-import DataGrid from "@/app/components/datagrid/DataGrid";
+import OperatorDataGrid from "@/app/components/datagrid/OperatorDataGrid";
 import { UserOperator } from "./types";
 import { statusStyle } from "@/app/components/datagrid/helpers";
 
@@ -52,8 +52,7 @@ export default async function AccessRequests() {
         classNames="mb-4 mt-6"
         message="Once “Approved,” the user will have access to their operator dashboard with full admin permissions, and can grant access and designate permissions to other authorized users there."
       />
-      <DataGrid
-        cntxt="user-operators"
+      <OperatorDataGrid
         rows={rows}
         columns={[
           {

--- a/client/app/components/routes/access-requests/AccessRequests.tsx
+++ b/client/app/components/routes/access-requests/AccessRequests.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { GridRowsProp } from "@mui/x-data-grid";
 import Note from "@/app/components/datagrid/Note";
 import OperatorDataGrid from "@/app/components/datagrid/OperatorDataGrid";
@@ -7,7 +5,7 @@ import { UserOperatorPaginated } from "./types";
 import { statusStyle } from "@/app/components/datagrid/helpers";
 
 export const formatUserOperatorRows = (rows: GridRowsProp) => {
-  return rows.map(
+  return rows?.map(
     ({ id, status, first_name, last_name, email, legal_name }) => {
       return {
         id,

--- a/client/app/components/routes/access-requests/types.ts
+++ b/client/app/components/routes/access-requests/types.ts
@@ -6,3 +6,9 @@ export interface UserOperator {
   email: string;
   legal_name: string;
 }
+
+export interface UserOperatorPaginated {
+  data: UserOperator[];
+  row_count: number;
+  page: number;
+}

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -10,7 +10,7 @@ import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 async function getOperations() {
   try {
     return await actionHandler(
-      "registration/operations",
+      "registration/operations?page=1",
       "GET",
       "/dashboard/operations"
     );
@@ -41,48 +41,55 @@ const formatTimestamp = (timestamp: string) => {
   return `${date}\n${timeWithTimeZone}`;
 };
 
+export const formatOperationRows = (rows: GridRowsProp) => {
+  return rows.map(
+    ({
+      id,
+      bc_obps_regulated_operation,
+      operator,
+      submission_date,
+      status,
+      name,
+      bcghg_id,
+    }) => {
+      return {
+        id,
+        bc_obps_regulated_operation: bc_obps_regulated_operation ?? "N/A",
+        operation_name: name,
+        bcghg_id: bcghg_id,
+        operator_name: operator,
+        submission_date: formatTimestamp(submission_date) ?? status,
+        status: status,
+      };
+    }
+  );
+};
+
 // 🧩 Main component
 export default async function Operations() {
   const session = await getServerSession(authOptions);
   // Fetch operations data
   const operations: {
-    id: number;
-    bcghg_id: string;
-    bc_obps_regulated_operation: string;
-    name: string;
-    operator: string;
-    submission_date: string;
-    status: string;
-  }[] = await getOperations();
+    operation_list: {
+      id: number;
+      bcghg_id: string;
+      bc_obps_regulated_operation: string;
+      name: string;
+      operator: string;
+      submission_date: string;
+      status: string;
+    }[];
+    total_pages: number;
+    row_count: number;
+  } = await getOperations();
   if (!operations) {
     return <div>No operations data in database.</div>;
   }
-  // Transform the fetched data into rows for the DataGrid component
-  const rows: GridRowsProp =
-    operations.length > 0
-      ? operations.map(
-          ({
-            id,
-            bc_obps_regulated_operation,
-            operator,
-            submission_date,
-            status,
-            name,
-            bcghg_id,
-          }) => {
-            return {
-              id,
-              bc_obps_regulated_operation: bc_obps_regulated_operation ?? "N/A",
-              operation_name: name,
-              bcghg_id: bcghg_id,
-              operator_name: operator,
-              submission_date: formatTimestamp(submission_date) ?? status,
-              status: status,
-            };
-          }
-        )
-      : [];
 
+  const { row_count: rowCount } = operations;
+  // Transform the fetched data into rows for the DataGrid component
+
+  const rows = formatOperationRows(operations.operation_list);
   // Show the operator column if the user is CAS internal
   const isOperatorColumn =
     session?.user.app_role?.includes("cas") &&
@@ -135,7 +142,7 @@ export default async function Operations() {
   // Render the DataGrid component
   return (
     <div className="mt-5">
-      <OperationDataGrid rows={rows} columns={columns} />
+      <OperationDataGrid rows={rows} rowCount={rowCount} columns={columns} />
     </div>
   );
 }

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -13,7 +13,7 @@ async function getOperations() {
       // Fetch page one of the operations data on initial load
       "registration/operations?page=1",
       "GET",
-      "/dashboard/operations"
+      "/dashboard/operations",
     );
   } catch (error) {
     // Handle the error here or rethrow it to handle it at a higher level
@@ -62,7 +62,7 @@ export const formatOperationRows = (rows: GridRowsProp) => {
         submission_date: formatTimestamp(submission_date) ?? status,
         status,
       };
-    }
+    },
   );
 };
 

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -11,7 +11,7 @@ async function getOperations() {
   try {
     return await actionHandler(
       // Fetch page one of the operations data on initial load
-      "registration/operations?page=1",
+      "registration/operations",
       "GET",
       "/dashboard/operations",
     );

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -71,7 +71,7 @@ export default async function Operations() {
   const session = await getServerSession(authOptions);
   // Fetch operations data
   const operations: {
-    operation_list: {
+    data: {
       id: number;
       bcghg_id: string;
       bc_obps_regulated_operation: string;
@@ -90,7 +90,7 @@ export default async function Operations() {
   const { row_count: rowCount } = operations;
   // Transform the fetched data into rows for the DataGrid component
 
-  const rows = formatOperationRows(operations.operation_list);
+  const rows = formatOperationRows(operations.data);
   // Show the operator column if the user is CAS internal
   const isOperatorColumn =
     session?.user.app_role?.includes("cas") &&

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -10,6 +10,7 @@ import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 async function getOperations() {
   try {
     return await actionHandler(
+      // Fetch page one of the operations data on initial load
       "registration/operations?page=1",
       "GET",
       "/dashboard/operations"

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -56,11 +56,11 @@ export const formatOperationRows = (rows: GridRowsProp) => {
       return {
         id,
         bc_obps_regulated_operation: bc_obps_regulated_operation ?? "N/A",
-        operation_name: name,
-        bcghg_id: bcghg_id,
-        operator_name: operator,
+        name,
+        bcghg_id,
+        operator: operator,
         submission_date: formatTimestamp(submission_date) ?? status,
-        status: status,
+        status,
       };
     }
   );
@@ -98,7 +98,7 @@ export default async function Operations() {
   const columns = [
     { field: "bcghg_id", headerName: "BC GHG ID", width: 160 },
     {
-      field: "operation_name",
+      field: "name",
       headerName: "Operation",
       width: isOperatorColumn ? 320 : 560,
     },
@@ -133,7 +133,7 @@ export default async function Operations() {
   if (isOperatorColumn) {
     // Add the operator column if the user is CAS internal
     columns.splice(operatorColumnIndex, 0, {
-      field: "operator_name",
+      field: "operator",
       headerName: "Operator",
       width: 320,
     });

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -1,7 +1,7 @@
 import { GridRowsProp } from "@mui/x-data-grid";
 
 import { actionHandler } from "@/app/utils/actions";
-import DataGrid from "@/app/components/datagrid/DataGrid";
+import OperationDataGrid from "@/app/components/datagrid/OperationDataGrid";
 import { statusStyle } from "@/app/components/datagrid/helpers";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
@@ -12,7 +12,7 @@ async function getOperations() {
     return await actionHandler(
       "registration/operations",
       "GET",
-      "/dashboard/operations",
+      "/dashboard/operations"
     );
   } catch (error) {
     // Handle the error here or rethrow it to handle it at a higher level
@@ -79,7 +79,7 @@ export default async function Operations() {
               submission_date: formatTimestamp(submission_date) ?? status,
               status: status,
             };
-          },
+          }
         )
       : [];
 
@@ -135,12 +135,7 @@ export default async function Operations() {
   // Render the DataGrid component
   return (
     <div className="mt-5">
-      <DataGrid
-        cntxt="operations"
-        rows={rows}
-        columns={columns}
-        session={session}
-      />
+      <OperationDataGrid rows={rows} columns={columns} />
     </div>
   );
 }

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -80,7 +80,6 @@ export default async function Operations() {
       submission_date: string;
       status: string;
     }[];
-    total_pages: number;
     row_count: number;
   } = await getOperations();
   if (!operations) {

--- a/client/app/components/routes/operators/OperatorsPage.tsx
+++ b/client/app/components/routes/operators/OperatorsPage.tsx
@@ -1,0 +1,34 @@
+"use server";
+
+import { Suspense } from "react";
+import AccessRequests from "@/app/components/routes/access-requests/AccessRequests";
+import Loading from "@/app/components/loading/SkeletonGrid";
+import { actionHandler } from "@/app/utils/actions";
+import { UserOperatorPaginated } from "@/app/components/routes/access-requests/types";
+
+// 🛠️ Function to fetch user-operators
+async function getUserOperators() {
+  try {
+    return await actionHandler(
+      "registration/user-operators?page=1",
+      "GET",
+      "/dashboard/operators",
+    );
+  } catch (error) {
+    // Handle the error here or rethrow it to handle it at a higher level
+    throw error;
+  }
+}
+
+const OperatorsPage = async () => {
+  // Fetch userOperator data
+  const userOperators: UserOperatorPaginated = await getUserOperators();
+
+  return (
+    <Suspense fallback={<Loading />}>
+      <AccessRequests userOperators={userOperators} />
+    </Suspense>
+  );
+};
+
+export default OperatorsPage;

--- a/client/app/components/routes/operators/OperatorsPage.tsx
+++ b/client/app/components/routes/operators/OperatorsPage.tsx
@@ -1,5 +1,3 @@
-"use server";
-
 import { Suspense } from "react";
 import AccessRequests from "@/app/components/routes/access-requests/AccessRequests";
 import Loading from "@/app/components/loading/SkeletonGrid";

--- a/client/app/components/routes/operators/OperatorsPage.tsx
+++ b/client/app/components/routes/operators/OperatorsPage.tsx
@@ -10,7 +10,7 @@ import { UserOperatorPaginated } from "@/app/components/routes/access-requests/t
 async function getUserOperators() {
   try {
     return await actionHandler(
-      "registration/user-operators?page=1",
+      "registration/user-operators",
       "GET",
       "/dashboard/operators",
     );


### PR DESCRIPTION
Implements #782 

This enables serverside pagination for both Operator and Operations dashboards and works with sorting.

One thing that I could use a second set of eyes on is the updates to the `/operations` `GET` route have increased the amount of queries from 3 to 4 (Viewing through django-silk backend at `http://localhost:8000/silk/requests/`). Would be nice if we could get that back down to 3 though I am unsure of what the cause is.

Also found an example to add a numbered pagination component to the bottom of the datagrid. I found while testing that it was poor ux to make the user go through every page to get to later pages:

<img width="1186" alt="Screenshot 2024-02-07 at 8 31 50 AM" src="https://github.com/bcgov/cas-registration/assets/14259474/9bc74f2e-675e-4244-a019-e7979c29e20f">
