### PR TITLE
1113 e2e ci matrix cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,33 +202,57 @@ jobs:
           fail_action: false
 
   e2e-tests:
-    needs:
-      ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]
-    timeout-minutes: 60
+    name: 🧪 e2e tests ${{ matrix.project }}
     runs-on: ubuntu-latest
+    needs:
+      - backend-docker-build
+      - frontend-docker-build
+      - install-dev-tools
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        include:
+          - project: chromium
+            os: ubuntu-latest
+            cache_dir: ~/.cache/ms-playwright
+          - project: firefox
+            os: ubuntu-latest
+            cache_dir: ~/.cache/ms-playwright
+          - project: webkit
+            os: macos-12
+            cache_dir: ~/Library/Caches/ms-playwright
     steps:
       - uses: actions/checkout@v3
-      - name: dev env setup
+
+      - name: 🎁 setup dev env
         uses: ./.github/actions/dev-env-setup
-      - name: run app locally
+
+      - name: 🎁 setup local app
         uses: ./.github/actions/local-app-run
         with:
           django_secret_key: ${{ env.DJANGO_SECRET_KEY }}
           keycloak_client_id: ${{ env.KEYCLOAK_CLIENT_ID }}
           keycloak_client_secret: ${{ env.KEYCLOAK_CLIENT_SECRET }}
           nextauth_secret: ${{ env.NEXTAUTH_SECRET }}
-      - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps
+
+      - name: ⚡️ cache Playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: ${{ matrix.cache_dir }}
+          key: ${{ runner.os }}-${{ matrix.project }}-playwright
+
+      - name: 📥 install Playwright ${{ matrix.project }}
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: yarn playwright install --with-deps ${{ matrix.project }}
         working-directory: ./client
-      - name: Run Playwright Tests
+
+      - name: 🎭 run Playwright
         run: |
