### PR TITLE
chore: set default crumb state

### DIFF
--- a/client/app/components/navigation/Bread.tsx
+++ b/client/app/components/navigation/Bread.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import React, { ReactNode, useEffect, useState } from "react";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
 import Box from "@mui/material/Box";
@@ -92,7 +93,7 @@ export default function Bread({
   // and useState which is maintained between renders of a top-level React component (required for next\back) navigations
   const searchParams = useSearchParams();
   const paramTitle = searchParams.get("title") as string;
-  const [crumbTitle, setCrumbTitle] = useState<string>("");
+  const [crumbTitle, setCrumbTitle] = useState<string>(paramTitle ?? "");
   useEffect(() => {
     // Set the title state to rowTitle if it exists
     if (paramTitle) {


### PR DESCRIPTION
Ran into more Happo screenshot diffs I forgot to set assertions for this dynamic bread crumb title that takes a second to pop in. Testing setting it as the default state to see if this fixes the issue, I think it is much preferable than having to worry about it in every page we take a screenshot in, especially after we add more enhanced breadcrumbs.