### PR TITLE
Fix: 954 update draft operator flow

### DIFF
--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -335,7 +335,7 @@ def create_operator_and_user_operator(request, payload: UserOperatorOperatorIn):
     response={200: RequestAccessOut, codes_4xx: Message},
     url_name="update_operator_and_user_operator",
 )
-@authorize(["industry_user"], UserOperator.get_all_industry_user_operator_roles())
+@authorize(["industry_user"], ["admin"])
 def update_operator_and_user_operator(request, payload: UserOperatorOperatorIn, user_operator_id: UUID):
     user: User = request.current_user
     try:

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -1100,27 +1100,22 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         operator = operator_baker()
         operator.created_by = self.user
         operator.save(update_fields=["created_by"])
+        mock_payload = {
+            "legal_name": "Unauthorized",
+            "trade_name": "Unauthorized",
+            "cra_business_number": 678123654,
+            "bc_corporate_registry_number": "jkl1234321",
+            "business_structure": BusinessStructure.objects.first().pk,
+            "physical_street_address": "add",
+            "physical_municipality": "add",
+            "physical_province": "BC",
+            "physical_postal_code": "H0H0H0",
+            "mailing_address_same_as_physical": True,
+            "operator_has_parent_operators": False,
+        }
         user_operator = baker.make(
             UserOperator, user=self.user, operator=operator, role=UserOperator.Roles.REPORTER, created_by=self.user
         )
-        mock_payload = {
-            "legal_name": "Put Operator Legal Name",
-            "trade_name": "Put Operator Trade Name",
-            "cra_business_number": 963852741,
-            "bc_corporate_registry_number": "abc1234321",
-            "business_structure": BusinessStructure.objects.first().pk,
-            "physical_street_address": "test physical street address",
-            "physical_municipality": "test physical municipality",
-            "physical_province": "BC",
-            "physical_postal_code": "H0H0H0",
-            "mailing_address_same_as_physical": False,
-            "mailing_street_address": "test mailing street address",
-            "mailing_municipality": "test mailing municipality",
-            "mailing_province": "BC",
-            "mailing_postal_code": "V0V0V0",
-            "operator_has_parent_operators": True,
-            "parent_operators_array": [],
-        }
         put_response = TestUtils.mock_put_with_auth_role(
             self,
             'industry_user',

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -873,7 +873,9 @@ class TestUserOperatorEndpoint(CommonTestSetup):
 
     def test_edit_and_archive_parent_operators(self):
         child_operator = operator_baker()
-        user_operator = baker.make(UserOperator, operator=child_operator, user=self.user, role='admin', status='Approved')
+        user_operator = baker.make(
+            UserOperator, operator=child_operator, user=self.user, role='admin', status='Approved'
+        )
 
         parent_operator_1 = parent_operator_baker()
         parent_operator_1.child_operator_id = child_operator.id

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -1118,6 +1118,17 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         user_operator = baker.make(
             UserOperator, user=self.user, operator=operator, role=UserOperator.Roles.REPORTER, created_by=self.user
         )
+        # Test REPORTER 401
+        put_response = TestUtils.mock_put_with_auth_role(
+            self,
+            'industry_user',
+            self.content_type,
+            mock_payload,
+            custom_reverse_lazy('update_operator_and_user_operator', kwargs={'user_operator_id': user_operator.id}),
+        )
+        user_operator.role = UserOperator.Roles.PENDING
+        user_operator.save(update_fields=["role"])
+        # Test PENDING 401
         put_response = TestUtils.mock_put_with_auth_role(
             self,
             'industry_user',

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -39,7 +39,10 @@ export default async function MyOperatorPage() {
     );
   }
 
-  if (status === UserOperatorStatus.PENDING || (operatorStatus === OperatorStatus.DRAFT && !isNew)) {
+  if (
+    status === UserOperatorStatus.PENDING ||
+    (operatorStatus === OperatorStatus.DRAFT && !isNew)
+  ) {
     if (isNew) {
       return permanentRedirect(
         `/dashboard/select-operator/received/add-operator/${operatorId}`,

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -28,9 +28,7 @@ export default async function MyOperatorPage() {
   const userOperator = await getUserOperator();
   const isNew = userOperator.is_new;
   const { status, id, operatorId, operatorStatus } = userOperator;
-  if (
-    status === UserOperatorStatus.APPROVED
-  ) {
+  if (status === UserOperatorStatus.APPROVED) {
     // Using permanentRedirect instead of redirect to avoid the double rendering bug
     // https://github.com/vercel/next.js/issues/57257
     return permanentRedirect(

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -29,8 +29,7 @@ export default async function MyOperatorPage() {
   const isNew = userOperator.is_new;
   const { status, id, operatorId, operatorStatus } = userOperator;
   if (
-    status === UserOperatorStatus.APPROVED ||
-    (operatorStatus === OperatorStatus.DRAFT && isNew)
+    status === UserOperatorStatus.APPROVED
   ) {
     // Using permanentRedirect instead of redirect to avoid the double rendering bug
     // https://github.com/vercel/next.js/issues/57257

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -30,7 +30,7 @@ export default async function MyOperatorPage() {
   const { status, id, operatorId, operatorStatus } = userOperator;
   if (
     status === UserOperatorStatus.APPROVED ||
-    operatorStatus === OperatorStatus.DRAFT
+    (operatorStatus === OperatorStatus.DRAFT && isNew)
   ) {
     // Using permanentRedirect instead of redirect to avoid the double rendering bug
     // https://github.com/vercel/next.js/issues/57257
@@ -39,7 +39,7 @@ export default async function MyOperatorPage() {
     );
   }
 
-  if (status === UserOperatorStatus.PENDING) {
+  if (status === UserOperatorStatus.PENDING || (operatorStatus === OperatorStatus.DRAFT && !isNew)) {
     if (isNew) {
       return permanentRedirect(
         `/dashboard/select-operator/received/add-operator/${operatorId}`,


### PR DESCRIPTION
This PR fixes some access control in the API & fixes the redirects under certain conditions:

- API: Only external admins can access the PUT endpoint for updating an operator
- Client: If operator.status = DRAFT && operator.is_new = false then the user is redirected to the access received page instead of the edit operator form