### PR TITLE
fix-internal-users-can-approve-existing-operators

### DIFF
--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -428,7 +428,6 @@ def update_user_operator_status(request, payload: UserOperatorStatusUpdate):
         in [
             Operator.Statuses.PENDING,
             Operator.Statuses.DECLINED,
-            Operator.Statuses.DRAFT,
         ]
         or operator.is_new
     ):


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=53448161