### PR TITLE
976 authorize decorator

### DIFF
--- a/bc_obps/registration/api/business_structure.py
+++ b/bc_obps/registration/api/business_structure.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 
 ##### GET #####
 @router.get("/business_structures", response=List[BusinessStructureOut], url_name="list_business_structures")
-@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
+@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles(), False)
 def list_business_structures(request):
     cached_data = cache.get("business_structures")
     if cached_data:

--- a/bc_obps/registration/api/naics.py
+++ b/bc_obps/registration/api/naics.py
@@ -9,7 +9,7 @@ from django.core.cache import cache
 
 
 @router.get("/naics_codes", response=List[NaicsCodeSchema], url_name="list_naics_codes")
-@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
+@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles(), False)
 def list_naics_codes(request):
     cached_data = cache.get("naics_codes")
     if cached_data:

--- a/bc_obps/registration/api/operator.py
+++ b/bc_obps/registration/api/operator.py
@@ -46,6 +46,7 @@ def get_operators_by_cra_number_or_legal_name(
     return 404, {"message": "No matching operator found. Retry or add operator."}
 
 
+# We have to let unapproved users to reach this endpoint otherwise they can't see operator info when they select it
 @router.get(
     "/operators/{operator_id}", response={200: ConfirmSelectedOperatorOut, codes_4xx: Message}, url_name="get_operator"
 )

--- a/bc_obps/registration/api/operator.py
+++ b/bc_obps/registration/api/operator.py
@@ -22,7 +22,7 @@ from django.core.exceptions import ValidationError
     response={200: Union[List[OperatorSearchOut], OperatorSearchOut], codes_4xx: Message, codes_5xx: Message},
     url_name="get_operators_by_cra_number_or_legal_name",
 )
-@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
+@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles(), False)
 def get_operators_by_cra_number_or_legal_name(
     request, cra_business_number: Optional[int] = None, legal_name: Optional[str] = ""
 ):
@@ -49,7 +49,7 @@ def get_operators_by_cra_number_or_legal_name(
 @router.get(
     "/operators/{operator_id}", response={200: ConfirmSelectedOperatorOut, codes_4xx: Message}, url_name="get_operator"
 )
-@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
+@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles(), False)
 def get_operator(request, operator_id: UUID):
     try:
         operator = get_object_or_404(Operator, id=operator_id)

--- a/bc_obps/registration/api/regulated_products.py
+++ b/bc_obps/registration/api/regulated_products.py
@@ -11,7 +11,7 @@ from django.core.cache import cache
 
 
 @router.get("/regulated_products", response=List[RegulatedProductSchema], url_name="list_regulated_products")
-@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
+@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles(), False)
 def list_regulated_products(request):
     cached_data = cache.get("regulated_products")
     if cached_data:

--- a/bc_obps/registration/api/reporting_activities.py
+++ b/bc_obps/registration/api/reporting_activities.py
@@ -11,7 +11,7 @@ from django.core.cache import cache
 
 
 @router.get("/reporting_activities", response=List[ReportingActivitySchema], url_name="list_reporting_activities")
-@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
+@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles(), False)
 def list_reporting_activities(request):
     cached_data = cache.get("reporting_activities")
     if cached_data:

--- a/bc_obps/registration/api/user.py
+++ b/bc_obps/registration/api/user.py
@@ -18,7 +18,7 @@ from django.core.exceptions import ValidationError
 
 
 @router.get("/user", response=UserOut, url_name="get_user")
-@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
+@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles(), False)
 def get_user(request):
     user: User = request.current_user
     return user
@@ -90,7 +90,7 @@ def create_user_profile(request, identity_provider: str, payload: UserIn):
 
 # Endpoint to update a user
 @router.put("/user-profile", response={200: UserOut, codes_4xx: Message}, url_name="update_user_profile")
-@authorize(AppRole.get_all_app_roles(), UserOperator.get_all_industry_user_operator_roles())
+@authorize(AppRole.get_all_app_roles(), UserOperator.get_all_industry_user_operator_roles(), False)
 def update_user_profile(request, payload: UserIn):
     user: User = request.current_user
     try:

--- a/bc_obps/registration/api/user_operator.py
+++ b/bc_obps/registration/api/user_operator.py
@@ -48,7 +48,6 @@ from registration.constants import PAGE_SIZE
     response={200: PendingUserOperatorOut, codes_4xx: Message},
     url_name="get_user_operator_from_user",
 )
-# brianna I think it's fine for them to see this unapproved
 @authorize(["industry_user"], UserOperator.get_all_industry_user_operator_roles(), False)
 def get_user_operator_from_user(request):
     try:
@@ -98,7 +97,6 @@ def get_user_operator_operator(request):
 
 
 @router.get("/user-operator-id", response={200: UserOperatorIdOut, codes_4xx: Message}, url_name="get_user_operator_id")
