### PR TITLE
e2e performance optimization

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,10 +202,16 @@ jobs:
           fail_action: false
 
   e2e:
+    name: 🧪 e2e test shard (${{ matrix.shardIndex }}/${{ strategy.job-total }})
     needs:
       ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     steps:
       - uses: actions/checkout@v3
       - name: dev env setup
@@ -222,7 +228,7 @@ jobs:
         working-directory: ./client
       - name: Run Playwright Tests
         run: |
-          DEBUG=pw:browser npx happo-e2e -- npx playwright test --trace=on --workers=1 client/e2e/*
+          DEBUG=pw:browser npx happo-e2e -- npx playwright test --shard=${{ matrix.shardIndex }}/${{ strategy.job-total }} client/e2e/*
         env:
           API_URL: http://127.0.0.1:8000/api/
           DB_USER: postgres
@@ -233,31 +239,54 @@ jobs:
           E2E_CAS_USER: ${{ secrets.E2E_CAS_USER }}
           E2E_CAS_USER_GUID: ${{ secrets.E2E_CAS_USER_GUID }}
           E2E_CAS_USER_PASSWORD: ${{ secrets.E2E_CAS_USER_PASSWORD}}
-          E2E_CAS_ADMIN_STORAGE: playwright/.auth/cas_admin.json
-          E2E_CAS_ANALYST_STORAGE: playwright/.auth/cas_analyst.json
-          E2E_CAS_PENDING_STORAGE: playwright/.auth/cas_pending.json
+          E2E_CAS_ADMIN_STORAGE: ${{ secrets.E2E_CAS_ADMIN_STORAGE}}
+          E2E_CAS_ANALYST_STORAGE: ${{ secrets.E2E_CAS_ANALYST_STORAGE}}
+          E2E_CAS_PENDING_STORAGE: ${{ secrets.E2E_CAS_PENDING_STORAGE}}
           E2E_INDUSTRY_USER_ADMIN: bc-cas-dev
           E2E_INDUSTRY_USER_ADMIN_GUID: ${{ secrets.E2E_INDUSTRY_USER_ADMIN_GUID }}
           E2E_INDUSTRY_USER_ADMIN_PASSWORD: ${{ secrets.E2E_INDUSTRY_USER_ADMIN_PASSWORD }}
-          E2E_INDUSTRY_USER_ADMIN_STORAGE: playwright/.auth/industry_user_admin.json
+          E2E_INDUSTRY_USER_ADMIN_STORAGE: ${{ secrets.E2E_INDUSTRY_USER_ADMIN_STORAGE}}
           E2E_INDUSTRY_USER: bc-cas-dev-secondary
           E2E_INDUSTRY_USER_GUID: ${{ secrets.E2E_INDUSTRY_USER_GUID }}
           E2E_INDUSTRY_USER_PASSWORD: ${{ secrets.E2E_INDUSTRY_USER_PASSWORD }}
-          E2E_INDUSTRY_USER_STORAGE: playwright/.auth/industry_user.json
+          E2E_INDUSTRY_USER_STORAGE: ${{ secrets.E2E_INDUSTRY_USER_STORAGE}}
           E2E_NEW_USER: bc-cas-dev-three
           E2E_NEW_USER_GUID: ${{ secrets.E2E_NEW_USER_GUID }}
           E2E_NEW_USER_PASSWORD: ${{ secrets.E2E_NEW_USER_PASSWORD }}
-          E2E_NEW_USER_STORAGE: playwright/.auth/new_user.json
+          E2E_NEW_USER_STORAGE: ${{ secrets.E2E_NEW_USER_STORAGE}}
           HAPPO_ENABLED: true
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
         working-directory: ./client
-      - uses: actions/upload-artifact@v3
+      - name: Upload blob report to GitHub Actions Artifacts
         if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: client/blob-report
+          retention-days: 1
+  merge-reports:
+    name: 🧩 e2e test shard reports merging
+    if: always()
+    needs: [e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge into HTML Report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: client/playwright-report
-          retention-days: 30
+          path: playwright-report
+          retention-days: 14
   backend-tests:
     needs:
       ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -201,7 +201,7 @@ jobs:
           issue_title: OWASP Baseline - Backend
           fail_action: false
 
-  e2e:
+  e2e-tests:
     needs:
       ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]
     timeout-minutes: 60
@@ -264,10 +264,10 @@ jobs:
           name: blob-report-${{ matrix.shardIndex }}
           path: client/blob-report
           retention-days: 1
-  merge-reports:
-    name: 🧩 e2e test shard reports merging
+  e2e-report:
+    name: e2e report
     if: always()
-    needs: [e2e]
+    needs: [e2e-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Download blob reports from GitHub Actions Artifacts
@@ -286,6 +286,19 @@ jobs:
           name: playwright-report
           path: playwright-report
           retention-days: 14
+  e2e:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: e2e Final Results
+    needs: [e2e-tests, e2e-report]
+    steps:
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}
   backend-tests:
     needs:
       ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -289,7 +289,6 @@ jobs:
   e2e:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: e2e Final Results
     needs: [e2e-tests, e2e-report]
     steps:
       - run: exit 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,7 +202,6 @@ jobs:
           fail_action: false
 
   e2e:
-    name: 🧪 e2e test shard (${{ matrix.shardIndex }}/${{ strategy.job-total }})
     needs:
       ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]
     timeout-minutes: 60

--- a/client/e2e/.env.local.example
+++ b/client/e2e/.env.local.example
@@ -1,3 +1,7 @@
+# HAPPO
+HAPPO_API_KEY=
+HAPPO_API_SECRET=
+
 # BASEURL
 E2E_BASEURL=http://localhost:3000/
 
@@ -18,10 +22,10 @@ E2E_NEW_USER=bc-cas-dev-three
 E2E_NEW_USER_PASSWORD=find-in-1password
 E2E_NEW_USER_GUID=find-in-1password
 
-# STORAGE
-E2E_CAS_ADMIN_STORAGE="playwright/.auth/cas_admin.json"
-E2E_CAS_ANALYST_STORAGE="playwright/.auth/cas_analyst.json"
-E2E_CAS_PENDING_STORAGE="playwright/.auth/cas_pending.json"
-E2E_INDUSTRY_USER_STORAGE="playwright/.auth/industry_user.json"
-E2E_INDUSTRY_USER_ADMIN_STORAGE="playwright/.auth/industry_user_admin.json"
-E2E_NEW_USER_STORAGE="playwright/.auth/new_user.json"
+# E2E STORAGESTATE: Find in 1password `OBPS FE E2E STORAGESTATES`
+E2E_CAS_ADMIN_STORAGE=
+E2E_CAS_ANALYST_STORAGE=
+E2E_CAS_PENDING_STORAGE=
+E2E_INDUSTRY_USER_ADMIN_STORAGE=
+E2E_INDUSTRY_USER_STORAGE=
+E2E_NEW_USER_STORAGE=

--- a/client/e2e/pages/authenticated/dashboard/page.spec.ts
+++ b/client/e2e/pages/authenticated/dashboard/page.spec.ts
@@ -72,7 +72,7 @@ test.describe("Test Dashboard Page", () => {
   // ➰ Loop through the entries of UserRole enum
   for (let [role, value] of Object.entries(UserRole)) {
     role = "E2E_" + role;
-    const storageState = process.env[role + "_STORAGE"] as string;
+    const storageState = JSON.parse(process.env[role + "_STORAGE"] as string);
     test.describe(`Test Role ${value}`, () => {
       // 👤 run test as this role
       test.use({ storageState: storageState });

--- a/client/e2e/pages/authenticated/dashboard/profile/page.spec.ts
+++ b/client/e2e/pages/authenticated/dashboard/profile/page.spec.ts
@@ -35,7 +35,7 @@ test.describe("Test Profile Page", () => {
   // ➰ Loop through the entries of UserRole enum
   for (let [role, value] of Object.entries(UserRole)) {
     role = "E2E_" + role;
-    const storageState = process.env[role + "_STORAGE"] as string;
+    const storageState = JSON.parse(process.env[role + "_STORAGE"] as string);
     test.describe(`Test Role ${value}`, () => {
       // 👤 run test as this role
       test.use({ storageState: storageState });

--- a/client/e2e/pages/authenticated/routes/page.spec.ts
+++ b/client/e2e/pages/authenticated/routes/page.spec.ts
@@ -62,7 +62,7 @@ test.describe("Test Route Access", () => {
   // ➰ Loop through the entries of UserRole enum
   for (let [role, value] of Object.entries(UserRole)) {
     role = "E2E_" + role;
-    const storageState = process.env[role + "_STORAGE"] as string;
+    const storageState = JSON.parse(process.env[role + "_STORAGE"] as string);
     test.describe(`Test Role ${value}`, () => {
       // 👤 Run test as this role
       test.use({ storageState: storageState });
@@ -141,14 +141,8 @@ test.describe("Test Route Access", () => {
                       // 🔍 Assert that the current URL is correct
                       await pomPage.urlIsCorrect();
                       // 🔍 Assert that the not-found selector is not available
-                      // Wait for the selector to not be available
-                      await page.waitForSelector(DataTestID.NOTFOUND, {
-                        state: "hidden",
-                      });
-                      const notFoundSelector = await page.$(
-                        DataTestID.NOTFOUND,
-                      );
-                      expect(notFoundSelector).toBeFalsy();
+                      const msgNotFound = page.locator(DataTestID.NOTFOUND);
+                      await expect(msgNotFound).toBeHidden();
                       break;
                   }
                 } else {
@@ -164,8 +158,9 @@ test.describe("Test Route Access", () => {
                     const dashboardPage = new DashboardPOM(page);
                     dashboardPage.urlIsCorrect();
                   } else {
-                    // 🔍 Assert that the role has NO access, not-found selector is available
-                    await pomPage.page.waitForSelector(DataTestID.NOTFOUND);
+                    // 🔍 Assert that the role has NO access, not-found message is available
+                    const msgNotFound = page.locator(DataTestID.NOTFOUND);
+                    await expect(msgNotFound).toBeVisible();
                   }
                 }
                 break;

--- a/client/e2e/poms/dashboard.ts
+++ b/client/e2e/poms/dashboard.ts
@@ -27,7 +27,7 @@ export class DashboardPOM {
   }
 
   async hasMessagePending() {
-    await expect(this.msgPending.isVisible());
+    await expect(this.msgPending).toBeVisible();
   }
 
   async urlIsCorrect() {

--- a/client/e2e/poms/dashboard.ts
+++ b/client/e2e/poms/dashboard.ts
@@ -3,9 +3,9 @@
  * Page objects model (POM) simplify test authoring by creating a higher-level API
  * POM simplify maintenance by capturing element selectors in one place and create reusable code to avoid repetition. *
  */
