### PR TITLE
chore: alternative fix to 1368

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -6,9 +6,8 @@ review:
 
 deploy:
   override:
-    - |
-      bash deploy.sh
-      timeout: 5000
+    - make install:
+        timeout: 1800
 
 ci:
   allow_failures:


### PR DESCRIPTION
Since the deploy.sh script won't work to deploy giraffe stuff anyway, this is an alternative fix to #1368. It just calls make install & we can figure out a combined deploy strategy later.