### PR TITLE
chore: remove --dry-run flag from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,7 @@ install: CHART_DIR=./helm/cas-registration
 install: CHART_INSTANCE=cas-registration
 install: HELM_OPTS=--atomic --wait-for-jobs --timeout 2400s --namespace $(NAMESPACE) \
 										--set defaultImageTag=$(IMAGE_TAG) \
-										--values $(CHART_DIR)/values-$(ENVIRONMENT).yaml \
-										--dry-run
+										--values $(CHART_DIR)/values-$(ENVIRONMENT).yaml
 install:
 	@set -euo pipefail; \
 	helm dep up $(CHART_DIR); \

--- a/helm/cas-registration/templates/backend/job/reset-database.yaml
+++ b/helm/cas-registration/templates/backend/job/reset-database.yaml
@@ -69,6 +69,7 @@ spec:
               psql -c "grant all on schema public to $(APP_USER);";
               psql -c "drop schema erc cascade;";
               psql -c "drop schema erc_history cascade;";
+              psql -c "drop schema common cascade;";
 {{ end }}
 {{- if (hasSuffix "-dev" .Release.Namespace)}}
           command:
@@ -81,6 +82,7 @@ spec:
               psql -c "grant all on schema public to $(APP_USER);";
               psql -c "drop schema erc cascade;";
               psql -c "drop schema erc_history cascade;";
+              psql -c "drop schema common cascade;";
 {{ end }}
       restartPolicy: Never
 {{ end }}


### PR DESCRIPTION
--dry-run flag was added to `make install` target. This caused shipit to only print the manifest on deploy rather than actually deploying