### PR TITLE
chore: update depreciated github actions

### DIFF
--- a/.github/actions/dev-env-setup/action.yml
+++ b/.github/actions/dev-env-setup/action.yml
@@ -4,15 +4,15 @@ runs:
   using: composite
   steps:
     - name: asdf setup
-      uses: asdf-vm/actions/setup@v1
-    - uses: actions/cache@v3
+      uses: asdf-vm/actions/setup@v3
+    - uses: actions/cache@v4
       id: asdf-cache-client
       with:
         path: |
           ~/.asdf
           ./client/.tool-versions
         key: ${{ runner.os }}-asdf-cache-client-${{ hashFiles('client/.tool-versions') }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: asdf-cache-backend
       with:
         path: |
@@ -23,14 +23,14 @@ runs:
       uses: ./.github/actions/yarn-cache
     - name: Set up python
       id: setup-python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.9.16"
     - name: Install Poetry
       uses: snok/install-poetry@v1
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -42,7 +42,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -63,6 +63,6 @@ jobs:
       #    uses a compiled language
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/scan-code-trivy.yaml
+++ b/.github/workflows/scan-code-trivy.yaml
@@ -35,7 +35,7 @@ jobs:
           severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
           timeout: 10m0s
       - name: Upload Trivy scan results as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: trivy-results
           path: trivy-results.sarif

--- a/.github/workflows/scan-code-trivy.yaml
+++ b/.github/workflows/scan-code-trivy.yaml
@@ -17,9 +17,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache Scan Dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/trivy
           key: callee-trivy-${{ github.workflow }}-${{ github.run_id }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,7 @@ jobs:
             ./.pre-commit-cache
           key: pre-commit-${{ env.PY }}-${{ hashFiles('.pre-commit-config.yaml') }}-v3
       - run: pip install -r requirements.txt
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
   backend-docker-build:
     runs-on: ubuntu-latest
     steps:
@@ -185,7 +185,7 @@ jobs:
         with:
           django_secret_key: ${{ env.DJANGO_SECRET_KEY }}
       - name: ZAP Frontend Scan
-        uses: zaproxy/action-baseline@v0.9.0
+        uses: zaproxy/action-baseline@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: "owasp/zap2docker-stable"
@@ -195,7 +195,7 @@ jobs:
           issue_title: OWASP Baseline - Frontend
           fail_action: false
       - name: ZAP Backend Scan
-        uses: zaproxy/action-baseline@v0.9.0
+        uses: zaproxy/action-baseline@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: "owasp/zap2docker-stable"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
   install-dev-tools:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - run: yarn install --frozen-lockfile
@@ -31,7 +31,7 @@ jobs:
     needs: install-dev-tools
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - run: yarn test
@@ -40,7 +40,7 @@ jobs:
     needs: install-dev-tools
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - run: yarn audit-deps
@@ -49,7 +49,7 @@ jobs:
     needs: install-dev-tools
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - name: set pre-commit cache directory
@@ -64,7 +64,7 @@ jobs:
           else
               touch .git/COMMIT_EDITMSG
           fi
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ./.pre-commit-cache
@@ -74,7 +74,7 @@ jobs:
   backend-docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
@@ -96,7 +96,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-bc_obps-${{ github.sha }}
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: backend-docker-build # Necessary to ensure backend image is built first
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
@@ -147,7 +147,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-client-${{ github.sha }}
@@ -177,7 +177,7 @@ jobs:
       ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - name: run app locally
@@ -227,7 +227,7 @@ jobs:
             os: macos-12
             cache_dir: ~/Library/Caches/ms-playwright
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 🎁 setup dev env
         uses: ./.github/actions/dev-env-setup
@@ -241,7 +241,7 @@ jobs:
           nextauth_secret: ${{ env.NEXTAUTH_SECRET }}
 
       - name: ⚡️ cache Playwright binaries
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: playwright-cache
         with:
           path: ${{ matrix.cache_dir }}
@@ -351,7 +351,7 @@ jobs:
       ["backend-docker-build", "frontend-docker-build", "install-dev-tools"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - name: run app locally
@@ -365,7 +365,7 @@ jobs:
     needs: install-dev-tools
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - run: poetry run python manage.py makemigrations --check --dry-run

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,12 +77,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           install: true
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/bcgov/cas-reg-backend
           tags: |
@@ -103,7 +103,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-bc_obps
       - name: Build image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: bc_obps
           builder: ${{ steps.buildx.outputs.name }}
@@ -128,12 +128,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           install: true
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/bcgov/cas-reg-frontend
           tags: |
@@ -154,7 +154,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-client
       - name: Build image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: client
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,7 +90,7 @@ jobs:
             latest
             type=ref,event=pr
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -141,7 +141,7 @@ jobs:
             latest
             type=ref,event=pr
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/update-manifests.yaml
+++ b/.github/workflows/update-manifests.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get HEAD sha
         id: get-sha
         run: |
@@ -21,7 +21,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.MANIFEST_REPO_DEPLOY_KEY }}
       - name: Check out manifest repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.MANIFEST_REPO_DEPLOY_KEY }}
           repository: ${{ secrets.MANIFEST_REPO }}


### PR DESCRIPTION
#159

Updated our actions, now none of our workflows have these depreciated warnings under them:
<img width="1067" alt="Screenshot 2024-03-28 at 11 31 39 AM" src="https://github.com/bcgov/cas-registration/assets/14259474/8754bd80-2539-4610-a17b-c059bd1751b4">
