### PR TITLE
1006 e2e route access by role

### DIFF
--- a/client/app/not-found.tsx
+++ b/client/app/not-found.tsx
@@ -15,7 +15,7 @@ export default async function NotFound() {
           marginTop: 20,
         }}
       >
-        <Typography variant="h5" gutterBottom>
+        <Typography data-testid="not-found" variant="h5" gutterBottom>
           The page you’re looking for is unavailable.
         </Typography>
         <Typography variant="body1" paragraph>

--- a/client/e2e/.env.local.example
+++ b/client/e2e/.env.local.example
@@ -4,7 +4,7 @@ E2E_BASEURL=http://localhost:3000/
 # KEYCLOAK LOGINS
 E2E_CAS_USER=your-IDIR-that-is-in-users-fixture-with-cas_admin
 E2E_CAS_USER_PASSWORD=your-password
-E2E_CAS_USER_GUID=your-IDIR-Keycloak-token-user_guid
+E2E_CAS_USER_GUID=your-IDIR-Keycloak-token-user_guid-without-hyphens
 
 E2E_INDUSTRY_USER_ADMIN=bc-cas-dev
 E2E_INDUSTRY_USER_ADMIN_PASSWORD=find-in-1password

--- a/client/e2e/pages/authenticated/routes/page.spec.ts
+++ b/client/e2e/pages/authenticated/routes/page.spec.ts
@@ -15,6 +15,7 @@ import {
   appRouteRoles,
   DataTestID,
   UserOperatorStatus,
+  UserOperatorUUID,
   UserRole,
 } from "@/e2e/utils/enums";
 // 🥞 DB CRUD
@@ -47,10 +48,13 @@ test.beforeAll(async () => {
       process.env.E2E_INDUSTRY_USER_GUID as string,
       AppRole.ADMIN,
       UserOperatorStatus.APPROVED,
+      {
+        id: UserOperatorUUID.INDUSTRY_USER,
+      },
     );
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error("❌ Error in Db setup for dashboard:", error);
+    console.error("❌ Error in Db setup for routes:", error);
     throw error;
   }
 });

--- a/client/e2e/pages/authenticated/routes/page.spec.ts
+++ b/client/e2e/pages/authenticated/routes/page.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/test";
 // 🪄 Page Object Models
 import { DashboardPOM } from "@/e2e/poms/dashboard";
+import { HomePOM } from "@/e2e/poms/home";
 import { OperationPOM } from "@/e2e/poms/operation";
 import { OperationsPOM } from "@/e2e/poms/operations";
 import { OperatorPOM } from "@/e2e/poms/operator";
@@ -79,6 +80,7 @@ for (let [role, value] of Object.entries(UserRole)) {
             pomPage = new DashboardPOM(page);
             break;
           case AppRoute.HOME:
+            pomPage = new HomePOM(page);
             break;
           case AppRoute.OPERATION:
             pomPage = new OperationPOM(page);
@@ -105,7 +107,13 @@ for (let [role, value] of Object.entries(UserRole)) {
           // 🔍 Assert that the current URL role access
           const isAllowedRoute = accessLists.includes(route);
           if (isAllowedRoute) {
-            await pomPage.urlIsCorrect();
+            if (route === AppRoute.HOME) {
+              // authenticated users never get to home, redirected to dashboard
+              const dashboardPage = new DashboardPOM(page);
+              dashboardPage.urlIsCorrect();
+            } else {
+              await pomPage.urlIsCorrect();
+            }
           } else {
             await pomPage.page.waitForSelector(DataTestID.NOTFOUND); //the test will fail with a timeout error if no selector
           }

--- a/client/e2e/pages/authenticated/routes/page.spec.ts
+++ b/client/e2e/pages/authenticated/routes/page.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test } from "@playwright/test";
 // 🪄 Page Object Models
 import { DashboardPOM } from "@/e2e/poms/dashboard";
 import { OperationPOM } from "@/e2e/poms/operation";
@@ -8,7 +8,7 @@ import { OperatorsPOM } from "@/e2e/poms/operators";
 import { ProfilePOM } from "@/e2e/poms/profile";
 import { UsersPOM } from "@/e2e/poms/users";
 // ☰ Enums
-import { AppRoute, UserRole } from "@/e2e/utils/enums";
+import { AppRoute, UserRole, DataTestID } from "@/e2e/utils/enums";
 // 🚨 Object literal policing route access by role
 const appRouteRoles: Record<AppRoute, UserRole[]> = {
   [AppRoute.DASHBOARD]: [
@@ -104,12 +104,11 @@ for (let [role, value] of Object.entries(UserRole)) {
           await pomPage.route();
           // 🔍 Assert that the current URL role access
           const isAllowedRoute = accessLists.includes(route);
-          const code = isAllowedRoute ? 500 : 404;
-          // Listen for response status code
-          page.on("response", async (response) => {
-            // Add your expect test for the response status code
-            expect(response.status()).toBe(code);
-          });
+          if (isAllowedRoute) {
+            await pomPage.urlIsCorrect();
+          } else {
+            await pomPage.page.waitForSelector(DataTestID.NOTFOUND); //the test will fail with a timeout error if no selector
+          }
         }
       }
     });

