### PR TITLE
test: check that newly created operations are visible

### DIFF
--- a/.github/actions/local-app-run/action.yml
+++ b/.github/actions/local-app-run/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: start backend
       shell: bash
-      run: docker run -d --network=host -e "DB_USER=postgres" -e "DB_NAME=registration" -e "DB_PORT=5432" -e "DB_HOST=localhost" -e "DJANGO_SECRET_KEY=${{ inputs.django_secret_key }}" -e "ALLOWED_HOSTS=localhost,0.0.0.0,127.0.0.1" -e "ENVIRONMENT=develop" ghcr.io/bcgov/cas-reg-backend:${{ github.sha }}
+      run: docker run -d --network=host -e "DB_USER=postgres" -e "DB_NAME=registration" -e "DB_PORT=5432" -e "DB_HOST=localhost" -e "DJANGO_SECRET_KEY=${{ inputs.django_secret_key }}" -e "ALLOWED_HOSTS=localhost,0.0.0.0,127.0.0.1" -e "ENVIRONMENT=develop" -e "CI=true" ghcr.io/bcgov/cas-reg-backend:${{ github.sha }}
     - name: start frontend
       shell: bash
       run: docker run -d --network=host -e "NEXTAUTH_URL_INTERNAL=http://localhost:3000/" -e "NEXTAUTH_URL=http://localhost:3000/" -e "NEXTAUTH_SECRET=${{ inputs.nextauth_secret }}" -e "API_URL=http://127.0.0.1:8000/api/" -e "KEYCLOAK_LOGIN_URL=https://dev.loginproxy.gov.bc.ca/auth/realms/standard" -e "KEYCLOAK_CLIENT_SECRET=${{ inputs.keycloak_client_secret }}" -e "KEYCLOAK_CLIENT_ID=${{ inputs.keycloak_client_id }}" ghcr.io/bcgov/cas-reg-frontend:${{ github.sha }}

--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -30,6 +30,24 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
+# If we're in the CI environment, don't hit Google Cloud Storage
+if os.environ.get('CI', None) == 'true':
+    # Use local file storage for tests
+    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+    MEDIA_ROOT = os.path.join(BASE_DIR, 'test_media/')
+else:
+    # Google Cloud Storage Settings
+    STORAGES = {
+        "default": {"BACKEND": "storages.backends.gcloud.GoogleCloudStorage"},
+        "staticfiles": {"BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"},
+    }
+    GS_BUCKET_NAME = os.environ.get("GS_BUCKET_NAME")
+    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+        GS_CREDENTIALS = service_account.Credentials.from_service_account_file(
+            os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        )
+    GS_FILE_OVERWRITE = False
+
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 
@@ -153,17 +171,6 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-# Google Cloud Storage Settings
-STORAGES = {
-    "default": {"BACKEND": "storages.backends.gcloud.GoogleCloudStorage"},
-    "staticfiles": {"BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"},
-}
-GS_BUCKET_NAME = os.environ.get("GS_BUCKET_NAME")
-if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
-    GS_CREDENTIALS = service_account.Credentials.from_service_account_file(
-        os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-    )
-GS_FILE_OVERWRITE = False
 CORS_ALLOWED_ORIGINS = ["http://localhost:3000"]
 
 DATA_UPLOAD_MAX_MEMORY_SIZE = 20000000

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -51,6 +51,8 @@ class OperationUpdateIn(ModelSchema):
     @field_validator("statutory_declaration")
     @classmethod
     def validate_statutory_declaration(cls, value: str):
+        if ENVIRONMENT == "develop":
+            return None
         if value:
             return data_url_to_file(value)
 

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -4,7 +4,6 @@ from registration.utils import file_to_data_url, data_url_to_file
 from ninja import Field, FilterSchema, ModelSchema, Schema
 from registration.models import Operation, User
 from pydantic import field_validator
-from bc_obps.settings import ENVIRONMENT
 
 
 #### Operation schemas
@@ -91,12 +90,6 @@ class OperationOut(ModelSchema):
 
     @staticmethod
     def resolve_statutory_declaration(obj: Operation):
