### PR TITLE
Chore: mailhog

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -253,6 +253,8 @@ jobs:
         working-directory: ./client
 
       - name: 🎭 run Playwright
+      - run: docker run -d -p 1025:1025 -p 8025:8025 mailhog/mailhog # start mailhog
+      - name: Run Playwright Tests
         run: |
           npx happo-e2e -- npx playwright test --project=${{ matrix.project }} client/e2e/*
         env:
@@ -284,6 +286,7 @@ jobs:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
           HAPPO_NONCE: ${{ github.sha }}
+          SMTP_CONNECTION_STRING: smtp://@localhost:1025
         working-directory: ./client
       - name: 💾 save ${{ matrix.project }} report artifact
         # prefer to upload the report only in case of test failure

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -252,8 +252,8 @@ jobs:
         run: yarn playwright install --with-deps ${{ matrix.project }}
         working-directory: ./client
 
-      - name: 🎭 run Playwright
-      - run: docker run -d -p 1025:1025 -p 8025:8025 mailhog/mailhog # start mailhog
+      - name: 🎭 Start Mailhog
+        run: docker run -d -p 1025:1025 -p 8025:8025 mailhog/mailhog # start mailhog
       - name: Run Playwright Tests
         run: |
           npx happo-e2e -- npx playwright test --project=${{ matrix.project }} client/e2e/*

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore /charts helm directory
+helm/**/charts

--- a/helm/cas-registration/Chart.lock
+++ b/helm/cas-registration/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mailhog
+  repository: https://codecentric.github.io/helm-charts/
+  version: 5.2.3
+digest: sha256:aa764930f0dd89e7cd8c48b19119b8e99b1a05c0e97841bf5bf6110d40286fab
+generated: "2024-03-11T14:42:08.251363378-07:00"

--- a/helm/cas-registration/Chart.yaml
+++ b/helm/cas-registration/Chart.yaml
@@ -22,3 +22,9 @@ version: 0.1.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "1.16.0"
+
+dependencies:
+  - name: mailhog
+    version: "5.2.3"
+    repository: "https://codecentric.github.io/helm-charts/"
+    condition: mailhog.enable

--- a/helm/cas-registration/templates/mailhog/mailhog-ingress.yaml
+++ b/helm/cas-registration/templates/mailhog/mailhog-ingress.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.mailhog.enable }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-mailhog-ingress
+  labels: {{ include "cas-registration.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: mailhog
+  ingress:
+  - ports:
+      - port: 1025
+    from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: {{ .Release.Name }}
+{{- end }}

--- a/helm/cas-registration/templates/mailhog/mailhog-route.yaml
+++ b/helm/cas-registration/templates/mailhog/mailhog-route.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.mailhog.enable }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "cas-registration.fullname" . }}-mailhog
+  labels:
+{{ include "cas-registration.labels" . | indent 4 }}
+
+spec:
+  host: {{ .Values.mailhog.host }}
+  port:
+    targetPort: http
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name:  {{ template "cas-registration.fullname" . }}-mailhog
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress:
+  - conditions:
+    - status: 'True'
+      type: Admitted
+    host: {{ .Values.mailhog.host }}
+    routerName: router
+    wildcardPolicy: None
+{{- end }}

--- a/helm/cas-registration/values-dev.yaml
+++ b/helm/cas-registration/values-dev.yaml
@@ -45,3 +45,10 @@ frontend:
 
 growthbook:
   clientKey: sdk-YMBcx9KglRDGzGTE
+mailhog:
+  enable: true
+  securityContext:
+    runAsUser: 1001650000
+    fsGroup: 1001650000
+    runAsNonRoot: true
+  host: cas-obps-mailhog-dev.apps.silver.devops.gov.bc.ca

--- a/helm/cas-registration/values-test.yaml
+++ b/helm/cas-registration/values-test.yaml
@@ -43,3 +43,10 @@ frontend:
 
 growthbook:
   clientKey: sdk-9Vyna67jpIYdjMa
+mailhog:
+  enable: true
+  securityContext:
+    runAsUser: 1001650000
+    fsGroup: 1001650000
+    runAsNonRoot: true
+  host: cas-obps-mailhog-test.apps.silver.devops.gov.bc.ca

--- a/helm/cas-registration/values.yaml
+++ b/helm/cas-registration/values.yaml
@@ -85,3 +85,6 @@ devops:
     requests:
       cpu: 100m
       memory: 64Mi
+
+mailhog:
+  enable: false


### PR DESCRIPTION
Adds mailhog to the dev & test environments to ensure test emails are not actually delivered outside of our environment.

This implementation was pulled mostly from what we're doing in CIIP. It may need tweaking once we have CHES set up if there are any differences in that setup from what we have in CIIP.