--- a/client/e2e/pages/authenticated/routes/page.spec.ts
+++ b/client/e2e/pages/authenticated/routes/page.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test";
+// 🪄 Page Object Models
+import { DashboardPOM } from "@/e2e/poms/dashboard";
+import { OperationPOM } from "@/e2e/poms/operation";
+import { OperationsPOM } from "@/e2e/poms/operations";
+import { OperatorPOM } from "@/e2e/poms/operator";
+import { OperatorsPOM } from "@/e2e/poms/operators";
+import { ProfilePOM } from "@/e2e/poms/profile";
+import { UsersPOM } from "@/e2e/poms/users";
+// ☰ Enums
+import { AppRoute, UserRole } from "@/e2e/utils/enums";
+// 🚨 Object literal policing route access by role
+const appRouteRoles: Record<AppRoute, UserRole[]> = {
+  [AppRoute.DASHBOARD]: [
+    UserRole.CAS_PENDING,
+    UserRole.CAS_ANALYST,
+    UserRole.CAS_ADMIN,
+    UserRole.INDUSTRY_USER,
+    UserRole.INDUSTRY_USER_ADMIN,
+  ],
+  [AppRoute.HOME]: [
+    UserRole.CAS_PENDING,
+    UserRole.CAS_ANALYST,
+    UserRole.CAS_ADMIN,
+    UserRole.INDUSTRY_USER,
+    UserRole.INDUSTRY_USER_ADMIN,
+    UserRole.NEW_USER,
+  ],
+  [AppRoute.OPERATION]: [UserRole.INDUSTRY_USER, UserRole.INDUSTRY_USER_ADMIN],
+  [AppRoute.OPERATIONS]: [
+    UserRole.CAS_ANALYST,
+    UserRole.CAS_ADMIN,
+    UserRole.INDUSTRY_USER,
+    UserRole.INDUSTRY_USER_ADMIN,
+  ],
+  [AppRoute.OPERATOR]: [UserRole.INDUSTRY_USER, UserRole.INDUSTRY_USER_ADMIN],
+  [AppRoute.OPERATORS]: [UserRole.CAS_ANALYST, UserRole.CAS_ADMIN],
+  [AppRoute.PROFILE]: [
+    UserRole.CAS_PENDING,
+    UserRole.CAS_ANALYST,
+    UserRole.CAS_ADMIN,
+    UserRole.INDUSTRY_USER,
+    UserRole.INDUSTRY_USER_ADMIN,
+    UserRole.NEW_USER,
+  ],
+  [AppRoute.USERS]: [UserRole.CAS_ADMIN, UserRole.INDUSTRY_USER_ADMIN],
+};
+// ℹ️ Environment variables
+import * as dotenv from "dotenv";
+dotenv.config({ path: "./e2e/.env.local" });
+
+// 🛠️ Function to build allow and deny lists based on current user role
+function buildAccessLists(currentRole: UserRole): AppRoute[] {
+  return Object.entries(appRouteRoles).reduce((acc, [route, allowedRoles]) => {
+    if (allowedRoles.includes(currentRole)) {
+      acc.push(route as AppRoute);
+    }
+    return acc;
+  }, [] as AppRoute[]);
+}
+
+// 🏷 Annotate test suite as serial
+test.describe.configure({ mode: "serial" });
+// ➰ Loop through the entries of UserRole enum
+for (let [role, value] of Object.entries(UserRole)) {
+  role = "E2E_" + role;
+  const storageState = process.env[role + "_STORAGE"] as string;
+  test.describe(`Test Route Access for ${value}`, () => {
+    // 👤 run test as this role
+    test.use({ storageState: storageState });
+    test("Test Navigate to Routes", async ({ page }) => {
+      // 🚨 Build user role's allow and deny list
+      const accessLists = buildAccessLists(value);
+      // 🛸 Navigate to all routes
+      for (let route of Object.values(AppRoute)) {
+        let pomPage;
+        switch (route) {
+          case AppRoute.DASHBOARD:
+            pomPage = new DashboardPOM(page);
+            break;
+          case AppRoute.HOME:
+            break;
+          case AppRoute.OPERATION:
+            pomPage = new OperationPOM(page);
+            break;
+          case AppRoute.OPERATIONS:
+            pomPage = new OperationsPOM(page);
+            break;
+          case AppRoute.OPERATOR:
+            pomPage = new OperatorPOM(page);
+            break;
+          case AppRoute.OPERATORS:
+            pomPage = new OperatorsPOM(page);
+            break;
+          case AppRoute.PROFILE:
+            pomPage = new ProfilePOM(page);
+            break;
+          case AppRoute.USERS:
+            pomPage = new UsersPOM(page);
+            break;
+        }
+        if (pomPage) {
+          // 🛸 Navigate to page
+          await pomPage.route();
+          // 🔍 Assert that the current URL role access
+          const isAllowedRoute = accessLists.includes(route);
+          const code = isAllowedRoute ? 500 : 404;
+          // Listen for response status code
+          page.on("response", async (response) => {
+            // Add your expect test for the response status code
+            expect(response.status()).toBe(code);
+          });
+        }
+      }
+    });
+  });
+}

