### PR TITLE
Email_Service

### DIFF
--- a/.github/actions/local-app-run/action.yml
+++ b/.github/actions/local-app-run/action.yml
@@ -14,13 +14,25 @@ inputs:
   nextauth_secret:
     description: "NextAuth client secret"
     required: true
+  ches_client_id:
+    description: "Identifier for CHES dev client"
+    required: true
+  ches_client_secret:
+    description: "CHES dev client secret"
+    required: true
+  ches_token_endpoint:
+    description: "Endpoint for fetching auth token to access CHES dev client"
+    required: true
+  ches_api_url:
+    description: "URL for CHES dev API"
+    required: true
 
 runs:
   using: composite
   steps:
     - name: start backend
       shell: bash
-      run: docker run -d --network=host -e "DB_USER=postgres" -e "DB_NAME=registration" -e "DB_PORT=5432" -e "DB_HOST=localhost" -e "DJANGO_SECRET_KEY=${{ inputs.django_secret_key }}" -e "ALLOWED_HOSTS=localhost,0.0.0.0,127.0.0.1" -e "ENVIRONMENT=develop" ghcr.io/bcgov/cas-reg-backend:${{ github.sha }}
+      run: docker run -d --network=host -e "DB_USER=postgres" -e "DB_NAME=registration" -e "DB_PORT=5432" -e "DB_HOST=localhost" -e "DJANGO_SECRET_KEY=${{ inputs.django_secret_key }}" -e "CHES_CLIENT_ID=${{ inputs.ches_client_id }}" -e "CHES_CLIENT_SECRET=${{ inputs.ches_client_secret }}" -e "CHES_TOKEN_ENDPOINT=${{ inputs.ches_token_endpoint }}" -e "CHES_API_URL=${{ inputs.ches_api_url }}" -e "ALLOWED_HOSTS=localhost,0.0.0.0,127.0.0.1" -e "ENVIRONMENT=develop" ghcr.io/bcgov/cas-reg-backend:${{ github.sha }}
     - name: start frontend
       shell: bash
       run: docker run -d --network=host -e "NEXTAUTH_URL_INTERNAL=http://localhost:3000/" -e "NEXTAUTH_URL=http://localhost:3000/" -e "NEXTAUTH_SECRET=${{ inputs.nextauth_secret }}" -e "API_URL=http://127.0.0.1:8000/api/" -e "KEYCLOAK_LOGIN_URL=https://dev.loginproxy.gov.bc.ca/auth/realms/standard" -e "KEYCLOAK_CLIENT_SECRET=${{ inputs.keycloak_client_secret }}" -e "KEYCLOAK_CLIENT_ID=${{ inputs.keycloak_client_id }}" ghcr.io/bcgov/cas-reg-frontend:${{ github.sha }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,10 @@ env:
   KEYCLOAK_CLIENT_ID: ${{ secrets.KEYCLOAK_CLIENT_ID }}
   KEYCLOAK_CLIENT_SECRET: ${{ secrets.KEYCLOAK_CLIENT_SECRET }}
   NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+  CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
+  CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
+  CHES_API_URL: ${{ secrets.CHES_API_URL }}
+  CHES_TOKEN_ENDPOINT: ${{ secrets.CHES_TOKEN_ENDPOINT }}
 
 # Cancel current job when pushing new commit into the PR
 concurrency:
@@ -325,7 +329,6 @@ jobs:
           keycloak_client_id: ${{ env.KEYCLOAK_CLIENT_ID }}
           keycloak_client_secret: ${{ env.KEYCLOAK_CLIENT_SECRET }}
           nextauth_secret: ${{ env.NEXTAUTH_SECRET }}
-
       - name: ⚡️ cache Playwright binaries
         uses: actions/cache@v4
         id: playwright-cache
@@ -447,6 +450,10 @@ jobs:
         uses: ./.github/actions/local-app-run
         with:
           django_secret_key: ${{ env.DJANGO_SECRET_KEY }}
+          ches_client_id: ${{ env.CHES_CLIENT_ID }}
+          ches_client_secret: ${{ env.CHES_CLIENT_SECRET }}
+          ches_token_endpoint: ${{ env.CHES_TOKEN_ENDPOINT }}
+          ches_api_url: ${{ env.CHES_API_URL }}
       - name: Run pytest
         working-directory: ./bc_obps
         run: make pythontests

--- a/bc_obps/.env.example
+++ b/bc_obps/.env.example
@@ -9,6 +9,12 @@ DB_PORT=5432
 GS_BUCKET_NAME='your_bucket_name'
 GOOGLE_APPLICATION_CREDENTIALS='path/to/your/credentials.json'
 
+# CHES config - DEV
+CHES_CLIENT_ID=""
+CHES_CLIENT_SECRET=""
+CHES_TOKEN_ENDPOINT="https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token"
+CHES_API_URL="https://ches-dev.api.gov.bc.ca/api/v1"
+
 ALLOWED_HOSTS=localhost,0.0.0.0,127.0.0.1
 
 ENVIRONMENT=develop

--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -37,6 +37,10 @@ BYPASS_ROLE_ASSIGNMENT = os.environ.get("BYPASS_ROLE_ASSIGNMENT", False) == "Tru
 
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "localhost").split(",")
 
