### PR TITLE
474 rejection

### DIFF
--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -434,12 +434,16 @@ def update_user_operator_status(request, payload: UserOperatorStatusUpdate):
     else:
         return 404, {"message": "No parameters provided"}
 
-    # We can't update the status of a user_operator if the operator has been declined or is awaiting review
+
+    # We can't update the status of a user_operator if the operator has been declined or is awaiting review, or if the operator is new
+    operator = get_object_or_404(Operator, id=user_operator.operator.id)
     if user_operator.operator.status in [
         Operator.Statuses.PENDING,
         Operator.Statuses.DECLINED,
         Operator.Statuses.DRAFT,
-    ]:
+    ] or operator.is_new:
+
+
         return 400, {"message": "Operator must be approved before approving users."}
     try:
         with transaction.atomic():

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -434,15 +434,17 @@ def update_user_operator_status(request, payload: UserOperatorStatusUpdate):
     else:
         return 404, {"message": "No parameters provided"}
 
-
     # We can't update the status of a user_operator if the operator has been declined or is awaiting review, or if the operator is new
     operator = get_object_or_404(Operator, id=user_operator.operator.id)
-    if user_operator.operator.status in [
-        Operator.Statuses.PENDING,
-        Operator.Statuses.DECLINED,
-        Operator.Statuses.DRAFT,
-    ] or operator.is_new:
-
+    if (
+        user_operator.operator.status
+        in [
+            Operator.Statuses.PENDING,
+            Operator.Statuses.DECLINED,
+            Operator.Statuses.DRAFT,
+        ]
+        or operator.is_new
+    ):
 
         return 400, {"message": "Operator must be approved before approving users."}
     try:

--- a/bc_obps/registration/schema/operator.py
+++ b/bc_obps/registration/schema/operator.py
@@ -36,6 +36,8 @@ class OperatorIn(ModelSchema):
     Schema for the Operator model
     """
 
+    user_operator_id: int
+
     class Config:
         model = Operator
         model_fields = ['status']

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -45,6 +45,7 @@ class UserOperatorOut(ModelSchema):
     Custom schema for the user operator form
     """
 
+    operator_status: str = Field(..., alias="operator.status")
     legal_name: str = Field(..., alias="operator.legal_name")
     trade_name: Optional[str] = Field("", alias="operator.trade_name")
     cra_business_number: Optional[int] = Field(None, alias="operator.cra_business_number")

--- a/bc_obps/registration/tests/endpoints/test_operator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operator_endpoints.py
@@ -134,15 +134,9 @@ class TestOperatorsEndpoint(CommonTestSetup):
         assert response.json() == {'message': 'No matching operator found'}
 
     def test_put_approve_operator(self):