--- a/client/e2e/poms/operation.ts
+++ b/client/e2e/poms/operation.ts
@@ -1,0 +1,25 @@
+/**
+ * 📖 https://playwright.dev/docs/pom
+ * Page objects model (POM) simplify test authoring by creating a higher-level API
+ * POM simplify maintenance by capturing element selectors in one place and create reusable code to avoid repetition. *
+ */
+import { Page, expect } from "@playwright/test";
+// ☰ Enums
+import { AppRoute } from "@/e2e/utils/enums";
+// ℹ️ Environment variables
+import * as dotenv from "dotenv";
+dotenv.config({ path: "./e2e/.env.local" });
+
+export class OperationPOM {
+  readonly page: Page;
+
+  readonly url: string = process.env.E2E_BASEURL + AppRoute.OPERATION;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async route() {
+    await this.page.goto(this.url);
+  }
+}

--- a/client/e2e/poms/operation.ts
+++ b/client/e2e/poms/operation.ts
@@ -22,4 +22,10 @@ export class OperationPOM {
   async route() {
     await this.page.goto(this.url);
   }
+
+  async urlIsCorrect() {
+    const path = this.url;
+    const currentUrl = await this.page.url();
+    await expect(currentUrl.toLowerCase()).toMatch(path.toLowerCase());
+  }
 }

--- a/client/e2e/poms/operations.ts
+++ b/client/e2e/poms/operations.ts
@@ -1,0 +1,25 @@
+/**
+ * 📖 https://playwright.dev/docs/pom
+ * Page objects model (POM) simplify test authoring by creating a higher-level API
+ * POM simplify maintenance by capturing element selectors in one place and create reusable code to avoid repetition. *
+ */
+import { Page, expect } from "@playwright/test";
+// ☰ Enums
+import { AppRoute } from "@/e2e/utils/enums";
+// ℹ️ Environment variables
+import * as dotenv from "dotenv";
+dotenv.config({ path: "./e2e/.env.local" });
+
+export class OperationsPOM {
+  readonly page: Page;
+
+  readonly url: string = process.env.E2E_BASEURL + AppRoute.OPERATIONS;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async route() {
+    await this.page.goto(this.url);
+  }
+}

--- a/client/e2e/poms/operations.ts
+++ b/client/e2e/poms/operations.ts
@@ -22,4 +22,10 @@ export class OperationsPOM {
   async route() {
     await this.page.goto(this.url);
   }
+
+  async urlIsCorrect() {
+    const path = this.url;
+    const currentUrl = await this.page.url();
+    await expect(currentUrl.toLowerCase()).toMatch(path.toLowerCase());
+  }
 }

