### PR TITLE
fix: phone widget lockout error

### DIFF
--- a/client/app/components/form/widgets/PhoneWidget.tsx
+++ b/client/app/components/form/widgets/PhoneWidget.tsx
@@ -34,7 +34,7 @@ const PhoneWidget: React.FC<WidgetProps> = ({
       onChange={handleChange}
       forceCallingCode
       defaultCountry="CA"
-      onlyCountries={["CA"]}
+      onlyCountries={["CA", "US"]}
       sx={styles}
     />
   );


### PR DESCRIPTION
Fix for #816 

I had difficulty recreating this at first though it turns out it's an error with US phone numbers. Since both Canada and US use the same phone format a US number can pass our validation.

To recreate it log in as either `bc-cas-dev-three` or through IDIR on a fresh database so it brings you to the profile page. For the phone number use an American phone number eg `(234)-555-1234`, fill out the position field and submit the form.

Return to the profile page either by clicking back or clicking the user on the top right and the phone field will be a US number. If you try to edit it the widget will be locked out and show an error:
<img width="862" alt="Screenshot 2024-03-14 at 3 42 03 PM" src="https://github.com/bcgov/cas-registration/assets/14259474/e8ae19b0-234a-4947-9ae0-431a7ead4b3b">

There are a couple options to fix this and I think we should go with adding US to the `onlyCountries` prop. In the edge case that someone uses a US number this will allow them to edit it with no problems.

The other option is to check if it's a Canadian phone number which the library supports. Though I hesitate to do this as there are potential edge cases to block users who have valid phone numbers, either because they have a US number or else the validation is outdated due to new area codes. 

```
import { matchIsValidTel } from 'mui-tel-input'

 const isValid = matchIsValidTel(val, {
       defaultCountry: "CA",
 }),
```