### PR TITLE
Fix: 885 declined request side effects

### DIFF
--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -130,7 +130,12 @@ def list_operations(request, page: int = 1, sort_field: str = "created_at", sort
             row_count=paginator.count,
         )
     # Industry users can only see their companies' operations (if there's no user_operator or operator, then the user hasn't requested access to the operator)
-    user_operator = UserOperator.objects.filter(user_id=user.user_guid).only("operator_id").first()
+    user_operator = (
+      UserOperator.objects.filter(user_id=user.user_guid)
+      .exclude(status=UserOperator.Statuses.DECLINED)
+      .only("operator_id")
+      .first()
+    )
     if not user_operator:
         raise HttpError(401, UNAUTHORIZED_MESSAGE)
     approved_users = get_an_operators_approved_users(user_operator.operator_id)
@@ -205,11 +210,9 @@ def create_operation(request, payload: OperationCreateIn):
     user: User = request.current_user
     # Adding this part instead to prevent an extra call from the frontend to get operator_id and pass it in the payload
     try:
-        user_operator = UserOperator.objects.only("operator__id").get(user=user.user_guid)
+        user_operator = UserOperator.objects.exclude(status=UserOperator.Statuses.DECLINED).only("operator__id").get(user=user.user_guid)
     except UserOperator.DoesNotExist:
         return 404, {"message": "User is not associated with any operator"}
