### PR TITLE
1074 fix e2e flaky tests

### DIFF
--- a/client/e2e/pages/authenticated/dashboard/page.spec.ts
+++ b/client/e2e/pages/authenticated/dashboard/page.spec.ts
@@ -41,7 +41,7 @@ test.beforeAll(async () => {
     await upsertUserOperatorRecord(
       process.env.E2E_INDUSTRY_USER_ADMIN_GUID as string,
       AppRole.ADMIN,
-      UserOperatorStatus.APPROVED
+      UserOperatorStatus.APPROVED,
     );
     // Scenario FrontEndRoles.INDUSTRY_USER where userOperatorStatus !== UserOperatorStatus.APPROVED
     // Shows "Select Operator\...1 pending action(s) required" bceidSelectOperatorTile
@@ -49,7 +49,7 @@ test.beforeAll(async () => {
     // Upsert a User record: bc-cas-dev-secondary
     await upsertUserRecord(UserRole.INDUSTRY_USER);
     await deleteUserOperatorRecord(
-      process.env.E2E_INDUSTRY_USER_GUID as string
+      process.env.E2E_INDUSTRY_USER_GUID as string,
     );
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/client/e2e/pages/authenticated/dashboard/page.spec.ts
+++ b/client/e2e/pages/authenticated/dashboard/page.spec.ts
@@ -41,7 +41,7 @@ test.beforeAll(async () => {
     await upsertUserOperatorRecord(
       process.env.E2E_INDUSTRY_USER_ADMIN_GUID as string,
       AppRole.ADMIN,
-      UserOperatorStatus.APPROVED
+      UserOperatorStatus.APPROVED,
     );
     // Scenario FrontEndRoles.INDUSTRY_USER where userOperatorStatus !== UserOperatorStatus.APPROVED
     // Shows "Select Operator\...1 pending action(s) required" bceidSelectOperatorTile
@@ -49,7 +49,7 @@ test.beforeAll(async () => {
     // Upsert a User record: bc-cas-dev-secondary
     await upsertUserRecord(UserRole.INDUSTRY_USER);
     await deleteUserOperatorRecord(
-      process.env.E2E_INDUSTRY_USER_GUID as string
+      process.env.E2E_INDUSTRY_USER_GUID as string,
     );
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -76,7 +76,7 @@ test.describe("Test Dashboard Page", () => {
     test.describe(`Test Role ${value}`, () => {
       // 👤 run test as this role
       test.use({ storageState: storageState });
-      test("Test Selfie", async ({ page }, testInfo) => {
+      test("Test Selfie", async ({ page }) => {
         // 🛸 Navigate to dashboard page
         const dashboardPage = new DashboardPOM(page);
 

--- a/client/e2e/pages/authenticated/dashboard/page.spec.ts
+++ b/client/e2e/pages/authenticated/dashboard/page.spec.ts
@@ -41,7 +41,7 @@ test.beforeAll(async () => {
     await upsertUserOperatorRecord(
       process.env.E2E_INDUSTRY_USER_ADMIN_GUID as string,
       AppRole.ADMIN,
-      UserOperatorStatus.APPROVED,
+      UserOperatorStatus.APPROVED
     );
     // Scenario FrontEndRoles.INDUSTRY_USER where userOperatorStatus !== UserOperatorStatus.APPROVED
     // Shows "Select Operator\...1 pending action(s) required" bceidSelectOperatorTile
@@ -49,7 +49,7 @@ test.beforeAll(async () => {
     // Upsert a User record: bc-cas-dev-secondary
     await upsertUserRecord(UserRole.INDUSTRY_USER);
     await deleteUserOperatorRecord(
-      process.env.E2E_INDUSTRY_USER_GUID as string,
+      process.env.E2E_INDUSTRY_USER_GUID as string
     );
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/client/e2e/pages/authenticated/dashboard/page.spec.ts
+++ b/client/e2e/pages/authenticated/dashboard/page.spec.ts
@@ -41,7 +41,7 @@ test.beforeAll(async () => {
     await upsertUserOperatorRecord(
       process.env.E2E_INDUSTRY_USER_ADMIN_GUID as string,
       AppRole.ADMIN,
-      UserOperatorStatus.APPROVED,
+      UserOperatorStatus.APPROVED
     );
     // Scenario FrontEndRoles.INDUSTRY_USER where userOperatorStatus !== UserOperatorStatus.APPROVED
     // Shows "Select Operator\...1 pending action(s) required" bceidSelectOperatorTile
@@ -49,7 +49,7 @@ test.beforeAll(async () => {
     // Upsert a User record: bc-cas-dev-secondary
     await upsertUserRecord(UserRole.INDUSTRY_USER);
     await deleteUserOperatorRecord(
-      process.env.E2E_INDUSTRY_USER_GUID as string,
+      process.env.E2E_INDUSTRY_USER_GUID as string
     );
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -68,35 +68,38 @@ test.afterEach(async () => {
 
 // 🏷 Annotate test suite as serial
 test.describe.configure({ mode: "serial" });
-// ➰ Loop through the entries of UserRole enum
-for (let [role, value] of Object.entries(UserRole)) {
-  role = "E2E_" + role;
-  const storageState = process.env[role + "_STORAGE"] as string;
-  test.describe(`Test Dashboard for ${value}`, () => {
-    // 👤 run test as this role
-    test.use({ storageState: storageState });
-    test("Test Selfie", async ({ page }) => {
-      // 🛸 Navigate to dashboard page
-      const dashboardPage = new DashboardPOM(page);
+test.describe("Test Dashboard Page", () => {
+  // ➰ Loop through the entries of UserRole enum
+  for (let [role, value] of Object.entries(UserRole)) {
+    role = "E2E_" + role;
+    const storageState = process.env[role + "_STORAGE"] as string;
+    test.describe(`Test Role ${value}`, () => {
+      // 👤 run test as this role
+      test.use({ storageState: storageState });
+      test("Test Selfie", async ({ page }, testInfo) => {
+        // 🛸 Navigate to dashboard page
+        const dashboardPage = new DashboardPOM(page);
 
-      await dashboardPage.route();
-      switch (value) {
-        case UserRole.NEW_USER:
-          // 🔍 Assert that the current URL ends with "/profile"
-          const profilePage = new ProfilePOM(page);
-          await profilePage.urlIsCorrect();
-          break;
-        default:
-          // 🔍 Assert that the current URL ends with "/dashboard"
-          await dashboardPage.urlIsCorrect();
+        await dashboardPage.route();
+        switch (value) {
+          case UserRole.NEW_USER:
+            // 🔍 Assert that the current URL ends with "/profile"
+            const profilePage = new ProfilePOM(page);
+            await profilePage.urlIsCorrect();
+            break;
+          default:
+            // 🔍 Assert that the current URL ends with "/dashboard"
+            await dashboardPage.urlIsCorrect();
 
-          const pageContent = page.locator("html");
-          await happoPlaywright.screenshot(dashboardPage.page, pageContent, {
-            component: `${role} Dashboard page`,
-            variant: "default",
-          });
-          break;
-      }
+            const pageContent = page.locator("html");
+            await happoPlaywright.screenshot(dashboardPage.page, pageContent, {
+              component: `${role} Dashboard page`,
+              variant: "default",
+            });
+
+            break;
+        }
+      });
     });
-  });
-}
+  }
+});

--- a/client/e2e/pages/authenticated/dashboard/profile/page.spec.ts
+++ b/client/e2e/pages/authenticated/dashboard/profile/page.spec.ts
@@ -51,7 +51,7 @@ test.describe("Test Profile Page", () => {
         await profilePage.updateSuccess();
         //🔍 Assert profile name reflects the updated user profile full name
         await profilePage.userFullNameIsCorrect(
-          "e2e first name* e2e last name*",
+          "e2e first name* e2e last name*"
         );
 
         switch (value) {

--- a/client/e2e/pages/authenticated/dashboard/profile/page.spec.ts
+++ b/client/e2e/pages/authenticated/dashboard/profile/page.spec.ts
@@ -6,39 +6,62 @@ import { DashboardPOM } from "@/e2e/poms/dashboard";
 import { ProfilePOM } from "@/e2e/poms/profile";
 // ☰ Enums
 import { UserRole } from "@/e2e/utils/enums";
+// 🥞 DB CRUD
+import { deleteUserRecord } from "@/e2e/utils/queries";
 // ℹ️ Environment variables
 import * as dotenv from "dotenv";
 dotenv.config({ path: "./e2e/.env.local" });
 
+// 📚 Declare a beforeAll hook that is executed once per worker process before all tests.
+// 🥞 Set DB for e2e login roles
+/*
+For "new user":
+-  delete record in the db so that on "new user" login the ID will have no app_role
+*/
+test.beforeAll(async () => {
+  try {
+    // 👤 delete new user: bc-cas-dev-three
+    await deleteUserRecord(process.env.E2E_NEW_USER_GUID as string);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("❌ Error in Db setup for profile by roles:", error);
+    throw error;
+  }
+});
+
 // 🏷 Annotate test suite as serial
 test.describe.configure({ mode: "serial" });
-// ➰ Loop through the entries of UserRole enum
-for (let [role, value] of Object.entries(UserRole)) {
-  role = "E2E_" + role;
-  const storageState = process.env[role + "_STORAGE"] as string;
-  test.describe(`Test Profile for ${value}`, () => {
-    // 👤 run test as this role
-    test.use({ storageState: storageState });
-    test("Test Update", async ({ page }) => {
-      // 🛸 Navigate to profile page
-      const profilePage = new ProfilePOM(page);
-      await profilePage.route();
-      // 🔍 Assert that the current URL
-      await profilePage.urlIsCorrect();
-      // 🔍 Assert profile update validates required fields
-      await profilePage.updateFail();
-      // 🔍 Assert profile update success
-      await profilePage.updateSuccess();
-      //🔍 Assert profile name reflects the updated user profile full name
-      await profilePage.userFullNameIsCorrect("e2e first name* e2e last name*");
+test.describe("Test Profile Page", () => {
+  // ➰ Loop through the entries of UserRole enum
+  for (let [role, value] of Object.entries(UserRole)) {
+    role = "E2E_" + role;
+    const storageState = process.env[role + "_STORAGE"] as string;
+    test.describe(`Test Role ${value}`, () => {
+      // 👤 run test as this role
+      test.use({ storageState: storageState });
+      test("Test Update", async ({ page }) => {
+        // 🛸 Navigate to profile page
+        const profilePage = new ProfilePOM(page);
+        await profilePage.route();
+        // 🔍 Assert that the current URL
+        await profilePage.urlIsCorrect();
+        // 🔍 Assert profile update validates required fields
+        await profilePage.updateFail();
+        // 🔍 Assert profile update success
+        await profilePage.updateSuccess();
+        //🔍 Assert profile name reflects the updated user profile full name
+        await profilePage.userFullNameIsCorrect(
+          "e2e first name* e2e last name*"
+        );
 
-      switch (value) {
-        case UserRole.NEW_USER:
-          // 🔍 Assert that the current URL
-          const dashboardPage = new DashboardPOM(page);
-          await dashboardPage.urlIsCorrect();
-          break;
-      }
+        switch (value) {
+          case UserRole.NEW_USER:
+            // 🔍 Assert that the current URL
+            const dashboardPage = new DashboardPOM(page);
+            await dashboardPage.urlIsCorrect();
+            break;
+        }
+      });
     });
-  });
-}
+  }
+});

--- a/client/e2e/pages/authenticated/dashboard/profile/page.spec.ts
+++ b/client/e2e/pages/authenticated/dashboard/profile/page.spec.ts
@@ -51,7 +51,7 @@ test.describe("Test Profile Page", () => {
         await profilePage.updateSuccess();
         //🔍 Assert profile name reflects the updated user profile full name
         await profilePage.userFullNameIsCorrect(
-          "e2e first name* e2e last name*"
+          "e2e first name* e2e last name*",
         );
 
         switch (value) {

--- a/client/e2e/pages/authenticated/routes/page.spec.ts
+++ b/client/e2e/pages/authenticated/routes/page.spec.ts
@@ -17,19 +17,27 @@ import {
 } from "@/e2e/utils/enums";
 // ℹ️ Environment variables
 import * as dotenv from "dotenv";
-import { deleteUserOperatorRecord } from "@/e2e/utils/queries";
+import {
+  deleteUserOperatorRecord,
+  deleteUserRecord,
+} from "@/e2e/utils/queries";
 dotenv.config({ path: "./e2e/.env.local" });
 
 // 📚 Declare a beforeAll hook that is executed once per worker process before all tests.
-// 🥞 Set DB for dashboard tiles
+// 🥞 Set DB for route access
 /*
+For industry_user new
+- delete user
 For industry_user: create scenario for Operator Select\1 action pending
 - delete user operator
 */
 test.beforeAll(async () => {
   try {
+    // 👤 delete new user: bc-cas-dev-three
+    await deleteUserRecord(process.env.E2E_NEW_USER_GUID as string);
+    // 👤 delete user operator
     await deleteUserOperatorRecord(
-      process.env.E2E_INDUSTRY_USER_GUID as string,
+      process.env.E2E_INDUSTRY_USER_GUID as string
     );
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -50,119 +58,121 @@ function buildAccessLists(currentRole: UserRole): AppRoute[] {
 
 // 🏷 Annotate test suite as serial
 test.describe.configure({ mode: "serial" });
-// ➰ Loop through the entries of UserRole enum
-for (let [role, value] of Object.entries(UserRole)) {
-  role = "E2E_" + role;
-  const storageState = process.env[role + "_STORAGE"] as string;
-  test.describe(`Test Route Access for ${value}`, () => {
-    // 👤 Run test as this role
-    test.use({ storageState: storageState });
-    test("Test Navigate to Routes", async ({ page }) => {
-      // 🚨 Build routes allowed list for this user role
-      const accessLists = buildAccessLists(value);
+test.describe("Test Route Access", () => {
+  // ➰ Loop through the entries of UserRole enum
+  for (let [role, value] of Object.entries(UserRole)) {
+    role = "E2E_" + role;
+    const storageState = process.env[role + "_STORAGE"] as string;
+    test.describe(`Test Role ${value}`, () => {
+      // 👤 Run test as this role
+      test.use({ storageState: storageState });
       // 🛸 Navigate to all routes
       for (let route of Object.values(AppRoute)) {
-        // 🧩 Create instance of this route's POM
-        let pomPage;
-        switch (route) {
-          case AppRoute.DASHBOARD:
-            pomPage = new DashboardPOM(page);
-            break;
-          case AppRoute.HOME:
-            pomPage = new HomePOM(page);
-            break;
-          case AppRoute.OPERATION:
-            pomPage = new OperationPOM(page);
-            break;
-          case AppRoute.OPERATIONS:
-            pomPage = new OperationsPOM(page);
-            break;
-          case AppRoute.OPERATOR:
-            pomPage = new OperatorPOM(page);
-            break;
-          case AppRoute.OPERATORS:
-            pomPage = new OperatorsPOM(page);
-            break;
-          case AppRoute.PROFILE:
-            pomPage = new ProfilePOM(page);
-            break;
-          case AppRoute.USERS:
-            pomPage = new UsersPOM(page);
-            break;
-        }
-        if (pomPage) {
-          // 🚨 Check if route is in the role's allow list
-          const isAllowedRoute = accessLists.includes(route);
-          // 🛸 Navigate to route
-          await pomPage.route();
-          // 📌 Some roles have exceptions to the expected results
-          switch (value) {
-            case UserRole.CAS_PENDING:
-              // 👤 Authenticated cas_pending have no role; so, redirected to dashboard for all routes except `profile`
-              if (route === AppRoute.PROFILE) {
-                // 🔍 Assert that the current URL ends with "/profile"
-                const profilePage = new ProfilePOM(page);
-                profilePage.urlIsCorrect();
-              } else {
-                // 🔍 Assert that the current URL ends with "/dashboard"
-                const dashboardPage = new DashboardPOM(page);
-                dashboardPage.urlIsCorrect();
-              }
+        test(`Test Route ${route}`, async ({ page }) => {
+          // 🚨 Build routes allowed list for this user role
+          const accessLists = buildAccessLists(value);
+          // 🧩 Create instance of this route's POM
+          let pomPage;
+          switch (route) {
+            case AppRoute.DASHBOARD:
+              pomPage = new DashboardPOM(page);
               break;
-            case UserRole.NEW_USER:
-              // 👤 Authenticated new user is redirected to  `profile` for all routes
-              // 🔍 Assert that the current URL ends with "/profile"
-              const profilePage = new ProfilePOM(page);
-              profilePage.urlIsCorrect();
+            case AppRoute.HOME:
+              pomPage = new HomePOM(page);
               break;
-            default:
-              // 👤 All other roles, routing results are based on route accesibility
-              if (isAllowedRoute) {
-                // 🔑 Accessible route, role has access
-                // 📌 Some routes have exceptions to the expected results
-                switch (route) {
-                  case AppRoute.HOME:
-                    // 👤 Authenticated users never get to home, redirected to dashboard
-                    // 🔍 Assert that the current URL ends with "/dashboard"
-                    const dashboardPage = new DashboardPOM(page);
-                    dashboardPage.urlIsCorrect();
-                    break;
-                  default:
-                    // 🛸 All other routes
-                    // 🔍 Assert that the current URL is correct
-                    await pomPage.urlIsCorrect();
-                    // 🔍 Assert that the not-found selector is not available
-                    // Wait for the selector to not be available
-                    await page.waitForSelector('[data-testid="not-found"]', {
-                      state: "hidden",
-                    });
-                    const notFoundSelector = await page.$(
-                      '[data-testid="not-found"]',
-                    );
-                    expect(notFoundSelector).toBeFalsy();
-                    break;
-                }
-              } else {
-                // 🔒 Inaccessible route, role has no access
-                // 📌 Some role && routes have exceptions to the expected results
-                if (
-                  value === UserRole.INDUSTRY_USER &&
-                  (route === AppRoute.OPERATION ||
-                    route === AppRoute.OPERATIONS)
-                ) {
-                  // 👤 Authenticated INDUSTRY_USER with 1 action pending get redirected to dashboard
+            case AppRoute.OPERATION:
+              pomPage = new OperationPOM(page);
+              break;
+            case AppRoute.OPERATIONS:
+              pomPage = new OperationsPOM(page);
+              break;
+            case AppRoute.OPERATOR:
+              pomPage = new OperatorPOM(page);
+              break;
+            case AppRoute.OPERATORS:
+              pomPage = new OperatorsPOM(page);
+              break;
+            case AppRoute.PROFILE:
+              pomPage = new ProfilePOM(page);
+              break;
+            case AppRoute.USERS:
+              pomPage = new UsersPOM(page);
+              break;
+          }
+          if (pomPage) {
+            // 🚨 Check if route is in the role's allow list
+            const isAllowedRoute = accessLists.includes(route);
+            // 🛸 Navigate to route
+            await pomPage.route();
+            // 📌 Some roles have exceptions to the expected results
+            switch (value) {
+              case UserRole.CAS_PENDING:
+                // 👤 Authenticated cas_pending have no role; so, redirected to dashboard for all routes except `profile`
+                if (route === AppRoute.PROFILE) {
+                  // 🔍 Assert that the current URL ends with "/profile"
+                  const profilePage = new ProfilePOM(page);
+                  profilePage.urlIsCorrect();
+                } else {
                   // 🔍 Assert that the current URL ends with "/dashboard"
                   const dashboardPage = new DashboardPOM(page);
                   dashboardPage.urlIsCorrect();
-                } else {
-                  // 🔍 Assert that the role has NO access, not-found selector is available
-                  await pomPage.page.waitForSelector(DataTestID.NOTFOUND);
                 }
-              }
-              break;
+                break;
+              case UserRole.NEW_USER:
+                // 👤 Authenticated new user is redirected to  `profile` for all routes
+                // 🔍 Assert that the current URL ends with "/profile"
+                const profilePage = new ProfilePOM(page);
+                profilePage.urlIsCorrect();
+                break;
+              default:
+                // 👤 All other roles, routing results are based on route accesibility
+                if (isAllowedRoute) {
+                  // 🔑 Accessible route, role has access
+                  // 📌 Some routes have exceptions to the expected results
+                  switch (route) {
+                    case AppRoute.HOME:
+                      // 👤 Authenticated users never get to home, redirected to dashboard
+                      // 🔍 Assert that the current URL ends with "/dashboard"
+                      const dashboardPage = new DashboardPOM(page);
+                      dashboardPage.urlIsCorrect();
+                      break;
+                    default:
+                      // 🛸 All other routes
+                      // 🔍 Assert that the current URL is correct
+                      await pomPage.urlIsCorrect();
+                      // 🔍 Assert that the not-found selector is not available
+                      // Wait for the selector to not be available
+                      await page.waitForSelector(DataTestID.NOTFOUND, {
+                        state: "hidden",
+                      });
+                      const notFoundSelector = await page.$(
+                        DataTestID.NOTFOUND
+                      );
+                      expect(notFoundSelector).toBeFalsy();
+                      break;
+                  }
+                } else {
+                  // 🔒 Inaccessible route, role has no access
+                  // 📌 Some role && routes have exceptions to the expected results
+                  if (
+                    value === UserRole.INDUSTRY_USER &&
+                    (route === AppRoute.OPERATION ||
+                      route === AppRoute.OPERATIONS)
+                  ) {
+                    // 👤 Authenticated INDUSTRY_USER with 1 action pending get redirected to dashboard
+                    // 🔍 Assert that the current URL ends with "/dashboard"
+                    const dashboardPage = new DashboardPOM(page);
+                    dashboardPage.urlIsCorrect();
+                  } else {
+                    // 🔍 Assert that the role has NO access, not-found selector is available
+                    await pomPage.page.waitForSelector(DataTestID.NOTFOUND);
+                  }
+                }
+                break;
+            }
           }
-        }
+        });
       }
     });
-  });
-}
+  }
+});

--- a/client/e2e/pages/authenticated/routes/page.spec.ts
+++ b/client/e2e/pages/authenticated/routes/page.spec.ts
@@ -37,7 +37,7 @@ test.beforeAll(async () => {
     await deleteUserRecord(process.env.E2E_NEW_USER_GUID as string);
     // 👤 delete user operator
     await deleteUserOperatorRecord(
-      process.env.E2E_INDUSTRY_USER_GUID as string,
+      process.env.E2E_INDUSTRY_USER_GUID as string
     );
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -146,7 +146,7 @@ test.describe("Test Route Access", () => {
                         state: "hidden",
                       });
                       const notFoundSelector = await page.$(
-                        DataTestID.NOTFOUND,
+                        DataTestID.NOTFOUND
                       );
                       expect(notFoundSelector).toBeFalsy();
                       break;

--- a/client/e2e/pages/authenticated/routes/page.spec.ts
+++ b/client/e2e/pages/authenticated/routes/page.spec.ts
@@ -37,7 +37,7 @@ test.beforeAll(async () => {
     await deleteUserRecord(process.env.E2E_NEW_USER_GUID as string);
     // 👤 delete user operator
     await deleteUserOperatorRecord(
-      process.env.E2E_INDUSTRY_USER_GUID as string
+      process.env.E2E_INDUSTRY_USER_GUID as string,
     );
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -146,7 +146,7 @@ test.describe("Test Route Access", () => {
                         state: "hidden",
                       });
                       const notFoundSelector = await page.$(
-                        DataTestID.NOTFOUND
+                        DataTestID.NOTFOUND,
                       );
                       expect(notFoundSelector).toBeFalsy();
                       break;

--- a/client/e2e/poms/profile.ts
+++ b/client/e2e/poms/profile.ts
@@ -18,12 +18,14 @@ export class ProfilePOM {
   readonly url: string = process.env.E2E_BASEURL + AppRoute.PROFILE;
 
   readonly buttonSubmit: Locator;
+  readonly errorList: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.buttonSubmit = this.page.getByRole("button", {
       name: ActionButton.SUBMIT,
     });
+    this.errorList = this.page.locator(DataTestID.ERROR_PROFILE);
   }
 
   async route() {
@@ -51,11 +53,7 @@ export class ProfilePOM {
     await this.buttonSubmit.isEditable();
     // Response from submit either shows errors or triggeres handleSubmit which handles state changes on submit button etc.
     // 🔍 Assert that the error selector is not available
-    await this.page.waitForSelector(DataTestID.ERROR_PROFILE, {
-      state: "hidden",
-    });
-    const notFoundSelector = await this.page.$(DataTestID.ERROR_PROFILE);
-    expect(notFoundSelector).toBeFalsy();
+    return !(await this.errorList.isVisible());
   }
 
   async userFullNameIsCorrect(expectedText: string) {

--- a/client/e2e/poms/profile.ts
+++ b/client/e2e/poms/profile.ts
@@ -58,7 +58,7 @@ export class ProfilePOM {
   async userFullNameIsCorrect(expectedText: string) {
     // Waits for the selector to appear with the expected text
     await this.page.waitForSelector(
-      `${DataTestID.PROFILE}:has-text("${expectedText}")`
+      `${DataTestID.PROFILE}:has-text("${expectedText}")`,
     );
   }
 

--- a/client/e2e/poms/profile.ts
+++ b/client/e2e/poms/profile.ts
@@ -3,7 +3,7 @@
  * Page objects model (POM) simplify test authoring by creating a higher-level API
  * POM simplify maintenance by capturing element selectors in one place and create reusable code to avoid repetition. *
  */
-import { ElementHandle, Locator, Page, expect } from "@playwright/test";
+import { Locator, Page, expect } from "@playwright/test";
 // ⛏️ Helpers
 import { fieldsClear, fieldsUpdate, getFieldAlerts } from "@/e2e/utils/helpers";
 // ☰ Enums
@@ -46,26 +46,20 @@ export class ProfilePOM {
     await fieldsUpdate(this.page);
     // Click the Submit button
     await this.buttonSubmit.click();
-    // Wait for the success message to appear
-    await this.page.waitForSelector('div:has-text("✅ Success")', {
-      timeout: 15000,
+    // Response from submit either shows errors or triggeres handleSubmit which handles state changes on submit button etc.
+    // 🔍 Assert that the error selector is not available
+    await this.page.waitForSelector(DataTestID.ERROR_PROFILE, {
+      state: "hidden",
     });
-    // If all actions succeed, return true
-    return true;
+    const notFoundSelector = await this.page.$(DataTestID.ERROR_PROFILE);
+    expect(notFoundSelector).toBeFalsy();
   }
 
   async userFullNameIsCorrect(expectedText: string) {
-    // Get the element handle
-    const elementHandle: ElementHandle | null = await this.page.$(
-      DataTestID.PROFILE,
+    // Waits for the selector to appear with the expected text
+    await this.page.waitForSelector(
+      `${DataTestID.PROFILE}:has-text("${expectedText}")`
     );
-    // If elementHandle is null, return false
-    if (!elementHandle) {
-      return false;
-    }
-    // Get the text value of the profile link
-    const actualText = (await elementHandle.textContent()) as string;
-    await expect(actualText.toLowerCase()).toMatch(expectedText.toLowerCase());
   }
 
   async urlIsCorrect() {

--- a/client/e2e/poms/profile.ts
+++ b/client/e2e/poms/profile.ts
@@ -18,6 +18,7 @@ export class ProfilePOM {
   readonly url: string = process.env.E2E_BASEURL + AppRoute.PROFILE;
 
   readonly buttonSubmit: Locator;
+
   readonly errorList: Locator;
 
   constructor(page: Page) {
@@ -39,7 +40,7 @@ export class ProfilePOM {
     await this.buttonSubmit.click();
     // Locate all alert elements within the fieldset
     const alertElements = await getFieldAlerts(this.page);
-    // 🔍 Assert there to be exactly the same number of required fields and alert elements
+    // Assert there to be exactly the same number of required fields and alert elements
     await expect(clearedFields).toBe(alertElements.length);
   }
 
@@ -51,15 +52,14 @@ export class ProfilePOM {
     // Wait for API request/response
     await this.buttonSubmit.isDisabled();
     await this.buttonSubmit.isEditable();
-    // Response from submit either shows errors or triggeres handleSubmit which handles state changes on submit button etc.
-    // 🔍 Assert that the error selector is not available
+    // Assert that the error selector is not available
     return !(await this.errorList.isVisible());
   }
 
   async userFullNameIsCorrect(expectedText: string) {
     // Waits for the selector to appear with the expected text
     await this.page.waitForSelector(
-      `${DataTestID.PROFILE}:has-text("${expectedText}")`
+      `${DataTestID.PROFILE}:has-text("${expectedText}")`,
     );
   }
 

--- a/client/e2e/poms/profile.ts
+++ b/client/e2e/poms/profile.ts
@@ -46,6 +46,9 @@ export class ProfilePOM {
     await fieldsUpdate(this.page);
     // Click the Submit button
     await this.buttonSubmit.click();
+    // Wait for API request/response
+    await this.buttonSubmit.isDisabled();
+    await this.buttonSubmit.isEditable();
     // Response from submit either shows errors or triggeres handleSubmit which handles state changes on submit button etc.
     // 🔍 Assert that the error selector is not available
     await this.page.waitForSelector(DataTestID.ERROR_PROFILE, {
@@ -58,7 +61,7 @@ export class ProfilePOM {
   async userFullNameIsCorrect(expectedText: string) {
     // Waits for the selector to appear with the expected text
     await this.page.waitForSelector(
-      `${DataTestID.PROFILE}:has-text("${expectedText}")`,
+      `${DataTestID.PROFILE}:has-text("${expectedText}")`
     );
   }
 

--- a/client/e2e/poms/profile.ts
+++ b/client/e2e/poms/profile.ts
@@ -58,7 +58,7 @@ export class ProfilePOM {
   async userFullNameIsCorrect(expectedText: string) {
     // Waits for the selector to appear with the expected text
     await this.page.waitForSelector(
-      `${DataTestID.PROFILE}:has-text("${expectedText}")`,
+      `${DataTestID.PROFILE}:has-text("${expectedText}")`
     );
   }
 

--- a/client/e2e/utils/enums.ts
+++ b/client/e2e/utils/enums.ts
@@ -22,6 +22,7 @@ export enum AppRoute {
 
 // 👋 playwright selectors targeting an HTML element
 export enum DataTestID {
+  ERROR_PROFILE = '[data-testid="alert-error-user-profile"]',
   NOTFOUND = '[data-testid="not-found"]',
   PROFILE = '[data-testid="nav-user-profile"]',
 }


### PR DESCRIPTION
[Card](https://github.com/bcgov/cas-registration/issues/1074)


## 🚀 Impact:
   - Fixes flaky ` Test Profile Page › Test Role none › Test Update `
   - Redesign looping to improve test describe details


##  🔬 Testing:

**Option 1:** CI e2e test
Validate [e2e test](https://github.com/bcgov/cas-registration/actions/runs/8300523821) status is  `pass` 
**OR**
Download artefact files from `GitHub Actions\Test Registration App` to your `client/playwright-report` folder and run command `cd client && yarn playwright show-report`
[CI artefact](https://github.com/bcgov/cas-registration/actions/runs/8300523821#artifacts)
[CI artefact download](https://github.com/bcgov/cas-registration/actions/runs/8300523821/artifacts/1330478519)

![image](https://github.com/bcgov/cas-registration/assets/120038448/0f3b8482-ad6f-4a8b-9ecd-2e30f08d101a)


**Option 2:** Local e2e testing:

**Pre-reqs** 

1. From file `client/e2e/.env.local.example` create `client/e2e/.env.local` with values reflecting instructions in file `client/e2e/.env.local.example`

2.  From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
3.  From terminal command, start the app development server:
 ```
cd client && yarn build && yarn start
```  
 
**e2e tests**

1. From terminal command, run Playwright e2e tests:
```
cd client && yarn e2e
```   
2. Test Results:
![image](https://github.com/bcgov/cas-registration/assets/120038448/cb531437-b187-4c65-abdb-ee15cae0bc09)
