### PR TITLE
Fix: URL encode DB_PASSWORD in database conn string

### DIFF
--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -99,7 +99,7 @@ WSGI_APPLICATION = "bc_obps.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
-default_db_url = f"postgres://{os.environ.get('DB_USER', 'postgres')}:{urllib.parse.quote(os.environ.get('DB_PASSWORD'))}@{os.environ.get('DB_HOST', '127.0.0.1')}:{os.environ.get('DB_PORT', '5432')}/{os.environ.get('DB_NAME', 'registration')}"
+default_db_url = f"postgres://{os.environ.get('DB_USER', 'postgres')}:{urllib.parse.quote(str(os.environ.get('DB_PASSWORD')))}@{os.environ.get('DB_HOST', '127.0.0.1')}:{os.environ.get('DB_PORT', '5432')}/{os.environ.get('DB_NAME', 'registration')}"
 DATABASES = {'default': dj_database_url.config(default=default_db_url, conn_max_age=600, conn_health_checks=True)}
 
 # Password validation

--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -14,6 +14,7 @@ import os
 from google.oauth2 import service_account
 from pathlib import Path
 import dj_database_url
+import urllib.parse
 
 from dotenv import load_dotenv
 
@@ -98,7 +99,7 @@ WSGI_APPLICATION = "bc_obps.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
-default_db_url = f"postgres://{os.environ.get('DB_USER', 'postgres')}:{os.environ.get('DB_PASSWORD')}@{os.environ.get('DB_HOST', '127.0.0.1')}:{os.environ.get('DB_PORT', '5432')}/{os.environ.get('DB_NAME', 'registration')}"
+default_db_url = f"postgres://{os.environ.get('DB_USER', 'postgres')}:{urllib.parse.quote(os.environ.get('DB_PASSWORD'))}@{os.environ.get('DB_HOST', '127.0.0.1')}:{os.environ.get('DB_PORT', '5432')}/{os.environ.get('DB_NAME', 'registration')}"
 DATABASES = {'default': dj_database_url.config(default=default_db_url, conn_max_age=600, conn_health_checks=True)}
 
 # Password validation


### PR DESCRIPTION
Issue: #914 

**Manual testing**
I updated my local `bc_obps/.env` file with: `DB_PASSWORD=D)b7?m{hkukhklh*nk,8798}` and inserted a temporary print statement in `bc_obps/settings.py` to print out the parsed value of `default_db_url`, which output `postgres://awilliam:D%29b7%3Fm%7Bhkukhklh%2Ank%2C8798%7D@localhost:5432/registration`