### PR TITLE
Happo merge reports

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -281,9 +281,9 @@ jobs:
           E2E_NEW_USER_GUID: ${{ secrets.E2E_NEW_USER_GUID }}
           E2E_NEW_USER_PASSWORD: ${{ secrets.E2E_NEW_USER_PASSWORD }}
           E2E_NEW_USER_STORAGE: ${{ secrets.E2E_NEW_USER_STORAGE}}
-          HAPPO_ENABLED: true
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
+          HAPPO_NONCE: ${{ github.event.pull_request.head.sha }}
         working-directory: ./client
       - name: 💾 save ${{ matrix.project }} report artifact
         # prefer to upload the report only in case of test failure
@@ -330,6 +330,21 @@ jobs:
             || contains(needs.*.result, 'cancelled')
             || contains(needs.*.result, 'skipped')
           }}
+
+  happo-finalize:
+    runs-on: ubuntu-latest
+    needs: [e2e-tests]
+    steps:
+      - uses: actions/checkout@v4
+      - name: dev env setup
+        uses: ./.github/actions/dev-env-setup
+      - name: finalize happo e2e tests
+        env:
+          HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+          HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
+          HAPPO_NONCE: ${{ github.event.pull_request.head.sha }}
+        run: npx happo-e2e finalize
+        working-directory: ./client
 
   backend-tests:
     needs:


### PR DESCRIPTION
Implements issue #1168

Merging Happo reports after the recent PR which runs parallel using shards.

Happo docs for this here: https://docs.happo.io/docs/playwright#parallel-builds

One thing I could use some feedback on is the addition of yet another e2e job, `happo-finalize`. I had considered putting it in the `e2e report` job to keep the job list cleaner but left it here for now.

<img width="814" alt="Screenshot 2024-03-18 at 2 40 34 PM" src="https://github.com/bcgov/cas-registration/assets/14259474/43c2ddbb-6c29-4048-82de-5c79bd61dbfe">