--- a/client/e2e/poms/operator.ts
+++ b/client/e2e/poms/operator.ts
@@ -1,0 +1,25 @@
+/**
+ * 📖 https://playwright.dev/docs/pom
+ * Page objects model (POM) simplify test authoring by creating a higher-level API
+ * POM simplify maintenance by capturing element selectors in one place and create reusable code to avoid repetition. *
+ */
+import { Page, expect } from "@playwright/test";
+// ☰ Enums
+import { AppRoute } from "@/e2e/utils/enums";
+// ℹ️ Environment variables
+import * as dotenv from "dotenv";
+dotenv.config({ path: "./e2e/.env.local" });
+
+export class OperatorPOM {
+  readonly page: Page;
+
+  readonly url: string = process.env.E2E_BASEURL + AppRoute.OPERATOR;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async route() {
+    await this.page.goto(this.url);
+  }
+}

--- a/client/e2e/poms/operator.ts
+++ b/client/e2e/poms/operator.ts
@@ -22,4 +22,10 @@ export class OperatorPOM {
   async route() {
     await this.page.goto(this.url);
   }
+
+  async urlIsCorrect() {
+    const path = this.url;
+    const currentUrl = await this.page.url();
+    await expect(currentUrl.toLowerCase()).toMatch(path.toLowerCase());
+  }
 }

--- a/client/e2e/poms/operators.ts
+++ b/client/e2e/poms/operators.ts
@@ -1,0 +1,25 @@
+/**
+ * 📖 https://playwright.dev/docs/pom
+ * Page objects model (POM) simplify test authoring by creating a higher-level API
+ * POM simplify maintenance by capturing element selectors in one place and create reusable code to avoid repetition. *
+ */
+import { Page, expect } from "@playwright/test";
+// ☰ Enums
+import { AppRoute } from "@/e2e/utils/enums";
+// ℹ️ Environment variables
+import * as dotenv from "dotenv";
+dotenv.config({ path: "./e2e/.env.local" });
+
+export class OperatorsPOM {
+  readonly page: Page;
+
+  readonly url: string = process.env.E2E_BASEURL + AppRoute.OPERATORS;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async route() {
+    await this.page.goto(this.url);
+  }
+}

--- a/client/e2e/poms/operators.ts
+++ b/client/e2e/poms/operators.ts
@@ -22,4 +22,10 @@ export class OperatorsPOM {
   async route() {
     await this.page.goto(this.url);
   }
+
+  async urlIsCorrect() {
+    const path = this.url;
+    const currentUrl = await this.page.url();
+    await expect(currentUrl.toLowerCase()).toMatch(path.toLowerCase());
+  }
 }

--- a/client/e2e/poms/users.ts
+++ b/client/e2e/poms/users.ts
@@ -1,0 +1,25 @@
+/**
+ * 📖 https://playwright.dev/docs/pom
+ * Page objects model (POM) simplify test authoring by creating a higher-level API
+ * POM simplify maintenance by capturing element selectors in one place and create reusable code to avoid repetition. *
+ */
+import { Page, expect } from "@playwright/test";
+// ☰ Enums
+import { AppRoute } from "@/e2e/utils/enums";
+// ℹ️ Environment variables
+import * as dotenv from "dotenv";
+dotenv.config({ path: "./e2e/.env.local" });
+
+export class UsersPOM {
+  readonly page: Page;
+
+  readonly url: string = process.env.E2E_BASEURL + AppRoute.USERS;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async route() {
+    await this.page.goto(this.url);
+  }
+}

--- a/client/e2e/poms/users.ts
+++ b/client/e2e/poms/users.ts
@@ -22,4 +22,10 @@ export class UsersPOM {
   async route() {
     await this.page.goto(this.url);
   }
+
+  async urlIsCorrect() {
+    const path = this.url;
+    const currentUrl = await this.page.url();
+    await expect(currentUrl.toLowerCase()).toMatch(path.toLowerCase());
+  }
 }

--- a/client/e2e/utils/enums.ts
+++ b/client/e2e/utils/enums.ts
@@ -2,13 +2,20 @@ export enum ActionButton {
   CONTINUE = "Continue",
   SUBMIT = "Submit",
 }
+
 export enum AppRole {
   ADMIN = "admin",
 }
