### PR TITLE
Fix: 879 bcghgid opt ins

### DIFF
--- a/client/app/components/form/titles/operationsTitles.tsx
+++ b/client/app/components/form/titles/operationsTitles.tsx
@@ -8,15 +8,18 @@ export const PointOfContactTitle = (
 export const OptInOperationTitle = (
   <div className="max-w-2xl">
     Operations within regulated sectors that emit less than 10,000 tonnes CO2e
-    per year may voluntarily opt-in to the B.C. OBPS.<br/><br/>
-
-    Operators of industrial operations that intend to apply to be
-    an opted-in operation must submit an application form by email which is
-    available on our website.<br/><br/>
-
-    Operations that emit greater than 10,000 tonnes CO2e per year are required to participate
-    and are not considered opt ins.<br/><br/>
-
+    per year may voluntarily opt-in to the B.C. OBPS.
+    <br />
+    <br />
+    Operators of industrial operations that intend to apply to be an opted-in
+    operation must submit an application form by email which is available on our
+    website.
+    <br />
+    <br />
+    Operations that emit greater than 10,000 tonnes CO2e per year are required
+    to participate and are not considered opt ins.
+    <br />
+    <br />
     Further information and opt-in application forms can be found on the &nbsp;
     <a
       href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/bc-output-based-pricing-system"
@@ -24,8 +27,8 @@ export const OptInOperationTitle = (
       rel="noopener noreferrer"
     >
       B.C. OBPS website
-    </a>.
-
+    </a>
+    .
   </div>
 );
 

--- a/client/app/components/form/titles/operationsTitles.tsx
+++ b/client/app/components/form/titles/operationsTitles.tsx
@@ -7,9 +7,25 @@ export const PointOfContactTitle = (
 
 export const OptInOperationTitle = (
   <div className="max-w-2xl">
-    <b>Note:</b> Operators of industrial operations that intend to apply to be
+    Operations within regulated sectors that emit less than 10,000 tonnes CO2e
+    per year may voluntarily opt-in to the B.C. OBPS.<br/><br/>
+
+    Operators of industrial operations that intend to apply to be
     an opted-in operation must submit an application form by email which is
-    available on our website.
+    available on our website.<br/><br/>
+
+    Operations that emit greater than 10,000 tonnes CO2e per year are required to participate
+    and are not considered opt ins.<br/><br/>
+
+    Further information and opt-in application forms can be found on the &nbsp;
+    <a
+      href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/bc-output-based-pricing-system"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      B.C. OBPS website
+    </a>.
+
   </div>
 );
 

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -443,10 +443,6 @@ export const operationUiSchema = {
     ...subheading,
     "ui:title": PointOfContactTitle,
   },
-  bcghg_id: {
-    "ui:field": "markupBlock",
-    "webStringKey": "info.markup.block"
-  },
   opt_in_section: {
     ...subheading,
   },

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -50,16 +50,23 @@ const operationPage1: RJSFSchema = {
     //   },
     //   title: "Reporting Activities",
     // },
-    ghg_emissions_section: {
+    bcghg_id: { type: "string", title: "BCGHG ID", readOnly: true, default: 'New operations will be assigned a BCGHGID by the Climate Action Secretariat' },
+    opt_in_section: {
       //Not an actual field in the db - this is just to make the form look like the wireframes
-      title:
-        "Please provide information about the GHG emissions report for 2022",
+      title: "Opt-in information",
       type: "object",
       readOnly: true,
     },
-    "Did you submit a GHG emissions report for reporting year 2022?": {
+    opt_in: {
       type: "boolean",
+      title: "Are you applying to be an opted-in operation?",
       default: false,
+    },
+    opt_in_note_section: {
+      //Not an actual field in the db - this is just to make the form look like the wireframes
+      title: "Opt-in information Note",
+      type: "object",
+      readOnly: true,
     },
     // multiple_operators_section: {
     //   //Not an actual field in the db - this is just to make the form look like the wireframes
@@ -73,58 +80,6 @@ const operationPage1: RJSFSchema = {
     //   default: false,
     // },
   },
-  allOf: [
-    {
-      if: {
-        properties: {
-          "Did you submit a GHG emissions report for reporting year 2022?": {
-            const: true,
-          },
-        },
-      },
-      then: {
-        properties: {
-          bcghg_id: { type: "string", title: "BCGHG ID", readOnly: true },
-        },
-        required: [
-          "previous_year_attributable_emissions",
-          "swrs_facility_id",
-          "bcghg_id",
-        ],
-      },
-    },
-    {
-      if: {
-        properties: {
-          "Did you submit a GHG emissions report for reporting year 2022?": {
-            const: false,
-          },
-        },
-      },
-      then: {
-        properties: {
-          opt_in_section: {
-            //Not an actual field in the db - this is just to make the form look like the wireframes
-            title: "Opt-in information",
-            type: "object",
-            readOnly: true,
-          },
-          opt_in: {
-            type: "boolean",
-            title: "Are you applying to be an opted-in operation?",
-            default: false,
-          },
-          opt_in_note_section: {
-            //Not an actual field in the db - this is just to make the form look like the wireframes
-            title: "Opt-in information Note",
-            type: "object",
-            readOnly: true,
-          },
-        },
-
-        required: ["opt_in"],
-      },
-    },
     // {
     //   if: {
     //     properties: {
@@ -272,7 +227,6 @@ const operationPage1: RJSFSchema = {
     //     },
     //   },
     // },
-  ],
 };
 
 const operationPage2: RJSFSchema = {
@@ -431,8 +385,8 @@ export const operationUiSchema = {
     "Did you submit a GHG emissions report for reporting year 2022?",
     "bcghg_id",
     "opt_in_section",
-    "opt_in",
     "opt_in_note_section",
+    "opt_in",
     "opt_in_signed_statuatory_declaration",
     "is_external_point_of_contact",
     "point_of_contact_section",
@@ -477,12 +431,6 @@ export const operationUiSchema = {
     "ui:widget": "ComboBox",
     "ui:placeholder": "Select Primary NAICS code",
   },
-  "Did you submit a GHG emissions report for reporting year 2022?": {
-    "ui:widget": "RadioWidget",
-  },
-  ghg_emissions_section: {
-    ...subheading,
-  },
   operation_has_multiple_operators: {
     "ui:FieldTemplate": FieldTemplate,
     "ui:widget": "RadioWidget",
@@ -495,16 +443,21 @@ export const operationUiSchema = {
     ...subheading,
     "ui:title": PointOfContactTitle,
   },
+  bcghg_id: {
+    "ui:field": "markupBlock",
+    "webStringKey": "info.markup.block"
+  },
   opt_in_section: {
     ...subheading,
-  },
-  opt_in: {
-    "ui:widget": "RadioWidget",
   },
   opt_in_note_section: {
     "ui:FieldTemplate": TitleOnlyFieldTemplate,
     "ui:title": OptInOperationTitle,
   },
+  opt_in: {
+    "ui:widget": "RadioWidget",
+  },
+
   province: {
     "ui:widget": "ComboBox",
   },

--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -50,7 +50,13 @@ const operationPage1: RJSFSchema = {
     //   },
     //   title: "Reporting Activities",
     // },
-    bcghg_id: { type: "string", title: "BCGHG ID", readOnly: true, default: 'New operations will be assigned a BCGHGID by the Climate Action Secretariat' },
+    bcghg_id: {
+      type: "string",
+      title: "BCGHG ID",
+      readOnly: true,
+      default:
+        "New operations will be assigned a BCGHGID by the Climate Action Secretariat",
+    },
     opt_in_section: {
       //Not an actual field in the db - this is just to make the form look like the wireframes
       title: "Opt-in information",
@@ -80,153 +86,153 @@ const operationPage1: RJSFSchema = {
     //   default: false,
     // },
   },
-    // {
-    //   if: {
-    //     properties: {
-    //       operation_has_multiple_operators: {
-    //         const: true,
-    //       },
-    //     },
-    //   },
-    //   then: {
-    //     properties: {
-    //       multiple_operators_array: {
-    //         type: "array",
-    //         default: [{}],
-    //         items: {
-    //           type: "object",
-    //           required: [
-    //             "mo_legal_name",
-    //             "mo_trade_name",
-    //             "mo_cra_business_number",
-    //             "mo_bc_corporate_registry_number",
-    //             "mo_business_structure",
-    //             "mo_percentage_ownership",
-    //             "mo_physical_street_address",
-    //             "mo_physical_municipality",
-    //             "mo_physical_province",
-    //             "mo_physical_postal_code",
-    //           ],
-    //           properties: {
-    //             mo_legal_name: {
-    //               type: "string",
-    //               title: "Legal Name",
-    //             },
-    //             mo_trade_name: {
-    //               type: "string",
-    //               title: "Trade Name",
-    //             },
-    //             mo_cra_business_number: {
-    //               type: "number",
-    //               title: "CRA Business Number",
-    //             },
-    //             mo_bc_corporate_registry_number: {
-    //               type: "string",
-    //               title: "BC Corporate Registry Number",
-    //               format: "bc_corporate_registry_number",
-    //             },
-    //             mo_business_structure: {
-    //               type: "string",
-    //               title: "Business Structure",
-    //             },
-    //             mo_website: {
-    //               type: "string",
-    //               title: "Website (optional)",
-    //               format: "uri",
-    //             },
-    //             mo_percentage_ownership: {
-    //               type: "number",
-    //               title: "Percentage of ownership of operation (%)",
-    //             },
-    //             mo_proof_of_authority: {
-    //               type: "string",
-    //               title:
-    //                 "Proof of authority of designated operator from partner company",
-    //               format: "data-url",
-    //             },
-    //             mo_physical_address_section: {
-    //               //Not an actual field in the db - this is just to make the form look like the wireframes
-    //               title:
-    //                 "Please provide information about the physical address of this operator:",
-    //               type: "object",
-    //               readOnly: true,
-    //             },
-    //             mo_physical_street_address: {
-    //               type: "string",
-    //               title: "Physical Address",
-    //             },
-    //             mo_physical_municipality: {
-    //               type: "string",
-    //               title: "Municipality",
-    //             },
-    //             mo_physical_province: {
-    //               type: "string",
-    //               title: "Province",
-    //               anyOf: provinceOptions,
-    //             },
-    //             mo_physical_postal_code: {
-    //               type: "string",
-    //               title: "Postal Code",
-    //               format: "postal-code",
-    //             },
-    //             mo_mailing_address_section: {
-    //               //Not an actual field in the db - this is just to make the form look like the wireframes
-    //               title:
-    //                 "Please provide information about the business mailing address of this operator:",
-    //               type: "object",
-    //               readOnly: true,
-    //             },
-    //             mo_mailing_address_same_as_physical: {
-    //               title:
-    //                 "Is the business mailing address the same as the physical address?",
-    //               type: "boolean",
-    //               default: true,
-    //             },
-    //           },
-    //           allOf: [
-    //             {
-    //               if: {
-    //                 properties: {
-    //                   mo_mailing_address_same_as_physical: {
-    //                     const: false,
-    //                   },
-    //                 },
-    //               },
-    //               then: {
-    //                 required: [
-    //                   "mo_mailing_street_address",
-    //                   "mo_mailing_municipality",
-    //                   "mo_mailing_province",
-    //                   "mo_mailing_postal_code",
-    //                 ],
-    //                 properties: {
-    //                   mo_mailing_street_address: {
-    //                     type: "string",
-    //                     title: "Business Mailing Address",
-    //                   },
-    //                   mo_mailing_municipality: {
-    //                     type: "string",
-    //                     title: "Municipality",
-    //                   },
-    //                   mo_mailing_province: {
-    //                     type: "string",
-    //                     title: "Province",
-    //                     anyOf: provinceOptions,
-    //                   },
-    //                   mo_mailing_postal_code: {
-    //                     type: "string",
-    //                     title: "Postal Code",
-    //                     format: "postal-code",
-    //                   },
-    //                 },
-    //               },
-    //             },
-    //           ],
-    //         },
-    //       },
-    //     },
-    //   },
-    // },
+  // {
+  //   if: {
+  //     properties: {
+  //       operation_has_multiple_operators: {
+  //         const: true,
+  //       },
+  //     },
+  //   },
+  //   then: {
+  //     properties: {
+  //       multiple_operators_array: {
+  //         type: "array",
+  //         default: [{}],
+  //         items: {
+  //           type: "object",
+  //           required: [
+  //             "mo_legal_name",
+  //             "mo_trade_name",
+  //             "mo_cra_business_number",
+  //             "mo_bc_corporate_registry_number",
+  //             "mo_business_structure",
+  //             "mo_percentage_ownership",
+  //             "mo_physical_street_address",
+  //             "mo_physical_municipality",
+  //             "mo_physical_province",
+  //             "mo_physical_postal_code",
+  //           ],
+  //           properties: {
+  //             mo_legal_name: {
+  //               type: "string",
+  //               title: "Legal Name",
+  //             },
+  //             mo_trade_name: {
+  //               type: "string",
+  //               title: "Trade Name",
+  //             },
+  //             mo_cra_business_number: {
+  //               type: "number",
+  //               title: "CRA Business Number",
+  //             },
+  //             mo_bc_corporate_registry_number: {
+  //               type: "string",
+  //               title: "BC Corporate Registry Number",
+  //               format: "bc_corporate_registry_number",
+  //             },
+  //             mo_business_structure: {
+  //               type: "string",
+  //               title: "Business Structure",
+  //             },
+  //             mo_website: {
+  //               type: "string",
+  //               title: "Website (optional)",
+  //               format: "uri",
+  //             },
+  //             mo_percentage_ownership: {
+  //               type: "number",
+  //               title: "Percentage of ownership of operation (%)",
+  //             },
+  //             mo_proof_of_authority: {
+  //               type: "string",
+  //               title:
+  //                 "Proof of authority of designated operator from partner company",
+  //               format: "data-url",
+  //             },
+  //             mo_physical_address_section: {
+  //               //Not an actual field in the db - this is just to make the form look like the wireframes
+  //               title:
+  //                 "Please provide information about the physical address of this operator:",
+  //               type: "object",
+  //               readOnly: true,
+  //             },
+  //             mo_physical_street_address: {
+  //               type: "string",
+  //               title: "Physical Address",
+  //             },
+  //             mo_physical_municipality: {
+  //               type: "string",
+  //               title: "Municipality",
+  //             },
+  //             mo_physical_province: {
+  //               type: "string",
+  //               title: "Province",
+  //               anyOf: provinceOptions,
+  //             },
+  //             mo_physical_postal_code: {
+  //               type: "string",
+  //               title: "Postal Code",
+  //               format: "postal-code",
+  //             },
+  //             mo_mailing_address_section: {
+  //               //Not an actual field in the db - this is just to make the form look like the wireframes
+  //               title:
+  //                 "Please provide information about the business mailing address of this operator:",
+  //               type: "object",
+  //               readOnly: true,
+  //             },
+  //             mo_mailing_address_same_as_physical: {
+  //               title:
+  //                 "Is the business mailing address the same as the physical address?",
+  //               type: "boolean",
+  //               default: true,
+  //             },
+  //           },
+  //           allOf: [
+  //             {
+  //               if: {
+  //                 properties: {
+  //                   mo_mailing_address_same_as_physical: {
+  //                     const: false,
+  //                   },
+  //                 },
+  //               },
+  //               then: {
+  //                 required: [
+  //                   "mo_mailing_street_address",
+  //                   "mo_mailing_municipality",
+  //                   "mo_mailing_province",
+  //                   "mo_mailing_postal_code",
+  //                 ],
+  //                 properties: {
+  //                   mo_mailing_street_address: {
+  //                     type: "string",
+  //                     title: "Business Mailing Address",
+  //                   },
+  //                   mo_mailing_municipality: {
+  //                     type: "string",
+  //                     title: "Municipality",
+  //                   },
+  //                   mo_mailing_province: {
+  //                     type: "string",
+  //                     title: "Province",
+  //                     anyOf: provinceOptions,
+  //                   },
+  //                   mo_mailing_postal_code: {
+  //                     type: "string",
+  //                     title: "Postal Code",
+  //                     format: "postal-code",
+  //                   },
+  //                 },
+  //               },
+  //             },
+  //           ],
+  //         },
+  //       },
+  //     },
+  //   },
+  // },
 };
 
 const operationPage2: RJSFSchema = {


### PR DESCRIPTION
Some decisions around the operations form were made while investigating this bug:

- Remove the "Did you submit a GHG Report for 2022"  section entirely. It served no purpose and was the source of the bug
- Add a readonly bcghgid field to always display the bcghgid (if they have it, otherwise shows a message that it will be assigned by CAS)
- Add additional context around opt-ins and a link to the site with more information and opt-in application forms