### PR TITLE
1113 e2e ci cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -220,8 +220,8 @@ jobs:
             os: ubuntu-latest
             cache_dir: ~/.cache/ms-playwright
           - project: webkit
-            os: ubuntu-latest
-            cache_dir: ~/.cache/ms-playwright
+            os: macos-12
+            cache_dir: ~/Library/Caches/ms-playwright
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -220,7 +220,7 @@ jobs:
             os: ubuntu-latest
             cache_dir: ~/.cache/ms-playwright
           - project: webkit
-            os: ubuntu-latest
+            os: macos-12
             cache_dir: ~/Library/Caches/ms-playwright
     steps:
       - uses: actions/checkout@v3
@@ -241,7 +241,7 @@ jobs:
         id: playwright-cache
         with:
           path: ${{ matrix.cache_dir }}
-          key: ${{ runner.os }}-${{ matrix.project }}-pw-${{ hashFiles('**/.playwright-version') }}
+          key: ${{ runner.os }}-${{ matrix.project }}-playwright
 
       - name: 📥 install Playwright ${{ matrix.project }}
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,33 +202,57 @@ jobs:
           fail_action: false
 
   e2e-tests:
-    needs:
-      ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]
-    timeout-minutes: 60
+    name: 🧪 ${{ matrix.project }} E2E Tests
     runs-on: ubuntu-latest
+    needs:
+      - backend-docker-build
+      - frontend-docker-build
+      - install-dev-tools
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        include:
+          - project: chromium
+            os: ubuntu-latest
+            cache_dir: ~/.cache/ms-playwright
+          - project: firefox
+            os: ubuntu-latest
+            cache_dir: ~/.cache/ms-playwright
+          - project: webkit
+            os: macos-12
+            cache_dir: ~/Library/Caches/ms-playwright
     steps:
       - uses: actions/checkout@v3
-      - name: dev env setup
+
+      - name: 🎁 Setup dev env
         uses: ./.github/actions/dev-env-setup
-      - name: run app locally
+
+      - name: 🎁 Setup local app
         uses: ./.github/actions/local-app-run
         with:
           django_secret_key: ${{ env.DJANGO_SECRET_KEY }}
           keycloak_client_id: ${{ env.KEYCLOAK_CLIENT_ID }}
           keycloak_client_secret: ${{ env.KEYCLOAK_CLIENT_SECRET }}
           nextauth_secret: ${{ env.NEXTAUTH_SECRET }}
-      - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps
+
+      - name: ⚡️ Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: ${{ matrix.cache_dir }}
+          key: ${{ runner.os }}-${{ matrix.project }}-pw-${{ hashFiles('**/.playwright-version') }}
+
+      - name: 📥 Install ${{ matrix.project }} with Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: yarn playwright install --with-deps ${{ matrix.project }}
         working-directory: ./client
-      - name: Run Playwright Tests
+
+      - name: 🎭 Playwright tests
         run: |
