### PR TITLE
Fix: set text as placeholder on BCGHG ID field instead of default

### DIFF
--- a/client/app/utils/jsonSchema/operations.ts
+++ b/client/app/utils/jsonSchema/operations.ts
@@ -54,8 +54,6 @@ const operationPage1: RJSFSchema = {
       type: "string",
       title: "BCGHG ID",
       readOnly: true,
-      default:
-        "New operations will be assigned a BCGHGID by the Climate Action Secretariat",
     },
     opt_in_section: {
       //Not an actual field in the db - this is just to make the form look like the wireframes
@@ -388,7 +386,6 @@ export const operationUiSchema = {
     "regulated_products",
     // "reporting_activities",
     "ghg_emissions_section",
-    "Did you submit a GHG emissions report for reporting year 2022?",
     "bcghg_id",
     "opt_in_section",
     "opt_in_note_section",
@@ -436,6 +433,10 @@ export const operationUiSchema = {
   naics_code_id: {
     "ui:widget": "ComboBox",
     "ui:placeholder": "Select Primary NAICS code",
+  },
+  bcghg_id: {
+    "ui:placeholder":
+      "New operations will be assigned a BCGHGID by the Climate Action Secretariat",
   },
   operation_has_multiple_operators: {
     "ui:FieldTemplate": FieldTemplate,


### PR DESCRIPTION
Quick fix for major bug that meant that only 1 new operation could be created. In the BCGHG ID field on the Operations form, the string "New operations will be ...." was set to be a default value when it should have been a placeholder. That string was then being treated as a BCGHG ID, which must be unique, so no subsequent operations could be created nor could the value be changed because it's readonly in the form. 

No E2E tests for Operations yet, so instead here's manually created proof that I was able to log in as external user and create 2 new operations for my operator. As a bonus, in the Operations table, the BCGHG ID field is now empty (when null) instead of rendering "New operations will be..."

![Screenshot 2024-02-21 at 3 58 19 PM](https://github.com/bcgov/cas-registration/assets/54914403/8c47f963-db7a-4825-a065-9cacc065491c)

