### PR TITLE
chore: deploy reporting with specific shipit environment

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,8 +4,9 @@
 echo "Branch: $BRANCH"
 
 # Check if the current branch is 'giraffe-develop'
-if [ "$BRANCH" == "giraffe-develop" ]; then
-    echo "Running giraffe make target..."
+if [[ "$ENVIRONMENT" =~ "reporting" ]]; then
+    ENVIRONMENT="${ENVIRONMENT#*-}"
+    echo "Running giraffe make target for $(ENVIRONMENT) environment..."
     make install_giraffe
 else
     echo "Running default make target..."

--- a/shipit.yml
+++ b/shipit.yml
@@ -6,8 +6,8 @@ review:
 
 deploy:
   override:
-    - make install:
-        timeout: 1800
+    - ./deploy:
+      timeout: 1800
 
 ci:
   allow_failures:


### PR DESCRIPTION
- Re-adds using the deploy.sh script in shipit.yml
- Updates deploy.sh to parse a reporting-specific environment from shipit into an environment that can be used by helm to deploy to openshift