### PR TITLE
chore: create placeholder page for API results, add BCeID login

### DIFF
--- a/bciers/apps/reporting/src/app/(authenticated)/authenticated/facilities/Operators.tsx
+++ b/bciers/apps/reporting/src/app/(authenticated)/authenticated/facilities/Operators.tsx
@@ -1,0 +1,19 @@
+import { actionHandler } from "@/app/utils/actions";
+
+async function getOperators() {
+    try {
+      return await actionHandler(
+        "registration/operations",
+        "GET",
+      );
+    } catch (error) {
+      // Handle the error here or rethrow it to handle it at a higher level
+      throw error;
+    }
+  }
+
+export default async function Operators() {
+    const operators = await getOperators();
+
+    return <p>{JSON.stringify(operators.data, null, 2)}</p>;
+}

--- a/bciers/apps/reporting/src/app/(authenticated)/authenticated/facilities/page.tsx
+++ b/bciers/apps/reporting/src/app/(authenticated)/authenticated/facilities/page.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from "react";
+import Loading from "@/app/components/loading/SkeletonForm";
+import Operators from './Operators';
+
+export default async function OperatorsPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <div>
+        <h1>Facilities and operators page</h1>
+        <h2>Operators:</h2>
+        <Operators />
+      </div>
+    </Suspense>
+  );
+}

--- a/bciers/apps/reporting/src/app/(authenticated)/authenticated/page.tsx
+++ b/bciers/apps/reporting/src/app/(authenticated)/authenticated/page.tsx
@@ -1,19 +1,16 @@
+import Link from 'next/link';
 import { Grid } from "@mui/material";
 import { Main } from "@bciers/components/server";
 
 export default function Index() {
   return (
     <Main>
-      <Grid
-        container
-        spacing={2}
-        sx={{
-          marginTop: "24px",
-          marginBottom: "48px",
-        }}
-      >
-        You have been signed in!
-      </Grid>
+        <h1>You have been signed in!</h1>
+        <div>
+          <Link href="/authenticated/facilities">
+            Go to Facilities
+          </Link>
+        </div>
     </Main>
   );
 }

--- a/bciers/apps/reporting/src/app/page.tsx
+++ b/bciers/apps/reporting/src/app/page.tsx
@@ -12,6 +12,10 @@ export default function Index() {
     signIn("keycloak", undefined, { kc_idp_hint: "idir" });
   };
 
+  const handleBceidLogin = () => {
+    signIn("keycloak", undefined, { kc_idp_hint: "bceidbusiness" });
+  };
+
   return (
     <Main>
       <Image src={Logo} alt="testing" width="200" height="43" />
@@ -29,6 +33,14 @@ export default function Index() {
           onClick={handleIdirLogin}
         >
           Log in with IDIR
+        </Button>
+        <div></div>
+        <Button
+          variant="outlined"
+          className="w-full md:max-w-[70%]"
+          onClick={handleBceidLogin}
+        >
+          Log in with Business BCeID
         </Button>
       </Grid>
     </Main>


### PR DESCRIPTION
Recreated this PR off develop after nx migration

card: https://github.com/bcgov/cas-reporting/issues/123

Adding a placeholder page to fetch and display operations and facilities for the user viewing the page. If a user without operators is signed in, the space after operators: will be blank.

To test:

    navigate to /bc_obps/ in the terminal and follow the instructions in /docs/developer-environment-setup.md/ to get it running
    in another terminal run yarn dev from /client/, open on localhost:3000 and sign in using BCeID. Go through first time setup with one of the accounts in the 1password (bc-cas-dev etc)
    in another terminal access the django shell by navigating to /bc_obps/ and running python manage.py shell
    in the django shell, modify the app_role value of your user from before. The commands I used to do this are:

from registration.models import User
from registration.models import AppRole
my_user = User.objects.get(first_name=’cas-dev-three’)
cas_admin_role = ppRole.objects.get(role_name=’cas-admin’)
my_user.app_role = cas_admin_role
my_user.save()

replacing 'cas-dev-three' with whatever your user's first name is. You can check this with the command

[print(”name: “ + user.first_name + “ role: “ + str(user.app_role)) for user in User.objects.all()]

    in another terminal, navigate to /bciers/ and run yarn dev, and open on localhost:3000 (or 3001 if 3000 is in use by /client/). Log in with the same BCeID account. You should be redirected to a welcome page at localhost:3000/dashboard. Click the link to the facilities page. This should display a wall of text with the operator data for this user.