### PR TITLE
fix owasp-zap scan ci issue

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -274,7 +274,7 @@ jobs:
         uses: zaproxy/action-baseline@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: "owasp/zap2docker-stable"
+          docker_name: "ghcr.io/zaproxy/zaproxy:stable"
           target: "http://localhost:3000/"
           rules_file_name: ".zap/rules-frontend.tsv"
           cmd_options: "-a -d -T 5 -m 2"
@@ -284,7 +284,7 @@ jobs:
         uses: zaproxy/action-baseline@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: "owasp/zap2docker-stable"
+          docker_name: "ghcr.io/zaproxy/zaproxy:stable"
           target: "http://0.0.0.0:8000/"
           rules_file_name: ".zap/rules-backend.tsv"
           cmd_options: "-a -d -T 5 -m 2"


### PR DESCRIPTION
Looks like their DockerHub images went down, so switching to GHCR images since I saw they are hosted there as well:

https://www.zaproxy.org/blog/2023-06-13-ghcr-docker-images/

Fixed run here: 
https://github.com/bcgov/cas-registration/actions/runs/8790774852/job/24123733697?pr=1443