-    except UserOperator.MultipleObjectsReturned:
-        return 400, {"message": "User is associated with multiple operators."}
 
     payload_dict: dict = payload.dict(
         exclude={
@@ -256,7 +259,7 @@ def update_operation(request, operation_id: int, submit: str, form_section: int,
     user: User = request.current_user
     try:
         # if there's no user_operator or operator, then the user hasn't requested access to the operator
-        user_operator = UserOperator.objects.only('operator__id').get(user=user.user_guid)
+        user_operator = UserOperator.objects.exclude(status=UserOperator.Statuses.DECLINED).only('operator__id').get(user=user.user_guid)
     except UserOperator.DoesNotExist:
         raise HttpError(401, UNAUTHORIZED_MESSAGE)
 

--- a/bc_obps/registration/api/operation.py
+++ b/bc_obps/registration/api/operation.py
@@ -131,10 +131,10 @@ def list_operations(request, page: int = 1, sort_field: str = "created_at", sort
         )
     # Industry users can only see their companies' operations (if there's no user_operator or operator, then the user hasn't requested access to the operator)
     user_operator = (
-      UserOperator.objects.filter(user_id=user.user_guid)
-      .exclude(status=UserOperator.Statuses.DECLINED)
-      .only("operator_id")
-      .first()
+        UserOperator.objects.filter(user_id=user.user_guid)
+        .exclude(status=UserOperator.Statuses.DECLINED)
+        .only("operator_id")
+        .first()
     )
     if not user_operator:
         raise HttpError(401, UNAUTHORIZED_MESSAGE)
@@ -210,7 +210,11 @@ def create_operation(request, payload: OperationCreateIn):
     user: User = request.current_user
     # Adding this part instead to prevent an extra call from the frontend to get operator_id and pass it in the payload
     try:
-        user_operator = UserOperator.objects.exclude(status=UserOperator.Statuses.DECLINED).only("operator__id").get(user=user.user_guid)
+        user_operator = (
+            UserOperator.objects.exclude(status=UserOperator.Statuses.DECLINED)
+            .only("operator__id")
+            .get(user=user.user_guid)
+        )
     except UserOperator.DoesNotExist:
         return 404, {"message": "User is not associated with any operator"}
 
@@ -259,7 +263,11 @@ def update_operation(request, operation_id: int, submit: str, form_section: int,
     user: User = request.current_user
     try:
         # if there's no user_operator or operator, then the user hasn't requested access to the operator
-        user_operator = UserOperator.objects.exclude(status=UserOperator.Statuses.DECLINED).only('operator__id').get(user=user.user_guid)
+        user_operator = (
+            UserOperator.objects.exclude(status=UserOperator.Statuses.DECLINED)
+            .only('operator__id')
+            .get(user=user.user_guid)
+        )
     except UserOperator.DoesNotExist:
         raise HttpError(401, UNAUTHORIZED_MESSAGE)
 

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -104,13 +104,9 @@ def save_operator(payload: UserOperatorOperatorIn, operator_instance: Operator, 
 )
 @authorize(["industry_user"], UserOperator.get_all_industry_user_operator_roles())
 def get_user_operator_from_user(request):
-    user_operator = get_object_or_404(UserOperator, user_id=request.current_user.user_guid)
-    operator = get_object_or_404(Operator, id=user_operator.operator_id)
-    return 200, {**user_operator.__dict__, "is_new": operator.is_new, "operator_status": operator.status}
-def get_user_operator_status(request):
     try:
         user_operator = (
-            UserOperator.objects.only("id", "status", "operator__id", "operator__is_new")
+            UserOperator.objects.only("id", "status", "operator__id", "operator__is_new", "operator__status")
             .exclude(status=UserOperator.Statuses.DECLINED)
             .select_related("operator")
             .get(user_id=request.current_user.user_guid)

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -410,9 +410,7 @@ def update_operator_and_user_operator(request, payload: UserOperatorOperatorIn, 
 @authorize(AppRole.get_all_authorized_app_roles(), ["admin"])
 def update_user_operator_status(request, payload: UserOperatorStatusUpdate):
     current_user: User = request.current_user  # irc user or industry user admin
-    if payload.user_guid:  # to update the status of a user_operator by user_guid
-        user_operator = get_object_or_404(UserOperator, user_id=payload.user_guid)
-    elif payload.user_operator_id:  # to update the status of a user_operator by user_operator_id
+    if payload.user_operator_id:  # to update the status of a user_operator by user_operator_id
         user_operator = get_object_or_404(UserOperator, id=payload.user_operator_id)
     else:
         return 404, {"message": "No parameters provided"}

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -110,11 +110,10 @@ def get_user_operator_from_user(request):
 def get_user_operator_status(request):
     try:
         user_operator = (
-          UserOperator.objects.only("id", "status", "operator__id", "operator__is_new")
-          .exclude(status=UserOperator.Statuses.DECLINED)
-          .select_related("operator")
-          .get(user_id=request.current_user.user_guid)
-
+            UserOperator.objects.only("id", "status", "operator__id", "operator__is_new")
+            .exclude(status=UserOperator.Statuses.DECLINED)
+            .select_related("operator")
+            .get(user_id=request.current_user.user_guid)
         )
     except UserOperator.DoesNotExist:
         return 404, {"message": "User is not associated with any operator"}
@@ -149,7 +148,6 @@ def get_user_operator_operator(request):
             .exclude(status=UserOperator.Statuses.DECLINED)
             .select_related("operator")
             .get(user=user.user_guid)
-
         )
     except UserOperator.DoesNotExist:
         return 404, {"message": "User is not associated with any operator"}
@@ -200,6 +198,7 @@ def get_user_operator_admin_exists(request, operator_id: int):
     ).exists()
     return 200, has_admin
 
+
 @router.get("/operator-access-declined/{operator_id}", response={200: bool, codes_4xx: Message})
 @authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
 def get_user_operator_admin_exists(request, operator_id: int):
@@ -218,8 +217,15 @@ def get_user_operator_admin_exists(request, operator_id: int):
 @authorize(["industry_user"], ["admin"])
 def get_user_operator_list_from_user(request):
     user: User = request.current_user
-    operator = UserOperator.objects.select_related("operator").exclude(status=UserOperator.Statuses.DECLINED).get(user=user.user_guid).operator
-    user_operator_list = UserOperator.objects.select_related("user").filter(operator_id=operator, user__business_guid=user.business_guid)
+    operator = (
+        UserOperator.objects.select_related("operator")
+        .exclude(status=UserOperator.Statuses.DECLINED)
+        .get(user=user.user_guid)
+        .operator
+    )
+    user_operator_list = UserOperator.objects.select_related("user").filter(
+        operator_id=operator, user__business_guid=user.business_guid
+    )
     return user_operator_list
 
 

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -199,7 +199,7 @@ def get_user_operator_admin_exists(request, operator_id: int):
     return 200, has_admin
 
 
-@router.get("/operator-access-declined/{operator_id}", response={200: bool, codes_4xx: Message})
+@router.get("/operator-access-declined/{operator_id}", response={200: bool, codes_4xx: Message}, url_name="operator_access_declined",)
 @authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
 def get_user_operator_admin_exists(request, operator_id: int):
     user: User = request.current_user

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -153,8 +153,6 @@ def get_user_operator_operator(request):
         )
     except UserOperator.DoesNotExist:
         return 404, {"message": "User is not associated with any operator"}
-    except UserOperator.MultipleObjectsReturned:
-        return 400, {"message": "User is associated with multiple operators"}
     return 200, user_operator.operator
 
 
@@ -220,8 +218,8 @@ def get_user_operator_admin_exists(request, operator_id: int):
 @authorize(["industry_user"], ["admin"])
 def get_user_operator_list_from_user(request):
     user: User = request.current_user
-    operator = UserOperator.objects.get(user=user.user_guid).operator
-    user_operator_list = UserOperator.objects.filter(operator_id=operator)
+    operator = UserOperator.objects.select_related("operator").exclude(status=UserOperator.Statuses.DECLINED).get(user=user.user_guid).operator
+    user_operator_list = UserOperator.objects.select_related("user").filter(operator_id=operator, user__business_guid=user.business_guid)
     return user_operator_list
 
 

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -199,7 +199,11 @@ def get_user_operator_admin_exists(request, operator_id: int):
     return 200, has_admin
 
 
-@router.get("/operator-access-declined/{operator_id}", response={200: bool, codes_4xx: Message}, url_name="operator_access_declined",)
+@router.get(
+    "/operator-access-declined/{operator_id}",
+    response={200: bool, codes_4xx: Message},
+    url_name="operator_access_declined",
+)
 @authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
 def get_user_operator_admin_exists(request, operator_id: int):
     user: User = request.current_user

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -200,7 +200,7 @@ def get_user_operator_admin_exists(request, operator_id: int):
     response={200: bool, codes_4xx: Message},
     url_name="operator_access_declined",
 )
-@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
+@authorize(['industry_user'])
 def get_user_operator_admin_exists(request, operator_id: int):
     user: User = request.current_user
     is_declined = UserOperator.objects.filter(

--- a/bc_obps/registration/middleware/current_user_middleware.py
+++ b/bc_obps/registration/middleware/current_user_middleware.py
@@ -14,18 +14,17 @@ class CurrentUserMiddleware:
         if auth_header:
             try:
                 user_guid = json.loads(auth_header).get('user_guid')
-                user = get_object_or_404(User, user_guid=user_guid)
 
-                # # Try to get the user from cache
-                # cache_key = f"{USER_CACHE_PREFIX}{user_guid}"
-                # user = cache.get(cache_key)
+                # Try to get the user from cache
+                cache_key = f"{USER_CACHE_PREFIX}{user_guid}"
+                user = cache.get(cache_key)
 
-                # if not user:
-                #     # If user is not in cache, fetch from database
-                #     user = get_object_or_404(User, user_guid=user_guid)
+                if not user:
+                    # If user is not in cache, fetch from database
+                    user = get_object_or_404(User, user_guid=user_guid)
 
-                #     # Cache the user for 5 minutes
-                #     cache.set(cache_key, user, 300)
+                    # Cache the user for 5 minutes
+                    cache.set(cache_key, user, 300)
 
                 request.current_user = user  # Attach user to request for access in API endpoints
 

--- a/bc_obps/registration/middleware/current_user_middleware.py
+++ b/bc_obps/registration/middleware/current_user_middleware.py
@@ -14,17 +14,18 @@ class CurrentUserMiddleware:
         if auth_header:
             try:
                 user_guid = json.loads(auth_header).get('user_guid')
+                user = get_object_or_404(User, user_guid=user_guid)
 
-                # Try to get the user from cache
-                cache_key = f"{USER_CACHE_PREFIX}{user_guid}"
-                user = cache.get(cache_key)
+                # # Try to get the user from cache
+                # cache_key = f"{USER_CACHE_PREFIX}{user_guid}"
+                # user = cache.get(cache_key)
 
-                if not user:
-                    # If user is not in cache, fetch from database
-                    user = get_object_or_404(User, user_guid=user_guid)
+                # if not user:
+                #     # If user is not in cache, fetch from database
+                #     user = get_object_or_404(User, user_guid=user_guid)
 
-                    # Cache the user for 5 minutes
-                    cache.set(cache_key, user, 300)
+                #     # Cache the user for 5 minutes
+                #     cache.set(cache_key, user, 300)
 
                 request.current_user = user  # Attach user to request for access in API endpoints
 

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -21,7 +21,6 @@ class PendingUserOperatorOut(ModelSchema):
 
 
 class UserOperatorStatusUpdate(ModelSchema):
-    user_guid: Optional[uuid.UUID] = None
     user_operator_id: Optional[int] = None
 
     class Config:

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -13,7 +13,7 @@ from .business_structure import validate_business_structure
 class PendingUserOperatorOut(ModelSchema):
     operator_status: str
     is_new: bool = Field(..., alias="operator.is_new")
-    operator_id: int = Field(..., alias="operator.id")
+    operatorId: int = Field(..., alias="operator.id")
 
     class Config:
         model = UserOperator

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -11,12 +11,13 @@ from .business_structure import validate_business_structure
 
 
 class PendingUserOperatorOut(ModelSchema):
-    is_new: bool
     operator_status: str
+    is_new: bool = Field(..., alias="operator.is_new")
+    operator_id: int = Field(..., alias="operator.id")
 
     class Config:
         model = UserOperator
-        model_exclude = [*AUDIT_FIELDS]
+        model_fields = ["id", "status"]
 
 
 class UserOperatorStatusUpdate(ModelSchema):

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -11,9 +11,9 @@ from .business_structure import validate_business_structure
 
 
 class PendingUserOperatorOut(ModelSchema):
-    operator_status: str
     is_new: bool = Field(..., alias="operator.is_new")
     operatorId: int = Field(..., alias="operator.id")
+    operatorStatus: str = Field(..., alias="operator.status")
 
     class Config:
         model = UserOperator

--- a/bc_obps/registration/schema/user_operator.py
+++ b/bc_obps/registration/schema/user_operator.py
@@ -159,7 +159,7 @@ class ExternalDashboardUsersTileData(ModelSchema):
 
     class Config:
         model = UserOperator
-        model_fields = ["role", "status"]
+        model_fields = ["role", "status", "id"]
 
 
 class UserOperatorListOut(Schema):

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -214,6 +214,39 @@ class TestOperationsEndpoint(CommonTestSetup):
         response_data = response.json().get('data')
         assert len(response_data) == PAGE_SIZE
 
+    def test_operations_endpoint_get_ignores_declined_user_operators(self):
+        # IRC users can get all operations except ones with a not Started status
+        operator1 = operator_baker()
+        operator2 = operator_baker()
+        baker.make(
+            Operation,
+            operator_id=operator1.id,
+            status=Operation.Statuses.PENDING,
+            naics_code=baker.make(NaicsCode, naics_code=123456, naics_description='desc'),
+        )
+        baker.make(
+            Operation,
+            operator_id=operator2.id,
+            status=Operation.Statuses.APPROVED,
+            naics_code=baker.make(NaicsCode, naics_code=123456, naics_description='desc'),
+        )
+        baker.make(
+            Operation,
+            operator_id=operator2.id,
+            status=Operation.Statuses.NOT_STARTED,
+            naics_code=baker.make(NaicsCode, naics_code=123456, naics_description='desc'),
+        )
+        baker.make(
+            UserOperator, user_id=self.user.user_guid, status=UserOperator.Statuses.DECLINED, operator_id=operator1.id
+        )
+        baker.make(
+            UserOperator, user_id=self.user.user_guid, status=UserOperator.Statuses.APPROVED, operator_id=operator2.id
+        )
+        response = TestUtils.mock_get_with_auth_role(self, "industry_user")
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        assert len(response_data) == 2
+
     def test_operations_endpoint_get_method_paginated(self):
         operator1 = operator_baker()
         baker.make(
@@ -273,6 +306,29 @@ class TestOperationsEndpoint(CommonTestSetup):
             self, "industry_user", self.content_type, mock_operation.json(), endpoint=None
         )
         assert post_response.status_code == 201
+
+    def test_post_new_operation_ignores_declined_user_operator_records(self):
+      operator = operator_baker()
+      operator2 = operator_baker()
+      baker.make(
+            UserOperator, user_id=self.user.user_guid, status=UserOperator.Statuses.DECLINED, operator_id=operator2.id
+        )
+      TestUtils.authorize_current_user_as_operator_user(self, operator)
+      mock_operation = TestUtils.mock_OperationCreateIn()
+      post_response = TestUtils.mock_post_with_auth_role(
+          self, "industry_user", self.content_type, mock_operation.json()
+      )
+      assert post_response.status_code == 201
+      assert post_response.json().get('name') == "Springfield Nuclear Power Plant"
+      assert post_response.json().get('id') is not None
+      # check that the default status of pending was applied
+      get_response = TestUtils.mock_get_with_auth_role(self, "industry_user").json()
+      get_response_data = get_response.get('data')[0]
+      assert 'status' in get_response_data and get_response_data['status'] == 'Not Started'
+      post_response = TestUtils.mock_post_with_auth_role(
+          self, "industry_user", self.content_type, mock_operation.json(), endpoint=None
+      )
+      assert post_response.status_code == 201
 
     # commenting out this unit test for now because multiple_operators are not included in MVP
     # def test_post_new_operation_with_multiple_operators(self):
@@ -764,6 +820,42 @@ class TestOperationsEndpoint(CommonTestSetup):
             fake_timestamp_from_past, fake_timestamp_from_past_str_format
         )
         assert retrieved_operation.status == Operation.Statuses.APPROVED
+
+    def test_put_operation_ignores_declines_user_operator_records(self):
+        operator = operator_baker()
+        operator2 = operator_baker()
+        baker.make(
+            UserOperator, user_id=self.user.user_guid, status=UserOperator.Statuses.DECLINED, operator_id=operator2.id
+        )
+        operation = operation_baker()
+        operation.operator_id = operator.id
+        operation.status = Operation.Statuses.APPROVED
+        operation.submission_date = fake_timestamp_from_past
+        operation.save(update_fields=['status', 'operator_id', 'submission_date'])
+
+        update = OperationUpdateIn(
+            name='Shorter legal Name',
+            type='Type',
+            operator_id=operator.id,
+            naics_code_id=operation.naics_code_id,
+            documents=[],
+            regulated_products=[],
+            # reporting_activities=[],
+        )
+
+        TestUtils.authorize_current_user_as_operator_user(self, operator)
+        put_response = TestUtils.mock_put_with_auth_role(
+            self,
+            'industry_user',
+            self.content_type,
+            update.json(),
+            custom_reverse_lazy("update_operation", kwargs={"operation_id": operation.id})
+            + "?submit=true&form_section=1",
+        )
+        assert put_response.status_code == 200
+        assert Operation.objects.count() == 1
+        retrieved_operation = Operation.objects.first()
+        assert retrieved_operation.name == 'Shorter legal Name'
 
     def test_put_operation_with_changes_requested(self):
         operator = operator_baker()

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -215,7 +215,7 @@ class TestOperationsEndpoint(CommonTestSetup):
         assert len(response_data) == PAGE_SIZE
 
     def test_operations_endpoint_get_ignores_declined_user_operators(self):
-        # IRC users can get all operations except ones with a not Started status
+        # Endpoint ignores user_operator records with a 'DECLINED' status
         operator1 = operator_baker()
         operator2 = operator_baker()
         baker.make(

--- a/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_operations_endpoints.py
@@ -308,27 +308,27 @@ class TestOperationsEndpoint(CommonTestSetup):
         assert post_response.status_code == 201
 
     def test_post_new_operation_ignores_declined_user_operator_records(self):
-      operator = operator_baker()
-      operator2 = operator_baker()
-      baker.make(
+        operator = operator_baker()
+        operator2 = operator_baker()
+        baker.make(
             UserOperator, user_id=self.user.user_guid, status=UserOperator.Statuses.DECLINED, operator_id=operator2.id
         )
-      TestUtils.authorize_current_user_as_operator_user(self, operator)
-      mock_operation = TestUtils.mock_OperationCreateIn()
-      post_response = TestUtils.mock_post_with_auth_role(
-          self, "industry_user", self.content_type, mock_operation.json()
-      )
-      assert post_response.status_code == 201
-      assert post_response.json().get('name') == "Springfield Nuclear Power Plant"
-      assert post_response.json().get('id') is not None
-      # check that the default status of pending was applied
-      get_response = TestUtils.mock_get_with_auth_role(self, "industry_user").json()
-      get_response_data = get_response.get('data')[0]
-      assert 'status' in get_response_data and get_response_data['status'] == 'Not Started'
-      post_response = TestUtils.mock_post_with_auth_role(
-          self, "industry_user", self.content_type, mock_operation.json(), endpoint=None
-      )
-      assert post_response.status_code == 201
+        TestUtils.authorize_current_user_as_operator_user(self, operator)
+        mock_operation = TestUtils.mock_OperationCreateIn()
+        post_response = TestUtils.mock_post_with_auth_role(
+            self, "industry_user", self.content_type, mock_operation.json()
+        )
+        assert post_response.status_code == 201
+        assert post_response.json().get('name') == "Springfield Nuclear Power Plant"
+        assert post_response.json().get('id') is not None
+        # check that the default status of pending was applied
+        get_response = TestUtils.mock_get_with_auth_role(self, "industry_user").json()
+        get_response_data = get_response.get('data')[0]
+        assert 'status' in get_response_data and get_response_data['status'] == 'Not Started'
+        post_response = TestUtils.mock_post_with_auth_role(
+            self, "industry_user", self.content_type, mock_operation.json(), endpoint=None
+        )
+        assert post_response.status_code == 201
 
     # commenting out this unit test for now because multiple_operators are not included in MVP
     # def test_post_new_operation_with_multiple_operators(self):

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -534,8 +534,9 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         user_operator.status = UserOperator.Statuses.DECLINED
         user_operator.save(update_fields=['user_id', 'status'])
         response = TestUtils.mock_get_with_auth_role(
-            self, 'industry_user', custom_reverse_lazy('operator_access_declined', kwargs={'operator_id': user_operator.operator_id}),
-
+            self,
+            'industry_user',
+            custom_reverse_lazy('operator_access_declined', kwargs={'operator_id': user_operator.operator_id}),
         )
         response_json = response.json()
         assert response.status_code == 200
@@ -547,12 +548,8 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         operator = operator_baker()
         operator.status = 'Approved'
         operator.save(update_fields=["created_by", "status"])
-        baker.make(
-            UserOperator, user=self.user, operator=operator, role=UserOperator.Roles.ADMIN, created_by=self.user
-        )
-        baker.make(
-            UserOperator, operator=operator, status=UserOperator.Statuses.DECLINED
-        )
+        baker.make(UserOperator, user=self.user, operator=operator, role=UserOperator.Roles.ADMIN, created_by=self.user)
+        baker.make(UserOperator, operator=operator, status=UserOperator.Statuses.DECLINED)
         response = TestUtils.mock_get_with_auth_role(
             self, 'industry_user', custom_reverse_lazy('get_user_operator_list_from_user')
         )

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -800,6 +800,7 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         }
 
         parent_operators: List[ParentOperator] = operator.parent_operators.all()
+        assert len(parent_operators) == 2
 
         # Assert that the parent operator 1 is the same as the first object in the parent_operators_array
         assert {

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -151,7 +151,7 @@ def raise_401_if_user_not_authorized(request, authorized_app_roles, authorized_u
         if sorted(authorized_user_operator_roles) != sorted(UserOperator.get_all_industry_user_operator_roles()):
             user_operator_role = None
             try:
-                user_operator = UserOperator.objects.get(user=user.user_guid)
+                user_operator = UserOperator.objects.exclude(status=UserOperator.Statuses.DECLINED).get(user=user.user_guid)
                 user_operator_role = user_operator.role
             except UserOperator.DoesNotExist:
                 pass

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -151,7 +151,9 @@ def raise_401_if_user_not_authorized(request, authorized_app_roles, authorized_u
         if sorted(authorized_user_operator_roles) != sorted(UserOperator.get_all_industry_user_operator_roles()):
             user_operator_role = None
             try:
-                user_operator = UserOperator.objects.exclude(status=UserOperator.Statuses.DECLINED).get(user=user.user_guid)
+                user_operator = UserOperator.objects.exclude(status=UserOperator.Statuses.DECLINED).get(
+                    user=user.user_guid
+                )
                 user_operator_role = user_operator.role
             except UserOperator.DoesNotExist:
                 pass

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -72,7 +72,7 @@ export default async function Page() {
     business: uOS.operator.legal_name,
     accessType: uOS.role.charAt(0).toLocaleUpperCase() + uOS.role.slice(1), // Capitalize first letter
     status: uOS.status,
-    userOperatorId: uOS.id
+    userOperatorId: uOS.id,
   }));
 
   return <DataGrid rows={statusRows} columns={columns} />;

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -66,7 +66,6 @@ export default async function Page() {
   ];
 
   const statusRows: GridRowsProp = userOperatorStatuses.map((uOS) => ({
-    id: uOS.user.user_guid,
     name: `${uOS.user.first_name} ${uOS.user.last_name.slice(0, 1)}`,
     email: uOS.user.email,
     business: uOS.operator.legal_name,

--- a/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
+++ b/client/app/(authenticated)/bceidbusiness/industry_user_admin/dashboard/users/page.tsx
@@ -72,6 +72,7 @@ export default async function Page() {
     business: uOS.operator.legal_name,
     accessType: uOS.role.charAt(0).toLocaleUpperCase() + uOS.role.slice(1), // Capitalize first letter
     status: uOS.status,
+    userOperatorId: uOS.id
   }));
 
   return <DataGrid rows={statusRows} columns={columns} />;

--- a/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
+++ b/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
@@ -25,10 +25,11 @@ interface ButtonRenderCellParams extends GridRenderCellParams {
     userRole: string;
     status: Status;
     actions: string;
+    userOperatorId: number;
   };
 }
 
-const handleUpdateStatus = async (userGuid: string, statusUpdate: Status) => {
+const handleUpdateStatus = async (userOperatorId: number, userGuid: string, statusUpdate: Status) => {
   try {
     return await actionHandler(
       `registration/select-operator/user-operator/update-status`,
@@ -38,6 +39,7 @@ const handleUpdateStatus = async (userGuid: string, statusUpdate: Status) => {
         body: JSON.stringify({
           status: statusUpdate,
           user_guid: userGuid,
+          user_operator_id: userOperatorId
         }),
       },
     );
@@ -51,6 +53,7 @@ export async function ChangeUserOperatorStatusColumnCell(
 ) {
   const userOperatorStatus = params.row.status;
   const userGuid = params.row.id;
+  const userOperatorId = params.row.userOperatorId
 
   const buttonsToShow = (status: Status): UserOperatorStatusAction[] => {
     if (status === Status.MYSELF) {
@@ -88,7 +91,7 @@ export async function ChangeUserOperatorStatusColumnCell(
         <Button
           variant={item.title === "Undo" ? "text" : "outlined"}
           key={index}
-          onClick={async () => handleUpdateStatus(userGuid, item.statusTo)}
+          onClick={async () => handleUpdateStatus(userOperatorId, userGuid, item.statusTo)}
           color={item.color}
           endIcon={item.icon}
         >

--- a/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
+++ b/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
@@ -29,7 +29,11 @@ interface ButtonRenderCellParams extends GridRenderCellParams {
   };
 }
 
-const handleUpdateStatus = async (userOperatorId: number, userGuid: string, statusUpdate: Status) => {
+const handleUpdateStatus = async (
+  userOperatorId: number,
+  userGuid: string,
+  statusUpdate: Status,
+) => {
   try {
     return await actionHandler(
       `registration/select-operator/user-operator/update-status`,
@@ -39,7 +43,7 @@ const handleUpdateStatus = async (userOperatorId: number, userGuid: string, stat
         body: JSON.stringify({
           status: statusUpdate,
           user_guid: userGuid,
-          user_operator_id: userOperatorId
+          user_operator_id: userOperatorId,
         }),
       },
     );
@@ -53,7 +57,7 @@ export async function ChangeUserOperatorStatusColumnCell(
 ) {
   const userOperatorStatus = params.row.status;
   const userGuid = params.row.id;
-  const userOperatorId = params.row.userOperatorId
+  const userOperatorId = params.row.userOperatorId;
 
   const buttonsToShow = (status: Status): UserOperatorStatusAction[] => {
     if (status === Status.MYSELF) {
@@ -91,7 +95,9 @@ export async function ChangeUserOperatorStatusColumnCell(
         <Button
           variant={item.title === "Undo" ? "text" : "outlined"}
           key={index}
-          onClick={async () => handleUpdateStatus(userOperatorId, userGuid, item.statusTo)}
+          onClick={async () =>
+            handleUpdateStatus(userOperatorId, userGuid, item.statusTo)
+          }
           color={item.color}
           endIcon={item.icon}
         >

--- a/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
+++ b/client/app/components/datagrid/ChangeUserOperatorStatusColumnCell.tsx
@@ -31,7 +31,6 @@ interface ButtonRenderCellParams extends GridRenderCellParams {
 
 const handleUpdateStatus = async (
   userOperatorId: number,
-  userGuid: string,
   statusUpdate: Status,
 ) => {
   try {
@@ -42,7 +41,6 @@ const handleUpdateStatus = async (
       {
         body: JSON.stringify({
           status: statusUpdate,
-          user_guid: userGuid,
           user_operator_id: userOperatorId,
         }),
       },
@@ -56,7 +54,6 @@ export async function ChangeUserOperatorStatusColumnCell(
   params: Readonly<ButtonRenderCellParams>,
 ) {
   const userOperatorStatus = params.row.status;
-  const userGuid = params.row.id;
   const userOperatorId = params.row.userOperatorId;
 
   const buttonsToShow = (status: Status): UserOperatorStatusAction[] => {
@@ -96,7 +93,7 @@ export async function ChangeUserOperatorStatusColumnCell(
           variant={item.title === "Undo" ? "text" : "outlined"}
           key={index}
           onClick={async () =>
-            handleUpdateStatus(userOperatorId, userGuid, item.statusTo)
+            handleUpdateStatus(userOperatorId, item.statusTo)
           }
           color={item.color}
           endIcon={item.icon}

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -27,8 +27,7 @@ export default async function MyOperatorPage() {
   const userName = getUserFullName(session);
   const userOperator = await getUserOperator();
   const isNew = userOperator.is_new;
-  const operatorStatus = userOperator.operator_status;
-  const { status, id, operator } = userOperator;
+  const { status, id, operatorId, operatorStatus } = userOperator;
   if (
     status === UserOperatorStatus.APPROVED ||
     operatorStatus === OperatorStatus.DRAFT
@@ -43,11 +42,11 @@ export default async function MyOperatorPage() {
   if (status === UserOperatorStatus.PENDING) {
     if (isNew) {
       return permanentRedirect(
-        `/dashboard/select-operator/received/add-operator/${operator}`,
+        `/dashboard/select-operator/received/add-operator/${operatorId}`,
       );
     }
     return permanentRedirect(
-      `/dashboard/select-operator/received/request-access/${operator}`,
+      `/dashboard/select-operator/received/request-access/${operatorId}`,
   }
 
   return (

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -48,7 +48,6 @@ export default async function MyOperatorPage() {
     }
     return permanentRedirect(
       `/dashboard/select-operator/received/request-access/${operator}`,
-    );
   }
 
   return (

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -47,6 +47,7 @@ export default async function MyOperatorPage() {
     }
     return permanentRedirect(
       `/dashboard/select-operator/received/request-access/${operatorId}`,
+    )
   }
 
   return (

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -47,7 +47,7 @@ export default async function MyOperatorPage() {
     }
     return permanentRedirect(
       `/dashboard/select-operator/received/request-access/${operatorId}`,
-    )
+    );
   }
 
   return (

--- a/client/app/components/routes/select-operator/form/ConfirmSelectedOperator.tsx
+++ b/client/app/components/routes/select-operator/form/ConfirmSelectedOperator.tsx
@@ -29,7 +29,6 @@ export async function getOperatorAccessDeclined(id: number) {
   );
 }
 
-
 export default async function ConfirmSelectedOperator({
   params,
 }: Readonly<{
@@ -39,16 +38,19 @@ export default async function ConfirmSelectedOperator({
   const hasAdmin: boolean | { error: string } = await getOperatorHasAdmin(
     params.id,
   );
-  const accessDeclined: boolean | { error: string} = await getOperatorAccessDeclined(params.id);
+  const accessDeclined: boolean | { error: string } =
+    await getOperatorAccessDeclined(params.id);
 
   if (accessDeclined) {
     const declinedHasAdminJSX: JSX.Element = (
       <>
         <p>
-          Your access request was declined by an Administrator of <b>{operator.legal_name}</b>
+          Your access request was declined by an Administrator of{" "}
+          <b>{operator.legal_name}</b>
         </p>
         <p className="text-center">
-          If you believe this is an error and you should be granted access, please contact the administrator of <b>{operator.legal_name}</b>
+          If you believe this is an error and you should be granted access,
+          please contact the administrator of <b>{operator.legal_name}</b>
         </p>
       </>
     );
@@ -56,37 +58,38 @@ export default async function ConfirmSelectedOperator({
     const declinedNoAdminJSX: JSX.Element = (
       <>
         <p>
-          Your Administrator access request to be the Operation Representative of{" "}
-          <b>{operator.legal_name}</b> was declined.
+          Your Administrator access request to be the Operation Representative
+          of <b>{operator.legal_name}</b> was declined.
         </p>
         <p className="text-center">
-        If you believe this is an error and you should be granted access, please email us at <br />
-        <a
-          href="mailto:GHGRegulator@gov.bc.ca"
-          className="text-black font-bold no-underline"
-        >
-          GHGRegulator@gov.bc.ca
-        </a>
+          If you believe this is an error and you should be granted access,
+          please email us at <br />
+          <a
+            href="mailto:GHGRegulator@gov.bc.ca"
+            className="text-black font-bold no-underline"
+          >
+            GHGRegulator@gov.bc.ca
+          </a>
         </p>
       </>
     );
     return (
       <section className="text-center my-auto text-2xl flex flex-col gap-3">
-      <span>
-        <CancelIcon sx={{ color: "#FF0000", fontSize: 50 }} />
-      </span>
-      {hasAdmin ? declinedHasAdminJSX : declinedNoAdminJSX}
-      <span className="text-sm">
-              <Link
-                href="/dashboard/select-operator"
-                className="underline hover:no-underline text-sm"
-                style={{ color: BC_GOV_LINKS_COLOR }}
-              >
-                Select another operator
-              </Link>
-            </span>
-    </section>
-    )
+        <span>
+          <CancelIcon sx={{ color: "#FF0000", fontSize: 50 }} />
+        </span>
+        {hasAdmin ? declinedHasAdminJSX : declinedNoAdminJSX}
+        <span className="text-sm">
+          <Link
+            href="/dashboard/select-operator"
+            className="underline hover:no-underline text-sm"
+            style={{ color: BC_GOV_LINKS_COLOR }}
+          >
+            Select another operator
+          </Link>
+        </span>
+      </section>
+    );
   }
 
   if (

--- a/client/app/components/routes/select-operator/form/ConfirmSelectedOperator.tsx
+++ b/client/app/components/routes/select-operator/form/ConfirmSelectedOperator.tsx
@@ -46,11 +46,11 @@ export default async function ConfirmSelectedOperator({
       <>
         <p>
           Your access request was declined by an Administrator of{" "}
-          <b>{operator.legal_name}</b>
+          <b>{(operator as Operator).legal_name}</b>
         </p>
         <p className="text-center">
           If you believe this is an error and you should be granted access,
-          please contact the administrator of <b>{operator.legal_name}</b>
+          please contact the administrator of <b>{(operator as Operator).legal_name}</b>
         </p>
       </>
     );
@@ -59,7 +59,7 @@ export default async function ConfirmSelectedOperator({
       <>
         <p>
           Your Administrator access request to be the Operation Representative
-          of <b>{operator.legal_name}</b> was declined.
+          of <b>{(operator as Operator).legal_name}</b> was declined.
         </p>
         <p className="text-center">
           If you believe this is an error and you should be granted access,

--- a/client/app/components/routes/select-operator/form/ConfirmSelectedOperator.tsx
+++ b/client/app/components/routes/select-operator/form/ConfirmSelectedOperator.tsx
@@ -1,6 +1,9 @@
 import { actionHandler } from "@/app/utils/actions";
 import { Operator } from "@/app/components/routes/select-operator/form/types";
 import ConfirmSelectedOperatorForm from "@/app/components/form/ConfirmSelectedOperatorForm";
+import CancelIcon from "@mui/icons-material/Cancel";
+import Link from "next/link";
+import { BC_GOV_LINKS_COLOR } from "@/app/styles/colors";
 
 export async function getOperator(id: number) {
   return actionHandler(
@@ -18,6 +21,15 @@ export async function getOperatorHasAdmin(id: number) {
   );
 }
 
+export async function getOperatorAccessDeclined(id: number) {
+  return actionHandler(
+    `registration/operator-access-declined/${id}`,
+    "GET",
+    `dashboard/select-operator/confirm/${id}`,
+  );
+}
+
+
 export default async function ConfirmSelectedOperator({
   params,
 }: Readonly<{
@@ -27,6 +39,38 @@ export default async function ConfirmSelectedOperator({
   const hasAdmin: boolean | { error: string } = await getOperatorHasAdmin(
     params.id,
   );
+  const accessDeclined: boolean | { error: string} = await getOperatorAccessDeclined(params.id);
+
+  if (accessDeclined)
+    return (
+      <section className="text-center my-auto text-2xl flex flex-col gap-3">
+      <span>
+        <CancelIcon sx={{ color: "#FF0000", fontSize: 50 }} />
+      </span>
+      <p>
+        Your access request to be the Administrator of{" "}
+        <b>{operator.legal_name}</b> was declined.
+      </p>
+      <p className="text-center">
+        If you believe this is an error and you should be granted access, please email us at <br />
+        <a
+          href="mailto:GHGRegulator@gov.bc.ca"
+          className="text-black font-bold no-underline"
+        >
+          GHGRegulator@gov.bc.ca
+        </a>
+      </p>
+      <span className="text-sm">
+              <Link
+                href="/dashboard/select-operator"
+                className="underline hover:no-underline text-sm"
+                style={{ color: BC_GOV_LINKS_COLOR }}
+              >
+                Return to select operator
+              </Link>
+            </span>
+    </section>
+    )
 
   if (
     "error" in operator ||

--- a/client/app/components/routes/select-operator/form/ConfirmSelectedOperator.tsx
+++ b/client/app/components/routes/select-operator/form/ConfirmSelectedOperator.tsx
@@ -41,17 +41,25 @@ export default async function ConfirmSelectedOperator({
   );
   const accessDeclined: boolean | { error: string} = await getOperatorAccessDeclined(params.id);
 
-  if (accessDeclined)
-    return (
-      <section className="text-center my-auto text-2xl flex flex-col gap-3">
-      <span>
-        <CancelIcon sx={{ color: "#FF0000", fontSize: 50 }} />
-      </span>
-      <p>
-        Your access request to be the Administrator of{" "}
-        <b>{operator.legal_name}</b> was declined.
-      </p>
-      <p className="text-center">
+  if (accessDeclined) {
+    const declinedHasAdminJSX: JSX.Element = (
+      <>
+        <p>
+          Your access request was declined by an Administrator of <b>{operator.legal_name}</b>
+        </p>
+        <p className="text-center">
+          If you believe this is an error and you should be granted access, please contact the administrator of <b>{operator.legal_name}</b>
+        </p>
+      </>
+    );
+
+    const declinedNoAdminJSX: JSX.Element = (
+      <>
+        <p>
+          Your Administrator access request to be the Operation Representative of{" "}
+          <b>{operator.legal_name}</b> was declined.
+        </p>
+        <p className="text-center">
         If you believe this is an error and you should be granted access, please email us at <br />
         <a
           href="mailto:GHGRegulator@gov.bc.ca"
@@ -59,18 +67,27 @@ export default async function ConfirmSelectedOperator({
         >
           GHGRegulator@gov.bc.ca
         </a>
-      </p>
+        </p>
+      </>
+    );
+    return (
+      <section className="text-center my-auto text-2xl flex flex-col gap-3">
+      <span>
+        <CancelIcon sx={{ color: "#FF0000", fontSize: 50 }} />
+      </span>
+      {hasAdmin ? declinedHasAdminJSX : declinedNoAdminJSX}
       <span className="text-sm">
               <Link
                 href="/dashboard/select-operator"
                 className="underline hover:no-underline text-sm"
                 style={{ color: BC_GOV_LINKS_COLOR }}
               >
-                Return to select operator
+                Select another operator
               </Link>
             </span>
     </section>
     )
+  }
 
   if (
     "error" in operator ||

--- a/client/app/components/routes/select-operator/form/ConfirmSelectedOperator.tsx
+++ b/client/app/components/routes/select-operator/form/ConfirmSelectedOperator.tsx
@@ -50,7 +50,8 @@ export default async function ConfirmSelectedOperator({
         </p>
         <p className="text-center">
           If you believe this is an error and you should be granted access,
-          please contact the administrator of <b>{(operator as Operator).legal_name}</b>
+          please contact the administrator of{" "}
+          <b>{(operator as Operator).legal_name}</b>
         </p>
       </>
     );

--- a/client/app/utils/users/adminUserOperators.ts
+++ b/client/app/utils/users/adminUserOperators.ts
@@ -11,6 +11,7 @@ export interface ExternalDashboardUsersTile {
   email: string;
   role: string;
   status: string | Status;
+  id: number;
 }
 
 export async function getExternalDashboardUsersTileData(): Promise<


### PR DESCRIPTION
We made an incorrect assumption in many of our endpoints that users will have a 1:1 relationship with the user_operator table. A user can be declined (for example if they requested access to the incorrect operator) and then create a new request that is then approved. 

In this PR, many of our endpoints now ignore DECLINED statuses when fetching information and on the frontend a couple screens have been added to show that they have been declined when a user attempts to select an operator where their status is declined.

This PR has touch a lot of endpoints and will need thorough walkthroughs of all the workflows during review. 
Before pushing I tested the following workflows:
- External can request admin access
- Internal can decline admin access
- Internal sees the DECLINED request row
- External can still select operators when they have a row with DECLINED status in the user_operator table
- Externalwhen selecting the operator they were declined for from the select-operator flow sees a message that they were declined by CAS
- External can request admin access to a different operator
- Internal can approve the admin access to a different operator
- External can see the admin tiles for the APPROVED operator
- External can edit the operator data for the APPROVED operator
- External can complete a BORO ID request for an existing operation under the APPROVED operator
- External can create new operations and complete a BORO ID request under the APPROVED operator
- External can view their access in the User Management page
- A subsequent user can request access to the operator
- External can decline the subsequent user's access
- Subsequent user can still select operators with a row with DECLINED status in the user_operator table
- Subsequent user, when selecting the operator they were declined for sees a message that they were declined by the Operator's Admin
- Subsequent user can request access to a different operator
- Subsequent user can be given access to a different operator