### PR TITLE
feat: add carbon tax exemption link

### DIFF
--- a/client/app/(onboarding)/home/page.tsx
+++ b/client/app/(onboarding)/home/page.tsx
@@ -6,6 +6,11 @@ import Grid from "@mui/material/Grid/Grid";
 import events from "@/app/data/home/events.json";
 import { signIn } from "next-auth/react";
 import { getEnvValue } from "@/app/utils/actions";
+import {
+  bcObpsLink,
+  bcObpsGuidanceLink,
+  carbonTaxExemptionLink,
+} from "@/app/utils/urls";
 /*
 📚
 In the app directory, nested folders are normally mapped to URL paths.
@@ -88,7 +93,7 @@ export default function Page() {
           <p>
             Before getting started, take a moment to review the detailed{" "}
             <a
-              href="https://www2.gov.bc.ca/assets/gov/environment/climate-change/ind/obps/guidance/bc_obps_guidance.pdf"
+              href={bcObpsGuidanceLink}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -122,20 +127,14 @@ export default function Page() {
           <p>
             To check eligibility, and for further information about the B.C.
             OBPS, please visit the{" "}
-            <a
-              href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/bc-output-based-pricing-system"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <a href={bcObpsLink} target="_blank" rel="noopener noreferrer">
               program website.
             </a>
           </p>
-          {/*
-          This section is commented out because the link will not be available until post MVP.
           <p>
             Please visit the{" "}
             <a
-              href="https://www2.gov.bc.ca/gov/content?id=3EAC7D1EBBDA41F6937BA1F1A8A202F3"
+              href={carbonTaxExemptionLink}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -143,7 +142,7 @@ export default function Page() {
             </a>{" "}
             webpage to learn more about claiming an exemption from the carbon
             tax.
-          </p>*/}
+          </p>
         </section>
         <section className="flex flex-col items-center bg-bc-bg-light-grey my-10 py-8">
           <h2 className={headerStyle}>Contact us</h2>

--- a/client/app/components/form/titles/operationsTitles.tsx
+++ b/client/app/components/form/titles/operationsTitles.tsx
@@ -1,3 +1,5 @@
+import { bcObpsLink } from "@/app/utils/urls";
+
 export const PointOfContactTitle = (
   <>
     Please provide information about the <b>point of contact</b> of the B.C.
@@ -21,11 +23,7 @@ export const OptInOperationTitle = (
     <br />
     <br />
     Further information and opt-in application forms can be found on the &nbsp;
-    <a
-      href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/bc-output-based-pricing-system"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+    <a href={bcObpsLink} target="_blank" rel="noopener noreferrer">
       B.C. OBPS website
     </a>
     .

--- a/client/app/components/routes/operations/form/Operation.tsx
+++ b/client/app/components/routes/operations/form/Operation.tsx
@@ -19,6 +19,7 @@ import Link from "next/link";
 import OperationReviewForm from "@/app/components/form/OperationReviewForm";
 import { BusinessStructure } from "@/app/components/routes/select-operator/form/types";
 import { validate as isValidUUID } from "uuid";
+import { carbonTaxExemptionLink } from "@/app/utils/urls";
 
 // 🚀 API call: GET user's data
 async function getUserFormData(): Promise<
@@ -223,7 +224,7 @@ export default async function Operation({ numRow }: { numRow?: string }) {
               You will need this B.C. OBPS Regulated Operation ID to claim an
               exemption from carbon tax. For information about the exemption and
               how to claim it, please see the{" "}
-              <Link href="https://www2.gov.bc.ca/gov/content?id=3EAC7D1EBBDA41F6937BA1F1A8A202F3">
+              <Link href={carbonTaxExemptionLink}>
                 carbon tax exemption page
               </Link>
               .

--- a/client/app/utils/urls.ts
+++ b/client/app/utils/urls.ts
@@ -1,0 +1,8 @@
+export const bcObpsLink =
+  "https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/bc-output-based-pricing-system";
+
+export const bcObpsGuidanceLink =
+  "https://www2.gov.bc.ca/assets/gov/environment/climate-change/ind/obps/guidance/bc_obps_guidance.pdf";
+
+export const carbonTaxExemptionLink =
+  "https://www2.gov.bc.ca/gov/content/taxes/sales-taxes/motor-fuel-carbon-tax/business/exemptions/obps-carbon-tax-exemption";


### PR DESCRIPTION
Implements #1153 

I thought it would be good practice to store links in a constants file so I created a `app/utils/urls.ts` file. I didn't want to go too far beyond the scope of this ticket so I just added the 3 urls on the home page. I also replaced a repeated URL that is in the Operations form as you will need to go there to test these work anyways.

To test the two URLs in the Operations page you need to log in as `bc-cas-dev` and click `View Details` for the `Approved` Operation and check these two urls:

<img width="1022" alt="Screenshot 2024-03-18 at 3 39 59 PM" src="https://github.com/bcgov/cas-registration/assets/14259474/0c53df4b-cc5a-43a8-8725-05c721d5e398">