-        user = baker.make(User)
-        operator = operator_baker()
-        operator.status = Operator.Statuses.PENDING
-        operator.is_new = True
-        operator.save(update_fields=["status", "is_new"])
-        user_operator = user_operator_baker()
-        user_operator.user = user
-        user_operator.operator = operator
-        user_operator.save(update_fields=["user", "operator"])
+
+        operator = operator_baker({'status': Operator.Statuses.PENDING, 'is_new': True})
+        user_operator = user_operator_baker({'operator': operator})
 
         response = TestUtils.mock_put_with_auth_role(
             self,
@@ -159,14 +153,9 @@ class TestOperatorsEndpoint(CommonTestSetup):
         assert response.json().get("verified_by") == str(self.user.user_guid)
 
     def test_put_request_changes_to_operator(self):
-        user = baker.make(User)
-        operator = operator_baker()
-        operator.status = Operator.Statuses.PENDING
-        operator.save(update_fields=["status", "is_new"])
-        user_operator = user_operator_baker()
-        user_operator.user = user
-        user_operator.operator = operator
-        user_operator.save(update_fields=["user", "operator"])
+
+        operator = operator_baker({'status': Operator.Statuses.PENDING})
+        user_operator = user_operator_baker({'operator': operator})
 
         response = TestUtils.mock_put_with_auth_role(
             self,
@@ -183,13 +172,9 @@ class TestOperatorsEndpoint(CommonTestSetup):
 
     # declining a new operator declines the prime admin request too
     def test_put_decline_new_operator(self):
-        operator = operator_baker()
-        operator.status = Operator.Statuses.PENDING
-        operator.is_new = True
-        operator.save(update_fields=["status", "is_new"])
-        user_operator = user_operator_baker()
-        user_operator.operator = operator
-        user_operator.save
+
+        operator = operator_baker({'status': Operator.Statuses.PENDING, 'is_new': True})
+        user_operator = user_operator_baker({'operator': operator})
 
         response = TestUtils.mock_put_with_auth_role(
             self,
@@ -210,16 +195,8 @@ class TestOperatorsEndpoint(CommonTestSetup):
 
     # declining an existing operator only declines the operator, not the user_operator
     def test_put_decline_existing_operator(self):
-        user = baker.make(User)
-        operator = operator_baker()
-        operator.status = Operator.Statuses.PENDING
-        operator.is_new = False
-        operator.save(update_fields=["status", "is_new"])
-        user_operator = user_operator_baker()
-        user_operator.user = user
-        user_operator.operator = operator
-        user_operator.status = UserOperator.Statuses.PENDING
-        user_operator.save(update_fields=["user", "operator", "status"])
+        operator = operator_baker({'status': Operator.Statuses.PENDING, 'is_new': False})
+        user_operator = user_operator_baker({'operator': operator, 'status': UserOperator.Statuses.PENDING})
 
         response = TestUtils.mock_put_with_auth_role(
             self,

--- a/bc_obps/registration/tests/endpoints/test_operator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operator_endpoints.py
@@ -179,9 +179,9 @@ class TestOperatorsEndpoint(CommonTestSetup):
         response = TestUtils.mock_put_with_auth_role(
             self,
             'cas_admin',
-            content_type_json,
+            self.content_type,
             {"status": Operator.Statuses.DECLINED, 'user_operator_id': user_operator.id},
-            self.endpoint + "/" + str(operator.id),
+            custom_reverse_lazy('update_operator', kwargs={'operator_id': operator.id}),
         )
 
         assert response.status_code == 200
@@ -201,9 +201,9 @@ class TestOperatorsEndpoint(CommonTestSetup):
         response = TestUtils.mock_put_with_auth_role(
             self,
             'cas_admin',
-            content_type_json,
+            self.content_type,
             {"status": Operator.Statuses.DECLINED, 'user_operator_id': user_operator.id},
-            self.endpoint + "/" + str(operator.id),
+            custom_reverse_lazy('update_operator', kwargs={'operator_id': operator.id}),
         )
 
         assert response.status_code == 200

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -371,15 +371,8 @@ class TestUserOperatorEndpoint(CommonTestSetup):
 
     def test_user_operator_put_can_update_status(self):
 
-        user = baker.make(User)
-        operator = operator_baker()
-        operator.status = Operator.Statuses.APPROVED
-        operator.is_new = False
-        operator.save(update_fields=['status', 'is_new'])
-        user_operator = user_operator_baker()
-        user_operator.user_id = user.user_guid
-        user_operator.operator = operator
-        user_operator.save(update_fields=['user_id', 'operator_id'])
+        operator = operator_baker({'status': Operator.Statuses.APPROVED, 'is_new': False})
+        user_operator = user_operator_baker({'operator': operator})
 
         response_2 = TestUtils.mock_put_with_auth_role(
             self,

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -346,15 +346,16 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         response_data = response.json().get('data')
         # returns 1 since the user operator is tied to a different operator
         assert len(response_data) == 1
-
-    def test_user_operator_put_update_user_status(self):
+    def test_user_operator_put_cannot_update_status_when_operator_not_approved(self):
         user = baker.make(User)
+
+        operator = operator_baker()
+        operator.status = Operator.Statuses.PENDING
+        operator.save(update_fields=['status'])
         user_operator = user_operator_baker()
         user_operator.user_id = user.user_guid
-        user_operator.operator = baker.make(
-            Operator, status=Operator.Statuses.PENDING, bc_corporate_registry_number="abc1234567", _fill_optional=True
-        )
-        user_operator.save(update_fields=['user_id', 'operator'])
+        user_operator.operator = operator
+        user_operator.save(update_fields=['user_id', 'operator_id'])
 
         response_1 = TestUtils.mock_put_with_auth_role(
             self,
@@ -363,17 +364,23 @@ class TestUserOperatorEndpoint(CommonTestSetup):
             {"status": UserOperator.Statuses.APPROVED, "user_operator_id": user_operator.id},
             custom_reverse_lazy('update_user_operator_status'),
         )
-
         # make sure user can't change the status of a user_operator when operator is not approved
         assert response_1.status_code == 400
         response_1_json = response_1.json()
         assert response_1_json == {'message': 'Operator must be approved before approving users.'}
 
-        # Change operator status to approved
-        user_operator.operator = baker.make(
-            Operator, status=Operator.Statuses.APPROVED, bc_corporate_registry_number="efg1234567", _fill_optional=True
-        )
-        user_operator.save()
+    def test_user_operator_put_can_update_status(self):
+
+        user = baker.make(User)
+        operator = operator_baker()
+        operator.status = Operator.Statuses.APPROVED
+        operator.is_new = False
+        operator.save(update_fields=['status', 'is_new'])
+        user_operator = user_operator_baker()
+        user_operator.user_id = user.user_guid
+        user_operator.operator = operator
+        user_operator.save(update_fields=['user_id', 'operator_id'])
+
         response_2 = TestUtils.mock_put_with_auth_role(
             self,
             'cas_admin',
@@ -386,6 +393,16 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         assert user_operator.status == UserOperator.Statuses.APPROVED
         assert user_operator.verified_by == self.user
 
+    def test_user_operator_put_decline_rejects_everything(self):
+        user = baker.make(User)
+        operator = operator_baker()
+        operator.status = Operator.Statuses.APPROVED
+        operator.is_new = False
+        operator.save(update_fields=['status', 'is_new'])
+        user_operator = user_operator_baker()
+        user_operator.user_id = user.user_guid
+        user_operator.operator = operator
+        user_operator.save(update_fields=['user_id', 'operator_id'])
         # Assigning contacts to the operator of the user_operator
         contacts = baker.make(
             Contact,

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -346,6 +346,7 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         response_data = response.json().get('data')
         # returns 1 since the user operator is tied to a different operator
         assert len(response_data) == 1
+
     def test_user_operator_put_cannot_update_status_when_operator_not_approved(self):
         user = baker.make(User)
 

--- a/bc_obps/registration/tests/utils/bakers.py
+++ b/bc_obps/registration/tests/utils/bakers.py
@@ -44,14 +44,19 @@ def contact_baker():
     return baker.make(Contact)
 
 
-def operator_baker():
-    return baker.make(
-        Operator,
-        bc_corporate_registry_number=generate_random_bc_corporate_registry_number(),
-        business_structure=BusinessStructure.objects.first(),
-        physical_address=address_baker(),
-        website='https://www.example-operator.com',
-    )
+def operator_baker(custom_properties=None):
+    properties = {
+        'bc_corporate_registry_number': generate_random_bc_corporate_registry_number(),
+        'business_structure': BusinessStructure.objects.first(),
+        'physical_address': address_baker(),
+        'website': 'https://www.example-operator.com',
+    }
+
+    # Update properties with custom_properties if provided
+    if custom_properties:
+        properties.update(custom_properties)
+
+    return baker.make(Operator, **properties)
 
 
 def operation_baker(operator_id=None):
@@ -73,8 +78,17 @@ def operation_baker(operator_id=None):
     )
 
 
-def user_operator_baker():
-    return baker.make(UserOperator, user=user_baker(), operator=operator_baker())
+def user_operator_baker(custom_properties=None):
+    properties = {
+        'user': user_baker(),
+        'operator': operator_baker(),
+    }
+
+    # Update properties with custom_properties if provided
+    if custom_properties:
+        properties.update(custom_properties)
+
+    return baker.make(UserOperator, **properties)
 
 
 def multiple_operator_baker():

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -211,6 +211,7 @@ def custom_reverse_lazy(view_name, *args, **kwargs) -> str:
     """
     return reverse_lazy(f"{DEFAULT_API_NAMESPACE}:{view_name}", *args, **kwargs)
 
+
 def set_verification_columns(record, user_guid):
     record.verified_at = datetime.now(pytz.utc)
     record.verified_by_id = user_guid

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -16,6 +16,8 @@ from registration.models import (
     UserOperator,
 )
 from django.urls import reverse_lazy
+from datetime import datetime
+import pytz
 
 
 def check_users_admin_request_eligibility(user: User, operator: Operator) -> Union[None, tuple[int, dict]]:
@@ -208,3 +210,7 @@ def custom_reverse_lazy(view_name, *args, **kwargs) -> str:
     A custom reverse_lazy function that includes the default API namespace.
     """
     return reverse_lazy(f"{DEFAULT_API_NAMESPACE}:{view_name}", *args, **kwargs)
+
+def set_verification_columns(record, user_guid):
+    record.verified_at = datetime.now(pytz.utc)
+    record.verified_by_id = user_guid

--- a/client/app/components/form/formDataTypes.ts
+++ b/client/app/components/form/formDataTypes.ts
@@ -1,3 +1,5 @@
+import { OperatorStatus } from "@/app/utils/enums";
+
 export interface UserFormData {
   first_name: string;
   last_name: string;
@@ -33,6 +35,7 @@ interface ParentOperator {
 }
 
 export interface UserOperatorFormData extends UserFormData {
+  operator_status: OperatorStatus;
   is_senior_officer: string;
   legal_name: string;
   trade_name?: string;

--- a/client/app/components/routes/access-requests/form/UserOperatorReview.tsx
+++ b/client/app/components/routes/access-requests/form/UserOperatorReview.tsx
@@ -32,7 +32,7 @@ export default function UserOperatorReview({
         "PUT",
         "",
         {
-          body: JSON.stringify({ status }),
+          body: JSON.stringify({ status, user_operator_id: userOperatorId }),
         },
       );
       onSuccess?.();

--- a/client/app/components/routes/access-requests/form/UserOperatorReview.tsx
+++ b/client/app/components/routes/access-requests/form/UserOperatorReview.tsx
@@ -2,7 +2,7 @@
 
 import { actionHandler } from "@/app/utils/actions";
 import Review from "app/components/button/Review";
-import { Status } from "@/app/utils/enums";
+import { OperatorStatus, Status, UserOperatorStatus } from "@/app/utils/enums";
 import { UserOperatorFormData } from "@/app/components/form/formDataTypes";
 
 interface Props {
@@ -99,7 +99,10 @@ export default function UserOperatorReview({
       declinedMessage={`You have declined the ${requestText}.`}
       confirmApproveMessage={`Are you sure you want to approve the ${requestText}?`}
       confirmRejectMessage={`Are you sure you want to decline the ${requestText}?`}
-      isStatusPending={userOperator.status === Status.PENDING}
+      isStatusPending={
+        userOperator.status === UserOperatorStatus.PENDING &&
+        userOperator.operator_status !== OperatorStatus.DECLINED
+      }
       note={note}
       onApprove={
         isOperatorNew ? approveOperatorRequest : approvePrimeAdminRequest

--- a/client/app/components/routes/select-operator/form/UserOperator.tsx
+++ b/client/app/components/routes/select-operator/form/UserOperator.tsx
@@ -23,7 +23,6 @@ async function getBusinessStructures() {
 export async function getUserOperatorFormData(id: number | string) {
   if (!id || isNaN(Number(id))) return {};
   return actionHandler(
-    // brianna
     `registration/select-operator/user-operator/${id}`,
     "GET",
     `/user-operator/${id}`,

--- a/client/app/components/routes/select-operator/form/UserOperator.tsx
+++ b/client/app/components/routes/select-operator/form/UserOperator.tsx
@@ -23,6 +23,7 @@ async function getBusinessStructures() {
 export async function getUserOperatorFormData(id: number | string) {
   if (!id || isNaN(Number(id))) return {};
   return actionHandler(
+    // brianna
     `registration/select-operator/user-operator/${id}`,
     "GET",
     `/user-operator/${id}`,


### PR DESCRIPTION
https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=48609943

To manually test this:
- login with your IDIR and go to the operators tile
- decline New Operator 3 Legal Name
- check in the db that New Operator 3 Legal Name and its user_operator have both been declined

PS: sonarcloud fails are all in test files so I'll dismiss them unless the reviewer has concerns
PPS: the approve operator workflow isn't working well atm, there's already a ticket: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=52823560