### PR TITLE
chore: increase global Playwright timeout

### DIFF
--- a/client/e2e/pages/authenticated/routes/page.spec.ts
+++ b/client/e2e/pages/authenticated/routes/page.spec.ts
@@ -93,12 +93,6 @@ for (let [role, value] of Object.entries(UserRole)) {
         if (pomPage) {
           // 🚨 Check if route is in the role's allow list
           const isAllowedRoute = accessLists.includes(route);
-          const timeOut = 15000;
-          // eslint-disable-next-line no-console
-          console.log(
-            `🚀 Route ${route} for ${value} has access ${isAllowedRoute}`,
-          );
-
           // 🛸 Navigate to route
           await pomPage.route();
           // 📌 Some roles have exceptions to the expected results
@@ -138,10 +132,9 @@ for (let [role, value] of Object.entries(UserRole)) {
                     // 🔍 Assert that the current URL is correct
                     await pomPage.urlIsCorrect();
                     // 🔍 Assert that the not-found selector is not available
-                    // Wait for the selector to not be available with a timeout
+                    // Wait for the selector to not be available
                     await page.waitForSelector('[data-testid="not-found"]', {
                       state: "hidden",
-                      timeout: timeOut,
                     });
                     const notFoundSelector = await page.$(
                       '[data-testid="not-found"]',
@@ -163,9 +156,7 @@ for (let [role, value] of Object.entries(UserRole)) {
                   dashboardPage.urlIsCorrect();
                 } else {
                   // 🔍 Assert that the role has NO access, not-found selector is available
-                  await pomPage.page.waitForSelector(DataTestID.NOTFOUND, {
-                    timeout: timeOut,
-                  });
+                  await pomPage.page.waitForSelector(DataTestID.NOTFOUND);
                 }
               }
               break;

--- a/client/e2e/poms/profile.ts
+++ b/client/e2e/poms/profile.ts
@@ -48,14 +48,10 @@ export class ProfilePOM {
     await this.buttonSubmit.click();
     // Wait for the success message to appear
     await this.page.waitForSelector('div:has-text("✅ Success")', {
-      timeout: 11000,
+      timeout: 15000,
     });
-    // Check if the success message exists
-    const isSuccessExisted =
-      (await this.page.$('div:has-text("✅ Success")')) !== null;
-
-    //  🔍 Assert the success message
-    expect(isSuccessExisted).toBe(true);
+    // If all actions succeed, return true
+    return true;
   }
 
   async userFullNameIsCorrect(expectedText: string) {

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -14,6 +14,8 @@ import { defineConfig, devices } from "@playwright/test";
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  // Increase timeout from default to acomadate for slower CI
+  timeout: 60000, //Each test is given 60 seconds timeout
   testDir: "./e2e",
   /* Run tests in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION
[Card](https://github.com/bcgov/cas-registration/issues/1073)
and
[Card](https://github.com/bcgov/cas-registration/issues/1074)

## 🚀 Impact:
   - Increased in Playwright `timeout` configuration increased to improve test passing consistency.



##  🔬 Testing:

- Run the entire test suite multiple times in [CI](https://github.com/bcgov/cas-registration/actions/runs/8249642888)
- Observe tests pass consistently 

![image](https://github.com/bcgov/cas-registration/assets/120038448/1774b776-cf8b-482b-ae4c-a85caea6fdd2)


![image](https://github.com/bcgov/cas-registration/assets/120038448/2d24d6fb-5e6b-48e9-a9c2-aa44a27c1057)

![image](https://github.com/bcgov/cas-registration/assets/120038448/e80a09db-b9fa-467f-bc63-f12275d3ebf8)
![image](https://github.com/bcgov/cas-registration/assets/120038448/87182c26-70a2-402c-86ba-598755b05d04)