+CHES_CLIENT_ID = os.environ.get("CHES_CLIENT_ID")
+CHES_CLIENT_SECRET = os.environ.get("CHES_CLIENT_SECRET")
+CHES_TOKEN_ENDPOINT = os.environ.get("CHES_TOKEN_ENDPOINT")
+CHES_API_URL = os.environ.get("CHES_API_URL")
 
 # Application definition
 

--- a/bc_obps/common_utils/email/email_service.py
+++ b/bc_obps/common_utils/email/email_service.py
@@ -10,6 +10,10 @@ logger = logging.getLogger(__name__)
 
 
 class EmailService:
+    """
+    EmailService uses Common Hosted Email Service (CHES) API to enqueue emails for delivery. Uses BC Government-hosted SMTP server to send emails.
+    """
+
     def __init__(self):
         self.api_url: str = settings.CHES_API_URL
         self.client_id: str = settings.CHES_CLIENT_ID
@@ -20,6 +24,14 @@ class EmailService:
         logger.info(f'Initializing EmailService for clientID {self.client_id} to connect to {self.api_url}')
 
     def _get_token(self):
+        """
+        Every other function within EmailService should begin by calling this function.
+
+        If EmailService() object already has a valid token, no action is taken. Otherwise, will make call
+        to {self.token_endpoint} to renew CHES API access_token using credentials
+        {self.client_id} and {self.client_secret}. Then updates stored values
+        {self.token} and {self.token_expiry}.
+        """
         if not self.token or self.token_expiry < datetime.now():
             response = requests.post(
                 self.token_endpoint,
@@ -34,6 +46,9 @@ class EmailService:
                 logger.error("Failed to retrieve CHES access token")
 
     def _make_request(self, endpoint, method='GET', data: any = None):
+        """
+        Helper function to build and send either GET or POST request to CHES API with appropriate headers.
+        """
         headers = {"Authorization": f'Bearer {self.token}'} if self.token else {}
         if method == 'GET':
             response = requests.get(self.api_url + endpoint, headers=headers, timeout=10)
@@ -45,6 +60,11 @@ class EmailService:
         return response
 
     def health_check(self):
+        """
+        Retrieves health check data from CHES API.
+        Response is a dict with key "dependencies", containing a list of 3 dicts (one for each component).
+        For each key name ("database", "queue", and "smtp"), there is a corresponding key "healthy" with True/False.
+        """
         self._get_token()
         try:
             response = self._make_request("/health")
@@ -55,12 +75,16 @@ class EmailService:
 
     def get_message_status(self, message_id: UUID):
         """
+        Given a message_id (which is different from a transaction_id), returns the status of the message.
+
         The CHES API uses these status enums:
         - accepted: email request is valid and has been added to the CHES database
         - pending: the message request is queued in CHES. Queue is usually processed within a few seconds, unless the scheduling feature has been used for the message
         - cancelled: an email that was still in the queue has been cancelled at the client's request
         - completed: the CHES API has dispatched the message to the STMP service. Cannot assert that the email was actually delivered to the recipient(s).
         - failed: the CHES API attempted to dispatch the message to the STMP service but the attempt failed.
+
+        CHES API also provides option to query status by transaction ID rather than message ID. Querying by transaction ID has not been implemented in EmailService.
         """
         self._get_token()
         try:
@@ -71,6 +95,22 @@ class EmailService:
             raise
 
     def send_email(self, email_data: dict):
+        """
+        Email (content in either text or HTML format) is queued to be sent to each recipient listed in 'to'.
+
+        Required input data:
+            {
+                'bodyType': 'text' | 'html',
+                'body': str,
+                'from': str (email),
+                'subject': 'str,
+                'to': List[str] (one email per str),
+            }
+
+        See {self.api_url}/docs for more (optional) fields.
+
+        Response contains 'msgId' (message ID) and 'txId' (transaction ID), to be used as identifiers when querying message or transaction status.
+        """
         self._get_token()
         try:
             response = self._make_request(
@@ -84,6 +124,34 @@ class EmailService:
             raise
 
     def merge_template_and_send(self, email_template_data: dict):
+        """
+        Given an email template with variables for customized content, CHES API merges the template with the given
+        "contexts" (values of variables) and sends each message to the CHES API queue for email delivery. Each "context"
+        will be sent out as a separate email.
+
+        Required input data:
+            {
+                'attachments': List[{
+                    'content': str,
+                    'encoding': str,
+                    'filename': str,
+                    'contentType': str
+                }],
+                'bodyType': 'text' | 'html',
+                'body': str,
+                'contexts': [
+                    {
+                        'context': dict,
+                        'to': List[str],
+                    }
+                ],
+                'from': str,
+                'subject': str,
+            }
+        See {self.api_url}/docs or email_template fixture in test_email_service.py for examples of how to use contexts.
+
+        Response contains 'txId' (transaction ID) and list of 'msgId's (message IDs), to be used as identifiers when querying message or transaction status.
+        """
         self._get_token()
         try:
             response = self._make_request("/emailMerge", method='POST', data=email_template_data)

--- a/bc_obps/common_utils/email/email_service.py
+++ b/bc_obps/common_utils/email/email_service.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import Optional
 from uuid import UUID
 import logging
 
@@ -10,12 +11,12 @@ logger = logging.getLogger(__name__)
 
 class EmailService:
     def __init__(self):
-        self.api_url = settings.CHES_API_URL
-        self.client_id = settings.CHES_CLIENT_ID
-        self.client_secret = settings.CHES_CLIENT_SECRET
-        self.token_endpoint = settings.CHES_TOKEN_ENDPOINT
-        self.token = None
-        self.token_expiry = datetime.now()
+        self.api_url: str = settings.CHES_API_URL
+        self.client_id: str = settings.CHES_CLIENT_ID
+        self.client_secret: str = settings.CHES_CLIENT_SECRET
+        self.token_endpoint: str = settings.CHES_TOKEN_ENDPOINT
+        self.token: Optional[str] = None
+        self.token_expiry: datetime = datetime.now()
         logger.info(f'Initializing EmailService for clientID {self.client_id} to connect to {self.api_url}')
 
     def _get_token(self):

--- a/bc_obps/common_utils/email/email_service.py
+++ b/bc_obps/common_utils/email/email_service.py
@@ -1,10 +1,11 @@
-import json
 from datetime import datetime, timedelta
-from typing import List
 from uuid import UUID
+import logging
 
 import requests
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 
 class EmailService:
@@ -15,7 +16,7 @@ class EmailService:
         self.token_endpoint = settings.CHES_TOKEN_ENDPOINT
         self.token = None
         self.token_expiry = datetime.now()
-        print(f'Initializing EmailService for clientID {self.client_id} to connect to {self.api_url}')
+        logger.info(f'Initializing EmailService for clientID {self.client_id} to connect to {self.api_url}')
 
     def _get_token(self):
         if not self.token or self.token_expiry < datetime.now():
@@ -29,11 +30,10 @@ class EmailService:
                 self.token = response.json()["access_token"]
                 self.token_expiry = datetime.now() + timedelta(seconds=response.json()["expires_in"])
             else:
-                raise Exception("Failed to retrieve CHES access token")
+                logger.error("Failed to retrieve CHES access token")
 
     def _make_request(self, endpoint, method='GET', data: any = None):
         headers = {"Authorization": f'Bearer {self.token}'} if self.token else {}
-        print(f'Received request to {method} to {endpoint} with payload {data}')
         if method == 'GET':
             response = requests.get(self.api_url + endpoint, headers=headers, timeout=10)
         elif method == 'POST':
@@ -49,7 +49,8 @@ class EmailService:
             response = self._make_request("/health")
             return response.json()
         except Exception as exc:
-            raise Exception("Exception in /email/health_check ", str(exc))
+            logger.error(f'Exception in /email/health_check {str(exc)}')
+            raise
 
     def get_message_status(self, message_id: UUID):
         """
@@ -65,7 +66,8 @@ class EmailService:
             response = self._make_request(f'/status/{message_id}')
             return response.json()
         except Exception as exc:
-            raise Exception(f'Exception retrieving message status for {message_id} - ', str(exc))
+            logger.error(f'Exception retrieving message status for {message_id} - {str(exc)}')
+            raise
 
     def send_email(self, email_data: dict):
         self._get_token()
@@ -77,7 +79,8 @@ class EmailService:
             )
             return response.json()
         except Exception as exc:
-            raise Exception("Exception in send_email ", str(exc))
+            logger.error(f'Exception in send_email {str(exc)}')
+            raise
 
     def merge_template_and_send(self, email_template_data: dict):
         self._get_token()
@@ -85,4 +88,5 @@ class EmailService:
             response = self._make_request("/emailMerge", method='POST', data=email_template_data)
             return response.json()
         except Exception as exc:
-            raise Exception('Exception in merging template and sending! ', str(exc))
+            logger.error(f'Exception in merging template and sending! - {str(exc)}')
+            raise

--- a/bc_obps/common_utils/email/email_service.py
+++ b/bc_obps/common_utils/email/email_service.py
@@ -131,12 +131,6 @@ class EmailService:
 
         Required input data:
             {
-                'attachments': List[{
-                    'content': str,
-                    'encoding': str,
-                    'filename': str,
-                    'contentType': str
-                }],
                 'bodyType': 'text' | 'html',
                 'body': str,
                 'contexts': [

--- a/bc_obps/common_utils/email/email_service.py
+++ b/bc_obps/common_utils/email/email_service.py
@@ -1,0 +1,88 @@
+import json
+from datetime import datetime, timedelta
+from typing import List
+from uuid import UUID
+
+import requests
+from django.conf import settings
+
+
+class EmailService:
+    def __init__(self):
+        self.api_url = settings.CHES_API_URL
+        self.client_id = settings.CHES_CLIENT_ID
+        self.client_secret = settings.CHES_CLIENT_SECRET
+        self.token_endpoint = settings.CHES_TOKEN_ENDPOINT
+        self.token = None
+        self.token_expiry = datetime.now()
+        print(f'Initializing EmailService for clientID {self.client_id} to connect to {self.api_url}')
+
+    def _get_token(self):
+        if not self.token or self.token_expiry < datetime.now():
+            response = requests.post(
+                self.token_endpoint,
+                auth=(self.client_id, self.client_secret),
+                data={"grant_type": "client_credentials"},
+                timeout=10,
+            )
+            if response.status_code == 200:
+                self.token = response.json()["access_token"]
+                self.token_expiry = datetime.now() + timedelta(seconds=response.json()["expires_in"])
+            else:
+                raise Exception("Failed to retrieve CHES access token")
+
+    def _make_request(self, endpoint, method='GET', data: any = None):
+        headers = {"Authorization": f'Bearer {self.token}'} if self.token else {}
+        print(f'Received request to {method} to {endpoint} with payload {data}')
+        if method == 'GET':
+            response = requests.get(self.api_url + endpoint, headers=headers, timeout=10)
+        elif method == 'POST':
+            response = requests.post(self.api_url + endpoint, headers=headers, json=data, timeout=10)
+        else:
+            raise ValueError("Invalid HTTP method")
+
+        return response
+
+    def health_check(self):
+        self._get_token()
+        try:
+            response = self._make_request("/health")
+            return response.json()
+        except Exception as exc:
+            raise Exception("Exception in /email/health_check ", str(exc))
+
+    def get_message_status(self, message_id: UUID):
+        """
+        The CHES API uses these status enums:
+        - accepted: email request is valid and has been added to the CHES database
+        - pending: the message request is queued in CHES. Queue is usually processed within a few seconds, unless the scheduling feature has been used for the message
+        - cancelled: an email that was still in the queue has been cancelled at the client's request
+        - completed: the CHES API has dispatched the message to the STMP service. Cannot assert that the email was actually delivered to the recipient(s).
+        - failed: the CHES API attempted to dispatch the message to the STMP service but the attempt failed.
+        """
+        self._get_token()
+        try:
+            response = self._make_request(f'/status/{message_id}')
+            return response.json()
+        except Exception as exc:
+            raise Exception(f'Exception retrieving message status for {message_id} - ', str(exc))
+
+    def send_email(self, email_data: dict):
+        self._get_token()
+        try:
+            response = self._make_request(
+                '/email',
+                method='POST',
+                data=email_data,
+            )
+            return response.json()
+        except Exception as exc:
+            raise Exception("Exception in send_email ", str(exc))
+
+    def merge_template_and_send(self, email_template_data: dict):
+        self._get_token()
+        try:
+            response = self._make_request("/emailMerge", method='POST', data=email_template_data)
+            return response.json()
+        except Exception as exc:
+            raise Exception('Exception in merging template and sending! ', str(exc))

--- a/bc_obps/common_utils/tests/test_email_service.py
+++ b/bc_obps/common_utils/tests/test_email_service.py
@@ -1,0 +1,120 @@
+import pytest
+from datetime import datetime
+from uuid import UUID
+from unittest.mock import patch
+from common_utils.email.email_service import EmailService
+
+
+@pytest.fixture
+def email_service():
+    return EmailService()
+
+
+# NOTE: Most of this mock data was pulled from sample payloads from the CHES API docs
+# at https://ches.api.gov.bc.ca/api/v1/docs
+
+
+@pytest.fixture
+def email_data():
+    return {
+        'bodyType': 'text',
+        'body': 'This is the body of a test email for BCIERS Email Service',
+        'from': 'ggircs@gov.bc.ca',
+        'subject': 'Automated Test of Email_Service',
+        'to': ['baz@gov.bc.ca'],
+    }
+
+
+@pytest.fixture
+def email_template():
+    return {
+        'attachments': [
+            {
+                'content': 'PGI+SGVsbG8gV29ybGRcITwvYj4=',
+                'contentType': 'string',
+                'encoding': 'base64',
+                'filename': 'testfile.txt',
+            }
+        ],
+        'bodyType': 'html',
+        'body': '{{ something.greeting }} {{ something.target }} content',
+        'contexts': [
+            {
+                'bcc': ['foo@gov.bc.ca'],
+                'cc': ['fizz@gov.bc.ca'],
+                'context': {'something': {'greeting': 'Hello', 'target': 'World'}, 'someone': 'user'},
+                'delayTS': 1570000000,
+                'tag': 'tag',
+                'to': ['baz@gov.bc.ca'],
+            }
+        ],
+        'encoding': 'utf-8',
+        'from': 'example@gov.bc.ca',
+        'priority': 'normal',
+        'subject': 'Hello {{ someone }}',
+    }
+
+
+def test_get_token(email_service):
+    email_service._get_token()
+    assert email_service.token is not None
+    assert email_service.token_expiry > datetime.now()
+
+
+def test_health_check(email_service):
+    resp = email_service.health_check()
+    assert isinstance(resp, dict)
+    assert len(resp['dependencies']) == 3
+    dependency_names = ['database', 'queue', 'smtp']
+    for dep in resp['dependencies']:
+        assert dep['name'] in dependency_names
+        assert dep.get('healthy') is not None
+
+
+def test_send_email(email_service, email_data):
+    with patch.object(email_service, '_make_request') as mock_send_email_request:
+        mock_send_email_request.return_value.json.return_value = {
+            'messages': [{'msgId': '0000000-00000-0000-0000001', 'to': ['sample@email.com']}],
+            'txId': '00000000-0000-0000-0000-000000000000',
+        }
+        response = email_service.send_email(email_data)
+        assert len(response['messages']) == 1
+        assert response['txId'] == '00000000-0000-0000-0000-000000000000'
+        assert response['messages'][0]['msgId'] == '0000000-00000-0000-0000001'
+        assert response['messages'][0]['to'] == ['sample@email.com']
+
+
+def test_get_message_status(email_service):
+    with patch.object(email_service, '_make_request') as mock_get_status_request:
+        mock_get_status_request.return_value.json.return_value = {
+            'createdTS': 1560000000,
+            'delayTS': 1570000000,
+            'msgId': '00000000-0000-0000-0000-000000000000',
+            'smtpResponse': {
+                'smtpMsgId': '<11111111-1111-1111-1111-111111111111@gov.bc.ca>',
+                'response': '250 2.6.0 <11111111-1111-1111-1111-111111111111@gov.bc.ca> [InternalId=82420422419525, Hostname=E6PEDG05.idir.BCGOV] 1464 bytes in 0.225, 6.333 KB/sec Queued mail for delivery',
+            },
+            'status': 'completed',
+            'statusHistory': [{'description': 'string', 'status': 'completed', 'timestamp': 0}],
+            'tag': 'tag',
+            'txId': '00000000-0000-0000-0000-000000000000',
+            'updatedTS': 1570000000,
+        }
+        response = email_service.get_message_status(UUID('00000000-0000-0000-0000-000000000000'))
+        assert response['status'] == 'completed'
+        assert response['txId'] == '00000000-0000-0000-0000-000000000000'
+
+
+def test_merge_template_and_send(email_service, email_template):
+    with patch.object(email_service, '_make_request') as mock_merge_template_request:
+        mock_merge_template_request.return_value.json.return_value = [
+            {
+                'messages': [{'msgId': '00000000-0000-0000-0000-000000000000', 'tag': 'tag', 'to': ['baz@gov.bc.ca']}],
+                'txId': '00000000-0000-0000-0000-000000000000',
+            }
+        ]
+        response = email_service.merge_template_and_send(email_template)
+        assert len(response) == 1
+        assert response[0]['txId'] == '00000000-0000-0000-0000-000000000000'
+        assert len(response[0]['messages']) == 1
+        assert response[0]['messages'][0]['to'] == ['baz@gov.bc.ca']

--- a/bc_obps/common_utils/tests/test_email_service.py
+++ b/bc_obps/common_utils/tests/test_email_service.py
@@ -1,13 +1,26 @@
 import pytest
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import UUID
-from unittest.mock import patch
 from common_utils.email.email_service import EmailService
+from pytest_mock import mocker
 
 
 @pytest.fixture
-def email_service():
-    return EmailService()
+def email_service(mocker):
+    email_service = EmailService()
+    email_service.token_endpoint = "http://mock_token_endpoint"
+    email_service.client_id = "mock_client_id"
+    email_service.client_secret = "mock_client_secret"
+    mocker.patch.object(
+        email_service,
+        '_get_token',
+        return_value={
+            "access_token": "mocked_access_token",
+            "expires_in": 300,  # 5 minutes
+        },
+    )
+    mocker.patch.object(email_service, '_get_token', side_effect=email_service._get_token)
+    return email_service
 
 
 # NOTE: Most of this mock data was pulled from sample payloads from the CHES API docs
@@ -22,6 +35,17 @@ def email_data():
         'from': 'ggircs@gov.bc.ca',
         'subject': 'Automated Test of Email_Service',
         'to': ['baz@gov.bc.ca'],
+    }
+
+
+@pytest.fixture
+def health_check_data():
+    return {
+        "dependencies": [
+            {"name": "smtp", "healthy": True, "info": "SMTP Service connected successfully."},
+            {"name": "database", "healthy": True, "info": "Database connected successfully."},
+            {"name": "queue", "healthy": True, "info": "Queue is happy."},
+        ]
     }
 
 
@@ -55,22 +79,55 @@ def email_template():
     }
 
 
-# TODO: replace this with mock request to CHES API instead (so we're not getting a real token), instead just assert we're sending the right parameters
-def test_get_token(email_service):
+def test_init(email_service):
+    email_service_attributes = ['api_url', 'client_id', 'client_secret', 'token_endpoint', 'token_expiry']
+    for key_name in email_service_attributes:
+        assert hasattr(email_service, key_name)
+
+
+def test_fetch_new_token(email_service, mocker):
+    email_service.token = "mock_valid_token"
+    email_service.token_expiry = datetime.now() + timedelta(minutes=5)
+
     email_service._get_token()
-    assert email_service.token is not None
-    assert email_service.token_expiry > datetime.now()
+
+    current_time = datetime.now()
+
+    assert email_service.token == "mock_valid_token"
+    assert email_service.token_expiry > current_time
+    assert email_service.token_expiry <= timedelta(minutes=5) + current_time
+    email_service._get_token.assert_called_once()
 
 
-# TODO: replace this with mock request to CHES API instead, instead assert we're forming the request correctly
-def test_health_check(email_service):
+def test_get_token_when_expired(email_service, mocker):
+    email_service.token = "mock_expired_token"
+    email_service.token_expiry = datetime.now() - timedelta(days=1)
+
+    with mocker.patch('requests.post') as mock_token_post_request:
+        mock_token_post_request.return_value = mocker.Mock(status_code=200)
+        mock_token_post_request.return_value.json.return_value = {"access_token": "new_mock_token", "expires_in": 300}
+
+        email_service._get_token()
+
+    current_time = datetime.now()
+
+    assert email_service.token == "new_mock_token"
+    assert email_service.token_expiry > current_time
+    assert email_service.token_expiry <= current_time + timedelta(minutes=5)
+
+
+def test_health_check(email_service, health_check_data, mocker):
+    mock_health_request = mocker.patch.object(email_service, '_make_request')
+    mock_health_request.return_value.json.return_value = health_check_data
+
     resp = email_service.health_check()
-    assert isinstance(resp, dict)
     assert len(resp['dependencies']) == 3
-    dependency_names = ['database', 'queue', 'smtp']
+    dependency_names = ['database', 'smtp', 'queue']
     for dep in resp['dependencies']:
         assert dep['name'] in dependency_names
         assert dep.get('healthy') is not None
+    email_service._get_token.assert_called_once()
+    email_service._make_request.assert_called_once_with("/health")
 
 
 @pytest.mark.skip(reason="only run this if you want to receive an actual email")
@@ -90,50 +147,52 @@ def test_send_real_email(email_service):
     assert response['txId'] is not None
 
 
-def test_send_email(email_service, email_data):
-    with patch.object(email_service, '_make_request') as mock_send_email_request:
-        mock_send_email_request.return_value.json.return_value = {
-            'messages': [{'msgId': '0000000-00000-0000-0000001', 'to': ['sample@email.com']}],
+def test_send_email(email_service, email_data, mocker):
+    mock_send_email_request = mocker.patch.object(email_service, '_make_request')
+    mock_send_email_request.return_value.json.return_value = {
+        'messages': [{'msgId': '0000000-00000-0000-0000001', 'to': ['sample@email.com']}],
+        'txId': '00000000-0000-0000-0000-000000000000',
+    }
+
+    response = email_service.send_email(email_data)
+    assert len(response['messages']) == 1
+    assert response['txId'] == '00000000-0000-0000-0000-000000000000'
+    assert response['messages'][0]['msgId'] == '0000000-00000-0000-0000001'
+    assert response['messages'][0]['to'] == ['sample@email.com']
+
+
+def test_get_message_status(email_service, mocker):
+    mock_get_status_request = mocker.patch.object(email_service, '_make_request')
+    mock_get_status_request.return_value.json.return_value = {
+        'createdTS': 1560000000,
+        'delayTS': 1570000000,
+        'msgId': '00000000-0000-0000-0000-000000000000',
+        'smtpResponse': {
+            'smtpMsgId': '<11111111-1111-1111-1111-111111111111@gov.bc.ca>',
+            'response': '250 2.6.0 <11111111-1111-1111-1111-111111111111@gov.bc.ca> [InternalId=82420422419525, Hostname=E6PEDG05.idir.BCGOV] 1464 bytes in 0.225, 6.333 KB/sec Queued mail for delivery',
+        },
+        'status': 'completed',
+        'statusHistory': [{'description': 'string', 'status': 'completed', 'timestamp': 0}],
+        'tag': 'tag',
+        'txId': '00000000-0000-0000-0000-000000000000',
+        'updatedTS': 1570000000,
+    }
+
+    response = email_service.get_message_status(UUID('00000000-0000-0000-0000-000000000000'))
+    assert response['status'] == 'completed'
+    assert response['txId'] == '00000000-0000-0000-0000-000000000000'
+
+
+def test_merge_template_and_send(email_service, email_template, mocker):
+    mock_merge_template_request = mocker.patch.object(email_service, '_make_request')
+    mock_merge_template_request.return_value.json.return_value = [
+        {
+            'messages': [{'msgId': '00000000-0000-0000-0000-000000000000', 'tag': 'tag', 'to': ['baz@gov.bc.ca']}],
             'txId': '00000000-0000-0000-0000-000000000000',
         }
-        response = email_service.send_email(email_data)
-        assert len(response['messages']) == 1
-        assert response['txId'] == '00000000-0000-0000-0000-000000000000'
-        assert response['messages'][0]['msgId'] == '0000000-00000-0000-0000001'
-        assert response['messages'][0]['to'] == ['sample@email.com']
-
-
-def test_get_message_status(email_service):
-    with patch.object(email_service, '_make_request') as mock_get_status_request:
-        mock_get_status_request.return_value.json.return_value = {
-            'createdTS': 1560000000,
-            'delayTS': 1570000000,
-            'msgId': '00000000-0000-0000-0000-000000000000',
-            'smtpResponse': {
-                'smtpMsgId': '<11111111-1111-1111-1111-111111111111@gov.bc.ca>',
-                'response': '250 2.6.0 <11111111-1111-1111-1111-111111111111@gov.bc.ca> [InternalId=82420422419525, Hostname=E6PEDG05.idir.BCGOV] 1464 bytes in 0.225, 6.333 KB/sec Queued mail for delivery',
-            },
-            'status': 'completed',
-            'statusHistory': [{'description': 'string', 'status': 'completed', 'timestamp': 0}],
-            'tag': 'tag',
-            'txId': '00000000-0000-0000-0000-000000000000',
-            'updatedTS': 1570000000,
-        }
-        response = email_service.get_message_status(UUID('00000000-0000-0000-0000-000000000000'))
-        assert response['status'] == 'completed'
-        assert response['txId'] == '00000000-0000-0000-0000-000000000000'
-
-
-def test_merge_template_and_send(email_service, email_template):
-    with patch.object(email_service, '_make_request') as mock_merge_template_request:
-        mock_merge_template_request.return_value.json.return_value = [
-            {
-                'messages': [{'msgId': '00000000-0000-0000-0000-000000000000', 'tag': 'tag', 'to': ['baz@gov.bc.ca']}],
-                'txId': '00000000-0000-0000-0000-000000000000',
-            }
-        ]
-        response = email_service.merge_template_and_send(email_template)
-        assert len(response) == 1
-        assert response[0]['txId'] == '00000000-0000-0000-0000-000000000000'
-        assert len(response[0]['messages']) == 1
-        assert response[0]['messages'][0]['to'] == ['baz@gov.bc.ca']
+    ]
+    response = email_service.merge_template_and_send(email_template)
+    assert len(response) == 1
+    assert response[0]['txId'] == '00000000-0000-0000-0000-000000000000'
+    assert len(response[0]['messages']) == 1
+    assert response[0]['messages'][0]['to'] == ['baz@gov.bc.ca']

--- a/bc_obps/common_utils/tests/test_email_service.py
+++ b/bc_obps/common_utils/tests/test_email_service.py
@@ -55,12 +55,14 @@ def email_template():
     }
 
 
+# TODO: replace this with mock request to CHES API instead (so we're not getting a real token), instead just assert we're sending the right parameters
 def test_get_token(email_service):
     email_service._get_token()
     assert email_service.token is not None
     assert email_service.token_expiry > datetime.now()
 
 
+# TODO: replace this with mock request to CHES API instead, instead assert we're forming the request correctly
 def test_health_check(email_service):
     resp = email_service.health_check()
     assert isinstance(resp, dict)

--- a/bc_obps/common_utils/tests/test_email_service.py
+++ b/bc_obps/common_utils/tests/test_email_service.py
@@ -71,6 +71,23 @@ def test_health_check(email_service):
         assert dep.get('healthy') is not None
 
 
+@pytest.mark.skip(reason="only run this if you want to receive an actual email")
+def test_send_real_email(email_service):
+    real_recipient = 'andrea.williams@gov.bc.ca'
+    real_email_data = {
+        'bodyType': 'text',
+        'body': 'This is the body of a test email for BCIERS Email Service',
+        'from': 'ggircs@gov.bc.ca',
+        'subject': 'Automated Test of Email_Service',
+        'to': [real_recipient],
+    }
+    response = email_service.send_email(real_email_data)
+    assert len(response['messages']) == 1
+    assert response['messages'][0]['to'] == [real_recipient]
+    assert response['messages'][0]['msgId'] is not None
+    assert response['txId'] is not None
+
+
 def test_send_email(email_service, email_data):
     with patch.object(email_service, '_make_request') as mock_send_email_request:
         mock_send_email_request.return_value.json.return_value = {

--- a/bc_obps/common_utils/tests/test_email_service.py
+++ b/bc_obps/common_utils/tests/test_email_service.py
@@ -122,7 +122,9 @@ def test_health_check(email_service, health_check_data, mocker):
 
 
 @pytest.mark.skip(reason="only run this if you want to receive an actual email")
-def test_send_real_email(email_service):
+def test_send_real_email():
+    # creates a real instance of EmailService, instead of using the fixture
+    email_service = EmailService()
     real_recipient = 'andrea.williams@gov.bc.ca'
     real_email_data = {
         'bodyType': 'text',

--- a/bc_obps/poetry.lock
+++ b/bc_obps/poetry.lock
@@ -1619,6 +1619,23 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 testing = ["Django", "django-configurations (>=2.0)"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "pytest-picked"
 version = "0.5.0"
 description = "Run the tests related to the changed files"
@@ -1729,7 +1746,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -2148,4 +2164,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "0ba7b69f782a71adc213544840580f5e4b28f422b0571e24a81368e827c41b6f"
+content-hash = "9ea6c3f97571efa51321cf9c3fc21c0616c57cc612c034338e52f6b1a695d487"

--- a/bc_obps/pyproject.toml
+++ b/bc_obps/pyproject.toml
@@ -23,6 +23,7 @@ django-simple-history = "^3.4"
 gunicorn = "^21.2.0"
 sentry-sdk = {extras = ["django"], version = "^1.39.2"}
 dj-database-url = "^2.1.0"
+pytest-mock = "^3.14.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.3.0"

--- a/helm/cas-registration/templates/backend/deployment.yaml
+++ b/helm/cas-registration/templates/backend/deployment.yaml
@@ -31,6 +31,27 @@ spec:
                 secretKeyRef:
                   key: django-secret-key
                   name: {{ include "cas-registration.fullname" . }}-backend
+            - name: CHES_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: ches-client-secret
+                  name: {{ include "cas-registration.fullname" . }}-backend
+            - name: CHES_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: ches-client-id
+                  name: {{ include "cas-registration.fullname" . }}-backend
+            - name: CHES_TOKEN_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  key: ches-token-endpoint
+                  name: {{ include "cas-registration.fullname" . }}-backend
+            - name: CHES_API_URL
+              valueFrom:
+                secretKeyRef:
+                  key: ches-api-url
+                  name: {{ include "cas-registration.fullname" . }}-backend
+>>>>>>> 4be37c3f (Chore: added CHES env vars to more yamls)
             - name: DB_USER
               valueFrom:
                 secretKeyRef:

--- a/helm/cas-registration/templates/backend/deployment.yaml
+++ b/helm/cas-registration/templates/backend/deployment.yaml
@@ -51,7 +51,6 @@ spec:
                 secretKeyRef:
                   key: ches-api-url
                   name: {{ include "cas-registration.fullname" . }}-backend
->>>>>>> 4be37c3f (Chore: added CHES env vars to more yamls)
             - name: DB_USER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Created an EmailService for sending emails using CHES API.

See backend .env.example - there's some new env vars needed for local setup. To get the secret values, see the updated backend .env file in 1Password.

Have also added the relevant secrets to our Secrets in Github.

Note: most of the unit tests in `test_email_service.py` are simply mocking the calls to `EmailService`, so actual emails aren't being sent as part of CI (or pytests when running tests locally). However, I've included a unit test and marked it with `skip` - if you want to run the test locally and actually send an email, simply comment out the `@pytest.mark.skip` line (please also remember to change the value of `real_recipient` in the test to your own email address; my inbox is already at breaking point).
