### PR TITLE
happo e2e optimize

### DIFF
--- a/.github/actions/dev-env-setup/action.yml
+++ b/.github/actions/dev-env-setup/action.yml
@@ -19,13 +19,8 @@ runs:
           ~/.asdf
           ./bc_obps/.tool-versions
         key: ${{ runner.os }}-asdf-cache-backend-${{ hashFiles('bc_obps/.tool-versions') }}
-    - uses: actions/cache@v3
-      id: yarn-cache
-      with:
-        path: |
-          ~/.cache/yarn
-          ./client/node_modules
-        key: ${{ runner.os }}-yarn-cache-${{ hashFiles('client/yarn.lock') }}-v2
+    - name: yarn cache
+      uses: ./.github/actions/yarn-cache
     - name: Set up python
       id: setup-python
       uses: actions/setup-python@v4

--- a/.github/actions/yarn-cache/action.yml
+++ b/.github/actions/yarn-cache/action.yml
@@ -1,0 +1,12 @@
+name: "Yarn cache"
+description: "Cache Yarn dependencies"
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v4
+      id: yarn-cache
+      with:
+        path: |
+          ~/.cache/yarn
+          ./client/node_modules
+        key: ${{ runner.os }}-yarn-cache-${{ hashFiles('client/yarn.lock') }}-v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -283,7 +283,7 @@ jobs:
           E2E_NEW_USER_STORAGE: ${{ secrets.E2E_NEW_USER_STORAGE}}
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-          HAPPO_NONCE: ${{ github.event.pull_request.head.sha }}
+          HAPPO_NONCE: ${{ github.sha }}
         working-directory: ./client
       - name: 💾 save ${{ matrix.project }} report artifact
         # prefer to upload the report only in case of test failure
@@ -342,7 +342,7 @@ jobs:
         env:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-          HAPPO_NONCE: ${{ github.event.pull_request.head.sha }}
+          HAPPO_NONCE: ${{ github.sha }}
         run: npx happo-e2e finalize
         working-directory: ./client
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -336,8 +336,8 @@ jobs:
     needs: [e2e-tests]
     steps:
       - uses: actions/checkout@v4
-      - name: dev env setup
-        uses: ./.github/actions/dev-env-setup
+      - name: yarn cache
+        uses: ./.github/actions/yarn-cache
       - name: finalize happo e2e tests
         env:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}

--- a/client/e2e/workflows/bceidbusiness/industry_user.spec.ts
+++ b/client/e2e/workflows/bceidbusiness/industry_user.spec.ts
@@ -167,7 +167,9 @@ test.describe("Test Workflow industry_user", () => {
     );
 
     // Add short timeout to mitigate the Firefox text rendering issue causing spurious screenshot failures
-    await page.waitForTimeout(500);
+    if (test.info().project.name === "firefox") {
+      await page.waitForTimeout(500);
+    }
 
     pageContent = page.locator("html");
     await happoPlaywright.screenshot(page, pageContent, {

--- a/client/e2e/workflows/bceidbusiness/industry_user.spec.ts
+++ b/client/e2e/workflows/bceidbusiness/industry_user.spec.ts
@@ -166,6 +166,7 @@ test.describe("Test Workflow industry_user", () => {
       selectOperatorPage.buttonSubmit,
     );
 
+    // Add short timeout to mitigate the Firefox text rendering issue causing spurious screenshot failures
     await page.waitForTimeout(500);
 
     pageContent = page.locator("html");

--- a/client/e2e/workflows/bceidbusiness/industry_user.spec.ts
+++ b/client/e2e/workflows/bceidbusiness/industry_user.spec.ts
@@ -166,6 +166,8 @@ test.describe("Test Workflow industry_user", () => {
       selectOperatorPage.buttonSubmit,
     );
 
+    await page.waitForTimeout(500);
+
     pageContent = page.locator("html");
     await happoPlaywright.screenshot(page, pageContent, {
       component: "Add a new operator",

--- a/client/e2e/workflows/bceidbusiness/industry_user.spec.ts
+++ b/client/e2e/workflows/bceidbusiness/industry_user.spec.ts
@@ -42,19 +42,6 @@ test.describe("Test Workflow industry_user", () => {
   // Note: specify storageState for each test file or test group, instead of setting it in the config. https://playwright.dev/docs/next/auth#reuse-signed-in-state
   test.use({ storageState: storageState }); // this will error if no such file or directory
 
-  test("Test Redirect to Dashboard", async ({ page }) => {
-    // 🛸 Navigate to dashboard page
-    const dashboardPage = new DashboardPOM(page);
-    await dashboardPage.route();
-    // 🔍 Assert that the current URL ends with "(authenticated)/dashboard"
-    await dashboardPage.urlIsCorrect();
-    const pageContent = page.locator("html");
-    await happoPlaywright.screenshot(dashboardPage.page, pageContent, {
-      component: "Industry User Dashboard page",
-      variant: "industry_user",
-    });
-  });
-
   test("Select existing operator (via legal name) and request admin access", async ({
     page,
   }) => {
@@ -167,9 +154,7 @@ test.describe("Test Workflow industry_user", () => {
     );
 
     // Add short timeout to mitigate the Firefox text rendering issue causing spurious screenshot failures
-    if (test.info().project.name === "firefox") {
-      await page.waitForTimeout(500);
-    }
+    await page.waitForTimeout(500);
 
     pageContent = page.locator("html");
     await happoPlaywright.screenshot(page, pageContent, {


### PR DESCRIPTION
Follow up PR to #1168 

- Fixes a bug from using `github.event.pull_request.head.sha` as the `HAPPO_NONCE` variable. Since the pull request head sha doesn't exist when this is ran from develop it fails. I am using `github.sha` instead which is the sha of the commit that started the job. 
- Move the `yarn cache` step from `dev-env-action` into it's own composite action. This greatly reduces the time of the `happo-finalize` step and hopefully will be useful in the future when we need to run a command from a dependency that is in our `node_modules` folder.
- Added a timeout since we keep getting a Firefox screenshot diff which gives the text 500ms to settle and render correctly. If you use the zoom feature in Happo, set it to 400% and zoom into one of the affected characters using the swipe tab you can see that text characters are slightly moving once they appear. Though I know that using timeouts is considered bad practice so I'd love any other suggestions to stop this issue. 

Example of the failing diffs:
https://happo.io/a/336/p/1755/compare/8d06beaf31ebf85d9cca9d6d918d7ee7464e2859/e2ffbfa1350ede06bdccd06e519ba250037b3b6c

Failing happo-finalize job from main:
https://github.com/bcgov/cas-registration/actions/runs/8366960287/job/22908575263