### PR TITLE
fix: fix authorize definition causing incorrect declined message

### DIFF
--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -200,7 +200,7 @@ def get_user_operator_admin_exists(request, operator_id: int):
     response={200: bool, codes_4xx: Message},
     url_name="operator_access_declined",
 )
-@authorize(['industry_user'])
+@authorize(['industry_user'], UserOperator.get_all_industry_user_operator_roles())
 def get_user_operator_admin_exists(request, operator_id: int):
     user: User = request.current_user
     is_declined = UserOperator.objects.filter(


### PR DESCRIPTION
Follow up fix for the work done in #929. A last minute change in that PR to the @authorize check for the new /operator-access-declined endpoint caused an issue where nobody could access it, which was in turn causing the app to always direct a user to the access declined message.