### PR TITLE
Use Sentry Django DSN key instead of NextJS DSN key

### DIFF
--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -181,7 +181,7 @@ SENTRY_ENVIRONMENT = os.environ.get('SENTRY_ENVIRONMENT')
 SENTRY_TRACE_SAMPLE_RATE = os.environ.get('SENTRY_TRACE_SAMPLE_RATE')
 if SENTRY_ENVIRONMENT == 'prod':
     sentry_sdk.init(
-        dsn="https://c097ce7d51760bab348fa0608eea9870@o646776.ingest.sentry.io/4506621387407360",
+        dsn="https://cf402cd8318aab5c911728a16cbf8fcc@o646776.ingest.sentry.io/4506624068026368",
         integrations=[DjangoIntegration()],
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.


### PR DESCRIPTION
**Note:**

A while ago, we mistakenly used the Next.js Sentry DSN key instead of the Django DSN key, causing all Django-related errors to be directed to the Next.js project. Here is the fix for this issue.
