### PR TITLE
866 internal access requests view

### DIFF
--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -250,7 +250,7 @@ def list_user_operators(request, page: int = 1, sort_field: str = "created_at", 
         "last_name",
         "email",
     ]
-    print(UserOperator.objects.filter(status=UserOperator.Statuses.APPROVED).values_list("operator_id", flat=True))
+
     if sort_field in user_fields:
         sort_field = f"user__{sort_field}"
     if sort_field == "legal_name":

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -240,7 +240,7 @@ def get_user_operator_list_from_user(request):
     return user_operator_list
 
 
-@router.get("/user-operators", response=UserOperatorPaginatedOut, url_name="list_user_operators")
+@router.get("/user-operator-initial-requests", response=UserOperatorPaginatedOut, url_name="list_user_operators")
 @authorize(AppRole.get_authorized_irc_roles())
 def list_user_operators(request, page: int = 1, sort_field: str = "created_at", sort_order: str = "desc"):
     sort_direction = "-" if sort_order == "desc" else ""
@@ -259,6 +259,7 @@ def list_user_operators(request, page: int = 1, sort_field: str = "created_at", 
         UserOperator.objects.select_related("operator", "user")
         .only("id", "status", "user__last_name", "user__first_name", "user__email", "operator__legal_name")
         .order_by(f"{sort_direction}{sort_field}")
+        .exclude(status=UserOperator.Statuses.APPROVED)
     )
     paginator = Paginator(qs, PAGE_SIZE)
     user_operator_list = []

--- a/bc_obps/registration/fixtures/mock/operator.json
+++ b/bc_obps/registration/fixtures/mock/operator.json
@@ -63,8 +63,8 @@
     "model": "registration.operator",
     "pk": 4,
     "fields": {
-      "legal_name": "New Operator 4 Legal Name",
-      "trade_name": "New Operator 4 Trade Name",
+      "legal_name": "Existing Operator 4 Legal Name",
+      "trade_name": "Existing Operator 4 Trade Name",
       "cra_business_number": 987654323,
       "bc_corporate_registry_number": "jkl1234567",
       "business_structure": "BC Corporation",
@@ -74,7 +74,7 @@
       "documents": [],
       "contacts": [1],
       "status": "Rejected",
-      "is_new": true,
+      "is_new": false,
       "verified_at": null,
       "verified_by": null
     }
@@ -103,8 +103,8 @@
     "model": "registration.operator",
     "pk": 6,
     "fields": {
-      "legal_name": "New Operator 6 Legal Name",
-      "trade_name": "New Operator 6 Trade Name",
+      "legal_name": "Existing Operator 6 Legal Name",
+      "trade_name": "Existing Operator 6 Trade Name",
       "cra_business_number": 987654325,
       "bc_corporate_registry_number": "pqr1234567",
       "business_structure": "BC Corporation",
@@ -114,7 +114,7 @@
       "documents": [],
       "contacts": [1],
       "status": "Approved",
-      "is_new": true,
+      "is_new": false,
       "verified_at": "2024-01-03 08:09:51.133556-08",
       "verified_by": "00000000-0000-0000-0000-000000000002"
     }

--- a/bc_obps/registration/fixtures/mock/operator.json
+++ b/bc_obps/registration/fixtures/mock/operator.json
@@ -14,7 +14,7 @@
       "documents": [],
       "contacts": [],
       "status": "Draft",
-      "is_new": false,
+      "is_new": true,
       "verified_at": null,
       "verified_by": null
     }
@@ -93,7 +93,7 @@
       "website": "http://www.example2.com",
       "documents": [],
       "contacts": [1],
-      "status": "Approved",
+      "status": "Draft",
       "is_new": true,
       "verified_at": "2024-01-03 08:09:51.133556-08",
       "verified_by": "00000000-0000-0000-0000-000000000002"
@@ -113,7 +113,7 @@
       "website": "http://www.example2.com",
       "documents": [],
       "contacts": [1],
-      "status": "Approved",
+      "status": "Draft",
       "is_new": false,
       "verified_at": "2024-01-03 08:09:51.133556-08",
       "verified_by": "00000000-0000-0000-0000-000000000002"

--- a/bc_obps/registration/fixtures/mock/operator.json
+++ b/bc_obps/registration/fixtures/mock/operator.json
@@ -58,5 +58,65 @@
       "verified_at": null,
       "verified_by": null
     }