+
 export enum AppRoute {
   DASHBOARD = "dashboard",
   HOME = "home",
+  OPERATION = "dashboard/operations/create/1",
+  OPERATIONS = "dashboard/operations",
+  OPERATOR = "dashboard/select-operator",
+  OPERATORS = "dashboard/operators",
   PROFILE = "dashboard/profile",
+  USERS = "dashboard/users",
 }
 
 export enum DataTestID {

--- a/client/e2e/utils/enums.ts
+++ b/client/e2e/utils/enums.ts
@@ -19,6 +19,7 @@ export enum AppRoute {
 }
 
 export enum DataTestID {
+  NOTFOUND = '[data-testid="not-found"]',
   PROFILE = '[data-testid="nav-user-profile"]',
 }
 

--- a/client/e2e/utils/enums.ts
+++ b/client/e2e/utils/enums.ts
@@ -67,7 +67,8 @@ export enum UserOperatorStatus {
 
 // 🤳 UUIDs UserOperator
 export enum UserOperatorUUID {
-  DEFAULT = "9bb541e6-41f5-47d3-8359-2fab4f5bc4c0",
+  INDUSTRY_USER_ADMIN = "9bb541e6-41f5-47d3-8359-2fab4f5bc4c0",
+  INDUSTRY_USER = "c49122dc-b44a-44e6-b38e-77584bff606b",
 }
 
 //  // 👤  User roles

--- a/client/e2e/utils/enums.ts
+++ b/client/e2e/utils/enums.ts
@@ -68,7 +68,6 @@ export enum UserOperatorStatus {
 // 🤳 UUIDs UserOperator
 export enum UserOperatorUUID {
   INDUSTRY_USER_ADMIN = "9bb541e6-41f5-47d3-8359-2fab4f5bc4c0",
-  INDUSTRY_USER = "c49122dc-b44a-44e6-b38e-77584bff606b",
 }
 
 //  // 👤  User roles
@@ -98,11 +97,10 @@ export const appRouteRoles: Record<AppRoute, UserRole[]> = {
     UserRole.INDUSTRY_USER_ADMIN,
     UserRole.NEW_USER,
   ],
-  [AppRoute.OPERATION]: [UserRole.INDUSTRY_USER, UserRole.INDUSTRY_USER_ADMIN],
+  [AppRoute.OPERATION]: [UserRole.INDUSTRY_USER_ADMIN],
   [AppRoute.OPERATIONS]: [
     UserRole.CAS_ANALYST,
     UserRole.CAS_ADMIN,
-    UserRole.INDUSTRY_USER,
     UserRole.INDUSTRY_USER_ADMIN,
   ],
   [AppRoute.OPERATOR]: [UserRole.INDUSTRY_USER, UserRole.INDUSTRY_USER_ADMIN],

--- a/client/e2e/utils/enums.ts
+++ b/client/e2e/utils/enums.ts
@@ -1,3 +1,4 @@
+// 🔘 button text
 export enum ActionButton {
   CONTINUE = "Continue",
   SUBMIT = "Submit",
@@ -7,6 +8,7 @@ export enum AppRole {
   ADMIN = "admin",
 }
 
+// 🚀  App routes
 export enum AppRoute {
   DASHBOARD = "dashboard",
   HOME = "home",
@@ -18,26 +20,31 @@ export enum AppRoute {
   USERS = "dashboard/users",
 }
 
+// 👋 playwright selectors targeting an HTML element
 export enum DataTestID {
   NOTFOUND = '[data-testid="not-found"]',
   PROFILE = '[data-testid="nav-user-profile"]',
 }
 
+// 👋 keycloak selectors
 export enum Keycloak {
   FIELD_USER_LOCATOR = "id=user",
   FIELD_PW_LOCATOR = "Password",
 }
 
+// 🔘 button text
 export enum Login {
   CAS = "Log in with IDIR",
   INDUSTRY_USER = "Log in with Business BCeID",
 }
 
+// 🔘 button text
 export enum Logout {
   OUT = "Log out",
   SSO = "You are logged out",
 }
 
+// 📝 Status LOV Operator
 export enum OperatorStatus {
   DRAFT = "Draft",
   PENDING = "Pending",
@@ -46,19 +53,24 @@ export enum OperatorStatus {
   CHANGES_REQUESTED = "Changes Requested",
 }
 
+// 🤳 UUIDs Operator
 export enum OperatorUUID {
   DEFAULT = "4242ea9d-b917-4129-93c2-db00b7451051",
 }
 
+// 📝 Status LOV UserOperator
 export enum UserOperatorStatus {
   PENDING = "Pending",
   APPROVED = "Approved",
   DECLINED = "Declined",
 }
+
+// 🤳 UUIDs UserOperator
 export enum UserOperatorUUID {
   DEFAULT = "9bb541e6-41f5-47d3-8359-2fab4f5bc4c0",
 }
 
+//  // 👤  User roles
 export enum UserRole {
   CAS_PENDING = "cas_pending",
   CAS_ANALYST = "cas_analyst",
@@ -67,3 +79,40 @@ export enum UserRole {
   INDUSTRY_USER_ADMIN = "industry_user_admin",
   NEW_USER = "none",
 }
+
+// 🚨 Object literal policing route access by role
+export const appRouteRoles: Record<AppRoute, UserRole[]> = {
+  [AppRoute.DASHBOARD]: [
+    UserRole.CAS_PENDING,
+    UserRole.CAS_ANALYST,
+    UserRole.CAS_ADMIN,
+    UserRole.INDUSTRY_USER,
+    UserRole.INDUSTRY_USER_ADMIN,
+  ],
+  [AppRoute.HOME]: [
+    UserRole.CAS_PENDING,
+    UserRole.CAS_ANALYST,
+    UserRole.CAS_ADMIN,
+    UserRole.INDUSTRY_USER,
+    UserRole.INDUSTRY_USER_ADMIN,
+    UserRole.NEW_USER,
+  ],
+  [AppRoute.OPERATION]: [UserRole.INDUSTRY_USER, UserRole.INDUSTRY_USER_ADMIN],
+  [AppRoute.OPERATIONS]: [
+    UserRole.CAS_ANALYST,
+    UserRole.CAS_ADMIN,
+    UserRole.INDUSTRY_USER,
+    UserRole.INDUSTRY_USER_ADMIN,
+  ],
+  [AppRoute.OPERATOR]: [UserRole.INDUSTRY_USER, UserRole.INDUSTRY_USER_ADMIN],
+  [AppRoute.OPERATORS]: [UserRole.CAS_ANALYST, UserRole.CAS_ADMIN],
+  [AppRoute.PROFILE]: [
+    UserRole.CAS_PENDING,
+    UserRole.CAS_ANALYST,
+    UserRole.CAS_ADMIN,
+    UserRole.INDUSTRY_USER,
+    UserRole.INDUSTRY_USER_ADMIN,
+    UserRole.NEW_USER,
+  ],
+  [AppRoute.USERS]: [UserRole.CAS_ADMIN, UserRole.INDUSTRY_USER_ADMIN],
+};

--- a/client/e2e/utils/queries.ts
+++ b/client/e2e/utils/queries.ts
@@ -208,7 +208,7 @@ type UpsertUserOperatorValues = {
 
 // User Operator default values
 const defaultUserOperatorValues: UpsertUserOperatorValues = {
-  id: UserOperatorUUID.DEFAULT,
+  id: UserOperatorUUID.INDUSTRY_USER_ADMIN,
   operator_id: OperatorUUID.DEFAULT,
 };
 


### PR DESCRIPTION
Addresses [1006](https://github.com/bcgov/cas-registration/issues/1006)

## 🚀 Impact:
   - ` client/e2e/pages/authenticated/dashboard/routes/page.spec.ts` for comprehensive coverage of route access for each role



##  🔬 Testing:

**Option 1:** CI e2e test
Valid [e2e test](https://github.com/bcgov/cas-registration/actions/runs/8163648892) status is  `pass` 
**OR**
Download artefact files from `GitHub Actions\Test Registration App` to your `client/playwright-report` folder and run command `cd client && yarn playwright show-report`
[CI artefact](https://github.com/bcgov/cas-registration/actions/runs/8163648892#artifacts)
[CI artefact download](https://github.com/bcgov/cas-registration/actions/runs/8163648892/artifacts/1300215141)
![image](https://github.com/bcgov/cas-registration/assets/120038448/5946a831-44c4-4250-9b03-34a5ed768063)



**Option 2:** Local e2e testing:

**Pre-reqs** 

1. From file `client/e2e/.env.local.example` create `client/e2e/.env.local` with values reflecting instructions in file `client/e2e/.env.local.example`

2.  From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
3.  From terminal command, start the app development server:
 ```
cd client && yarn build && yarn start
```  
 
**e2e tests**

1. From terminal command, run Playwright e2e tests:
```
cd client && yarn e2e
```   
2. Test Results:
![image](https://github.com/bcgov/cas-registration/assets/120038448/f8e05615-83e7-4299-9d31-33c4a0b0d568)
