### PR TITLE
Add missing URLs to landing page and update key dates

### DIFF
--- a/client/app/(onboarding)/home/page.tsx
+++ b/client/app/(onboarding)/home/page.tsx
@@ -87,7 +87,11 @@ export default function Page() {
 
           <p>
             Before getting started, take a moment to review the detailed{" "}
-            <a href="ADD LINK HERE" target="_blank" rel="noopener noreferrer">
+            <a
+              href="https://www2.gov.bc.ca/assets/gov/environment/climate-change/ind/obps/guidance/bc_obps_guidance.pdf"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               guidance
             </a>
             .
@@ -117,10 +121,16 @@ export default function Page() {
           <p>
             To check eligibility, and for further information about the B.C.
             OBPS, please visit the{" "}
-            <a href="ADD LINK HERE" target="_blank" rel="noopener noreferrer">
+            <a
+              href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/bc-output-based-pricing-system"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               program website.
             </a>
           </p>
+          {/*
+          This section is commented out because the link will not be available until post MVP.
           <p>
             Please visit the{" "}
             <a
@@ -132,7 +142,7 @@ export default function Page() {
             </a>{" "}
             webpage to learn more about claiming an exemption from the carbon
             tax.
-          </p>
+          </p>*/}
         </section>
         <section className="flex flex-col items-center bg-bc-bg-light-grey my-10 py-8">
           <h2 className={headerStyle}>Contact us</h2>
@@ -181,9 +191,7 @@ export default function Page() {
           </p>
         </section>
         <h2 className={headerStyle}>Key Dates</h2>
-        <table
-          className={`table-auto w-full text-lg border-collapse ${tableBorder}`}
-        >
+        <table className={`table-auto w-full border-collapse ${tableBorder}`}>
           <colgroup>
             <col className="w-[30%]" />
             <col className="w-[70%]" />

--- a/client/app/(onboarding)/home/page.tsx
+++ b/client/app/(onboarding)/home/page.tsx
@@ -198,17 +198,17 @@ export default function Page() {
           </colgroup>
           <thead>
             <tr>
-              <th className={`p-4 ${tableBorder}`}>Date</th>
-              <th className={`p-4 ${tableBorder}`}>Event</th>
+              <th className={`py-4 px-2 text-left ${tableBorder}`}>Date</th>
+              <th className={`py-4 px-2 text-left ${tableBorder}`}>Event</th>
             </tr>
           </thead>
           <tbody>
             {events.map((row, index) => (
               <tr key={index}>
-                <td className={`px-6 py-8 ${tableBorder} whitespace-pre-line`}>
+                <td className={`px-2 py-6 ${tableBorder} whitespace-pre-line`}>
                   {row.date}
                 </td>
-                <td className={`px-6 py-8 ${tableBorder}`}>{row.event}</td>
+                <td className={`px-2 py-6 ${tableBorder}`}>{row.event}</td>
               </tr>
             ))}
           </tbody>

--- a/client/app/data/home/events.json
+++ b/client/app/data/home/events.json
@@ -1,8 +1,5 @@
 [
-  { "date": "February 1,\n2024", "event": "BCIERS opens" },
-  {
-    "date": "February 28,\n2024",
-    "event": "Deadline to apply to receive a BORO ID before April 1"
-  },
+  { "date": "March 5,\n2024", "event": "BCIERS opens" },
+
   { "date": "April 1,\n2024", "event": "Carbon tax exemption can be claimed" }
 ]


### PR DESCRIPTION
#668 - accidentally numbered this branch #163 which this is a follow up issue for.

There is a comment in #668 that says the exemption URL won't be ready for MVP so I've commented out that section. Also reduced the font size and padding in the `Key dates` section as that has been changed in Figma.