### PR TITLE
Fix: 944 relax update user operator status conditions

### DIFF
--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -424,13 +424,7 @@ def update_user_operator_status(request, payload: UserOperatorStatusUpdate):
     # We can't update the status of a user_operator if the operator has been declined or is awaiting review, or if the operator is new
     operator = get_object_or_404(Operator, id=user_operator.operator.id)
     if (
-        user_operator.operator.status
-        in [
-            Operator.Statuses.PENDING,
-            Operator.Statuses.DECLINED,
-            Operator.Statuses.DRAFT,
-        ]
-        or operator.is_new
+        user_operator.operator.status == Operator.Statuses.DECLINED or operator.is_new
     ):
 
         return 400, {"message": "Operator must be approved before approving users."}

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -423,9 +423,7 @@ def update_user_operator_status(request, payload: UserOperatorStatusUpdate):
 
     # We can't update the status of a user_operator if the operator has been declined or is awaiting review, or if the operator is new
     operator = get_object_or_404(Operator, id=user_operator.operator.id)
-    if (
-        user_operator.operator.status == Operator.Statuses.DECLINED or operator.is_new
-    ):
+    if user_operator.operator.status == Operator.Statuses.DECLINED or operator.is_new:
 
         return 400, {"message": "Operator must be approved before approving users."}
     try:


### PR DESCRIPTION
Bug details in #944

Fixed in this PR:
- Internal users cannot approve or decline access requests when operator is in DRAFT status
- External admin users cannot approve or decline subsequent access requests until their first BORO ID application approval.