### PR TITLE
Reduce sentry trace rate

### DIFF
--- a/bc_obps/.env.example
+++ b/bc_obps/.env.example
@@ -16,6 +16,8 @@ ENVIRONMENT=develop
 BYPASS_ROLE_ASSIGNMENT=<True/False>
 # Sentry
 SENTRY_DSN=your_sentry_dsn
+SENTRY_ENVIRONMENT=development # for local development, prod for production
+SENTRY_TRACE_SAMPLE_RATE=1.0 # float between 0.0 and 1.0 to trace all requests
 
 # SUPERUSER settings (To access the admin panel)
 SUPERUSER_USERNAME=your_superuser_username

--- a/bc_obps/.env.example
+++ b/bc_obps/.env.example
@@ -17,7 +17,7 @@ BYPASS_ROLE_ASSIGNMENT=<True/False>
 # Sentry
 SENTRY_DSN=your_sentry_dsn
 SENTRY_ENVIRONMENT=development # for local development, prod for production
-SENTRY_TRACE_SAMPLE_RATE=1.0 # float between 0.0 and 1.0 to trace all requests
+SENTRY_TRACE_SAMPLE_RATE=0 # float between 0.0 and 1.0 to trace all requests
 
 # SUPERUSER settings (To access the admin panel)
 SUPERUSER_USERNAME=your_superuser_username

--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -165,6 +165,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 
 # Only enable sentry in production
 SENTRY_ENVIRONMENT = os.environ.get('SENTRY_ENVIRONMENT')
+SENTRY_TRACE_SAMPLE_RATE = os.environ.get('SENTRY_TRACE_SAMPLE_RATE')
 if SENTRY_ENVIRONMENT == 'prod' and DEBUG == 'False':
     sentry_sdk.init(
         dsn="https://c097ce7d51760bab348fa0608eea9870@o646776.ingest.sentry.io/4506621387407360",
@@ -172,7 +173,7 @@ if SENTRY_ENVIRONMENT == 'prod' and DEBUG == 'False':
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.
-        traces_sample_rate=1.0,
+        traces_sample_rate=float(SENTRY_TRACE_SAMPLE_RATE) if SENTRY_TRACE_SAMPLE_RATE is not None else 0,
         # Specify environment (usually production or staging)
         environment='production',
     )

--- a/client/.env.example
+++ b/client/.env.example
@@ -28,4 +28,4 @@ HAPPO_API_SECRET=
 
 # Sentry environment variables should only be set when testing sentry error reporting on local development
 # SENTRY_ENVIRONMENT=development # for local development
-# SENTRY_TRACE_SAMPLE_RATE=1.0 # for local development
+# SENTRY_TRACE_SAMPLE_RATE=0 # float between 0.0 and 1.0 to trace all requests