-# brianna I think it's fine for them to see this
 @authorize(["industry_user"], UserOperator.get_all_industry_user_operator_roles(), False)
 def get_user_operator_id(request):
     user_operator = get_object_or_404(UserOperator, user_id=request.current_user.user_guid)
@@ -149,7 +147,7 @@ def get_user_operator_admin_exists(request, operator_id: UUID):
     url_name="operator_access_declined",
 )
 @authorize(['industry_user'], UserOperator.get_all_industry_user_operator_roles(), False)
-def get_user_operator_admin_exists(request, operator_id: UUID):
+def get_user_operator_access_declined(request, operator_id: UUID):
     user: User = request.current_user
     is_declined = UserOperator.objects.filter(
         operator_id=operator_id, user_id=user.user_guid, status=UserOperator.Statuses.DECLINED
@@ -296,7 +294,6 @@ def request_access(request, payload: SelectOperatorIn):
             if status != 200:
                 return status, message
 
-            # brianna how could one exist if this is an access request?
             # Making a draft UserOperator instance if one doesn't exist
             user_operator, created = UserOperator.objects.get_or_create(
                 user=user, operator=operator, status=UserOperator.Statuses.PENDING, role=UserOperator.Roles.REPORTER

--- a/bc_obps/registration/decorators.py
+++ b/bc_obps/registration/decorators.py
@@ -7,7 +7,9 @@ from django.http import HttpRequest
 
 
 def authorize(
-    authorized_app_roles: List[str], authorized_user_operator_roles: List[str] = []
+    authorized_app_roles: List[str],
+    authorized_user_operator_roles: List[str] = [],
+    industry_user_must_be_approved: bool = True,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     Decorator to authorize a user based on their app_role and UserOperator.role.
@@ -22,7 +24,9 @@ def authorize(
         @wraps(func)
         def wrapper(request: HttpRequest, *args: Any, **kwargs: Any) -> Any:
             try:
-                raise_401_if_user_not_authorized(request, authorized_app_roles, authorized_user_operator_roles)
+                raise_401_if_user_not_authorized(
+                    request, authorized_app_roles, authorized_user_operator_roles, industry_user_must_be_approved
+                )
             except HttpError as e:
                 raise HttpError(HTTPStatus.UNAUTHORIZED, str(e))
             return func(request, *args, **kwargs)

--- a/bc_obps/registration/models.py
+++ b/bc_obps/registration/models.py
@@ -351,7 +351,7 @@ class User(UserAndContactCommonInfo):
 
     def get_approved_user_operator(self) -> Optional['UserOperator']:
         """
-        Return the UserOperator associated with the user.
+        Return the approved UserOperator record associated with the user.
         Based on the Constraint, there should only be one UserOperator associated with a user and operator.
         """
         return self.user_operators.only("operator_id").filter(status=UserOperator.Statuses.APPROVED).first()

--- a/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
+++ b/bc_obps/registration/tests/endpoints/test_useroperator_endpoints.py
@@ -1156,7 +1156,12 @@ class TestUserOperatorEndpoint(CommonTestSetup):
         existing_operator = operator_baker()
         new_operator = operator_baker({'created_by': self.user})
         user_operator = baker.make(
-            UserOperator, user=self.user, operator=new_operator, role=UserOperator.Roles.ADMIN, created_by=self.user
+            UserOperator,
+            user=self.user,
+            operator=new_operator,
+            role=UserOperator.Roles.ADMIN,
+            created_by=self.user,
+            status=UserOperator.Statuses.APPROVED,
         )
         mock_payload = {
             "legal_name": "Put Operator Legal Name",

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -183,6 +183,13 @@ def raise_401_if_user_not_authorized(
                 raise HttpError(401, UNAUTHORIZED_MESSAGE)
 
 
+def get_current_user_approved_user_operator_or_raise(user):
+    user_operator = user.get_approved_user_operator()
+    if not user_operator:
+        raise HttpError(401, UNAUTHORIZED_MESSAGE)
+    return user_operator
+
+
 def get_an_operators_approved_users(operator_pk: int) -> QuerySet[UUID]:
     # get a list of all the operator's approved user ids
     user_ids = UserOperator.objects.filter(operator_id=operator_pk, status=UserOperator.Statuses.APPROVED).values_list(


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=54526586

This PR prevents unapproved industry_users from accessing endpoints by default. If an endpoint should be accessible to unapproved users, we can add an argument to the @authorize decorator. Therefore, manual testing for this PR is walking through all the industry user workflows to make sure people can still access everything they need to. I went through the workflows before posting the PR, but the reviewer should probably take a look too.

Sonarcloud fail is on duplicated code in tests