### PR TITLE
chore: reduce user cache timeout to 5 mins

### DIFF
--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -190,14 +190,12 @@ def get_user_operator(request, user_operator_id: int):
             )
         except UserOperator.DoesNotExist:
             return 404, {"message": "No matching userOperator found"}
-        # user_operator = get_object_or_404(UserOperator, id=user_operator_id, user=user.user_guid)
         return UserOperatorOut.from_orm(user_operator)
     else:
         try:
             user_operator = UserOperator.objects.select_related('operator').get(id=user_operator_id)
         except UserOperator.DoesNotExist:
             return 404, {"message": "No matching userOperator found"}
-        # user_operator = get_object_or_404(UserOperator, id=user_operator_id)
         return UserOperatorOut.from_orm(user_operator)
 
 

--- a/bc_obps/registration/middleware/current_user_middleware.py
+++ b/bc_obps/registration/middleware/current_user_middleware.py
@@ -23,7 +23,7 @@ class CurrentUserMiddleware:
                     # If user is not in cache, fetch from database
                     user = get_object_or_404(User, user_guid=user_guid)
 
-                    # Cache the user for 1 hour
+                    # Cache the user for 5 minutes
                     cache.set(cache_key, user, 300)
 
                 request.current_user = user  # Attach user to request for access in API endpoints

--- a/bc_obps/registration/middleware/current_user_middleware.py
+++ b/bc_obps/registration/middleware/current_user_middleware.py
@@ -24,7 +24,7 @@ class CurrentUserMiddleware:
                     user = get_object_or_404(User, user_guid=user_guid)
 
                     # Cache the user for 1 hour
-                    cache.set(cache_key, user, 3600)
+                    cache.set(cache_key, user, 300)
 
                 request.current_user = user  # Attach user to request for access in API endpoints
 


### PR DESCRIPTION
Reducing the timout on the cache to 5 minutes. This way we're still not sending a request to the database on every request (there will be a request every 5 minutes for the user) but we also don't have to wait 1 hour for manual changes to apply when assigning internal permissions. We can revisit the timeout and increase it after we have implemented the user management workflow for internal users.