### PR TITLE
chore: add default param to crumb title state

### DIFF
--- a/client/app/components/navigation/Bread.tsx
+++ b/client/app/components/navigation/Bread.tsx
@@ -92,7 +92,7 @@ export default function Bread({
   // and useState which is maintained between renders of a top-level React component (required for next\back) navigations
   const searchParams = useSearchParams();
   const paramTitle = searchParams.get("title") as string;
-  const [crumbTitle, setCrumbTitle] = useState<string>("");
+  const [crumbTitle, setCrumbTitle] = useState<string>(paramTitle ?? "");
   useEffect(() => {
     // Set the title state to rowTitle if it exists
     if (paramTitle) {


### PR DESCRIPTION
Adding the title param to the default state to mitigate flakey screenshots caused by the delay from the useEffect loading the param into state.