### PR TITLE
Fix happo flake

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -10,4 +10,4 @@ sonar.python.version=3.12
 # Path is relative to the sonar-project.properties file. Defaults to .
 sonar.sources=.
 
-sonar.exclusions=**/Makefile, **/migrations/**, **bc_obps/registration/tests/**, **/bciers/apps/registration/tests/**
+sonar.exclusions=**/Makefile, **/migrations/**, **bc_obps/registration/tests/**, **/bciers/apps/registration/tests/**, **/bciers/apps/registration/e2e/**

--- a/bciers/apps/registration/e2e/utils/enums.ts
+++ b/bciers/apps/registration/e2e/utils/enums.ts
@@ -70,6 +70,7 @@ export enum DataTestID {
   OPERATION_FIELD_TEMPLATE = "field-template-label",
   OPERATION_HEADER_TEMPLATE = "multistep-header-title",
   MODAL = "modal",
+  ARROW_DROPDOWN_ICON = "ArrowDropDownIcon",
 }
 
 // E2E values

--- a/bciers/apps/registration/e2e/utils/helpers.ts
+++ b/bciers/apps/registration/e2e/utils/helpers.ts
@@ -447,3 +447,41 @@ export async function waitForElementToStabilize(page: Page, element: string) {
   const el = await page.$(element);
   await el?.waitForElementState("stable");
 }
+
+// This function can be used instead of `happoPlaywright.screenshot` when experiencing flaky screenshots. It waits for the page to be stable before taking a screenshot.
+export async function takeStabilizedScreenshot(
+  happoPlaywright: any,
+  page: Page,
+  happoArgs: { component: string; variant: string; targets?: string[] },
+) {
+  const { component, variant, targets } = happoArgs;
+  const pageContent = page.locator("html");
+  await waitForElementToStabilize(page, "main");
+  await happoPlaywright.screenshot(page, pageContent, {
+    component,
+    variant,
+    targets,
+  });
+}
+export async function assertCount(
+  elementsToCount: Locator,
+  expectedCount: number,
+) {
+  expect(elementsToCount).toHaveCount(0);
+}
+
+export async function stabilizeGrid(page: Page, expectedRowCount: number) {
+  await tableHasExpectedRowCount(page, expectedRowCount);
+  await assertCount(page.locator(".MuiDataGrid-row:hover"), 0); // on hover, the table row colour changes, creating happo diffs
+}
+export async function stabilizeAccordion(
+  page: Page,
+  expectedArrowDropdownCount: number,
+) {
+  await waitForElementToStabilize(page, "section");
+  const arrowDropDownElements = await page.locator(
+    `[data-testid=${DataTestID.ARROW_DROPDOWN_ICON}]`,
+  );
+  expect(await arrowDropDownElements.count()).toBe(expectedArrowDropdownCount);
+  await waitForElementToStabilize(page, "section");
+}

--- a/bciers/apps/registration/e2e/workflows/bceidbusiness/industry_user.spec.ts
+++ b/bciers/apps/registration/e2e/workflows/bceidbusiness/industry_user.spec.ts
@@ -12,6 +12,8 @@ import { E2EValue, FormField, UserRole } from "@/e2e/utils/enums";
 import {
   analyzeAccessibility,
   setupTestEnvironment,
+  takeStabilizedScreenshot,
+  waitForElementToStabilize,
 } from "@/e2e/utils/helpers";
 dotenv.config({ path: "./e2e/.env.local" });
 const happoPlaywright = require("happo-playwright");
@@ -52,12 +54,12 @@ test.describe("Test Workflow industry_user", () => {
     await selectOperatorPage.urlIsCorrect();
     // 🔍 Assert the form is visible - needed to prevent analyzeAccessibility from failing
     await selectOperatorPage.formIsVisible();
-    // 📷 Cheese!
-    pageContent = page.locator("html");
-    await happoPlaywright.screenshot(page, pageContent, {
+
+    await takeStabilizedScreenshot(happoPlaywright, page, {
       component: "Select operator page",
       variant: "default",
     });
+
     // ♿️ Analyze accessibility
     await analyzeAccessibility(page);
     // 👉 Action search by legal name
@@ -165,8 +167,7 @@ test.describe("Test Workflow industry_user", () => {
     await selectOperatorPage.triggerErrorsFieldRequired();
     // 📷 Cheese!
 
-    pageContent = page.locator("html");
-    await happoPlaywright.screenshot(page, pageContent, {
+    await takeStabilizedScreenshot(happoPlaywright, page, {
       component: "Add a new operator",
       variant: "required errors",
     });
@@ -176,8 +177,8 @@ test.describe("Test Workflow industry_user", () => {
     // 👉 Action trigger form fields format errors
     await selectOperatorPage.triggerErrorsFieldFormat();
     // 📷 Cheese!
-    pageContent = page.locator("html");
-    await happoPlaywright.screenshot(page, pageContent, {
+
+    await takeStabilizedScreenshot(happoPlaywright, page, {
       component: "Add a new operator",
       variant: "format errors",
     });
@@ -196,8 +197,7 @@ test.describe("Test Workflow industry_user", () => {
       FormField.FIELDSET_PARENT_COMPANY_1,
     );
     // 📷 Cheese!
-    pageContent = page.locator("html");
-    await happoPlaywright.screenshot(page, pageContent, {
+    await takeStabilizedScreenshot(happoPlaywright, page, {
       component: "Add a new operator",
       variant: "filled",
     });

--- a/bciers/apps/registration/e2e/workflows/bceidbusiness/industry_user_admin.spec.ts
+++ b/bciers/apps/registration/e2e/workflows/bceidbusiness/industry_user_admin.spec.ts
@@ -15,8 +15,10 @@ import {
   filterTableByFieldId,
   setupTestEnvironment,
   sortTableByColumnLabel,
+  stabilizeGrid,
   tableHasExpectedRowCount,
   tableRowCount,
+  takeStabilizedScreenshot,
 } from "@/e2e/utils/helpers";
 import * as dotenv from "dotenv";
 dotenv.config({ path: "./e2e/.env.local" });
@@ -111,12 +113,12 @@ test.describe("Test Workflow industry_user_admin", () => {
     // 🔍 Assert `Operations` view, table and data reflect role `industry_user_admin`
     await operationsPage.tableIsVisible();
     await operationsPage.tableHasExpectedColumns(UserRole.INDUSTRY_USER_ADMIN);
-    await tableHasExpectedRowCount(page, 14);
-    expect(page.locator(".MuiDataGrid-row:hover")).toHaveCount(0);
     // 📷 Cheese!
-    await happoPlaywright.screenshot(operationPage.page, pageContent, {
+    await stabilizeGrid(page, 14);
+    await takeStabilizedScreenshot(happoPlaywright, operationPage.page, {
       component: "Operation grid",
       variant: UserRole.INDUSTRY_USER_ADMIN,
+      targets: ["chrome", "firefox", "safari"], // this screenshot is flaky in edge
     });
 
     // ♿️ Analyze accessibility

--- a/bciers/apps/registration/e2e/workflows/idir/cas_admin.spec.ts
+++ b/bciers/apps/registration/e2e/workflows/idir/cas_admin.spec.ts
@@ -11,7 +11,9 @@ import {
   setupTestEnvironment,
   tableRowCount,
   waitForElementToStabilize,
-  tableHasExpectedRowCount,
+  takeStabilizedScreenshot,
+  stabilizeGrid,
+  stabilizeAccordion,
 } from "@/e2e/utils/helpers";
 // ☰ Enums
 import {
@@ -66,8 +68,7 @@ test.describe("Test Workflow cas_admin", () => {
         UserRole.CAS_ADMIN,
         TableDataField.STATUS,
       );
-      await tableHasExpectedRowCount(page, 20);
-      expect(page.locator(".MuiDataGrid-row:hover")).toHaveCount(0);
+
       // 📷 Cheese!
       const pageContent = page.locator("html");
       await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
@@ -84,15 +85,8 @@ test.describe("Test Workflow cas_admin", () => {
       await operatorsPage.formHasExpectedUX(UserOperatorStatus.DECLINED);
 
       // 📷 Cheese!
-      let pageContent = page.locator("html");
-      await waitForElementToStabilize(page, "section");
-      const arrowDropDownElements = await page.locator(
-        '[data-testid="ArrowDropDownIcon"]',
-      );
-      expect(await arrowDropDownElements.count()).toBe(2);
-      await waitForElementToStabilize(page, "section");
-
-      await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
+      await stabilizeAccordion(page, 2);
+      await takeStabilizedScreenshot(happoPlaywright, operatorsPage.page, {
         component: "Operators Details Page cas_admin",
         variant: "declined",
       });
@@ -104,9 +98,8 @@ test.describe("Test Workflow cas_admin", () => {
       // 🔍 Assert cas_admin is able to click "View Details" on see detailed info related Approved
       await operatorsPage.formHasExpectedUX(UserOperatorStatus.APPROVED);
       // 📷 Cheese!
-      pageContent = page.locator("html");
-      await waitForElementToStabilize(page, "section");
-      await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
+      await stabilizeAccordion(page, 2);
+      await takeStabilizedScreenshot(happoPlaywright, operatorsPage.page, {
         component: "Operators Details Page cas_admin",
         variant: "approved",
       });
@@ -121,9 +114,8 @@ test.describe("Test Workflow cas_admin", () => {
         "New Operator 5 Legal Name",
       );
       // 📷 Cheese!
-      pageContent = page.locator("html");
-      await waitForElementToStabilize(page, "section");
-      await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
+      await stabilizeAccordion(page, 2);
+      await takeStabilizedScreenshot(happoPlaywright, operatorsPage.page, {
         component: "Operators Details Page cas_admin",
         variant: "pending",
       });
@@ -166,11 +158,9 @@ test.describe("Test Workflow cas_admin", () => {
         UserRole.CAS_ADMIN,
         TableDataField.STATUS,
       );
-      await tableHasExpectedRowCount(page, 20);
-      expect(page.locator(".MuiDataGrid-row:hover")).toHaveCount(0);
       // 📷 Cheese!
-      const pageContent = page.locator("html");
-      await happoPlaywright.screenshot(operationsPage.page, pageContent, {
+      await stabilizeGrid(page, 20);
+      await takeStabilizedScreenshot(happoPlaywright, operationsPage.page, {
         component: "Operations Grid cas_admin",
         variant: "default",
       });
@@ -196,12 +186,7 @@ test.describe("Test Workflow cas_admin", () => {
 
       await operationsPage.formHasExpectedUX(OperationStatus.DECLINED);
       // 📷 Cheese!
-      await waitForElementToStabilize(page, "section");
-      const arrowDropDownElements = await page.locator(
-        '[data-testid="ArrowDropDownIcon"]',
-      );
-      expect(await arrowDropDownElements.count()).toBe(4);
-      await waitForElementToStabilize(page, "section");
+      await stabilizeAccordion(page, 4);
       pageContent = page.locator("html");
       await happoPlaywright.screenshot(operationsPage.page, pageContent, {
         component: "Operations Details Page cas_admin",

--- a/bciers/apps/registration/e2e/workflows/idir/cas_admin.spec.ts
+++ b/bciers/apps/registration/e2e/workflows/idir/cas_admin.spec.ts
@@ -163,6 +163,7 @@ test.describe("Test Workflow cas_admin", () => {
       await takeStabilizedScreenshot(happoPlaywright, operationsPage.page, {
         component: "Operations Grid cas_admin",
         variant: "default",
+        targets: ["chrome", "firefox", "safari"], // edge screenshot is flaky
       });
     });
 

--- a/bciers/apps/registration/e2e/workflows/idir/cas_analyst.spec.ts
+++ b/bciers/apps/registration/e2e/workflows/idir/cas_analyst.spec.ts
@@ -7,7 +7,10 @@ import { OperatorsPOM } from "@/e2e/poms/operators";
 // 🛠️ Helpers
 import {
   setupTestEnvironment,
+  stabilizeAccordion,
+  stabilizeGrid,
   tableHasExpectedRowCount,
+  takeStabilizedScreenshot,
   waitForElementToStabilize,
 } from "@/e2e/utils/helpers";
 // ☰ Enums
@@ -64,9 +67,8 @@ test.describe("Test Workflow cas_analyst", () => {
         UserRole.CAS_ANALYST,
         TableDataField.STATUS,
       );
-      await tableHasExpectedRowCount(page, 20);
-      expect(page.locator(".MuiDataGrid-row:hover")).toHaveCount(0);
       // 📷 Cheese!
+      await stabilizeGrid(page, 20);
       const pageContent = page.locator("html");
       await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
         component: "Operators Grid cas_analyst",
@@ -81,10 +83,8 @@ test.describe("Test Workflow cas_analyst", () => {
       // 🔍 Assert cas_analyst is able to click "View Details" on see detailed info related Declined
       await operatorsPage.formHasExpectedUX(UserOperatorStatus.DECLINED);
       // 📷 Cheese!
-      let pageContent = page.locator("html");
-
-      await waitForElementToStabilize(page, "section");
-      await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
+      await stabilizeAccordion(page, 2);
+      await takeStabilizedScreenshot(happoPlaywright, operatorsPage.page, {
         component: "Operators Details Page cas_analyst",
         variant: "declined",
       });
@@ -96,8 +96,8 @@ test.describe("Test Workflow cas_analyst", () => {
       // 🔍 Assert cas_analyst is able to click "View Details" on see detailed info related Approved
       await operatorsPage.formHasExpectedUX(UserOperatorStatus.APPROVED);
       // 📷 Cheese!
-      pageContent = page.locator("html");
-      await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
+      await stabilizeAccordion(page, 2);
+      await takeStabilizedScreenshot(happoPlaywright, operatorsPage.page, {
         component: "Operators Details Page cas_analyst",
         variant: "approved",
       });
@@ -107,11 +107,13 @@ test.describe("Test Workflow cas_analyst", () => {
       await operatorsPage.tableIsVisible();
 
       // 🔍 Assert cas_analyst is able to click "View Details" on see detailed info related Pending
-      await operatorsPage.formHasExpectedUX(UserOperatorStatus.PENDING);
+      await operatorsPage.formHasExpectedUX(
+        UserOperatorStatus.PENDING,
+        "New Operator 3 Legal Name",
+      );
       // 📷 Cheese!
-      pageContent = page.locator("html");
-
-      await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
+      await stabilizeAccordion(page, 2);
+      await takeStabilizedScreenshot(happoPlaywright, operatorsPage.page, {
         component: "Operators Details Page cas_analyst",
         variant: "pending",
       });
@@ -154,12 +156,9 @@ test.describe("Test Workflow cas_analyst", () => {
         UserRole.CAS_ANALYST,
         TableDataField.STATUS,
       );
-      await tableHasExpectedRowCount(page, 20);
-      expect(page.locator(".MuiDataGrid-row:hover")).toHaveCount(0);
       // 📷 Cheese!
-      const pageContent = page.locator("html");
-
-      await happoPlaywright.screenshot(operationsPage.page, pageContent, {
+      await stabilizeGrid(page, 20);
+      await takeStabilizedScreenshot(happoPlaywright, operationsPage.page, {
         component: "Operations Grid cas_analyst",
         variant: "default",
       });
@@ -172,10 +171,11 @@ test.describe("Test Workflow cas_analyst", () => {
       // 🔍 Assert cas_analyst is able to click "View Details" on each status and see detailed info related to that status
       await operationsPage.formHasExpectedUX(OperationStatus.PENDING);
       // 📷 Cheese!
-      let pageContent = page.locator("html");
-      await happoPlaywright.screenshot(operationsPage.page, pageContent, {
+      await stabilizeAccordion(page, 4);
+      await takeStabilizedScreenshot(happoPlaywright, operationsPage.page, {
         component: "Operations Details Page cas_analyst",
         variant: "pending",
+        targets: ["chrome"], // only taking the shot in chrome because the other browsers are too flaky
       });
       // 🛸 Navigate back
       await operationsPage.navigateBack();
@@ -184,9 +184,8 @@ test.describe("Test Workflow cas_analyst", () => {
 
       await operationsPage.formHasExpectedUX(OperationStatus.DECLINED);
       // 📷 Cheese!
-      pageContent = page.locator("html");
-      await waitForElementToStabilize(page, "section");
-      await happoPlaywright.screenshot(operationsPage.page, pageContent, {
+      await stabilizeAccordion(operationsPage.page, 4);
+      await takeStabilizedScreenshot(happoPlaywright, operationsPage.page, {
         component: "Operations Details Page cas_analyst",
         variant: "declined",
       });

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -322,6 +322,18 @@ If you experience flakiness, you can use the `takeStabilizedScreenshot` function
 
 Additionally, we have two helper functions to stabilize specfic page elements, the grids (`stabilizeGrid`) and accordions (`stabilizeAccordion`).
 
+Additionally additionally, sometimes we were unable to get the screenshots to stabilize. In these cases, we only took the screenshots in the browsers that were stable. For example:
+
+```
+// 📷 Cheese!
+      await stabilizeAccordion(page, 4);
+      await takeStabilizedScreenshot(happoPlaywright, operationsPage.page, {
+        component: "Operations Details Page cas_analyst",
+        variant: "pending",
+        targets: ["chrome"],
+      });
+```
+
 #### Using Happo on your local e2e tests
 
 To view diffs found while running your local e2e tests ask the dev team for access to the Happo dashboard. Add the Happo API key and secret to your .env file. The API key and secret can be found in the Happo dashboard under the Account section.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -318,6 +318,10 @@ await happoPlaywright.screenshot(page, selector, {
 });
 ```
 
+If you experience flakiness, you can use the `takeStabilizedScreenshot` function instead. It contains an assertion to wait for the page to stabilize before taking the shot. See https://playwright.dev/docs/api/class-elementhandle#element-handle-wait-for-element-state for more information about the `stable` state.
+
+Additionally, we have two helper functions to stabilize specfic page elements, the grids (`stabilizeGrid`) and accordions (`stabilizeAccordion`).
+
 #### Using Happo on your local e2e tests
 
 To view diffs found while running your local e2e tests ask the dev team for access to the Happo dashboard. Add the Happo API key and secret to your .env file. The API key and secret can be found in the Happo dashboard under the Account section.


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=61334238

This PR:
- refactors .spec file code to use POMs and helper functions
- adds three stabilization functions to help with flakiness
- there were a couple of the screenshots that were flaky no matter how much stabilization I threw at them. I made sure to leave one screenshot in at least one browser everywhere and put notes about this in the docs