### PR TITLE
test yarn cache v2

### DIFF
--- a/.github/actions/dev-env-setup/action.yml
+++ b/.github/actions/dev-env-setup/action.yml
@@ -49,8 +49,3 @@ runs:
         make install_backend_asdf_tools
         make start_pg
         make create_db
-    - name: Install yarn dependencies
-      if: steps.yarn-cache.outputs.cache-hit != 'true'
-      run: yarn install
-      working-directory: ./client
-      shell: bash

--- a/.github/actions/yarn-cache/action.yml
+++ b/.github/actions/yarn-cache/action.yml
@@ -10,3 +10,8 @@ runs:
           ~/.cache/yarn
           ./client/node_modules
         key: ${{ runner.os }}-yarn-cache-${{ hashFiles('client/yarn.lock') }}-v2
+    - name: Install yarn dependencies
+      if: steps.yarn-cache.outputs.cache-hit != 'true'
+      run: yarn install
+      working-directory: ./client
+      shell: bash


### PR DESCRIPTION
Made a small mistake with the last PR. Since we previously modularized the yarn cache step to use for steps that didn't need the entire dev environment setup, the `Happo-finalize` step that used the `yarn-cache` action didn't install the needed dependencies when the cache was missing. 

Moving the yarn install step into that action.