-          DEBUG=pw:browser npx happo-e2e -- npx playwright test --shard=${{ matrix.shardIndex }}/${{ strategy.job-total }} client/e2e/*
+          npx happo-e2e -- npx playwright test --project=${{ matrix.project }} client/e2e/*
         env:
+          DEBUG: pw:api,pw:browser*
           API_URL: http://127.0.0.1:8000/api/
           DB_USER: postgres
           DB_NAME: registration
@@ -257,15 +281,18 @@ jobs:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
         working-directory: ./client
-      - name: Upload blob report to GitHub Actions Artifacts
+
+      - name: 💾 Upload blob report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: blob-report-${{ matrix.shardIndex }}
+          # Store all of the reports separately by reconfiguring the report name
+          name: blob-report-${{ matrix.project }}
           path: client/blob-report
           retention-days: 1
+  # Merge the e2e blob reports to one HTML report
   e2e-report:
-    name: e2e report
+    name: 📊 Create HTML report
     if: always()
     needs: [e2e-tests]
     runs-on: ubuntu-latest
@@ -286,6 +313,7 @@ jobs:
           name: playwright-report
           path: playwright-report
           retention-days: 14
+  # Ensure the e2e tests and e2e report completed successfully
   e2e:
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -294,10 +322,11 @@ jobs:
       - run: exit 1
         if: >-
           ${{
-               contains(needs.*.result, 'failure')
+              contains(needs.*.result, 'failure')
             || contains(needs.*.result, 'cancelled')
             || contains(needs.*.result, 'skipped')
           }}
+
   backend-tests:
     needs:
       ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -282,7 +282,8 @@ jobs:
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
         working-directory: ./client
       - name: 💾 save ${{ matrix.project }} report artifact
-        if: always()
+        # prefer to upload artifacts with the report only in case of test failures.
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           # Store all of the reports separately by reconfiguring the report name
@@ -291,7 +292,7 @@ jobs:
           retention-days: 1
   # Merge the e2e blob reports to one HTML report
   e2e-report:
-    name: 📊 create HTML report artifact
+    name: 📊 e2e report artifact
     if: always()
     needs: [e2e-tests]
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -282,7 +282,7 @@ jobs:
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
         working-directory: ./client
       - name: 💾 save ${{ matrix.project }} report artifact
-        # prefer to upload artifacts with the report only in case of test failures.
+        # prefer to upload the report only in case of test failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -293,9 +293,9 @@ jobs:
   # Merge the e2e blob reports to one HTML report
   e2e-report:
     name: 📊 e2e report artifact
-    if: always()
-    needs: [e2e-tests]
     runs-on: ubuntu-latest
+    needs: [e2e-tests]
+    if: ${{ needs.e2e-tests.result == 'failure' }}
     steps:
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
@@ -323,7 +323,7 @@ jobs:
       - run: exit 1
         if: >-
           ${{
-              contains(needs.*.result, 'failure')
+               contains(needs.*.result, 'failure')
             || contains(needs.*.result, 'cancelled')
             || contains(needs.*.result, 'skipped')
           }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -220,7 +220,7 @@ jobs:
             os: ubuntu-latest
             cache_dir: ~/.cache/ms-playwright
           - project: webkit
-            os: macos-12
+            os: ubuntu-latest
             cache_dir: ~/Library/Caches/ms-playwright
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,7 +202,7 @@ jobs:
           fail_action: false
 
   e2e-tests:
-    name: 🧪 ${{ matrix.project }} E2E Tests
+    name: 🧪 e2e tests ${{ matrix.project }}
     runs-on: ubuntu-latest
     needs:
       - backend-docker-build
@@ -225,10 +225,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: 🎁 Setup dev env
+      - name: 🎁 setup dev env
         uses: ./.github/actions/dev-env-setup
 
-      - name: 🎁 Setup local app
+      - name: 🎁 setup local app
         uses: ./.github/actions/local-app-run
         with:
           django_secret_key: ${{ env.DJANGO_SECRET_KEY }}
@@ -236,19 +236,19 @@ jobs:
           keycloak_client_secret: ${{ env.KEYCLOAK_CLIENT_SECRET }}
           nextauth_secret: ${{ env.NEXTAUTH_SECRET }}
 
-      - name: ⚡️ Cache playwright binaries
+      - name: ⚡️ cache Playwright binaries
         uses: actions/cache@v3
         id: playwright-cache
         with:
           path: ${{ matrix.cache_dir }}
           key: ${{ runner.os }}-${{ matrix.project }}-pw-${{ hashFiles('**/.playwright-version') }}
 
-      - name: 📥 Install ${{ matrix.project }} with Playwright
+      - name: 📥 install Playwright ${{ matrix.project }}
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: yarn playwright install --with-deps ${{ matrix.project }}
         working-directory: ./client
 
-      - name: 🎭 Playwright tests
+      - name: 🎭 run Playwright
         run: |
           npx happo-e2e -- npx playwright test --project=${{ matrix.project }} client/e2e/*
         env:
@@ -281,8 +281,7 @@ jobs:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
         working-directory: ./client
-
-      - name: 💾 Upload blob report
+      - name: 💾 save ${{ matrix.project }} report artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -292,7 +291,7 @@ jobs:
           retention-days: 1
   # Merge the e2e blob reports to one HTML report
   e2e-report:
-    name: 📊 Create HTML report
+    name: 📊 create HTML report artifact
     if: always()
     needs: [e2e-tests]
     runs-on: ubuntu-latest
@@ -315,6 +314,7 @@ jobs:
           retention-days: 14
   # Ensure the e2e tests and e2e report completed successfully
   e2e:
+    name: 📣 e2e status update
     if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [e2e-tests, e2e-report]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -220,8 +220,8 @@ jobs:
             os: ubuntu-latest
             cache_dir: ~/.cache/ms-playwright
           - project: webkit
-            os: macos-12
-            cache_dir: ~/Library/Caches/ms-playwright
+            os: ubuntu-latest
+            cache_dir: ~/.cache/ms-playwright
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -318,7 +318,7 @@ jobs:
     name: 📣 e2e status update
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [e2e-tests, e2e-report]
+    needs: [e2e-tests]
     steps:
       - run: exit 1
         if: >-


### PR DESCRIPTION
[Card](https://github.com/bcgov/cas-registration/issues/1113)


## 🚀 Impact:
   - Reduces CI pipeline's e2e Playwright tests run by 3-4 minute
   - Restricts CI pipeline's e2e Playwright tests report artifacts to failures

## ✏️ Notes:
- Implementing playwright binary cache using `shard` matrix variables results in test(s) finding the cache but then failing due to missing browsers installs 🤷 
- Implementing playwright binary cache using `browser` matrix results in `e2e test webkit`  NOT finding cache with key `Linux-webkit-pw`; so, that test takes extra 30 seconds to install Playwright deps 🤷 
- Overall, we have reduced e2e test run by another 3-4 minutes (~ 30s per install per shard)  🎯

##  🔬 Testing:

Validate `1113-e2e-ci-matrix-cache` [e2e test](https://github.com/bcgov/cas-registration/actions/) status is  `pass` 

