### PR TITLE
1234 util tests

### DIFF
--- a/client/app/api/auth/[...nextauth]/route.ts
+++ b/client/app/api/auth/[...nextauth]/route.ts
@@ -72,7 +72,7 @@ export const authOptions: NextAuthOptions = {
         }
         // 🚀 API call: Get user name from user table
         const response = await actionHandler(
-          "registration/user/user-profile",
+          `registration/user/user-profile/${token.user_guid}`,
           "GET",
         );
         const { first_name: firstName, last_name: lastName } = response || {};

--- a/client/app/components/form/FormBase.tsx
+++ b/client/app/components/form/FormBase.tsx
@@ -3,7 +3,7 @@ import readOnlyTheme from "./readOnlyTheme";
 import { useMemo, useState } from "react";
 import { customizeValidator } from "@rjsf/validator-ajv8";
 import { FormProps, IChangeEvent, withTheme, ThemeProps } from "@rjsf/core";
-import { customTransformErrors } from "@/app/utils/customTransformErrors";
+import customTransformErrors from "@/app/utils/customTransformErrors";
 import { RJSFValidationError } from "@rjsf/utils";
 
 const customFormats = {
@@ -13,7 +13,7 @@ const customFormats = {
   bc_corporate_registry_number: "^[A-Za-z]{1,3}\\d{7}$",
 };
 
-const customFormatsErrorMessages = {
+export const customFormatsErrorMessages = {
   bc_corporate_registry_number:
     "BC Corporate Registry number should be 1-3 letters followed by 7 digits",
   cra_business_number: "CRA Business Number should be 9 digits.",

--- a/client/app/components/navigation/Profile.tsx
+++ b/client/app/components/navigation/Profile.tsx
@@ -2,7 +2,8 @@ import Button from "@mui/material/Button/Button";
 import Link from "@mui/material/Link";
 import { signOut, useSession } from "next-auth/react";
 import { getEnvValue } from "@/app/utils/actions";
-import { getUserFullName } from "@/app/utils/getUserFullName";
+import getUserFullName from "@/app/utils/getUserFullName";
+
 export default function Profile() {
   const { data: session } = useSession();
   const userFullName = getUserFullName(session);

--- a/client/app/components/routes/profile/User.tsx
+++ b/client/app/components/routes/profile/User.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/app/components/form/formDataTypes";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
-import { getUserFullName } from "@/app/utils/getUserFullName";
+import getUserFullName from "@/app/utils/getUserFullName";
 
 // 🚀 API call: GET user's data
 async function getUserFormData(): Promise<

--- a/client/app/components/routes/select-operator/Page.tsx
+++ b/client/app/components/routes/select-operator/Page.tsx
@@ -8,7 +8,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { actionHandler } from "@/app/utils/actions";
 import { OperatorStatus, UserOperatorStatus } from "@/app/utils/enums";
-import { getUserFullName } from "@/app/utils/getUserFullName";
+import getUserFullName from "@/app/utils/getUserFullName";
 
 export const getUserOperator = async () => {
   try {

--- a/client/app/utils/actions.ts
+++ b/client/app/utils/actions.ts
@@ -6,6 +6,8 @@ and can be called from server components or from client components.
 💡 You can define Server actins in RSC or define multiple Server Actions in a single file.
 */
 "use server";
+
+import getUUIDFromEndpoint from "@/app/utils/getUUIDFromEndpoint";
 import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import * as Sentry from "@sentry/nextjs";
@@ -28,27 +30,6 @@ export async function getToken() {
     console.error(`An error occurred while fetching token: ${error}`);
     return {};
   }
-}
-
-// 🛠️ Function to get the last non-empty segment as a UUID from an endpoint URL
-function getUUIDFromEndpoint(endpoint: string): string | null {
-  // Split the endpoint URL by '/'
-  const segments = endpoint.split("/");
-
-  // Filter out empty segments
-  const nonEmptySegments = segments.filter((segment) => segment.trim() !== "");
-
-  // Find the last non-empty segment
-  const lastSegment: string | null =
-    nonEmptySegments.length > 0
-      ? nonEmptySegments[nonEmptySegments.length - 1]
-      : null;
-
-  // Validate if the last segment is a UUID (a more permissive pattern)
-  const isUUID = /^[0-9a-fA-F]{32}$/.test(lastSegment as string);
-
-  // Return the last non-empty segment as a UUID or null if not a UUID
-  return isUUID ? (lastSegment as string) : null;
 }
 
 /**

--- a/client/app/utils/customTransformErrors.ts
+++ b/client/app/utils/customTransformErrors.ts
@@ -1,6 +1,6 @@
 import { RJSFValidationError } from "@rjsf/utils";
 
-export const customTransformErrors = (
+const customTransformErrors = (
   errors: RJSFValidationError[],
   customFormatsErrorMessages: { [key: string]: string },
 ) => {
@@ -29,3 +29,5 @@ export const customTransformErrors = (
     return error;
   });
 };
+
+export default customTransformErrors;

--- a/client/app/utils/getUUIDFromEndpoint.ts
+++ b/client/app/utils/getUUIDFromEndpoint.ts
@@ -1,0 +1,22 @@
+// 🛠️ Function to get the last non-empty segment as a UUID from an endpoint URL
+function getUUIDFromEndpoint(endpoint: string): string | null {
+  // Split the endpoint URL by '/'
+  const segments = endpoint.split("/");
+
+  // Filter out empty segments
+  const nonEmptySegments = segments.filter((segment) => segment.trim() !== "");
+
+  // Find the last non-empty segment
+  const lastSegment: string | null =
+    nonEmptySegments.length > 0
+      ? nonEmptySegments[nonEmptySegments.length - 1]
+      : null;
+
+  // Validate if the last segment is a UUID (a more permissive pattern)
+  const isUUID = /^[0-9a-fA-F]{32}$/.test(lastSegment as string);
+
+  // Return the last non-empty segment as a UUID or null if not a UUID
+  return isUUID ? (lastSegment as string) : null;
+}
+
+export default getUUIDFromEndpoint;

--- a/client/app/utils/getUUIDFromEndpoint.ts
+++ b/client/app/utils/getUUIDFromEndpoint.ts
@@ -1,10 +1,11 @@
+export const endpointAllowList = [
+  "registration/user/user-app-role",
+  "registration/user-operator/is-approved-admin-user-operator",
+  "registration/user/user-profile",
+];
+
 // 🛠️ Function to get the last non-empty segment as a UUID from an endpoint URL
 function getUUIDFromEndpoint(endpoint: string): string | null {
-  const endpointAllowList = [
-    "registration/user/user-app-role",
-    "registration/user-operator/is-approved-admin-user-operator",
-  ];
-
   const isEndpointAllowed = endpointAllowList.find((allowedEndpoint) =>
     endpoint.includes(allowedEndpoint),
   )

--- a/client/app/utils/getUUIDFromEndpoint.ts
+++ b/client/app/utils/getUUIDFromEndpoint.ts
@@ -1,5 +1,19 @@
 // 🛠️ Function to get the last non-empty segment as a UUID from an endpoint URL
 function getUUIDFromEndpoint(endpoint: string): string | null {
+  const endpointAllowList = [
+    "registration/user/user-app-role",
+    "registration/user-operator/is-approved-admin-user-operator",
+  ];
+
+  const isEndpointAllowed = endpointAllowList.find((allowedEndpoint) =>
+    endpoint.includes(allowedEndpoint),
+  )
+    ? true
+    : false;
+
+  if (!isEndpointAllowed) {
+    throw new Error("Endpoint is not allowed");
+  }
   // Split the endpoint URL by '/'
   const segments = endpoint.split("/");
 

--- a/client/app/utils/getUserFullName.ts
+++ b/client/app/utils/getUserFullName.ts
@@ -1,6 +1,6 @@
 import { Session } from "next-auth";
 
-export const getUserFullName = (session?: Session | null) => {
+const getUserFullName = (session?: Session | null) => {
   const fullName = session?.user?.full_name;
   const givenName = session?.user?.given_name;
   const familyName = session?.user?.family_name;
@@ -20,3 +20,5 @@ export const getUserFullName = (session?: Session | null) => {
 
   return userFullName;
 };
+
+export default getUserFullName;

--- a/client/app/utils/users/adminUserOperators.ts
+++ b/client/app/utils/users/adminUserOperators.ts
@@ -1,4 +1,4 @@
-import { Status } from "@/app/utils/enums";
+import { Status, UserOperatorStatus } from "@/app/utils/enums";
 import { actionHandler, getToken } from "@/app/utils/actions";
 
 export interface ExternalDashboardUsersTile {
@@ -39,17 +39,30 @@ export async function getExternalDashboardUsersTileData(): Promise<
 export async function processExternalDashboardUsersTileData() {
   const tileData = await getExternalDashboardUsersTileData();
 
+  // Ensure tileData is an array before using map
+  const transformedTileData = Array.isArray(tileData)
+    ? tileData.map((userOperator) => {
+        userOperator.status = userOperator.status
+          ? UserOperatorStatus[
+              userOperator.status.toUpperCase() as keyof typeof UserOperatorStatus
+            ]
+          : UserOperatorStatus.PENDING;
+
+        return userOperator;
+      })
+    : [];
+
   // 🤳Identify current admin user in the list
   const token = await getToken();
   const uid = token?.user_guid ?? "";
-  const selfIndex = tileData.findIndex((userOperator) => {
+  const selfIndex = transformedTileData.findIndex((userOperator) => {
     return userOperator.user.user_guid.replace(/-/g, "") === uid;
   });
 
   // Ensure selfIndex is within the valid range before modifying the array
-  if (selfIndex !== -1 && selfIndex < tileData.length) {
-    tileData[selfIndex].status = Status.MYSELF;
+  if (selfIndex !== -1 && selfIndex < transformedTileData.length) {
+    transformedTileData[selfIndex].status = Status.MYSELF;
   }
 
-  return tileData;
+  return transformedTileData;
 }

--- a/client/app/utils/users/adminUserOperators.ts
+++ b/client/app/utils/users/adminUserOperators.ts
@@ -1,6 +1,5 @@
-import { Status, UserOperatorStatus } from "@/app/utils/enums";
+import { Status } from "@/app/utils/enums";
 import { actionHandler, getToken } from "@/app/utils/actions";
-import { OperatorStatus, UserOperatorRoles } from "@/app/utils/enums";
 
 export interface ExternalDashboardUsersTile {
   user: { [key: string]: any };
@@ -31,7 +30,7 @@ export async function getExternalDashboardUsersTileData(): Promise<
     return await actionHandler(
       `registration/user-operator/user-operator-list-from-user`,
       "GET",
-      "/dashboard/users",
+      "/dashboard/users"
     );
   } catch (error) {
     throw error;
@@ -40,49 +39,17 @@ export async function getExternalDashboardUsersTileData(): Promise<
 export async function processExternalDashboardUsersTileData() {
   const tileData = await getExternalDashboardUsersTileData();
 
-  // Ensure tileData is an array before using map
-  const transformedTileData = Array.isArray(tileData)
-    ? tileData.map((userOperator) => {
-        userOperator.status = userOperator.status
-          ? UserOperatorStatus[
-              userOperator.status.toUpperCase() as keyof typeof UserOperatorStatus
-            ]
-          : UserOperatorStatus.PENDING;
-
-        return userOperator;
-      })
-    : [];
-
   // 🤳Identify current admin user in the list
   const token = await getToken();
   const uid = token?.user_guid ?? "";
-  const selfIndex = transformedTileData.findIndex((userOperator) => {
+  const selfIndex = tileData.findIndex((userOperator) => {
     return userOperator.user.user_guid.replace(/-/g, "") === uid;
   });
 
   // Ensure selfIndex is within the valid range before modifying the array
-  if (selfIndex !== -1 && selfIndex < transformedTileData.length) {
-    transformedTileData[selfIndex].status = Status.MYSELF;
+  if (selfIndex !== -1 && selfIndex < tileData.length) {
+    tileData[selfIndex].status = Status.MYSELF;
   }
 
-  const rowData = transformedTileData.map((uOS) => {
-    const { id, role, status, user, operator } = uOS;
-
-    // If the user is pending, we want to default the access type dropdown to Reporter
-    const accessType =
-      role === UserOperatorRoles.PENDING ? UserOperatorRoles.REPORTER : role;
-
-    return {
-      id: id, // This unique ID is needed for DataGrid to work properly
-      name: `${user.first_name} ${user.last_name}`,
-      email: user.email,
-      business: operator.legal_name,
-      accessType: status === OperatorStatus.DECLINED ? "N/A" : accessType,
-      status: status,
-    };
-  });
-
-  return {
-    rows: rowData as UserOperatorDataGridRow[],
-  };
+  return tileData;
 }

--- a/client/package.json
+++ b/client/package.json
@@ -85,6 +85,7 @@
     "prettier": "^3.0.3",
     "ts-jest": "^29.1.1",
     "vite-tsconfig-paths": "^4.3.2",
-    "vitest": "^1.4.0"
+    "vitest": "^1.4.0",
+    "vitest-fetch-mock": "^0.2.2"
   }
 }

--- a/client/tests/setup/global.tsx
+++ b/client/tests/setup/global.tsx
@@ -1,8 +1,8 @@
+/* eslint-disable import/no-extraneous-dependencies */
 // TODO(Nx Migration): Module added to Monorepo at `bciers/libs/shared/testConfig/src/setup/global.ts`
 
 import type { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers";
 import * as matchers from "@testing-library/jest-dom/matchers";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expect } from "vitest";
 import {
   actionHandler,
@@ -13,6 +13,8 @@ import {
   useSearchParams,
   useSession,
 } from "@/tests/setup/mocks";
+import createFetchMock from "vitest-fetch-mock";
+import { vi } from "vitest";
 
 declare module "vitest" {
   interface Assertion<T = any>
@@ -45,3 +47,8 @@ vi.mock("next-auth", () => ({
 vi.mock("@/app/utils/actions", () => ({
   actionHandler,
 }));
+
+// mock fetch
+export const fetchMocker = createFetchMock(vi);
+
+fetchMocker.enableMocks();

--- a/client/tests/setup/mocks.ts
+++ b/client/tests/setup/mocks.ts
@@ -1,3 +1,5 @@
+import { fetchMocker } from "@/tests/setup/global";
+
 // To reduce code duplication and simplify mocking you can import these common mocks from this file
 // and use them in your test files with custom return values
 //
@@ -16,6 +18,9 @@
 //    },
 //    replace: vi.fn(),
 //  });
+//
+// To mock fetch return values refer to the vitest-fetch-mock documentation:
+// https://github.com/IanVS/vitest-fetch-mock
 
 // TODO(Nx Migration): Module added to Monorepo at `bciers/libs/shared/testConfig/src/setup/mocks.ts`
 
@@ -29,6 +34,7 @@ const getServerSession = vi.fn();
 
 export {
   actionHandler,
+  fetchMocker as fetch,
   getServerSession,
   useRouter,
   useParams,

--- a/client/tests/utils/actions.test.ts
+++ b/client/tests/utils/actions.test.ts
@@ -33,7 +33,8 @@ const responseToken = {
   jti: "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
 };
 
-const mockTokenResponse = () => {
+// Mock the response for the getToken function
+const mockTokenResponse200 = () => {
   fetch.mockResponseOnce(JSON.stringify(responseToken), {
     status: 200,
   });
@@ -45,7 +46,7 @@ describe("getToken function", () => {
   });
 
   it("should return the token", async () => {
-    mockTokenResponse();
+    mockTokenResponse200();
     const result = await getToken();
 
     expect(result).toEqual(responseToken);
@@ -97,7 +98,7 @@ describe("actionHandler function", () => {
   });
 
   it("should return an error if the fetch throws an error", async () => {
-    mockTokenResponse();
+    mockTokenResponse200();
     fetch.mockReject(new Error("Fetch failed"));
     const result = await actionHandler("/endpoint", "GET");
 
@@ -154,7 +155,7 @@ describe("actionHandler function", () => {
   });
 
   it("should return an error if the fetch response is not ok", async () => {
-    mockTokenResponse();
+    mockTokenResponse200();
     fetch.mockReject(new Error("Fetch failed"));
     const result = await actionHandler("/endpoint", "GET");
 

--- a/client/tests/utils/actions.test.ts
+++ b/client/tests/utils/actions.test.ts
@@ -33,15 +33,19 @@ const responseToken = {
   jti: "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
 };
 
+const mockTokenResponse = () => {
+  fetch.mockResponseOnce(JSON.stringify(responseToken), {
+    status: 200,
+  });
+};
+
 describe("getToken function", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("should return the token", async () => {
-    fetch.mockResponse(JSON.stringify(responseToken), {
-      status: 200,
-    });
+    mockTokenResponse();
     const result = await getToken();
 
     expect(result).toEqual(responseToken);
@@ -93,10 +97,7 @@ describe("actionHandler function", () => {
   });
 
   it("should return an error if the fetch throws an error", async () => {
-    // getToken fetch
-    fetch.mockResponseOnce(JSON.stringify(responseToken), {
-      status: 200,
-    });
+    mockTokenResponse();
     fetch.mockReject(new Error("Fetch failed"));
     const result = await actionHandler("/endpoint", "GET");
 
@@ -112,6 +113,7 @@ describe("actionHandler function", () => {
   });
 
   it("can still return data from an allowed endpoint if fetching token fails", async () => {
+    // Note: this would still likely fail in a real-world scenario if no uuid was in the endpoint url which is grabbed by the getUUIDFromEndpoint function since our API requires a user_guid in the Authorization header
     fetch.mockResponses(
       // getToken fetch
       [JSON.stringify({ message: "Error message" }), { status: 400 }],
@@ -152,11 +154,7 @@ describe("actionHandler function", () => {
   });
 
   it("should return an error if the fetch response is not ok", async () => {
-    // getToken fetch
-    fetch.mockResponseOnce(JSON.stringify(responseToken), {
-      status: 200,
-    });
-
+    mockTokenResponse();
     fetch.mockReject(new Error("Fetch failed"));
     const result = await actionHandler("/endpoint", "GET");
 

--- a/client/tests/utils/actions.test.ts
+++ b/client/tests/utils/actions.test.ts
@@ -3,6 +3,7 @@ import { actionHandler, getToken } from "@/app/utils/actions";
 import { fetch } from "@/tests/setup/mocks";
 import * as Sentry from "@sentry/nextjs";
 
+// disable the global mock since we are testing actions here
 vi.unmock("@/app/utils/actions");
 
 vi.mock("next/headers", () => ({
@@ -50,7 +51,7 @@ describe("getToken function", () => {
     fetch.mockReject(new Error("Fetch failed"));
     const result = await getToken();
 
-    expect(consoleMock).toHaveBeenCalledTimes(1);
+    expect(consoleMock).toHaveBeenCalledOnce();
     expect(consoleMock).toHaveBeenLastCalledWith(
       "An error occurred while fetching token: Error: Fetch failed",
     );
@@ -124,7 +125,7 @@ describe("actionHandler function", () => {
       "GET",
     );
 
-    expect(consoleMock).toHaveBeenCalledTimes(1);
+    expect(consoleMock).toHaveBeenCalledOnce();
     expect(consoleMock).toHaveBeenCalledWith(
       "Failed to fetch token. Status: 400",
     );

--- a/client/tests/utils/actions.test.ts
+++ b/client/tests/utils/actions.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect } from "vitest";
+import { getToken } from "@/app/utils/actions";
+import { fetch } from "@/tests/setup/mocks";
+
+vi.unmock("@/app/utils/actions");
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() => ({
+    toString: vi.fn(() => "cookie"),
+  })),
+}));
+
+const response = {
+  name: "User, Test",
+  email: "test.user@gov.bc.ca",
+  sub: "ba2ba62a121842e0942aab9e92ce8822@idir",
+  given_name: "Test",
+  family_name: "User",
+  user_guid: "ba2ba62a121842e0942aab9e92ce8822",
+  identity_provider: "idir",
+  full_name: "Test User",
+  app_role: "cas_admin",
+  jti: "efb76d57-88b7-4eb6-9f26-ec12b49c14c1",
+};
+
+describe("getToken function", () => {
+  const consoleMock = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => undefined);
+
+  afterAll(() => {
+    consoleMock.mockReset();
+  });
+
+  it("should return the token", async () => {
+    fetch.mockResponse(JSON.stringify(response), {
+      status: 200,
+    });
+    const result = await getToken();
+
+    expect(result).toEqual(response);
+  });
+
+  it("should return an error if the fetch throws an error", async () => {
+    fetch.mockReject(new Error("Fetch failed"));
+    const result = await getToken();
+
+    expect(consoleMock).toHaveBeenCalledOnce();
+    expect(consoleMock).toHaveBeenLastCalledWith(
+      "An error occurred while fetching token: Error: Fetch failed",
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("should return an error if the fetch response is not ok", async () => {
+    fetch.mockResponse(JSON.stringify({ message: "Error message" }), {
+      status: 400,
+    });
+    const result = await getToken();
+
+    expect(consoleMock).toHaveBeenCalledTimes(2);
+    expect(consoleMock).toHaveBeenLastCalledWith(
+      "Failed to fetch token. Status: 400",
+    );
+
+    expect(result).toEqual({});
+  });
+});

--- a/client/tests/utils/actions.test.ts
+++ b/client/tests/utils/actions.test.ts
@@ -112,7 +112,6 @@ describe("actionHandler function", () => {
   });
 
   it("can still return data from an allowed endpoint if fetching token fails", async () => {
-    // Note: this would still likely fail in a real-world scenario if no uuid was in the endpoint url which is grabbed by the getUUIDFromEndpoint function since our API requires a user_guid in the Authorization header
     fetch.mockResponses(
       // getToken fetch
       [JSON.stringify({ message: "Error message" }), { status: 400 }],

--- a/client/tests/utils/customTransformErrors.test.ts
+++ b/client/tests/utils/customTransformErrors.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect } from "vitest";
+import customTransformErrors from "@/app/utils/customTransformErrors";
+import { customFormatsErrorMessages } from "@/app/components/form/FormBase";
+
+const requiredFieldError = [
+  {
+    name: "required",
+    property: "legal_name",
+    message: "must have required property 'Legal Name'",
+    params: {
+      missingProperty: "legal_name",
+    },
+    stack: "must have required property 'Legal Name'",
+    schemaPath: "#/required",
+  },
+];
+
+const mininumLengthError = [
+  {
+    name: "minLength",
+    property: "name",
+    message: "Minimum length of 3",
+    params: {
+      limit: 3,
+    },
+    stack: "must NOT have fewer than 3 characters",
+    schemaPath: "#/properties/name/minLength",
+  },
+];
+
+const craBusinessNumberError = [
+  {
+    name: "minimum",
+    property: ".cra_business_number",
+    message: "must be >= 100000000",
+    params: {
+      comparison: ">=",
+      limit: 100000000,
+    },
+    stack: "'CRA Business Number' must be >= 100000000",
+    schemaPath: "#/properties/cra_business_number/minimum",
+  },
+];
+
+const bcCorporateRegistryNumberError = [
+  {
+    name: "format",
+    property: ".bc_corporate_registry_number",
+    message: 'must match format "bc_corporate_registry_number"',
+    params: {
+      format: "bc_corporate_registry_number",
+    },
+    stack:
+      "'BC Corporate Registry Number' must match format \"bc_corporate_registry_number\"",
+    schemaPath: "#/properties/bc_corporate_registry_number/format",
+  },
+];
+
+const urlFormatError = [
+  {
+    name: "format",
+    property: ".website",
+    message: 'must match format "uri"',
+    params: {
+      format: "uri",
+    },
+    stack: "'Website (optional)' must match format \"uri\"",
+    schemaPath: "#/properties/website/format",
+  },
+];
+
+const postalCodeFormatError = [
+  {
+    name: "format",
+    property: ".physical_postal_code",
+    message: 'must match format "postal-code"',
+    params: {
+      format: "postal-code",
+    },
+    stack: "'Postal Code' must match format \"postal-code\"",
+    schemaPath: "#/properties/physical_postal_code/format",
+  },
+];
+
+const emailFormatError = [
+  {
+    name: "format",
+    property: ".email",
+    message: 'must match format "email"',
+    params: {
+      format: "email",
+    },
+    stack: "'Email' must match format \"email\"",
+    schemaPath: "#/properties/email/format",
+  },
+];
+
+const phoneFormatError = [
+  {
+    name: "format",
+    property: ".phone",
+    message: 'must match format "phone"',
+    params: {
+      format: "phone",
+    },
+    stack: "'Phone' must match format \"phone\"",
+    schemaPath: "#/properties/phone/format",
+  },
+];
+
+describe("customTransformErrors", () => {
+  it("returns the transformed error message for required field", () => {
+    const originalErrorMessage = requiredFieldError[0].message;
+    const transformedErrors = customTransformErrors(
+      requiredFieldError,
+      customFormatsErrorMessages,
+    );
+
+    expect(transformedErrors[0].message).not.toBe(originalErrorMessage);
+    expect(transformedErrors[0].message).toBe("Required field");
+  });
+
+  it("returns the same error message for minimum length", () => {
+    const transformedErrors = customTransformErrors(
+      mininumLengthError,
+      customFormatsErrorMessages,
+    );
+
+    expect(transformedErrors[0].message).toBe(mininumLengthError[0].message);
+  });
+
+  it("returns the transformed error message for CRA Business Number", () => {
+    const originalErrorMessage = craBusinessNumberError[0].message;
+    const transformedErrors = customTransformErrors(
+      craBusinessNumberError,
+      customFormatsErrorMessages,
+    );
+
+    expect(transformedErrors[0].message).not.toBe(originalErrorMessage);
+    expect(transformedErrors[0].message).toBe(
+      customFormatsErrorMessages.cra_business_number,
+    );
+  });
+
+  it("returns the transformed error message for BC Corporate Registry Number", () => {
+    const originalErrorMessage = bcCorporateRegistryNumberError[0].message;
+    const transformedErrors = customTransformErrors(
+      bcCorporateRegistryNumberError,
+      customFormatsErrorMessages,
+    );
+
+    expect(transformedErrors[0].message).not.toBe(originalErrorMessage);
+    expect(transformedErrors[0].message).toBe(
+      customFormatsErrorMessages.bc_corporate_registry_number,
+    );
+  });
+
+  it("returns the transformed error message for URL format", () => {
+    const originalErrorMessage = urlFormatError[0].message;
+    const transformedErrors = customTransformErrors(
+      urlFormatError,
+      customFormatsErrorMessages,
+    );
+
+    expect(transformedErrors[0].message).not.toBe(originalErrorMessage);
+    expect(transformedErrors[0].message).toBe(customFormatsErrorMessages.uri);
+  });
+
+  it("returns the transformed error message for Postal Code format", () => {
+    const originalErrorMessage = postalCodeFormatError[0].message;
+    const transformedErrors = customTransformErrors(
+      postalCodeFormatError,
+      customFormatsErrorMessages,
+    );
+
+    expect(transformedErrors[0].message).not.toBe(originalErrorMessage);
+    expect(transformedErrors[0].message).toBe(
+      customFormatsErrorMessages["postal-code"],
+    );
+  });
+
+  it("returns the transformed error message for Email format", () => {
+    const originalErrorMessage = emailFormatError[0].message;
+    const transformedErrors = customTransformErrors(
+      emailFormatError,
+      customFormatsErrorMessages,
+    );
+
+    expect(transformedErrors[0].message).not.toBe(originalErrorMessage);
+    expect(transformedErrors[0].message).toBe(customFormatsErrorMessages.email);
+  });
+
+  it("returns the transformed error message for Phone format", () => {
+    const originalErrorMessage = phoneFormatError[0].message;
+    const transformedErrors = customTransformErrors(
+      phoneFormatError,
+      customFormatsErrorMessages,
+    );
+
+    expect(transformedErrors[0].message).not.toBe(originalErrorMessage);
+    expect(transformedErrors[0].message).toBe(customFormatsErrorMessages.phone);
+  });
+});

--- a/client/tests/utils/getEnvValue.test.ts
+++ b/client/tests/utils/getEnvValue.test.ts
@@ -3,6 +3,8 @@ import { getEnvValue } from "@/app/utils/actions";
 
 vi.stubEnv("SITEMINDER_KEYCLOAK_LOGOUT_URL", "https://example.com");
 
+vi.unmock("@/app/utils/actions");
+
 describe("getEnvValue", () => {
   it("should return the value of the NODE_ENV environment variable", async () => {
     const result = await getEnvValue("NODE_ENV");

--- a/client/tests/utils/getEnvValue.test.ts
+++ b/client/tests/utils/getEnvValue.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, vi } from "vitest";
+import { getEnvValue } from "@/app/utils/actions";
+
+vi.stubEnv("SITEMINDER_KEYCLOAK_LOGOUT_URL", "https://example.com");
+
+describe("getEnvValue", () => {
+  it("should return the value of the NODE_ENV environment variable", async () => {
+    const result = await getEnvValue("NODE_ENV");
+    expect(result).toBe("test");
+  });
+
+  it("should return the value of the SITEMINDER_KEYCLOAK_LOGOUT_URL environment variable", async () => {
+    const result = await getEnvValue("SITEMINDER_KEYCLOAK_LOGOUT_URL");
+    expect(result).toBe("https://example.com");
+  });
+
+  it("should throw an error if the key is not in the allow list", async () => {
+    await expect(getEnvValue("ENV_VAR_NOT_IN_ALLOWED_LIST")).rejects.toThrow(
+      "Invalid env key",
+    );
+  });
+});

--- a/client/tests/utils/getUUIDFromEndpoint.test.ts
+++ b/client/tests/utils/getUUIDFromEndpoint.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect } from "vitest";
 
-import getUUIDFromEndpoint from "@/app/utils/getUUIDFromEndpoint";
+import getUUIDFromEndpoint, {
+  endpointAllowList,
+} from "@/app/utils/getUUIDFromEndpoint";
 
 describe("getUUIDFromEndpoint", () => {
-  it("should return the UUID from the endpoint", () => {
-    const endpoint =
-      "/registration/user/user-app-role/ba2ba62a121842e0942aab9e92ce8822";
-    const result = getUUIDFromEndpoint(endpoint);
-    expect(result).toBe("ba2ba62a121842e0942aab9e92ce8822");
-  });
-
+  it.each(endpointAllowList)(
+    "should return the UUID from the endpoint %s",
+    (endpoint) => {
+      const endpointWithUUID = `${endpoint}/ba2ba62a121842e0942aab9e92ce8822`;
+      const result = getUUIDFromEndpoint(endpointWithUUID);
+      expect(result).toBe("ba2ba62a121842e0942aab9e92ce8822");
+    },
+  );
   it("should return an empty string if the endpoint contains a malformed UUID", () => {
     const endpoint =
       "registration/user/user-app-role/ba2ba62a121842e0942aab9e92ce882";

--- a/client/tests/utils/getUUIDFromEndpoint.test.ts
+++ b/client/tests/utils/getUUIDFromEndpoint.test.ts
@@ -4,20 +4,29 @@ import getUUIDFromEndpoint from "@/app/utils/getUUIDFromEndpoint";
 
 describe("getUUIDFromEndpoint", () => {
   it("should return the UUID from the endpoint", () => {
-    const endpoint = "/registration/endpoint/ba2ba62a121842e0942aab9e92ce8822";
+    const endpoint =
+      "/registration/user/user-app-role/ba2ba62a121842e0942aab9e92ce8822";
     const result = getUUIDFromEndpoint(endpoint);
     expect(result).toBe("ba2ba62a121842e0942aab9e92ce8822");
   });
 
   it("should return an empty string if the endpoint contains a malformed UUID", () => {
-    const endpoint = "/registration/endpoint/ba2ba62a121842e0942aab9e92ce882";
+    const endpoint =
+      "registration/user/user-app-role/ba2ba62a121842e0942aab9e92ce882";
     const result = getUUIDFromEndpoint(endpoint);
     expect(result).toBe(null);
   });
 
   it("should return an empty string if the endpoint does not contain a UUID", () => {
-    const endpoint = "/registration/endpoint";
+    const endpoint = "registration/user/user-app-role";
     const result = getUUIDFromEndpoint(endpoint);
     expect(result).toBe(null);
+  });
+
+  it("should throw an error if the endpoint is not allowed", () => {
+    const endpoint = "registration/user/not-allowed-endpoint";
+    expect(() => getUUIDFromEndpoint(endpoint)).toThrowError(
+      "Endpoint is not allowed",
+    );
   });
 });

--- a/client/tests/utils/getUUIDFromEndpoint.test.ts
+++ b/client/tests/utils/getUUIDFromEndpoint.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect } from "vitest";
+
+import getUUIDFromEndpoint from "@/app/utils/getUUIDFromEndpoint";
+
+describe("getUUIDFromEndpoint", () => {
+  it("should return the UUID from the endpoint", () => {
+    const endpoint = "/registration/endpoint/ba2ba62a121842e0942aab9e92ce8822";
+    const result = getUUIDFromEndpoint(endpoint);
+    expect(result).toBe("ba2ba62a121842e0942aab9e92ce8822");
+  });
+
+  it("should return an empty string if the endpoint contains a malformed UUID", () => {
+    const endpoint = "/registration/endpoint/ba2ba62a121842e0942aab9e92ce882";
+    const result = getUUIDFromEndpoint(endpoint);
+    expect(result).toBe(null);
+  });
+
+  it("should return an empty string if the endpoint does not contain a UUID", () => {
+    const endpoint = "/registration/endpoint";
+    const result = getUUIDFromEndpoint(endpoint);
+    expect(result).toBe(null);
+  });
+});

--- a/client/tests/utils/getUserFullName.test.ts
+++ b/client/tests/utils/getUserFullName.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect } from "vitest";
+import { Session } from "next-auth";
+import getUserFullName from "@/app/utils/getUserFullName";
+
+const session = {
+  user: {
+    name: "Test User name field",
+    email: "test@gov.bc.ca",
+    bceid_business_guid: "business-guid-here",
+    bceid_business_name: "Cas, Bcgov",
+    given_name: "Test",
+    family_name: "User",
+    full_name: "Test User full_name field",
+    app_role: "industry_user_admin",
+  },
+  expires: "2024-04-18T21:15:11.264Z",
+  identity_provider: "bceidbusiness",
+} as Session;
+
+describe("getUserFullName function", () => {
+  it("returns the full name when it is available", () => {
+    const userFullName = getUserFullName(session);
+    expect(userFullName).toBe("Test User full_name field");
+  });
+
+  it("returns the given_name and family_name fields when the full name is not available", () => {
+    const sessionWithoutFullName = {
+      ...session,
+      user: { ...session.user, full_name: undefined },
+    };
+    const userFullName = getUserFullName(sessionWithoutFullName);
+    expect(userFullName).toBe("Test User");
+  });
+
+  it("returns the given_name when the full_name and family_name is not available", () => {
+    const sessionWithoutFamilyName = {
+      ...session,
+      user: { ...session.user, family_name: undefined, full_name: undefined },
+    };
+    const userFullName = getUserFullName(sessionWithoutFamilyName);
+
+    expect(userFullName).toBe("Test");
+  });
+
+  it("returns the family_name when the full_name and given_name is not available", () => {
+    const sessionWithoutGivenName = {
+      ...session,
+      user: { ...session.user, given_name: undefined, full_name: undefined },
+    };
+    const userFullName = getUserFullName(sessionWithoutGivenName);
+    expect(userFullName).toBe("User");
+  });
+
+  it("returns the name when the full_name, given, family names are not available", () => {
+    const sessionWithoutGivenName = {
+      ...session,
+      user: {
+        ...session.user,
+        given_name: undefined,
+        family_name: undefined,
+        full_name: undefined,
+      },
+    };
+    const userFullName = getUserFullName(sessionWithoutGivenName);
+    expect(userFullName).toBe("Test User name field");
+  });
+
+  it("returns empty string when the session is undefined", () => {
+    const userFullName = getUserFullName(undefined);
+    expect(userFullName).toBe("");
+  });
+});

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3765,7 +3765,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.0.4:
+cross-fetch@^3.0.4, cross-fetch@^3.0.6:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
   integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
@@ -8714,6 +8714,13 @@ vite@^5.0.0:
     rollup "^4.13.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vitest-fetch-mock@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/vitest-fetch-mock/-/vitest-fetch-mock-0.2.2.tgz#f6849dcf7a8e862a509e1cee2fa3bb0cb534f468"
+  integrity sha512-XmH6QgTSjCWrqXoPREIdbj40T7i1xnGmAsTAgfckoO75W1IEHKR8hcPCQ7SO16RsdW1t85oUm6pcQRLeBgjVYQ==
+  dependencies:
+    cross-fetch "^3.0.6"
 
 vitest@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Implements #1234 

Added tests most of the functions in the `/utils` folder

Re-added the `vitest-fetch-mock` library and added it to our mocks where it can be imported as `fetch`.

Please let me know if you can think of useful scenarios I haven't tested, especially for the action handler which is probably the most important util tested here 🙇 

What is not tested:
- the `jsonSchema` folder. These json schema files should probably live elsewhere and we aren't likely to test them on their own. They will get tested when we get to each form and are being tested in our e2e tests.
- the `/users/adminUserOperators.ts` file. It will likely get completely removed in #1433 and some of it is completely redundant and left over from early in the project (the `transformedTileData` map doesn't do anything anymore).
