### PR TITLE
956 user operator table

### DIFF
--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -31,6 +31,7 @@ from django.shortcuts import get_object_or_404
 from registration.models import (
     AppRole,
     BusinessRole,
+    Operation,
     Operator,
     User,
     UserOperator,
@@ -196,7 +197,7 @@ def list_user_operators(request, page: int = 1, sort_field: str = "created_at", 
         .order_by(f"{sort_direction}{sort_field}")
         .exclude(
             # exclude pending user_operators that belong to operators that already have approved admins
-            status='Pending',
+            status=Operation.Statuses.PENDING,
             operator_id__in=UserOperator.objects.filter(
                 role=UserOperator.Roles.ADMIN, status=UserOperator.Statuses.APPROVED
             ).values_list("operator_id", flat=True),
@@ -204,7 +205,7 @@ def list_user_operators(request, page: int = 1, sort_field: str = "created_at", 
         .exclude(
             # exclude approved user_operators that were approved by industry users
             id__in=UserOperator.objects.filter(
-                status='Approved', verified_by__in=User.objects.filter(app_role='industry_user')
+                status=UserOperator.Statuses.APPROVED, verified_by__in=User.objects.filter(app_role='industry_user')
             ).values_list("id", flat=True)
         )
     )

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -195,12 +195,20 @@ def list_user_operators(request, page: int = 1, sort_field: str = "created_at", 
         .only("id", "status", "user__last_name", "user__first_name", "user__email", "operator__legal_name")
         .order_by(f"{sort_direction}{sort_field}")
         .exclude(
-            # exclude access requests to an operator that already has an approved admin
-            operator_id__in=UserOperator.objects.filter(status=UserOperator.Statuses.APPROVED).values_list(
-                "operator_id", flat=True
-            ),
+            # exclude pending user_operators that belong to operators that already have approved admins
+            status='Pending',
+            operator_id__in=UserOperator.objects.filter(
+                role=UserOperator.Roles.ADMIN, status=UserOperator.Statuses.APPROVED
+            ).values_list("operator_id", flat=True),
+        )
+        .exclude(
+            # exclude approved user_operators that were approved by industry users
+            id__in=UserOperator.objects.filter(
+                status='Approved', verified_by__in=User.objects.filter(app_role='industry_user')
+            ).values_list("id", flat=True)
         )
     )
+
     paginator = Paginator(qs, PAGE_SIZE)
     user_operator_list = []
 

--- a/bc_obps/registration/fixtures/mock/userOperator.json
+++ b/bc_obps/registration/fixtures/mock/userOperator.json
@@ -6,8 +6,8 @@
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "role": "admin",
       "status": "Approved",
-      "verified_at": null,
-      "verified_by": null
+      "verified_at": "2024-02-26 06:24:57.293242-08",
+      "verified_by": "ba2ba62a121842e0942aab9e92ce8822"
     }
   },
   {
@@ -17,8 +17,8 @@
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "role": "admin",
       "status": "Approved",
-      "verified_at": null,
-      "verified_by": null
+      "verified_at": "2024-02-26 06:24:57.293242-08",
+      "verified_by": "4da70f32-65fd-4137-87c1-111f2daba3dd"
     }
   },
   {

--- a/bc_obps/registration/tests/utils/bakers.py
+++ b/bc_obps/registration/tests/utils/bakers.py
@@ -28,8 +28,12 @@ def generate_random_bc_corporate_registry_number():
     return dummy_data
 
 
-def user_baker():
-    return baker.make(User)
+def user_baker(custom_properties=None):
+    properties = {}
+    if custom_properties:
+        properties.update(custom_properties)
+
+    return baker.make(User, **properties)
 
 
 def address_baker():


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=54066703

To manually test:
part 1:
- login with IDIR and go to the user_operator table (operators tile)
- approve someone, noting their operator
- you should see the person you approved, but everyone else from that operator should disappear from the list

part 2:
- Login as bc-cas-dev and go to the users tile
- approve someone
- logout and log back in as IDIR
- whoever you approved should not show up in the operator tile list