### PR TITLE
fix: empty string causing url widget validation to trigger

### DIFF
--- a/client/app/components/form/widgets/URLWidget.tsx
+++ b/client/app/components/form/widgets/URLWidget.tsx
@@ -1,9 +1,20 @@
 "use client";
 
+import { useEffect } from "react";
 import TextWidget from "./TextWidget";
 import { WidgetProps } from "@rjsf/utils/lib/types";
 
 const URLWidget: React.FC<WidgetProps> = (props) => {
+  const { onChange, value } = props;
+
+  useEffect(() => {
+    // Set value to undefined if it's an empty string as this was causing validation to trigger
+    // If a user had previously saved a URL, then deleted it the field would have an empty string
+    if (!value) {
+      onChange(undefined);
+    }
+  }, [value, onChange]);
+
   return <TextWidget {...props} type="url" />;
 };
 export default URLWidget;

--- a/client/app/components/form/widgets/URLWidget.tsx
+++ b/client/app/components/form/widgets/URLWidget.tsx
@@ -1,19 +1,16 @@
 "use client";
 
-import { useEffect } from "react";
 import TextWidget from "./TextWidget";
 import { WidgetProps } from "@rjsf/utils/lib/types";
 
 const URLWidget: React.FC<WidgetProps> = (props) => {
   const { onChange, value } = props;
 
-  useEffect(() => {
-    // Set value to undefined if it's an empty string as this was causing validation to trigger
-    // If a user had previously saved a URL, then deleted it the field would have an empty string
-    if (!value) {
-      onChange(undefined);
-    }
-  }, [value, onChange]);
+  // Set value to undefined if it's an empty string as this was causing validation to trigger
+  // If a user had previously saved a URL, then deleted it the field would have an empty string
+  if (!value) {
+    onChange(undefined);
+  }
 
   return <TextWidget {...props} type="url" />;
 };


### PR DESCRIPTION
Fix for #887 

Steps to recreate this bug:
- Log in as `bc-cas-dev`
- Go to operator form
- Edit the `website` field and remove the URL all together and save
- Click edit again and try to save
- The URL validation triggers because django is returning empty string

To solve this I have added a useEffect which will convert an empty value to undefined so validation won't erroneously trigger.
