### PR TITLE
1513 API auth header consistency

### DIFF
--- a/bc_obps/registration/api/user/user_app_role.py
+++ b/bc_obps/registration/api/user/user_app_role.py
@@ -1,4 +1,4 @@
-import json
+from registration.api.utils.current_user_utils import get_current_user_guid
 from registration.decorators import handle_http_errors
 from service.data_access_service.user_service import UserDataAccessService
 from registration.schema import UserAppRoleOut, Message

--- a/bc_obps/registration/api/user/user_app_role.py
+++ b/bc_obps/registration/api/user/user_app_role.py
@@ -9,4 +9,5 @@ from ninja.responses import codes_4xx
 @router.get("user/user-app-role", response={200: UserAppRoleOut, codes_4xx: Message}, url_name="get_user_role")
 @handle_http_errors()
 def get_user_role(request):
-    return 200, UserDataAccessService.get_app_role(json.loads(request.headers.get('Authorization')).get('user_guid'))
+    user_guid = get_current_user_guid(request)
+    return 200, UserDataAccessService.get_app_role(user_guid)

--- a/bc_obps/registration/api/user/user_app_role.py
+++ b/bc_obps/registration/api/user/user_app_role.py
@@ -1,3 +1,4 @@
+import json
 from registration.decorators import handle_http_errors
 from service.data_access_service.user_service import UserDataAccessService
 from registration.schema import UserAppRoleOut, Message
@@ -5,9 +6,7 @@ from registration.api.api_base import router
 from ninja.responses import codes_4xx
 
 
-@router.get(
-    "user/user-app-role/{user_guid}", response={200: UserAppRoleOut, codes_4xx: Message}, url_name="get_user_role"
-)
+@router.get("user/user-app-role", response={200: UserAppRoleOut, codes_4xx: Message}, url_name="get_user_role")
 @handle_http_errors()
-def get_user_role(request, user_guid: str):
-    return 200, UserDataAccessService.get_app_role(user_guid)
+def get_user_role(request):
+    return 200, UserDataAccessService.get_app_role(json.loads(request.headers.get('Authorization')).get('user_guid'))

--- a/bc_obps/registration/api/user/user_profile.py
+++ b/bc_obps/registration/api/user/user_profile.py
@@ -1,4 +1,9 @@
-import json
+
+from typing import Optional
+from uuid import UUID
+from django.conf import settings
+from django.http import JsonResponse
+from service.error_service.handle_exception import handle_exception
 from registration.api.utils.current_user_utils import get_current_user_guid
 from service.data_access_service.user_service import UserDataAccessService
 from registration.decorators import authorize, handle_http_errors
@@ -13,9 +18,7 @@ from service.user_profile_service import UserProfileService
 @handle_http_errors()
 def get_user_profile(request):
     user_guid = get_current_user_guid(request)
-    return 200, UserDataAccessService.get_user_profile(
-        user_guid
-    )
+    return 200, UserDataAccessService.get_user_profile(user_guid)
 
 
 ##### POST #####

--- a/bc_obps/registration/api/user/user_profile.py
+++ b/bc_obps/registration/api/user/user_profile.py
@@ -12,8 +12,9 @@ from service.user_profile_service import UserProfileService
 @router.get("/user/user-profile", response={200: UserOut, codes_4xx: Message}, url_name="get_user_profile")
 @handle_http_errors()
 def get_user_profile(request):
+    user_guid = get_current_user_guid(request)
     return 200, UserDataAccessService.get_user_profile(
-        json.loads(request.headers.get('Authorization')).get('user_guid')
+        user_guid
     )
 
 

--- a/bc_obps/registration/api/user/user_profile.py
+++ b/bc_obps/registration/api/user/user_profile.py
@@ -1,9 +1,4 @@
-
-from typing import Optional
-from uuid import UUID
-from django.conf import settings
-from django.http import JsonResponse
-from service.error_service.handle_exception import handle_exception
+import json
 from registration.api.utils.current_user_utils import get_current_user_guid
 from service.data_access_service.user_service import UserDataAccessService
 from registration.decorators import authorize, handle_http_errors
@@ -17,8 +12,9 @@ from service.user_profile_service import UserProfileService
 @router.get("/user/user-profile", response={200: UserOut, codes_4xx: Message}, url_name="get_user_profile")
 @handle_http_errors()
 def get_user_profile(request):
