### PR TITLE
fix: Tile logic fixed so draft operators don't show blank dashboard

### DIFF
--- a/client/app/components/navigation/Tiles.tsx
+++ b/client/app/components/navigation/Tiles.tsx
@@ -87,10 +87,11 @@ export default function Tiles({
       ];
       break;
     case FrontEndRoles.INDUSTRY_USER_ADMIN:
-      if (userOperatorStatus === UserOperatorStatus.APPROVED && (
-        operatorStatus === OperatorStatus.PENDING ||
-        operatorStatus === OperatorStatus.APPROVED
-      )) {
+      if (
+        userOperatorStatus === UserOperatorStatus.APPROVED &&
+        (operatorStatus === OperatorStatus.PENDING ||
+          operatorStatus === OperatorStatus.APPROVED)
+      ) {
         contents = [
           ...bceidMyOperatorTile,
           ...bceidOperationsTile,
@@ -102,10 +103,11 @@ export default function Tiles({
       }
       break;
     case FrontEndRoles.INDUSTRY_USER:
-      if (userOperatorStatus === UserOperatorStatus.APPROVED && (
-        operatorStatus === OperatorStatus.PENDING ||
-        operatorStatus === OperatorStatus.APPROVED
-      )) {
+      if (
+        userOperatorStatus === UserOperatorStatus.APPROVED &&
+        (operatorStatus === OperatorStatus.PENDING ||
+          operatorStatus === OperatorStatus.APPROVED)
+      ) {
         contents = [
           ...bceidMyOperatorTile,
           ...bceidOperationsTile,

--- a/client/app/components/navigation/Tiles.tsx
+++ b/client/app/components/navigation/Tiles.tsx
@@ -87,34 +87,30 @@ export default function Tiles({
       ];
       break;
     case FrontEndRoles.INDUSTRY_USER_ADMIN:
-      if (userOperatorStatus === UserOperatorStatus.APPROVED) {
-        if (
-          operatorStatus === OperatorStatus.PENDING ||
-          operatorStatus === OperatorStatus.APPROVED
-        ) {
-          contents = [
-            ...bceidMyOperatorTile,
-            ...bceidOperationsTile,
-            ...bceidUsersTile,
-            ...reportAProblemTile,
-          ];
-        }
+      if (userOperatorStatus === UserOperatorStatus.APPROVED && (
+        operatorStatus === OperatorStatus.PENDING ||
+        operatorStatus === OperatorStatus.APPROVED
+      )) {
+        contents = [
+          ...bceidMyOperatorTile,
+          ...bceidOperationsTile,
+          ...bceidUsersTile,
+          ...reportAProblemTile,
+        ];
       } else {
         contents = [...bceidSelectOperatorTile, ...reportAProblemTile];
       }
       break;
     case FrontEndRoles.INDUSTRY_USER:
-      if (userOperatorStatus === UserOperatorStatus.APPROVED) {
-        if (
-          operatorStatus === OperatorStatus.PENDING ||
-          operatorStatus === OperatorStatus.APPROVED
-        ) {
-          contents = [
-            ...bceidMyOperatorTile,
-            ...bceidOperationsTile,
-            ...reportAProblemTile,
-          ];
-        }
+      if (userOperatorStatus === UserOperatorStatus.APPROVED && (
+        operatorStatus === OperatorStatus.PENDING ||
+        operatorStatus === OperatorStatus.APPROVED
+      )) {
+        contents = [
+          ...bceidMyOperatorTile,
+          ...bceidOperationsTile,
+          ...reportAProblemTile,
+        ];
       } else {
         contents = [...bceidSelectOperatorTile, ...reportAProblemTile];
       }


### PR DESCRIPTION
The logic in the Tiles component had a bug where the dashboard was blank when operators were in draft status. This fixes that bug. 

To test: 
request access to an operator that is in draft status & get approved. The dashboard should show tiles where it previously wasn't