+  },
+  {
+    "model": "registration.operator",
+    "pk": 4,
+    "fields": {
+      "legal_name": "New Operator 4 Legal Name",
+      "trade_name": "New Operator 4 Trade Name",
+      "cra_business_number": 987654323,
+      "bc_corporate_registry_number": "jkl1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [],
+      "contacts": [1],
+      "status": "Rejected",
+      "is_new": true,
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.operator",
+    "pk": 5,
+    "fields": {
+      "legal_name": "New Operator 5 Legal Name",
+      "trade_name": "New Operator 5 Trade Name",
+      "cra_business_number": 987654324,
+      "bc_corporate_registry_number": "mno1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [],
+      "contacts": [1],
+      "status": "Approved",
+      "is_new": true,
+      "verified_at": "2024-01-03 08:09:51.133556-08",
+      "verified_by": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "model": "registration.operator",
+    "pk": 6,
+    "fields": {
+      "legal_name": "New Operator 6 Legal Name",
+      "trade_name": "New Operator 6 Trade Name",
+      "cra_business_number": 987654325,
+      "bc_corporate_registry_number": "pqr1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [],
+      "contacts": [1],
+      "status": "Approved",
+      "is_new": true,
+      "verified_at": "2024-01-03 08:09:51.133556-08",
+      "verified_by": "00000000-0000-0000-0000-000000000002"
+    }
   }
 ]

--- a/bc_obps/registration/fixtures/mock/userOperator.json
+++ b/bc_obps/registration/fixtures/mock/userOperator.json
@@ -52,7 +52,7 @@
     "pk": 5,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000002",
-      "operator": 4,
+      "operator": 5,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -112,7 +112,7 @@
     "pk": 10,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000007",
-      "operator": 4,
+      "operator": 6,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -172,7 +172,7 @@
     "pk": 15,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000012",
-      "operator": 4,
+      "operator": 5,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -256,7 +256,7 @@
     "pk": 22,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000019",
-      "operator": 4,
+      "operator": 2,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,

--- a/bc_obps/registration/fixtures/mock/userOperator.json
+++ b/bc_obps/registration/fixtures/mock/userOperator.json
@@ -52,7 +52,7 @@
     "pk": 5,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000002",
-      "operator": 3,
+      "operator": 4,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -64,7 +64,7 @@
     "pk": 6,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000003",
-      "operator": 2,
+      "operator": 5,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -76,7 +76,7 @@
     "pk": 7,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000004",
-      "operator": 2,
+      "operator": 1,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -100,7 +100,7 @@
     "pk": 9,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000006",
-      "operator": 2,
+      "operator": 3,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -112,7 +112,7 @@
     "pk": 10,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000007",
-      "operator": 2,
+      "operator": 4,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -124,7 +124,7 @@
     "pk": 11,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000008",
-      "operator": 2,
+      "operator": 5,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -136,7 +136,7 @@
     "pk": 12,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000009",
-      "operator": 2,
+      "operator": 1,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -160,7 +160,7 @@
     "pk": 14,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000011",
-      "operator": 2,
+      "operator": 3,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -172,7 +172,7 @@
     "pk": 15,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000012",
-      "operator": 2,
+      "operator": 4,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -184,7 +184,7 @@
     "pk": 16,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000013",
-      "operator": 2,
+      "operator": 5,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -196,7 +196,7 @@
     "pk": 17,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000014",
-      "operator": 2,
+      "operator": 6,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -208,7 +208,7 @@
     "pk": 18,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000015",
-      "operator": 2,
+      "operator": 6,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -220,7 +220,7 @@
     "pk": 19,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000016",
-      "operator": 2,
+      "operator": 1,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -244,7 +244,7 @@
     "pk": 21,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000018",
-      "operator": 2,
+      "operator": 3,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -256,7 +256,7 @@
     "pk": 22,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000019",
-      "operator": 2,
+      "operator": 4,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -268,7 +268,7 @@
     "pk": 23,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000020",
-      "operator": 2,
+      "operator": 5,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -280,7 +280,7 @@
     "pk": 24,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000021",
-      "operator": 2,
+      "operator": 6,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -292,7 +292,7 @@
     "pk": 25,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000022",
-      "operator": 2,
+      "operator": 1,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,
@@ -316,7 +316,7 @@
     "pk": 27,
     "fields": {
       "user": "00000000-0000-0000-0000-000000000024",
-      "operator": 2,
+      "operator": 6,
       "role": "admin",
       "status": "Pending",
       "verified_at": null,

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -325,9 +325,7 @@ class TestUserOperatorEndpoint(CommonTestSetup):
             status=UserOperator.Statuses.PENDING,
         )
 
-        response = TestUtils.mock_get_with_auth_role(
-            custom_reverse_lazy('list_user_operators') + "user-operator-initial-requests"
-        )
+        response = TestUtils.mock_get_with_auth_role(self, "cas_admin", custom_reverse_lazy('list_user_operators'))
         assert response.status_code == 200
         response_data = response.json().get('data')
 
@@ -343,9 +341,7 @@ class TestUserOperatorEndpoint(CommonTestSetup):
             status=UserOperator.Statuses.PENDING,
         )
 