-    user_guid = get_current_user_guid(request)
-    return 200, UserDataAccessService.get_user_profile(user_guid)
+    return 200, UserDataAccessService.get_user_profile(
+        json.loads(request.headers.get('Authorization')).get('user_guid')
+    )
 
 
 ##### POST #####

--- a/bc_obps/registration/api/user_operator/is_approved_admin_user_operator.py
+++ b/bc_obps/registration/api/user_operator/is_approved_admin_user_operator.py
@@ -1,4 +1,4 @@
-import json
+from registration.api.utils.current_user_utils import get_current_user_guid
 from service.data_access_service.user_service import UserDataAccessService
 
 from registration.decorators import authorize, handle_http_errors
@@ -23,6 +23,4 @@ from service.error_service.custom_codes_4xx import custom_codes_4xx
 @handle_http_errors()
 def is_approved_admin_user_operator(request):
     user_guid = get_current_user_guid(request)
-    return 200, UserDataAccessService.is_user_an_approved_admin_user_operator(
-        user_guid
-    )
+    return 200, UserDataAccessService.is_user_an_approved_admin_user_operator(user_guid)

--- a/bc_obps/registration/api/user_operator/is_approved_admin_user_operator.py
+++ b/bc_obps/registration/api/user_operator/is_approved_admin_user_operator.py
@@ -1,3 +1,4 @@
+import json
 from service.data_access_service.user_service import UserDataAccessService
 
 from registration.decorators import authorize, handle_http_errors
@@ -14,11 +15,13 @@ from service.error_service.custom_codes_4xx import custom_codes_4xx
 
 
 @router.get(
-    "/user-operator/is-approved-admin-user-operator/{user_guid}",
+    "/user-operator/is-approved-admin-user-operator",
     response={200: IsApprovedUserOperator, custom_codes_4xx: Message},
     url_name="is_approved_admin_user_operator",
 )
 @authorize(["industry_user"], UserOperator.get_all_industry_user_operator_roles())
 @handle_http_errors()
-def is_approved_admin_user_operator(request, user_guid):
-    return 200, UserDataAccessService.is_user_an_approved_admin_user_operator(user_guid)
+def is_approved_admin_user_operator(request):
+    return 200, UserDataAccessService.is_user_an_approved_admin_user_operator(
+        json.loads(request.headers.get('Authorization')).get('user_guid')
+    )

--- a/bc_obps/registration/api/user_operator/is_approved_admin_user_operator.py
+++ b/bc_obps/registration/api/user_operator/is_approved_admin_user_operator.py
@@ -22,6 +22,7 @@ from service.error_service.custom_codes_4xx import custom_codes_4xx
 @authorize(["industry_user"], UserOperator.get_all_industry_user_operator_roles())
 @handle_http_errors()
 def is_approved_admin_user_operator(request):
+    user_guid = get_current_user_guid(request)
     return 200, UserDataAccessService.is_user_an_approved_admin_user_operator(
-        json.loads(request.headers.get('Authorization')).get('user_guid')
+        user_guid
     )

--- a/bc_obps/registration/tests/endpoints/user_operator/test_authorization.py
+++ b/bc_obps/registration/tests/endpoints/user_operator/test_authorization.py
@@ -19,19 +19,19 @@ class TestUserOperatorEndpointAuthorization(CommonTestSetup):
         response = TestUtils.mock_get_with_auth_role(
             self,
             'cas_pending',
-            custom_reverse_lazy('is_approved_admin_user_operator', kwargs={'user_guid': self.user.user_guid}),
+            custom_reverse_lazy('is_approved_admin_user_operator'),
         )
         assert response.status_code == 401
         response = TestUtils.mock_get_with_auth_role(
             self,
             'cas_admin',
-            custom_reverse_lazy('is_approved_admin_user_operator', kwargs={'user_guid': self.user.user_guid}),
+            custom_reverse_lazy('is_approved_admin_user_operator'),
         )
         assert response.status_code == 401
         response = TestUtils.mock_get_with_auth_role(
             self,
             'cas_analyst',
-            custom_reverse_lazy('is_approved_admin_user_operator', kwargs={'user_guid': self.user.user_guid}),
+            custom_reverse_lazy('is_approved_admin_user_operator'),
         )
         assert response.status_code == 401
 