-        # Using a mock file for e2e testing
-        use_mock_file = ENVIRONMENT == "develop" and not obj.documents.exists() and obj.status == obj.Statuses.APPROVED
-        if use_mock_file:
-            from registration.tests.utils.helpers import mock_file_to_data_url  # to avoid circular import
-
-            return mock_file_to_data_url()
         statutory_declaration = obj.get_statutory_declaration()
         if statutory_declaration:
             return file_to_data_url(statutory_declaration)

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -51,8 +51,6 @@ class OperationUpdateIn(ModelSchema):
     @field_validator("statutory_declaration")
     @classmethod
     def validate_statutory_declaration(cls, value: str):
-        # if CI or ENVIRONMENT == 'develop':
-        #     return None
         if value:
             return data_url_to_file(value)
 

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -51,8 +51,8 @@ class OperationUpdateIn(ModelSchema):
     @field_validator("statutory_declaration")
     @classmethod
     def validate_statutory_declaration(cls, value: str):
-        if ENVIRONMENT == "develop":
-            return None
+        # if CI or ENVIRONMENT == 'develop':
+        #     return None
         if value:
             return data_url_to_file(value)
 

--- a/bc_obps/registration/tests/utils/helpers.py
+++ b/bc_obps/registration/tests/utils/helpers.py
@@ -1,6 +1,5 @@
 import pytest
 import json
-import base64
 from registration.models import (
     Address,
     AppRole,
@@ -155,15 +154,3 @@ class CommonTestSetup:
         )  # Passing _fill_optional to fill all fields with random data
         self.auth_header = {'user_guid': str(self.user.user_guid)}
         self.auth_header_dumps = json.dumps(self.auth_header)
-
-
-def mock_file_to_data_url() -> str:
-    """
-    This util utilizes a mock file to be used in e2e tests
-    NOTE: Only be used in DEBUG mode
-    """
-    mock_pdf_path = "registration/fixtures/mock/mock_file.pdf"
-    with open(mock_pdf_path, "rb") as f:
-        mock_pdf_content = f.read()
-        encoded_content = base64.b64encode(mock_pdf_content).decode("utf-8")
-        return "data:application/pdf;name=" + f.name.split("/")[-1] + ";base64," + encoded_content

--- a/bciers/.gitignore
+++ b/bciers/.gitignore
@@ -34,6 +34,10 @@ yarn-error.log
 testem.log
 /typings
 
+# e2e
+playwright-report
+test-results
+
 # System Files
 .DS_Store
 Thumbs.db

--- a/bciers/apps/registration/e2e/poms/operation.ts
+++ b/bciers/apps/registration/e2e/poms/operation.ts
@@ -197,7 +197,6 @@ export class OperationPOM {
   }
 
   async successfulSubmissionIsVisible() {
-    console.log("$$$CI VARIABLE:", process.env.CI);
     await expect(this.messageBoroIdRequested).toBeVisible();
   }
 

--- a/bciers/apps/registration/e2e/poms/operation.ts
+++ b/bciers/apps/registration/e2e/poms/operation.ts
@@ -197,6 +197,7 @@ export class OperationPOM {
   }
 
   async successfulSubmissionIsVisible() {
+    console.log("$$$CI VARIABLE:", process.env.CI);
     await expect(this.messageBoroIdRequested).toBeVisible();
   }
 