--- a/client/.env.example
+++ b/client/.env.example
@@ -25,3 +25,7 @@ SITEMINDER_KEYCLOAK_LOGOUT_URL=${SITEMINDER_LOGOUT_URL}?retnow=1&returl=${KEYCLO
 # HAPPO
 HAPPO_API_KEY=
 HAPPO_API_SECRET=
+
+# Sentry environment variables should only be set when testing sentry error reporting on local development
+# SENTRY_ENVIRONMENT=development # for local development
+# SENTRY_TRACE_SAMPLE_RATE=1.0 # for local development

--- a/client/app/utils/actions.ts
+++ b/client/app/utils/actions.ts
@@ -106,6 +106,10 @@ export async function actionHandler(
         if (!response.ok) {
           const res = await response.json();
 
+          // if we have an error message, we want to capture it in Sentry otherwise we want to capture the status code
+          const error = res.message || `HTTP error! Status: ${response.status}`;
+          Sentry.captureException(new Error(error));
+
           // Handle API errors, if any
           if ("message" in res) return { error: res.message };
 
@@ -119,6 +123,7 @@ export async function actionHandler(
 
         return data;
       } catch (error: unknown) {
+        Sentry.captureException(error as Error);
         // Handle any errors, including network issues
         if (error instanceof Error) {
           // eslint-disable-next-line no-console

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -9,13 +9,13 @@ const SENTRY_DSN =
   SENTRY_ENVIRONMENT === "prod"
     ? "https://c097ce7d51760bab348fa0608eea9870@o646776.ingest.sentry.io/4506621387407360"
     : undefined;
+const SENTRY_TRACE_SAMPLE_RATE = process.env.SENTRY_TRACE_SAMPLE_RATE ?? "0";
 
 Sentry.init({
   dsn: SENTRY_DSN,
   environment: SENTRY_ENVIRONMENT,
   release: process.env.SENTRY_RELEASE,
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: parseFloat(SENTRY_TRACE_SAMPLE_RATE),
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/client/sentry.edge.config.ts
+++ b/client/sentry.edge.config.ts
@@ -10,14 +10,13 @@ const SENTRY_DSN =
   SENTRY_ENVIRONMENT === "prod"
     ? "https://c097ce7d51760bab348fa0608eea9870@o646776.ingest.sentry.io/4506621387407360"
     : undefined;
+const SENTRY_TRACE_SAMPLE_RATE = process.env.SENTRY_TRACE_SAMPLE_RATE ?? "0";
 
 Sentry.init({
   dsn: SENTRY_DSN,
   environment: SENTRY_ENVIRONMENT,
   release: process.env.SENTRY_RELEASE,
-
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: parseFloat(SENTRY_TRACE_SAMPLE_RATE),
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/client/sentry.server.config.ts
+++ b/client/sentry.server.config.ts
@@ -9,13 +9,13 @@ const SENTRY_DSN =
   SENTRY_ENVIRONMENT === "prod"
     ? "https://c097ce7d51760bab348fa0608eea9870@o646776.ingest.sentry.io/4506621387407360"
     : undefined;
+const SENTRY_TRACE_SAMPLE_RATE = process.env.SENTRY_TRACE_SAMPLE_RATE ?? "0";
 
 Sentry.init({
   dsn: SENTRY_DSN,
   environment: SENTRY_ENVIRONMENT,
   release: process.env.SENTRY_RELEASE,
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: parseFloat(SENTRY_TRACE_SAMPLE_RATE),
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/helm/cas-registration/templates/backend/deployment.yaml
+++ b/helm/cas-registration/templates/backend/deployment.yaml
@@ -72,6 +72,8 @@ spec:
               value: {{ include "cas-registration.namespaceSuffix" . }}
             - name: SENTRY_RELEASE
               value: {{ .Values.backend.image.tag }}
+            - name: SENTRY_TRACE_SAMPLE_RATE
+              value: {{ .Values.backend.sentry.traceSampleRate }}
             {{- end }}
           ports:
             - containerPort: {{ .Values.backend.service.port }}

--- a/helm/cas-registration/templates/frontend/deployment.yaml
+++ b/helm/cas-registration/templates/frontend/deployment.yaml
@@ -65,6 +65,8 @@ spec:
               value: {{ include "cas-registration.namespaceSuffix" . }}
             - name: SENTRY_RELEASE
               value: {{ .Values.frontend.image.tag }}
+            - name: SENTRY_TRACE_SAMPLE_RATE
+              value: {{ .Values.frontend.sentry.traceSampleRate }}
             {{- end }}
           image: "{{ .Values.frontend.image.repository }}:{{ .Values.defaultImageTag | default .Values.frontend.image.tag }}"
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}

--- a/helm/cas-registration/values-prod.yaml
+++ b/helm/cas-registration/values-prod.yaml
@@ -7,6 +7,9 @@ backend:
 
   environment: production
 
+  sentry:
+    traceSampleRate: 0.1
+
   resources:
     limits:
       cpu: 1000m
@@ -29,6 +32,9 @@ frontend:
   auth:
     keycloakAuthUrl: https://loginproxy.gov.bc.ca/auth
     siteminderAuthUrl: https://logon7.gov.bc.ca
+
+  sentry:
+    traceSampleRate: 0.1
 
   resources:
     limits:


### PR DESCRIPTION
[ISSUE 1189](https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=57110752)
### Notes:

We have made some changes to the sentry `traceSampleRate`. It will now only send 10% of the transactions to the sentry server. Additionally, we have added `traceSampleRate` as a deployment variable for better control. We can now manually change its value in Openshift and shuffle pods instead of making a release every time we want to change its value.

Furthermore, we have put the sentry exception handler in a try/catch block to track the number of errors we receive with this implementation. However, if we receive a lot of emails, we might want to remove the handler from the `try` block.