--- a/bc_obps/registration/tests/endpoints/user_operator/test_is_approved_admin_user_operator.py
+++ b/bc_obps/registration/tests/endpoints/user_operator/test_is_approved_admin_user_operator.py
@@ -1,3 +1,4 @@
+import json
 from model_bakery import baker
 from registration.models import (
     User,
@@ -21,13 +22,13 @@ class TestUserOperatorIsApprovedAdminUserOperatorEndpoint(CommonTestSetup):
         mock_user_operator.role = UserOperator.Roles.ADMIN
         mock_user_operator.status = UserOperator.Statuses.APPROVED
         mock_user_operator.save(update_fields=["user_id", "role", "status"])
+        self.user.user_guid = mock_user.user_guid
+        self.user.save()
+        self.auth_header_dumps = json.dumps({'user_guid': str(self.user.user_guid)})
         response = TestUtils.mock_get_with_auth_role(
             self,
             "industry_user",
-            custom_reverse_lazy(
-                "is_approved_admin_user_operator",
-                kwargs={"user_guid": mock_user.user_guid},
-            ),
+            custom_reverse_lazy("is_approved_admin_user_operator"),
         )
         assert response.status_code == 200
         assert response.json() == {"approved": True}
@@ -44,10 +45,7 @@ class TestUserOperatorIsApprovedAdminUserOperatorEndpoint(CommonTestSetup):
         response = TestUtils.mock_get_with_auth_role(
             self,
             "industry_user",
-            custom_reverse_lazy(
-                "is_approved_admin_user_operator",
-                kwargs={"user_guid": mock_user.user_guid},
-            ),
+            custom_reverse_lazy("is_approved_admin_user_operator"),
         )
         assert response.status_code == 200
         assert response.json() == {"approved": False}

--- a/client/app/api/auth/[...nextauth]/route.ts
+++ b/client/app/api/auth/[...nextauth]/route.ts
@@ -70,6 +70,12 @@ export const authOptions: NextAuthOptions = {
 
           token.identity_provider = account.providerAccountId.split("@")[1];
         }
+
+        //📌 API call notes:
+        // since API calls are made before JWT token is returned
+        // the actionHandler cannot get user_guid from `getToken`
+        // so, add parameter `token.user_guid` for actionHandler to use in Authorization header
+
         // 🚀 API call: Get user name from user table
         const response = await actionHandler(
           `registration/user/user-profile/${token.user_guid}`,

--- a/client/app/utils/actions.ts
+++ b/client/app/utils/actions.ts
@@ -63,7 +63,8 @@ export async function actionHandler(
         // get the user_guid from the JWT
         const userGuid =
           token?.user_guid || getUUIDFromEndpoint(endpoint) || "";
-
+        // strip any guid param from endpoint url
+        endpoint = endpoint.replace(`/${userGuid}`, "");
         // Add user_guid to Django API Authorization header
         const defaultOptions: RequestInit = {
           cache: "no-store", // Default cache option


### PR DESCRIPTION
Addresses:
 [1513](https://github.com/bcgov/cas-registration/issues/1513)

## 🚀 Impact:

   -  updated API endpoints to retrieve the `user_guid` from the Authorization header instead of the endpoint parameter
   - updated `client/app/utils/actions.ts` to splice endpoint `user_guid` parameter
   - API calls from `client/app/api/auth/[...nextauth]/route.ts\callback jwt` return correct JSON data
   - updated API endpoint tests


##  🔬 Testing:

- Validate app login process initializes app user session as expected:
1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd client && yarn dev
```  
3. Navigate to `http://localhost:3000`
4. Click a "Log in with Business BCeID" button
5. Sign in to Keycloak using `bc-cas-dev`
6. **Expected result**: redirection to `dashboard` page for role `industry_user_admin`
7. **Expected result**: no JSON errors in the app development server terminal
8. Click a "Log Out" button
9. Navigate to `http://localhost:3000`
10. Click a "Log in with Business BCeID" button
11. Sign in to Keycloak using `bc-cas-dev-secondary`
12. **Expected result**: redirection to `dashboard` page for role `industry_user`
13. **Expected result**: no JSON errors in the app development server terminal

- Validate `cd client && yarn test`  status is  `pass...` 
- Validate `cd bc_obps && make pythontests `  status is  `pass...` 
- Validate [e2e test](https://github.com/bcgov/cas-registration/actions/runs/8886389694) status is  `pass` 
![image](https://github.com/bcgov/cas-registration/assets/120038448/f5071f39-77ff-485d-9493-0ce19ce3efef)
