### PR TITLE
yarn cache fix v2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -430,6 +430,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: yarn cache
         uses: ./.github/actions/yarn-cache
+      - run: yarn install --frozen-lockfile
+        working-directory: ./client
       - name: finalize happo e2e tests
         env:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}


### PR DESCRIPTION
I missed a failing job for the last fix we merged in. The `happo-finalize` step uses just the `yarn-cache` action and needs a yarn install if it doesn't exist as well.