### PR TITLE
chore: add new make target and logic for shipit.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,12 @@ install_giraffe: check_environment
 install_giraffe:
 install_giraffe: GIT_SHA1=$(shell git rev-parse HEAD)
 install_giraffe: IMAGE_TAG=$(GIT_SHA1)
-install_giraffe: NAMESPACE=$(OBPS_NAMESPACE_PREFIX)-$(ENVIRONMENT)
+install_giraffe: NAMESPACE=$(CIF_NAMESPACE_PREFIX)-tools
 install_giraffe: CHART_DIR=./helm/cas-registration
 install_giraffe: CHART_INSTANCE=cas-registration
 install_giraffe: HELM_OPTS=--atomic --wait-for-jobs --timeout 2400s --namespace $(NAMESPACE) \
 										--set defaultImageTag=$(IMAGE_TAG) \
-										--values $(CHART_DIR)/values-giraffe.yaml # Find where to change $(ENVIRONMENT) source
+										--values $(CHART_DIR)/values-giraffe.yaml
 install_giraffe:
 	@set -euo pipefail; \
 	helm dep up $(CHART_DIR); \

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,30 @@ install:
 		helm upgrade $(HELM_OPTS) $(CHART_INSTANCE) $(CHART_DIR); \
 	fi;
 
+.PHONY: install_giraffe
+install_giraffe: ## Installs the helm chart on the OpenShift cluster
+install_giraffe: check_environment
+install_giraffe:
+install_giraffe: GIT_SHA1=$(shell git rev-parse HEAD)
+install_giraffe: IMAGE_TAG=$(GIT_SHA1)
+install_giraffe: NAMESPACE=$(OBPS_NAMESPACE_PREFIX)-$(ENVIRONMENT)
+install_giraffe: CHART_DIR=./helm/cas-registration
+install_giraffe: CHART_INSTANCE=cas-registration
+install_giraffe: HELM_OPTS=--atomic --wait-for-jobs --timeout 2400s --namespace $(NAMESPACE) \
+										--set defaultImageTag=$(IMAGE_TAG) \
+										--values $(CHART_DIR)/values-giraffe.yaml # Find where to change $(ENVIRONMENT) source
+install_giraffe:
+	@set -euo pipefail; \
+	helm dep up $(CHART_DIR); \
+	if ! helm status --namespace $(NAMESPACE) cas-obps-postgres; then \
+		echo "ERROR: Postgres is not deployed to $(NAMESPACE)."; \
+	elif ! helm status --namespace $(NAMESPACE) $(CHART_INSTANCE); then \
+		echo 'Installing the application'; \
+		helm install $(HELM_OPTS) $(CHART_INSTANCE) $(CHART_DIR); \
+	else \
+		helm upgrade $(HELM_OPTS) $(CHART_INSTANCE) $(CHART_DIR); \
+	fi;
+
 .PHONY: generate_credentials
 generate_credentials:
 	./scripts/generate-gcloud-credentials.sh $(service_account)

--- a/helm/cas-registration/values-giraffe.yaml
+++ b/helm/cas-registration/values-giraffe.yaml
@@ -27,7 +27,7 @@ frontend:
     tag: "latest"
 
   route:
-    host: cas-reg-giraffe-dev.apps.silver.devops.gov.bc.ca # Should be changed to correct route. Something like cas-reg-giraffe-dev.apps.silver.devops.gov.bc.ca
+    host: cas-reg-giraffe-dev.apps.silver.devops.gov.bc.ca
 
   environment: develop
 

--- a/helm/cas-registration/values-giraffe.yaml
+++ b/helm/cas-registration/values-giraffe.yaml
@@ -1,0 +1,44 @@
+
+backend:
+  replicaCount: 2
+
+  image:
+    tag: "latest"
+
+  route:
+    host: cas-reg-backend-dev.apps.silver.devops.gov.bc.ca
+
+  environment: develop
+
+  deployRoute: true
+
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 60m
+      memory: 256Mi
+
+frontend:
+  replicaCount: 2
+
+  image:
+    tag: "latest"
+
+  route:
+    host: cas-reg-giraffe-dev.apps.silver.devops.gov.bc.ca # Should be changed to correct route. Something like cas-reg-giraffe-dev.apps.silver.devops.gov.bc.ca
+
+  environment: develop
+
+  auth:
+    keycloakAuthUrl: https://dev.loginproxy.gov.bc.ca/auth
+    siteminderAuthUrl: https://logontest7.gov.bc.ca
+
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 60m
+      memory: 256Mi

--- a/shipit.yml
+++ b/shipit.yml
@@ -6,8 +6,14 @@ review:
 
 deploy:
   override:
-    - make install:
-        timeout: 5000
+    - |
+      CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+      if [ "$CURRENT_BRANCH" = "giraffe-develop" ]; then
+        make install-giraffe
+      else
+        make install
+      fi
+      timeout: 5000
 
 ci:
   allow_failures:


### PR DESCRIPTION
task: https://github.com/orgs/bcgov/projects/123/views/2?pane=issue&itemId=54817515

Created a new make target for deploying from the ```giraffe-develop``` branch to the ```CIF-tools``` namespace. I added some logic to the ```shipit.yml``` file to determine which branch it is being run from and choose the appropriate make target. 

The new make target is hard-coded to pull values from values-giraffe.yaml, which has a frontend route of cas-reg-giraffe-dev.apps.silver.devops.gov.bc.ca, which is subject to change.