### PR TITLE
chore: editing operator sets status to pending

### DIFF
--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -347,6 +347,8 @@ def update_operator_and_user_operator(request, payload: UserOperatorOperatorIn, 
     try:
         user_operator_instance: UserOperator = get_object_or_404(UserOperator, id=user_operator_id, user=user)
         operator_instance: Operator = user_operator_instance.operator
+        if operator_instance.status == 'Draft':
+            operator_instance.status = 'Pending'
 
         # save operator data
         return save_operator(payload, operator_instance, user)


### PR DESCRIPTION
https://github.com/bcgov/cas-registration/issues/591

To test this, you need an approved user_operator with an 'Draft' operator that you'll change to an 'approved' operator to see the tile show up. I tested with bc-cas-dev-three, requested access, approved the request with psql, and then used the form to edit the operator data.