-          DEBUG=pw:browser npx happo-e2e -- npx playwright test --shard=${{ matrix.shardIndex }}/${{ strategy.job-total }} client/e2e/*
+          npx happo-e2e -- npx playwright test --project=${{ matrix.project }} client/e2e/*
         env:
+          DEBUG: pw:api,pw:browser*
           API_URL: http://127.0.0.1:8000/api/
           DB_USER: postgres
           DB_NAME: registration
@@ -257,18 +281,21 @@ jobs:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
         working-directory: ./client
-      - name: Upload blob report to GitHub Actions Artifacts
-        if: always()
+      - name: 💾 save ${{ matrix.project }} report artifact
+        # prefer to upload the report only in case of test failure
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: blob-report-${{ matrix.shardIndex }}
+          # Store all of the reports separately by reconfiguring the report name
+          name: blob-report-${{ matrix.project }}
           path: client/blob-report
           retention-days: 1
+  # Merge the e2e blob reports to one HTML report
   e2e-report:
-    name: e2e report
-    if: always()
-    needs: [e2e-tests]
+    name: 📊 e2e report artifact
     runs-on: ubuntu-latest
+    needs: [e2e-tests]
+    if: ${{ needs.e2e-tests.result == 'failure' }}
     steps:
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
@@ -286,10 +313,12 @@ jobs:
           name: playwright-report
           path: playwright-report
           retention-days: 14
+  # Ensure the e2e tests and e2e report completed successfully
   e2e:
+    name: 📣 e2e status update
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [e2e-tests, e2e-report]
+    needs: [e2e-tests]
     steps:
       - run: exit 1
         if: >-
@@ -298,6 +327,7 @@ jobs:
             || contains(needs.*.result, 'cancelled')
             || contains(needs.*.result, 'skipped')
           }}
+
   backend-tests:
     needs:
       ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,6 @@ env:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   install-dev-tools:
     runs-on: ubuntu-latest
@@ -212,18 +211,21 @@ jobs:
       - backend-docker-build
       - frontend-docker-build
       - install-dev-tools
+    runs-on: ubuntu-latest
     timeout-minutes: 60
-    runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false # keep running other jobs if one fails
+      fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        browser: [chromium, firefox, webkit]
-    env:
-      # Playwright uses different paths on different OS's.
-      # To make it work cross-platform, we need to set the path manually.
-      # Alternatively, `PLAYWRIGHT_BROWSERS_PATH=0` install binaries in node_modules
-      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/ms-playwright
+        include:
+          - project: chromium
+            os: ubuntu-latest
+            cache_dir: ~/.cache/ms-playwright
+          - project: firefox
+            os: ubuntu-latest
+            cache_dir: ~/.cache/ms-playwright
+          - project: webkit
+            os: macos-12
+            cache_dir: ~/Library/Caches/ms-playwright
     steps:
       - uses: actions/checkout@v3
 
@@ -238,43 +240,16 @@ jobs:
           keycloak_client_secret: ${{ env.KEYCLOAK_CLIENT_SECRET }}
           nextauth_secret: ${{ env.NEXTAUTH_SECRET }}
 
-      # Install dependencies with cache
-      - name: ⚡️ cache dependencies
-        id: cache-deps
+      - name: ⚡️ cache Playwright binaries
         uses: actions/cache@v3
+        id: playwright-cache
         with:
-          path: ~/.cache/yarn
-          key: modules-${{ hashFiles('yarn.lock') }}
+          path: ${{ matrix.cache_dir }}
+          key: ${{ runner.os }}-${{ matrix.project }}-playwright
 
-      - name: 📥 install dependencies
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile --ignore-scripts
-
-      # Install Playwright browsers with cache
-      - name: ⚡️ cache Playwright version
-        shell: bash
-        run: echo "PLAYWRIGHT_VERSION=$(node -p 'require("@playwright/test/package.json").version')" >> $GITHUB_ENV
-        id: playwright-version
-
-      - name: ⚡️ cache Playwright browsers and maybe dependencies
-        id: cache-browsers
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ matrix.browser }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
-          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-
-      - name: 📥 install Playwright browsers
-        if: steps.cache-browsers.outputs.cache-hit != 'true'
-        run: yarn playwright install ${{ matrix.browser }}
-      - name: 📥 install Playwright dependencies
-        # Linux and Windows cannot cache deps.
-        # See: https://github.com/microsoft/playwright/issues/22146#issuecomment-1495821016
-        # if: steps.cache-browsers.outputs.cache-hit != 'true' || runner.os != 'macOS'
-        # BUT except for linux-webkit, they already include most of the necessary dependencies.
-        # So unless you use things like graphics, fonts, video playback etc. and you run into a problem,
-        # You can speed up your CI by using this less strict condition:
-        if: steps.cache-browsers.outputs.cache-hit != 'true' || (runner.os == 'Linux' && matrix.browser == 'webkit')
-        run: yarn playwright install-deps ${{ matrix.browser }}
+      - name: 📥 install Playwright ${{ matrix.project }}
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: yarn playwright install --with-deps ${{ matrix.project }}
         working-directory: ./client
 
       - name: 🎭 run Playwright

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,6 +202,7 @@ jobs:
           fail_action: false
 
   e2e-tests:
+    name: 🧪 e2e tests ${{ matrix.project }}
     needs:
       - backend-docker-build
       - frontend-docker-build
@@ -314,7 +315,6 @@ jobs:
           retention-days: 14
   # Ensure the e2e tests and e2e report completed successfully
   e2e:
-    name: 📣 e2e status update
     if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [e2e-tests]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,12 +202,11 @@ jobs:
           fail_action: false
 
   e2e-tests:
-    name: 🧪 e2e tests ${{ matrix.project }}
-    runs-on: ubuntu-latest
     needs:
       - backend-docker-build
       - frontend-docker-build
       - install-dev-tools
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -263,7 +263,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.browser }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
 
-      - name: Install Playwright browsers
+      - name: 📥 install Playwright browsers
         if: steps.cache-browsers.outputs.cache-hit != 'true'
         run: yarn playwright install ${{ matrix.browser }}
       - name: 📥 install Playwright dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,11 @@ env:
   KEYCLOAK_CLIENT_SECRET: ${{ secrets.KEYCLOAK_CLIENT_SECRET }}
   NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
 
+# Cancel current job when pushing new commit into the PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   install-dev-tools:
     runs-on: ubuntu-latest
@@ -207,21 +212,18 @@ jobs:
       - backend-docker-build
       - frontend-docker-build
       - install-dev-tools
-    runs-on: ubuntu-latest
     timeout-minutes: 60
+    runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: false # keep running other jobs if one fails
       matrix:
-        include:
-          - project: chromium
-            os: ubuntu-latest
-            cache_dir: ~/.cache/ms-playwright
-          - project: firefox
-            os: ubuntu-latest
-            cache_dir: ~/.cache/ms-playwright
-          - project: webkit
-            os: macos-12
-            cache_dir: ~/Library/Caches/ms-playwright
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        browser: [chromium, firefox, webkit]
+    env:
+      # Playwright uses different paths on different OS's.
+      # To make it work cross-platform, we need to set the path manually.
+      # Alternatively, `PLAYWRIGHT_BROWSERS_PATH=0` install binaries in node_modules
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/ms-playwright
     steps:
       - uses: actions/checkout@v3
 
@@ -236,16 +238,43 @@ jobs:
           keycloak_client_secret: ${{ env.KEYCLOAK_CLIENT_SECRET }}
           nextauth_secret: ${{ env.NEXTAUTH_SECRET }}
 
-      - name: ⚡️ cache Playwright binaries
+      # Install dependencies with cache
+      - name: ⚡️ cache dependencies
+        id: cache-deps
         uses: actions/cache@v3
-        id: playwright-cache
         with:
-          path: ${{ matrix.cache_dir }}
-          key: ${{ runner.os }}-${{ matrix.project }}-playwright
+          path: ~/.cache/yarn
+          key: modules-${{ hashFiles('yarn.lock') }}
 
-      - name: 📥 install Playwright ${{ matrix.project }}
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: yarn playwright install --with-deps ${{ matrix.project }}
+      - name: 📥 install dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --ignore-scripts
+
+      # Install Playwright browsers with cache
+      - name: ⚡️ cache Playwright version
+        shell: bash
+        run: echo "PLAYWRIGHT_VERSION=$(node -p 'require("@playwright/test/package.json").version')" >> $GITHUB_ENV
+        id: playwright-version
+
+      - name: ⚡️ cache Playwright browsers and maybe dependencies
+        id: cache-browsers
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ matrix.browser }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+
+      - name: Install Playwright browsers
+        if: steps.cache-browsers.outputs.cache-hit != 'true'
+        run: yarn playwright install ${{ matrix.browser }}
+      - name: 📥 install Playwright dependencies
+        # Linux and Windows cannot cache deps.
+        # See: https://github.com/microsoft/playwright/issues/22146#issuecomment-1495821016
+        # if: steps.cache-browsers.outputs.cache-hit != 'true' || runner.os != 'macOS'
+        # BUT except for linux-webkit, they already include most of the necessary dependencies.
+        # So unless you use things like graphics, fonts, video playback etc. and you run into a problem,
+        # You can speed up your CI by using this less strict condition:
+        if: steps.cache-browsers.outputs.cache-hit != 'true' || (runner.os == 'Linux' && matrix.browser == 'webkit')
+        run: yarn playwright install-deps ${{ matrix.browser }}
         working-directory: ./client
 
       - name: 🎭 run Playwright


### PR DESCRIPTION
[Card](https://github.com/bcgov/cas-registration/issues/1113)


## 🚀 Impact:
   - Reduces CI pipeline's e2e Playwright tests run time
   - Restricts CI pipeline's e2e Playwright tests report artifacts to failures
   - Cancels current job when pushing new commit into the PR

## ✏️ Notes:
- Implementing playwright binary cache using `shard` matrix variables results in test(s) finding the cache but then failing due to missing browsers installs 🤷 
- Implementing playwright binary cache using `browser` matrix results in 1 of 3 tests, the `e2e test webkit`,  NOT finding cache; so, that test takes extra 30 seconds to install Playwright deps 🤷 
**Possible Explanation** [This is expected...](https://github.com/microsoft/playwright/issues/22146#issuecomment-1493902369)
- Overall, we have reduced e2e test run by ~40 seconds 🎯

### AFTER CACHING IMPLEMENTATION
![image](https://github.com/bcgov/cas-registration/assets/120038448/99e5d6d1-21dc-4047-8a8a-aebc51c85843)

### BEFORE CACHING IMPLEMENTATION
![image](https://github.com/bcgov/cas-registration/assets/120038448/5d4a5dff-2a78-4fa5-ac6d-e18c7049188d)

##  🔬 Testing:

Validate `1113-e2e-ci-matrix-cache` [e2e test](https://github.com/bcgov/cas-registration/actions/) status is  `pass` 


