### PR TITLE
Fix django sentry when not passing `DEBUG` env variable

### DIFF
--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -172,7 +172,7 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 20000000
 # Only enable sentry in production
 SENTRY_ENVIRONMENT = os.environ.get('SENTRY_ENVIRONMENT')
 SENTRY_TRACE_SAMPLE_RATE = os.environ.get('SENTRY_TRACE_SAMPLE_RATE')
-if SENTRY_ENVIRONMENT == 'prod' and DEBUG == 'False':
+if SENTRY_ENVIRONMENT == 'prod':
     sentry_sdk.init(
         dsn="https://c097ce7d51760bab348fa0608eea9870@o646776.ingest.sentry.io/4506621387407360",
         integrations=[DjangoIntegration()],


### PR DESCRIPTION
**Note:**

Sentry was not able to capture backend errors since we don't pass `DEBUG` env variable in our namespaces. This fix will run the sentry on the backend again.