### PR TITLE
880 utc

### DIFF
--- a/client/app/components/navigation/Profile.tsx
+++ b/client/app/components/navigation/Profile.tsx
@@ -8,6 +8,7 @@ export default function Profile() {
   const userFullName = getUserFullName(session);
   return (
     <div className="flex items-center">
+      brianna date test {formatTimestamp(date)}
       <Link
         data-testid="nav-user-profile"
         href="/dashboard/profile"

--- a/client/app/components/navigation/Profile.tsx
+++ b/client/app/components/navigation/Profile.tsx
@@ -8,7 +8,6 @@ export default function Profile() {
   const userFullName = getUserFullName(session);
   return (
     <div className="flex items-center">
-      brianna date test {formatTimestamp(date)}
       <Link
         data-testid="nav-user-profile"
         href="/dashboard/profile"

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -20,14 +20,14 @@ async function getOperations() {
     throw error;
   }
 }
-const formatTimestamp = (timestamp: string) => {
+export const formatTimestamp = (timestamp: any) => {
   if (!timestamp) return undefined;
 
   const date = new Date(timestamp).toLocaleString("en-CA", {
     month: "short",
     day: "numeric",
     year: "numeric",
-    timeZone: "America/Vancouver",
+    // timeZone: "America/Vancouver",
   });
 
   const timeWithTimeZone = new Date(timestamp).toLocaleString("en-CA", {
@@ -35,7 +35,7 @@ const formatTimestamp = (timestamp: string) => {
     minute: "numeric",
     second: "numeric",
     timeZoneName: "short",
-    timeZone: "America/Vancouver",
+    // timeZone: "America/Vancouver",
   });
 
   // Return with a line break so we can display date and time on separate lines

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -27,7 +27,7 @@ const formatTimestamp = (timestamp: string) => {
     month: "short",
     day: "numeric",
     year: "numeric",
-    timeZone: "America/Vancouver",
+    // timeZone: "America/Vancouver",
   });
 
   const timeWithTimeZone = new Date(timestamp).toLocaleString("en-CA", {
@@ -35,7 +35,7 @@ const formatTimestamp = (timestamp: string) => {
     minute: "numeric",
     second: "numeric",
     timeZoneName: "short",
-    timeZone: "America/Vancouver",
+    // timeZone: "America/Vancouver",
   });
 
   // Return with a line break so we can display date and time on separate lines

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -20,7 +20,6 @@ async function getOperations() {
     throw error;
   }
 }
-
 const formatTimestamp = (timestamp: string) => {
   if (!timestamp) return undefined;
 
@@ -28,6 +27,7 @@ const formatTimestamp = (timestamp: string) => {
     month: "short",
     day: "numeric",
     year: "numeric",
+    timeZone: "America/Vancouver",
   });
 
   const timeWithTimeZone = new Date(timestamp).toLocaleString("en-CA", {
@@ -35,6 +35,7 @@ const formatTimestamp = (timestamp: string) => {
     minute: "numeric",
     second: "numeric",
     timeZoneName: "short",
+    timeZone: "America/Vancouver",
   });
 
   // Return with a line break so we can display date and time on separate lines

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -27,7 +27,7 @@ const formatTimestamp = (timestamp: string) => {
     month: "short",
     day: "numeric",
     year: "numeric",
-    // timeZone: "America/Vancouver",
+    timeZone: "America/Vancouver",
   });
 
   const timeWithTimeZone = new Date(timestamp).toLocaleString("en-CA", {
@@ -35,7 +35,7 @@ const formatTimestamp = (timestamp: string) => {
     minute: "numeric",
     second: "numeric",
     timeZoneName: "short",
-    // timeZone: "America/Vancouver",
+    timeZone: "America/Vancouver",
   });
 
   // Return with a line break so we can display date and time on separate lines

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -20,7 +20,7 @@ async function getOperations() {
     throw error;
   }
 }
-export const formatTimestamp = (timestamp: any) => {
+const formatTimestamp = (timestamp: string) => {
   if (!timestamp) return undefined;
 
   const date = new Date(timestamp).toLocaleString("en-CA", {

--- a/client/app/components/routes/operations/Operations.tsx
+++ b/client/app/components/routes/operations/Operations.tsx
@@ -27,7 +27,7 @@ export const formatTimestamp = (timestamp: any) => {
     month: "short",
     day: "numeric",
     year: "numeric",
-    // timeZone: "America/Vancouver",
+    timeZone: "America/Vancouver",
   });
 
   const timeWithTimeZone = new Date(timestamp).toLocaleString("en-CA", {
@@ -35,7 +35,7 @@ export const formatTimestamp = (timestamp: any) => {
     minute: "numeric",
     second: "numeric",
     timeZoneName: "short",
-    // timeZone: "America/Vancouver",
+    timeZone: "America/Vancouver",
   });
 
   // Return with a line break so we can display date and time on separate lines


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=53041800

This is tricky one to test because the problem only shows up in `dev`. On local, at least for me in my timezone, everything already shows up in PST, but in `dev` it's UTC. I ended up testing with CI since it also seems to use UTC like `dev`. I temporarily put a date on the homepage and looked at the playright report before making changes:
![image](https://github.com/bcgov/cas-registration/assets/77306764/22ddb899-1f0b-4430-a57a-980fff57b263)
After the fix, the playwright report shows the time in PST, so I think/hope `dev` will react the same way.
![image](https://github.com/bcgov/cas-registration/assets/77306764/8e067dff-8087-4def-ac15-6420251e5520)
