### PR TITLE
test: add extra assertion to fix flakey breadcrumb screenshot tests

### DIFF
--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -13,7 +13,8 @@
       "swrs_facility_id": 1001,
       "bcghg_id": "23219990005",
       "regulated_products": [],
-      "status": "Not Started"
+      "status": "Not Started",
+      "created_at": "2024-2-01T15:27:00.000Z"
     }
   },
   {
@@ -27,7 +28,8 @@
       "opt_in": false,
       "bcghg_id": "23219990004",
       "regulated_products": [],
-      "status": "Not Started"
+      "status": "Not Started",
+      "created_at": "2024-2-02T15:27:00.000Z"
     }
   },
   {
@@ -44,7 +46,8 @@
       "bcghg_id": "23219990003",
       "regulated_products": [],
       "status": "Approved",
-      "bc_obps_regulated_operation": "21-0001"
+      "bc_obps_regulated_operation": "21-0001",
+      "created_at": "2024-1-31T15:27:00.000Z"
     }
   },
   {
@@ -61,7 +64,8 @@
       "opt_in": false,
       "bcghg_id": "23219990002",
       "regulated_products": [],
-      "status": "Approved"
+      "status": "Approved",
+      "created_at": "2024-1-30T15:27:00.000Z"
     }
   },
   {
@@ -77,7 +81,8 @@
       "opt_in": false,
       "bcghg_id": "23219990001",
       "regulated_products": [],
-      "status": "Draft"
+      "status": "Draft",
+      "created_at": "2024-1-29T15:27:00.000Z"
     }
   },
   {
@@ -93,7 +98,8 @@
       "opt_in": false,
       "bcghg_id": "23219990000",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-28T15:27:00.000Z"
     }
   },
   {
@@ -109,7 +115,8 @@
       "opt_in": false,
       "bcghg_id": "23219990006",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-27T15:27:00.000Z"
     }
   },
   {
@@ -125,7 +132,8 @@
       "opt_in": false,
       "bcghg_id": "23219990007",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-26T15:27:00.000Z"
     }
   },
   {
@@ -141,7 +149,8 @@
       "opt_in": false,
       "bcghg_id": "23219990008",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-25T15:27:00.000Z"
     }
   },
   {
@@ -157,7 +166,8 @@
       "opt_in": false,
       "bcghg_id": "23219990009",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-24T15:27:00.000Z"
     }
   },
   {
@@ -173,7 +183,8 @@
       "opt_in": false,
       "bcghg_id": "23219990010",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-23T15:27:00.000Z"
     }
   },
   {
@@ -189,7 +200,8 @@
       "opt_in": false,
       "bcghg_id": "23219990011",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-22T15:27:00.000Z"
     }
   },
   {
@@ -205,7 +217,8 @@
       "opt_in": false,
       "bcghg_id": "23219990012",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-21T15:27:00.000Z"
     }
   },
   {
@@ -221,7 +234,8 @@
       "opt_in": false,
       "bcghg_id": "23219990013",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-20T15:27:00.000Z"
     }
   },
   {
@@ -237,7 +251,8 @@
       "opt_in": false,
       "bcghg_id": "23219990014",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-19T15:27:00.000Z"
     }
   },
   {
@@ -253,7 +268,8 @@
       "opt_in": false,
       "bcghg_id": "23219990015",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-18T15:27:00.000Z"
     }
   },
   {
@@ -269,7 +285,8 @@
       "opt_in": false,
       "bcghg_id": "23219990016",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-17T15:27:00.000Z"
     }
   },
   {
@@ -285,7 +302,8 @@
       "opt_in": false,
       "bcghg_id": "23219990017",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-16T15:27:00.000Z"
     }
   },
   {
@@ -301,7 +319,8 @@
       "opt_in": false,
       "bcghg_id": "23219990018",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-15T15:27:00.000Z"
     }
   },
   {
@@ -316,7 +335,8 @@
       "opt_in": false,
       "bcghg_id": "23219990019",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-14T15:27:00.000Z"
     }
   },
   {
@@ -330,7 +350,8 @@
       "opt_in": false,
       "bcghg_id": "23219990020",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-13T15:27:00.000Z"
     }
   },
   {
@@ -344,7 +365,8 @@
       "opt_in": false,
       "bcghg_id": "23219990021",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-12T15:27:00.000Z"
     }
   },
   {
@@ -358,7 +380,8 @@
       "opt_in": false,
       "bcghg_id": "23219990022",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-11T15:27:00.000Z"
     }
   },
   {
@@ -372,7 +395,8 @@
       "opt_in": false,
       "bcghg_id": "23219990023",
       "regulated_products": [],
-      "status": "Pending"
+      "status": "Pending",
+      "created_at": "2024-1-10T15:27:00.000Z"
     }
   }
 ]