-        response = TestUtils.mock_get_with_auth_role(
-            custom_reverse_lazy('list_user_operators') + "user-operator-initial-requests"
-        )
+        response = TestUtils.mock_get_with_auth_role(self, "cas_admin", custom_reverse_lazy('list_user_operators'))
         assert response.status_code == 200
         response_data = response.json().get('data')
         # returns 1 since the user operator is tied to a different operator

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -16,6 +16,7 @@ from registration.tests.utils.bakers import (
     address_baker,
     generate_random_bc_corporate_registry_number,
     operator_baker,
+    user_baker,
     user_operator_baker,
 )
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
@@ -304,16 +305,25 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         # assert that the first item in the page 2 response is not the same as the first item in the page 2 response with reversed order
         assert page_2_response_id != page_2_response_id_reverse
 
-    def test_get_user_operators_check_response_returns_only_correct_status(self):
-        # Add only approved user operators
-        for i in range(21):
-            baker.make(
-                UserOperator,
-                user=self.user,
-                operator=operator_baker(),
-                role=UserOperator.Roles.ADMIN,
-                status=UserOperator.Statuses.APPROVED,
-            )
+    def test_get_user_operators_check_response_returns_operators_with_no_approved_admins(self):
+        operator = operator_baker()
+
+        # Make two user operators tied to the same operator
+        baker.make(
+            UserOperator,
+            user=user_baker(),
+            operator=operator,
+            role=UserOperator.Roles.ADMIN,
+            status=UserOperator.Statuses.APPROVED,
+        )
+
+        baker.make(
+            UserOperator,
+            user=user_baker(),
+            operator=operator,
+            role=UserOperator.Roles.ADMIN,
+            status=UserOperator.Statuses.PENDING,
+        )
 
         response = TestUtils.mock_get_with_auth_role(
             custom_reverse_lazy('list_user_operators') + "user-operator-initial-requests"
@@ -321,26 +331,25 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         assert response.status_code == 200
         response_data = response.json().get('data')
 
-        # returns 0 because there are only approved user operators
+        # returns 0 since both user operators are tied to the same operator and one prime admin request is approved
         assert len(response_data) == 0
 
-        # Now add some pending user operators
-        for i in range(10):
-            baker.make(
-                UserOperator,
-                user=self.user,
-                operator=operator_baker(),
-                role=UserOperator.Roles.ADMIN,
-                status=UserOperator.Statuses.PENDING,
-            )
+        # Now add user operator tied to a different operator
+        baker.make(
+            UserOperator,
+            user=user_baker(),
+            operator=operator_baker(),
+            role=UserOperator.Roles.ADMIN,
+            status=UserOperator.Statuses.PENDING,
+        )
 
         response = TestUtils.mock_get_with_auth_role(
             custom_reverse_lazy('list_user_operators') + "user-operator-initial-requests"
         )
         assert response.status_code == 200
         response_data = response.json().get('data')
-        # returns 10 since we added 10 pending user operators
-        assert len(response_data) == 10
+        # returns 1 since the user operator is tied to a different operator
+        assert len(response_data) == 1
 
     def test_user_operator_put_update_user_status(self):
         user = baker.make(User)

--- a/client/app/components/datagrid/OperatorDataGrid.tsx
+++ b/client/app/components/datagrid/OperatorDataGrid.tsx
@@ -14,7 +14,7 @@ const fetchUserOperatorPageData = async (
   try {
     // fetch data from server
     const pageData = await actionHandler(
-      `registration/user-operators?page=${page}&sort_field=${sortField}&sort_order=${sortOrder}`,
+      `registration/user-operator-initial-requests?page=${page}&sort_field=${sortField}&sort_order=${sortOrder}`,
       "GET",
       "",
     );

--- a/client/app/components/routes/operators/OperatorsPage.tsx
+++ b/client/app/components/routes/operators/OperatorsPage.tsx
@@ -8,7 +8,7 @@ import { UserOperatorPaginated } from "@/app/components/routes/access-requests/t
 async function getUserOperators() {
   try {
     return await actionHandler(
-      "registration/user-operators",
+      "registration/user-operator-initial-requests",
       "GET",
       "/dashboard/operators",
     );


### PR DESCRIPTION
#866

I've also updated the fixtures so that we have multiple prime admin requests tied to different operators so the dashboard won't be empty once one is approved.

To test this you can sign in as `cas_admin` and approve the prime admin request of an operator. Once you return to the dashboard you should see no prime admin requests that are tied to that same operator.