### PR TITLE
fix: hide prime admin review when operator is declined

### DIFF
--- a/bc_obps/registration/fixtures/mock/operator.json
+++ b/bc_obps/registration/fixtures/mock/operator.json
@@ -118,5 +118,185 @@
       "verified_at": "2024-01-03 08:09:51.133556-08",
       "verified_by": "00000000-0000-0000-0000-000000000002"
     }
+  },
+  {
+    "model": "registration.operator",
+    "pk": "f3e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3e",
+    "fields": {
+      "legal_name": "New Operator 6 Legal Name",
+      "trade_name": "New Operator 6 Trade Name",
+      "cra_business_number": 987654326,
+      "bc_corporate_registry_number": "stu1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [],
+      "contacts": [1],
+      "status": "Draft",
+      "is_new": true,
+      "verified_at": "2024-01-03 08:09:51.133556-08",
+      "verified_by": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "model": "registration.operator",
+    "pk": "f3e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
+    "fields": {
+      "legal_name": "New Operator 7 Legal Name",
+      "trade_name": "New Operator 7 Trade Name",
+      "cra_business_number": 987654327,
+      "bc_corporate_registry_number": "vwx1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [],
+      "contacts": [1],
+      "status": "Draft",
+      "is_new": true,
+      "verified_at": "2024-01-03 08:09:51.133556-08",
+      "verified_by": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "model": "registration.operator",
+    "pk": "43e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
+    "fields": {
+      "legal_name": "New Operator 8 Legal Name",
+      "trade_name": "New Operator 8 Trade Name",
+      "cra_business_number": 987654328,
+      "bc_corporate_registry_number": "yza1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [],
+      "contacts": [1],
+      "status": "Draft",
+      "is_new": true,
+      "verified_at": "2024-01-03 08:09:51.133556-08",
+      "verified_by": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "model": "registration.operator",
+    "pk": "43e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
+    "fields": {
+      "legal_name": "New Operator 9 Legal Name",
+      "trade_name": "New Operator 9 Trade Name",
+      "cra_business_number": 987654329,
+      "bc_corporate_registry_number": "bcd1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [],
+      "contacts": [1],
+      "status": "Draft",
+      "is_new": true,
+      "verified_at": "2024-01-03 08:09:51.133556-08",
+      "verified_by": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "model": "registration.operator",
+    "pk": "63e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
+    "fields": {
+      "legal_name": "New Operator 10 Legal Name",
+      "trade_name": "New Operator 10 Trade Name",
+      "cra_business_number": 987654330,
+      "bc_corporate_registry_number": "efg1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [],
+      "contacts": [1],
+      "status": "Draft",
+      "is_new": true,
+      "verified_at": "2024-01-03 08:09:51.133556-08",
+      "verified_by": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "model": "registration.operator",
+    "pk": "73e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
+    "fields": {
+      "legal_name": "New Operator 11 Legal Name",
+      "trade_name": "New Operator 11 Trade Name",
+      "cra_business_number": 987654331,
+      "bc_corporate_registry_number": "hij1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [],
+      "contacts": [1],
+      "status": "Draft",
+      "is_new": true,
+      "verified_at": "2024-01-03 08:09:51.133556-08",
+      "verified_by": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "model": "registration.operator",
+    "pk": "83e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
+    "fields": {
+      "legal_name": "New Operator 12 Legal Name",
+      "trade_name": "New Operator 12 Trade Name",
+      "cra_business_number": 987654332,
+      "bc_corporate_registry_number": "klm1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [],
+      "contacts": [1],
+      "status": "Draft",
+      "is_new": true,
+      "verified_at": "2024-01-03 08:09:51.133556-08",
+      "verified_by": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "model": "registration.operator",
+    "pk": "93e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
+    "fields": {
+      "legal_name": "New Operator 13 Legal Name",
+      "trade_name": "New Operator 13 Trade Name",
+      "cra_business_number": 987654333,
+      "bc_corporate_registry_number": "nop1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [],
+      "contacts": [1],
+      "status": "Pending",
+      "is_new": true,
+      "verified_at": null,
+      "verified_by": null
+    }
+  },
+  {
+    "model": "registration.operator",
+    "pk": "53e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
+    "fields": {
+      "legal_name": "New Operator 14 Legal Name",
+      "trade_name": "New Operator 14 Trade Name",
+      "cra_business_number": 987654334,
+      "bc_corporate_registry_number": "pqz1234567",
+      "business_structure": "BC Corporation",
+      "physical_address": 3,
+      "mailing_address": 4,
+      "website": "http://www.example2.com",
+      "documents": [1],
+      "contacts": [1],
+      "status": "Pending",
+      "is_new": true,
+      "verified_at": null,
+      "verified_by": null
+    }
   }
 ]

--- a/bc_obps/registration/fixtures/mock/operator.json
+++ b/bc_obps/registration/fixtures/mock/operator.json
@@ -291,7 +291,7 @@
       "physical_address": 3,
       "mailing_address": 4,
       "website": "http://www.example2.com",
-      "documents": [1],
+      "documents": [],
       "contacts": [1],
       "status": "Pending",
       "is_new": true,

--- a/bc_obps/registration/fixtures/mock/userOperator.json
+++ b/bc_obps/registration/fixtures/mock/userOperator.json
@@ -63,7 +63,7 @@
     "model": "registration.useroperator",
     "fields": {
       "user": "00000000-0000-0000-0000-000000000003",
-      "operator": "4c1010c1-55ca-485d-84bd-6d975fd0af90",
+      "operator": "f3e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3e",
       "role": "pending",
       "status": "Pending",
       "verified_at": null,
@@ -99,7 +99,7 @@
     "model": "registration.useroperator",
     "fields": {
       "user": "00000000-0000-0000-0000-000000000006",
-      "operator": "438eff6c-d2e7-40ab-8220-29d3a86ef314",
+      "operator": "43e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
       "role": "pending",
       "status": "Pending",
       "verified_at": null,
@@ -123,7 +123,7 @@
     "model": "registration.useroperator",
     "fields": {
       "user": "00000000-0000-0000-0000-000000000008",
-      "operator": "4c1010c1-55ca-485d-84bd-6d975fd0af90",
+      "operator": "f3e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
       "role": "pending",
       "status": "Pending",
       "verified_at": null,
@@ -159,7 +159,7 @@
     "model": "registration.useroperator",
     "fields": {
       "user": "00000000-0000-0000-0000-000000000011",
-      "operator": "438eff6c-d2e7-40ab-8220-29d3a86ef314",
+      "operator": "53e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
       "role": "pending",
       "status": "Pending",
       "verified_at": null,
@@ -171,7 +171,7 @@
     "model": "registration.useroperator",
     "fields": {
       "user": "00000000-0000-0000-0000-000000000012",
-      "operator": "4c1010c1-55ca-485d-84bd-6d975fd0af90",
+      "operator": "63e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
       "role": "pending",
       "status": "Pending",
       "verified_at": null,
@@ -183,7 +183,7 @@
     "model": "registration.useroperator",
     "fields": {
       "user": "00000000-0000-0000-0000-000000000013",
-      "operator": "4c1010c1-55ca-485d-84bd-6d975fd0af90",
+      "operator": "73e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
       "role": "pending",
       "status": "Pending",
       "verified_at": null,
@@ -245,7 +245,7 @@
     "model": "registration.useroperator",
     "fields": {
       "user": "00000000-0000-0000-0000-000000000018",
-      "operator": "438eff6c-d2e7-40ab-8220-29d3a86ef314",
+      "operator": "83e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
       "role": "pending",
       "status": "Pending",
       "verified_at": null,
@@ -269,7 +269,7 @@
     "model": "registration.useroperator",
     "fields": {
       "user": "00000000-0000-0000-0000-000000000020",
-      "operator": "4c1010c1-55ca-485d-84bd-6d975fd0af90",
+      "operator": "f3e3e3e3-3e3e-3e3e-3e3e-3e3e3e3e3e3f",
       "role": "pending",
       "status": "Pending",
       "verified_at": null,

--- a/client/app/components/form/UserOperatorReviewForm.tsx
+++ b/client/app/components/form/UserOperatorReviewForm.tsx
@@ -7,6 +7,7 @@ import MultiStepAccordion from "@/app/components/form/MultiStepAccordion";
 import { UserOperatorFormData } from "@/app/components/form/formDataTypes";
 import { RJSFSchema } from "@rjsf/utils";
 import UserOperatorReview from "@/app/components/routes/access-requests/form/UserOperatorReview";
+import { OperatorStatus, UserOperatorStatus } from "@/app/utils/enums";
 
 interface Props {
   formData: UserOperatorFormData;
@@ -17,9 +18,14 @@ const UserOperatorReviewForm = ({ formData, schema }: Props) => {
   const params = useParams();
   const userOperatorId = params.id;
   const isNewOperator = formData.is_new;
-  const userOperatorStatus = formData.status;
+  const isUserOperatorPending = formData.status === UserOperatorStatus.PENDING;
+  const isOperatorStatusDeclined =
+    formData.operator_status === OperatorStatus.DECLINED;
   const [rerenderKey, setRerenderKey] = useState(
     crypto.getRandomValues(new Uint32Array(1))[0],
+  );
+  const [isOperatorDeclined, setIsOperatorDeclined] = useState(
+    isOperatorStatusDeclined,
   );
 
   return (
@@ -33,6 +39,9 @@ const UserOperatorReviewForm = ({ formData, schema }: Props) => {
           <UserOperatorReview
             userOperator={formData as UserOperatorFormData}
             userOperatorId={userOperatorId as string}
+            // Set Operator Declined to true if the operator is declined
+            // So that we can hide the Prime Admin Review component
+            onDecline={() => setIsOperatorDeclined(true)}
             // Set rerenderKey to a new random value to force a rerender when the operator is approved
             // So that we can reset the prime admin review if there was an error ie: operator needs to be approved first
             onSuccess={() =>
@@ -44,7 +53,7 @@ const UserOperatorReviewForm = ({ formData, schema }: Props) => {
             showRequestChanges={false}
           />
         ),
-        "User Information": (
+        "User Information": !isOperatorDeclined && (
           <UserOperatorReview
             key={rerenderKey}
             userOperator={formData as UserOperatorFormData}
@@ -58,7 +67,7 @@ const UserOperatorReviewForm = ({ formData, schema }: Props) => {
       // If the user is pending, the second section should be expanded
       expandedSteps={{
         "Operator Information": isNewOperator,
-        "User Information": userOperatorStatus === "Pending",
+        "User Information": isUserOperatorPending && !isOperatorDeclined,
       }}
     />
   );

--- a/client/app/components/routes/access-requests/form/UserOperatorReview.tsx
+++ b/client/app/components/routes/access-requests/form/UserOperatorReview.tsx
@@ -15,6 +15,7 @@ interface Props {
   userOperator: UserOperatorFormData;
   userOperatorId: string;
   onSuccess?: () => void;
+  onDecline?: () => void;
   operatorId?: number;
   isOperatorNew?: boolean;
   showRequestChanges?: boolean;
@@ -24,6 +25,7 @@ export default function UserOperatorReview({
   note,
   userOperator,
   userOperatorId,
+  onDecline,
   onSuccess,
   operatorId,
   isOperatorNew,
@@ -40,6 +42,9 @@ export default function UserOperatorReview({
           body: JSON.stringify({ status, user_operator_id: userOperatorId }),
         },
       );
+      if (response.status === Status.DECLINED && onDecline) {
+        onDecline();
+      }
       onSuccess?.();
       return response;
     } catch (error) {


### PR DESCRIPTION
Fix for #1007 

Also fixed the User Operator fixtures that were tied to a new Operator. Many of them were tied to the same new Operator which can't happen in the app since you can't create a new operator with the same CRA number or BC corporate registry number. To fix this I created a bunch of new Operators to tie to each of the offending User Operators.