--- a/bciers/apps/registration/e2e/poms/operation.ts
+++ b/bciers/apps/registration/e2e/poms/operation.ts
@@ -197,7 +197,7 @@ export class OperationPOM {
   }
 
   async successfulSubmissionIsVisible() {
-    this.messageBoroIdRequested.isVisible();
+    await expect(this.messageBoroIdRequested).toBeVisible();
   }
 
   async urlIsCorrect() {

--- a/bciers/apps/registration/e2e/poms/operations.ts
+++ b/bciers/apps/registration/e2e/poms/operations.ts
@@ -186,11 +186,6 @@ export class OperationsPOM {
       this.table,
       `[data-field="${TableDataField.NAME}"]:has-text("${operationName}")`,
     );
-    console.log("row is", row);
-    console.log(
-      "link selector",
-      row.getByRole("link", { name: ButtonText.VIEW_DETAILS }),
-    );
     await page.waitForTimeout(5000);
     // Click the `View Detail` for this row
     await row.getByRole("link", { name: ButtonText.VIEW_DETAILS }).click();

--- a/bciers/apps/registration/e2e/poms/operations.ts
+++ b/bciers/apps/registration/e2e/poms/operations.ts
@@ -178,7 +178,23 @@ export class OperationsPOM {
       .all();
     await viewDetailsButtons[index].click();
   }
-
+  async clickViewDetailsButtonByOperationName(
+    page: any,
+    operationName: string,
+  ) {
+    const row = await getTableRowByCellSelector(
+      this.table,
+      `[data-field="${TableDataField.NAME}"]:has-text("${operationName}")`,
+    );
+    console.log("row is", row);
+    console.log(
+      "link selector",
+      row.getByRole("link", { name: ButtonText.VIEW_DETAILS }),
+    );
+    await page.waitForTimeout(5000);
+    // Click the `View Detail` for this row
+    await row.getByRole("link", { name: ButtonText.VIEW_DETAILS }).click();
+  }
   async navigateBack() {
     // Navigate back to the table
     await this.linkOperations.click();

--- a/bciers/apps/registration/e2e/utils/enums.ts
+++ b/bciers/apps/registration/e2e/utils/enums.ts
@@ -162,7 +162,6 @@ export enum Keycloak {
 
 // 🔗 link src
 export enum LinkSrc {
-  PDF_FILE = "mock_file.pdf",
   TILE_REPORT_PROBLEM = "mailto:GHGRegulator@gov.bc.ca",
 }
 

--- a/bciers/apps/registration/e2e/utils/enums.ts
+++ b/bciers/apps/registration/e2e/utils/enums.ts
@@ -246,6 +246,7 @@ export enum UserOperatorUUID {
 export enum TableDataField {
   STATUS = "status",
   BCEID_BUSINESS_NAME = "bceid_business_name",
+  NAME = "name",
 }
 
 export enum OperationTableDataField {

--- a/bciers/apps/registration/e2e/utils/pool.ts
+++ b/bciers/apps/registration/e2e/utils/pool.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as dotenv from "dotenv";
 
 // Resolve the path to the .env file
-const envFilePath = path.resolve(__dirname, "../../../bc_obps/.env");
+const envFilePath = path.resolve(__dirname, "../../../../../bc_obps/.env");
 
 // Load environment variables from the .env file
 dotenv.config({ path: envFilePath });

--- a/bciers/apps/registration/e2e/utils/queries.ts
+++ b/bciers/apps/registration/e2e/utils/queries.ts
@@ -10,7 +10,7 @@ import {
 // ℹ️ Environment variables
 import * as dotenv from "dotenv";
 
-dotenv.config({ path: "./apps/registration/e2e/.env.local" });
+dotenv.config({ path: "./e2e/.env.local" });
 
 /***********************Operator********************************/
 

--- a/bciers/apps/registration/e2e/utils/queries.ts
+++ b/bciers/apps/registration/e2e/utils/queries.ts
@@ -9,7 +9,8 @@ import {
 } from "@/e2e/utils/enums";
 // ℹ️ Environment variables
 import * as dotenv from "dotenv";
-dotenv.config({ path: "./e2e/.env.local" });
+
+dotenv.config({ path: "./apps/registration/e2e/.env.local" });
 
 /***********************Operator********************************/
 

--- a/bciers/apps/registration/e2e/workflows/bceidbusiness/industry_user_admin.spec.ts
+++ b/bciers/apps/registration/e2e/workflows/bceidbusiness/industry_user_admin.spec.ts
@@ -27,6 +27,7 @@ import {
   OperationStatus,
   UserOperatorStatus,
   UserRole,
+  E2EValue,
 } from "@/e2e/utils/enums";
 import happoPlaywright from "happo-playwright";
 
@@ -167,6 +168,16 @@ test.describe("Test Workflow industry_user_admin", () => {
     });
 
     await analyzeAccessibility(page);
+
+    // check that the newly created operation is visible
+    await operationsPage.route();
+    await operationsPage.urlIsCorrect();
+    await operationsPage.tableIsVisible();
+    await operationsPage.clickViewDetailsButtonByOperationName(
+      page,
+      E2EValue.INPUT_OPERATION_NAME,
+    );
+    await operationPage.formIsVisible();
   });
 
   test("Operations Tile View Details workflow", async ({ page }) => {

--- a/bciers/apps/registration/project.json
+++ b/bciers/apps/registration/project.json
@@ -52,6 +52,13 @@
         "command": "happo-e2e -- playwright test --ui"
       }
     },
+    "e2e:report": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/registration",
+        "command": "playwright show-report"
+      }
+    },
     "e2e:sequential": {
       "executor": "nx:run-commands",
       "options": {

--- a/bciers/apps/registration/project.json
+++ b/bciers/apps/registration/project.json
@@ -41,12 +41,14 @@
     "e2e": {
       "executor": "nx:run-commands",
       "options": {
+        "cwd": "apps/registration",
         "command": "happo-e2e -- playwright test"
       }
     },
     "e2e:ui": {
       "executor": "nx:run-commands",
       "options": {
+        "cwd": "apps/registration",
         "command": "happo-e2e -- playwright test --ui"
       }
     },

--- a/bciers/apps/registration/tsconfig.json
+++ b/bciers/apps/registration/tsconfig.json
@@ -21,7 +21,8 @@
     "./**/*",
     "./.happo.js",
     "./.eslintrc.json",
-    "./.next/types/**/*.ts"
+    "./.next/types/**/*.ts",
+    ".next/types/**/*.ts"
   ],
   "exclude": [".next", "node_modules", "jest.config.*"]
 }

--- a/bciers/package.json
+++ b/bciers/package.json
@@ -4,7 +4,9 @@
   "license": "MIT",
   "scripts": {
     "dev": "nx dev reporting",
-    "reg": "nx dev registration"
+    "reg": "nx dev registration",
+    "reg:e2e": "nx run registration:e2e",
+    "reg:e2e:ui": "nx run registration:e2e:ui"
   },
   "private": true,
   "module": "commonjs",

--- a/bciers/package.json
+++ b/bciers/package.json
@@ -6,7 +6,8 @@
     "dev": "nx dev reporting",
     "reg": "nx dev registration",
     "reg:e2e": "nx run registration:e2e",
-    "reg:e2e:ui": "nx run registration:e2e:ui"
+    "reg:e2e:ui": "nx run registration:e2e:ui",
+    "reg:e2e:report": "nx run registration:report"
   },
   "private": true,
   "module": "commonjs",

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -378,10 +378,10 @@ pre-commit run --all-files
 **HTML report**
 The HTML report shows you a report of all your tests that have been ran and on which browsers as well as how long they took. Tests can be filtered by passed tests, failed, flakey or skipped tests. You can also search for a particular test. Clicking on a test will open the detailed view where you can see more information on your tests such as the errors, the test steps and the trace.
 
-For debugging CI, you can download the HTML report artifact found in `GitHub\Actions\Test Registration App\Artifacts\ playwright-report` and extract the files to `client/playwright-report`. To view the downloaded the HTML report artifact locally run terminal command:
+For debugging CI, you can download the HTML report artifact found in `GitHub\Actions\Test Registration App\Artifacts\ playwright-report` and extract the files to `bciers/playwright-report`. To view the downloaded the HTML report artifact locally run terminal command:
 
 ```bash
-cd client && yarn playwright show-report
+cd client && yarn nx run registration:e2e:report
 
 ```
 


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?filterQuery=&pane=issue&itemId=61490241

This PR revealed that the e2e test for creating and submitting an operation wasn't testing everything we thought it was.

This PR:
- steals @marcellmueller's work for getting the e2e tests running locally
- adds an assertion for the confirmation-of-submission message (the line of code we had for this previously was missing the assertion part)
- bypasses GCS when running in CI (so we don't have to set up GCS #718, which is an 8-pointer). @Sepehr-Sobhani and I looked at using a mock file, but it still hits the django endpoint and we get the GCS error
- adds the check that newly created operations are visible as the card describes

Note: most of the happo screenshots are flake; the one that isn't is now showing the confirmation screen instead of an error which is what we want