--- a/client/app/components/navigation/Bread.tsx
+++ b/client/app/components/navigation/Bread.tsx
@@ -159,6 +159,7 @@ export default function Bread({
                 return (
                   <li
                     key={link}
+                    id="breadcrumb-last-item"
                     style={{
                       fontWeight: isLastItem ? "bold" : "normal",
                       ...liStyle,

--- a/client/e2e/poms/operation.ts
+++ b/client/e2e/poms/operation.ts
@@ -70,7 +70,14 @@ export class OperationPOM {
     expect(currentUrl.toLowerCase()).toMatch(path.toLowerCase());
   }
 
+  async operationBreadcrumbIsVisible() {
+    // Check for the presence of the breadcrumb since it
+    // can take a second to load in and cause screenshot diffs
+    await this.page.locator("#breadcrumb-last-item").waitFor();
+  }
+
   async operationFormIsVisible() {
+    await this.operationBreadcrumbIsVisible();
     const form = this.page.locator("form");
     await form.waitFor();
     await expect(this.operationPage1Title).toBeVisible();
@@ -94,10 +101,12 @@ export class OperationPOM {
   }
 
   async operationFormStep2IsVisible() {
+    await this.operationBreadcrumbIsVisible();
     await expect(this.operationPage2Title).toBeVisible();
   }
 
   async operationFormStep3IsVisible() {
+    await this.operationBreadcrumbIsVisible();
     await expect(this.operationPage3Title).toBeVisible();
   }
 

--- a/client/e2e/workflows/bceidbusiness/industry_user.spec.ts
+++ b/client/e2e/workflows/bceidbusiness/industry_user.spec.ts
@@ -153,9 +153,6 @@ test.describe("Test Workflow industry_user", () => {
       selectOperatorPage.buttonSubmit,
     );
 
-    // Add short timeout to mitigate the Firefox text rendering issue causing spurious screenshot failures
-    await page.waitForTimeout(500);
-
     pageContent = page.locator("html");
     await happoPlaywright.screenshot(page, pageContent, {
       component: "Add a new operator",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6956,7 +6956,7 @@ postcss@8.4.31, postcss@^8.4.23, postcss@^8.4.30:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@^8.4.36:
+postcss@^8.4.38:
   version "8.4.38"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
   integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==
@@ -8315,12 +8315,12 @@ vite-tsconfig-paths@^4.3.2:
     tsconfck "^3.0.3"
 
 vite@^5.0.0:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-5.2.3.tgz#198efc2fd4d80eac813b146a68a4b0dbde884fc2"
-  integrity sha512-+i1oagbvkVIhEy9TnEV+fgXsng13nZM90JQbrcPrf6DvW2mXARlz+DK7DLiDP+qeKoD1FCVx/1SpFL1CLq9Mhw==
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.2.8.tgz#a99e09939f1a502992381395ce93efa40a2844aa"
+  integrity "sha1-qZ4Jk58aUCmSOBOVzpPvpAooRKo= sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA=="
   dependencies:
     esbuild "^0.20.1"
-    postcss "^8.4.36"
+    postcss "^8.4.38"
     rollup "^4.13.0"
   optionalDependencies:
     fsevents "~2.3.3"


### PR DESCRIPTION
Follow up to #843 as I introduced some flakey screenshots in that PR.

- Add assertions to make sure the `Operation name` breadcrumb is visible before taking a screenshot as it takes a second to appear.
- Add `created_at` values to ensure the Operations table is always in the same order
- Removed the wait added to fix the Firefox spurious diff for the `Add a new Operator - required errors` spurious diff. It made it happen less but it still popped up sometimes and was the only diff that showed when I pushed the fixtures updates. I am going to propose we add it to the `Permentantly ignored diffs` as suggested in the [Happo docs here](https://docs.happo.io/docs/ignoring-diffs). We test in 4 different browsers so losing this screenshot in Firefox should be safe. If you look in the sidebar to the left of the Happo repo report you can see some similar diffs that were auto ignored. 
- Looks like there is one spurious diff. I think this one can get added to the ignored diffs, not sure why it wasn't automatically added as it's very similar to the two that Happo auto added.