### PR TITLE
chore: fix shipit timeout definition

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -6,9 +6,8 @@ review:
 
 deploy:
   override:
-    - |
-      bash deploy.sh
-      timeout: 5000
+    - ./deploy:
+      timeout: 1800
 
 ci:
   allow_failures:


### PR DESCRIPTION
I think the shipit timeout was not being applied correctly in the yaml, the deploy was either timing out at 300 seconds or it would deploy and then throw an error that it doesn't know what "timeout" meant after a deploy was complete. I think this is the correct way to apply a timeout to a shell script. 

docs: https://github.com/Shopify/shipit-engine?tab=readme-ov-file#shell-commands-timeout