### PR TITLE
fix: install yarn dependencies in github actions if cache doesn't exist

### DIFF
--- a/.github/actions/dev-env-setup/action.yml
+++ b/.github/actions/dev-env-setup/action.yml
@@ -49,3 +49,8 @@ runs:
         make install_backend_asdf_tools
         make start_pg
         make create_db
+    - name: Install yarn dependencies
+      if: steps.yarn-cache.outputs.cache-hit != 'true'
+      run: yarn install
+      working-directory: ./client
+      shell: bash


### PR DESCRIPTION
Not sure if this was related to our other recent CI issues though I still had issues with multiple failing CI steps due to missing node_modules dependencies. I noticed we are retrieving the cache but not installing it if it doesn't exist.

Might have been something with the recent NX merge that finally caught us out on this. Looks like any PR that changes the `yarn.lock` is failing now, this seems to fix it.

Failing run: https://github.com/bcgov/cas-registration/actions/runs/8713164323
Passing run in the same PR with this fix applied: https://github.com/bcgov/cas-registration/actions/runs/8713247399

