### PR TITLE
chore: use pgbouncer to connect to postgres from backend

### DIFF
--- a/helm/cas-registration/templates/backend/deployment.yaml
+++ b/helm/cas-registration/templates/backend/deployment.yaml
@@ -49,12 +49,12 @@ spec:
             - name: DB_PORT
               valueFrom:
                 secretKeyRef:
-                  key: port
+                  key: pgbouncer-port
                   name: cas-obps-postgres-pguser-registration
             - name: DB_HOST
               valueFrom:
                 secretKeyRef:
-                  key: host
+                  key: pgbouncer-host
                   name: cas-obps-postgres-pguser-registration
             - name: ALLOWED_HOSTS
               value: '*'


### PR DESCRIPTION
Use pgbouncer to connect to db from backend instead of connecting to postgres directly