-import { Page, expect } from "@playwright/test";
+import { Locator, Page, expect } from "@playwright/test";
 // ☰ Enums
-import { AppRoute } from "@/e2e/utils/enums";
+import { AppRoute, DataTestID } from "@/e2e/utils/enums";
 // ℹ️ Environment variables
 import * as dotenv from "dotenv";
 dotenv.config({ path: "./e2e/.env.local" });
@@ -15,12 +15,19 @@ export class DashboardPOM {
 
   readonly url: string = process.env.E2E_BASEURL + AppRoute.DASHBOARD;
 
+  readonly msgPending: Locator;
+
   constructor(page: Page) {
     this.page = page;
+    this.msgPending = this.page.locator(DataTestID.MESSAGE_PENDING);
   }
 
   async route() {
     await this.page.goto(this.url);
+  }
+
+  async hasMessagePending() {
+    return await this.msgPending.isVisible();
   }
 
   async urlIsCorrect() {

--- a/client/e2e/poms/dashboard.ts
+++ b/client/e2e/poms/dashboard.ts
@@ -27,7 +27,7 @@ export class DashboardPOM {
   }
 
   async hasMessagePending() {
-    return await this.msgPending.isVisible();
+    await expect(this.msgPending.isVisible());
   }
 
   async urlIsCorrect() {

--- a/client/e2e/poms/profile.ts
+++ b/client/e2e/poms/profile.ts
@@ -59,7 +59,7 @@ export class ProfilePOM {
   async userFullNameIsCorrect(expectedText: string) {
     // Waits for the selector to appear with the expected text
     await this.page.waitForSelector(
-      `${DataTestID.PROFILE}:has-text("${expectedText}")`
+      `${DataTestID.PROFILE}:has-text("${expectedText}")`,
     );
   }
 

--- a/client/e2e/poms/profile.ts
+++ b/client/e2e/poms/profile.ts
@@ -52,8 +52,8 @@ export class ProfilePOM {
     // Wait for API request/response
     await this.buttonSubmit.isDisabled();
     await this.buttonSubmit.isEditable();
-    // Assert that the error selector is not available
-    return !(await this.errorList.isVisible());
+    // Assert that the error list is not available
+    await expect(this.errorList).toBeHidden();
   }
 
   async userFullNameIsCorrect(expectedText: string) {

--- a/client/e2e/poms/profile.ts
+++ b/client/e2e/poms/profile.ts
@@ -59,7 +59,7 @@ export class ProfilePOM {
   async userFullNameIsCorrect(expectedText: string) {
     // Waits for the selector to appear with the expected text
     await this.page.waitForSelector(
-      `${DataTestID.PROFILE}:has-text("${expectedText}")`,
+      `${DataTestID.PROFILE}:has-text("${expectedText}")`
     );
   }
 

--- a/client/e2e/utils/enums.ts
+++ b/client/e2e/utils/enums.ts
@@ -23,6 +23,7 @@ export enum AppRoute {
 // 👋 playwright selectors targeting an HTML element
 export enum DataTestID {
   ERROR_PROFILE = '[data-testid="alert-error-user-profile"]',
+  MESSAGE_PENDING = '[data-testid="dashboard-pending-message"]',
   NOTFOUND = '[data-testid="not-found"]',
   PROFILE = '[data-testid="nav-user-profile"]',
 }

--- a/client/e2e/workflows/bceidbusiness/industry_user.ts
+++ b/client/e2e/workflows/bceidbusiness/industry_user.ts
@@ -1,5 +1,4 @@
 // 🧪 Suite to test the bceidbusiness new user workflow using storageState
-// 🔍 Asserts new user is redirected to profile
 
 import { test } from "@playwright/test";
 // 🪄 Page Object Models
@@ -12,7 +11,9 @@ dotenv.config({ path: "./e2e/.env.local" });
 test.describe.configure({ mode: "serial" });
 test.describe("Test Workflow industry_user", () => {
   // 👤 run test using the storageState for this role
-  const storageState = process.env.E2E_INDUSTRY_USER_STORAGE;
+  const storageState = JSON.parse(
+    process.env.E2E_INDUSTRY_USER_STORAGE as string,
+  );
   // Note: specify storageState for each test file or test group, instead of setting it in the config. https://playwright.dev/docs/next/auth#reuse-signed-in-state
   test.use({ storageState: storageState }); // this will error if no such file or directory
   test("Test Redirect to Dashboard", async ({ page }) => {

--- a/client/e2e/workflows/bceidbusiness/industry_user_admin.ts
+++ b/client/e2e/workflows/bceidbusiness/industry_user_admin.ts
@@ -1,5 +1,4 @@
 // 🧪 Suite to test the bceidbusiness new user workflow using storageState
-// 🔍 Asserts new user is redirected to profile
 
 import { test } from "@playwright/test";
 // 🪄 Page Object Models
@@ -12,7 +11,9 @@ dotenv.config({ path: "./e2e/.env.local" });
 test.describe.configure({ mode: "serial" });
 test.describe("Test Workflow industry_user_admin", () => {
   // 👤 run test using the storageState for this role
-  const storageState = process.env.E2E_INDUSTRY_USER_ADMIN_STORAGE;
+  const storageState = JSON.parse(
+    process.env.E2E_INDUSTRY_USER_ADMIN_STORAGE as string,
+  );
   // Note: specify storageState for each test file or test group, instead of setting it in the config. https://playwright.dev/docs/next/auth#reuse-signed-in-state
   test.use({ storageState: storageState }); // this will error if no such file or directory
   test("Test Redirect to Dashboard", async ({ page }) => {

--- a/client/e2e/workflows/bceidbusiness/new_user.spec.ts
+++ b/client/e2e/workflows/bceidbusiness/new_user.spec.ts
@@ -1,5 +1,4 @@
 // 🧪 Suite to test the bceidbusiness new user workflow using storageState
-// 🔍 Asserts new user is redirected to profile
 
 import { test } from "@playwright/test";
 // 🪄 Page Object Models
@@ -13,7 +12,7 @@ dotenv.config({ path: "./e2e/.env.local" });
 test.describe.configure({ mode: "serial" });
 test.describe("Test Workflow new user", () => {
   // 👤 run test using the storageState for this role
-  const storageState = process.env.E2E_NEW_USER_STORAGE;
+  const storageState = JSON.parse(process.env.E2E_NEW_USER_STORAGE as string);
   test.use({ storageState: storageState }); // this will error if no such file or directory
   test("Test Redirect to Profile", async ({ page }) => {
     // 🛸 Navigate to dashboard page

--- a/client/e2e/workflows/idir/cas_admin.spec.ts
+++ b/client/e2e/workflows/idir/cas_admin.spec.ts
@@ -1,5 +1,4 @@
 // 🧪 Suite to test the bceidbusiness new user workflow using storageState
-// 🔍 Asserts new user is redirected to profile
 
 import { test } from "@playwright/test";
 // 🪄 Page Object Models
@@ -12,7 +11,7 @@ dotenv.config({ path: "./e2e/.env.local" });
 test.describe.configure({ mode: "serial" });
 test.describe("Test Workflow cas_admin", () => {
   // 👤 run test using the storageState for this role
-  const storageState = process.env.E2E_CAS_ADMIN_STORAGE;
+  const storageState = JSON.parse(process.env.E2E_CAS_ADMIN_STORAGE as string);
   // Note: specify storageState for each test file or test group, instead of setting it in the config. https://playwright.dev/docs/next/auth#reuse-signed-in-state
   test.use({ storageState: storageState }); // this will error if no such file or directory
   test("Test Redirect to Dashboard", async ({ page }) => {

--- a/client/e2e/workflows/idir/cas_analyst.spec.ts
+++ b/client/e2e/workflows/idir/cas_analyst.spec.ts
@@ -1,5 +1,4 @@
 // 🧪 Suite to test the bceidbusiness new user workflow using storageState
-// 🔍 Asserts new user is redirected to profile
 
 import { test } from "@playwright/test";
 // 🪄 Page Object Models
@@ -12,7 +11,9 @@ dotenv.config({ path: "./e2e/.env.local" });
 test.describe.configure({ mode: "serial" });
 test.describe("Test Workflow cas_analyst", () => {
   // 👤 run test using the storageState for this role
-  const storageState = process.env.E2E_CAS_ANALYST_STORAGE;
+  const storageState = JSON.parse(
+    process.env.E2E_CAS_ANALYST_STORAGE as string,
+  );
   // Note: specify storageState for each test file or test group, instead of setting it in the config. https://playwright.dev/docs/next/auth#reuse-signed-in-state
   test.use({ storageState: storageState }); // this will error if no such file or directory
   test("Test Redirect to Dashboard", async ({ page }) => {

--- a/client/e2e/workflows/idir/cas_pending.spec.ts
+++ b/client/e2e/workflows/idir/cas_pending.spec.ts
@@ -1,5 +1,4 @@
 // 🧪 Suite to test the bceidbusiness new user workflow using storageState
-// 🔍 Asserts new user is redirected to profile
 
 import { test } from "@playwright/test";
 // 🪄 Page Object Models
@@ -13,7 +12,9 @@ dotenv.config({ path: "./e2e/.env.local" });
 test.describe.configure({ mode: "serial" });
 test.describe("Test Workflow cas_pending", () => {
   // 👤 run test using the storageState for this role
-  const storageState = process.env.E2E_CAS_PENDING_STORAGE;
+  const storageState = JSON.parse(
+    process.env.E2E_CAS_PENDING_STORAGE as string
+  );
   // Note: specify storageState for each test file or test group, instead of setting it in the config. https://playwright.dev/docs/next/auth#reuse-signed-in-state
   test.use({ storageState: storageState }); // this will error if no such file or directory
   test("Test Navigation to `home` is redirected to Dashboard page", async ({
@@ -22,16 +23,16 @@ test.describe("Test Workflow cas_pending", () => {
     // 🛸 Navigate to home page
     const homePage = new HomePOM(page);
     await homePage.route();
-    // 🔍 Assert that the pending message is displayed
-    await homePage.page.waitForSelector(
-      '[data-testid="dashboard-pending-message"]',
-    );
+    // 🔍 Assert that the current URL ends with "/dashboard"
+    await new DashboardPOM(page).urlIsCorrect();
   });
-  test("Test Redirect to Dashboard", async ({ page }) => {
+  test("Test Dashboard Message", async ({ page }) => {
     // 🛸 Navigate to dashboard page
     const dashboardPage = new DashboardPOM(page);
     await dashboardPage.route();
-    // 🔍 Assert that the current URL ends with "(authenticated)/dashboard"
+    // 🔍 Assert that the current URL ends with "/dashboard"
     await dashboardPage.urlIsCorrect();
+    // 🔍 Assert pending message
+    await dashboardPage.hasMessagePending();
   });
 });

--- a/client/e2e/workflows/idir/cas_pending.spec.ts
+++ b/client/e2e/workflows/idir/cas_pending.spec.ts
@@ -13,7 +13,7 @@ test.describe.configure({ mode: "serial" });
 test.describe("Test Workflow cas_pending", () => {
   // 👤 run test using the storageState for this role
   const storageState = JSON.parse(
-    process.env.E2E_CAS_PENDING_STORAGE as string
+    process.env.E2E_CAS_PENDING_STORAGE as string,
   );
   // Note: specify storageState for each test file or test group, instead of setting it in the config. https://playwright.dev/docs/next/auth#reuse-signed-in-state
   test.use({ storageState: storageState }); // this will error if no such file or directory

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: process.env.CI ? "blob" : "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -35,9 +35,6 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
   },
-  // 🚩 The globalSetup option in playwright.config.js allows you to specify a JavaScript file that will be executed ONCE before all test suites.
-  globalSetup: require.resolve("e2e/setup/global.ts"),
-
   /* Configure projects for major browsers */
   projects: [
     {


### PR DESCRIPTION
[Card](https://github.com/bcgov/cas-registration/issues/1101)
[Card](https://github.com/bcgov/cas-registration/issues/1102)

## 🚀 Impact:
   - Removes dependency on `client/e2e/setup` login and file save for storageStates
   - Shards the e2e tests into chunks for faster test execution
   - Merges shard reports to one report

##  🔬 Testing:

**Option 1:** CI e2e test
Validate [e2e test](https://github.com/bcgov/cas-registration/actions/runs/8327573284) status is  `pass` 
![image](https://github.com/bcgov/cas-registration/assets/120038448/9180624a-ef10-4d48-ba73-686cf3a4c1a3)


**OR**
Download artefact files from `GitHub Actions\Test Registration App` to your `client/playwright-report` folder and run command `cd client && yarn playwright show-report`
[CI artefact](https://github.com/bcgov/cas-registration/actions/runs/8327573284#artifacts)
[CI artefact download](https://github.com/bcgov/cas-registration/actions/runs/8327573284/artifacts/1335244281)
![image](https://github.com/bcgov/cas-registration/assets/120038448/8c01dd77-d621-4860-bd1b-e099739bf1c4)




**Option 2:** Local e2e testing:

**Pre-reqs** 

1. From file `client/e2e/.env.local.example` create `client/e2e/.env.local` with values reflecting instructions in file `client/e2e/.env.local.example`

2.  From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
3.  From terminal command, start the app development server:
 ```
cd client && yarn build && yarn start
```  
 
**e2e tests**

1. From terminal command, run Playwright e2e tests:
```
cd client && yarn e2e
```   
2. Test Results:
![image](https://github.com/bcgov/cas-registration/assets/120038448/bcb85d69-0bf3-452c-9059-2b08ac92e729)

