### PR TITLE
1686 2 external operations grid

### DIFF
--- a/bc_obps/registration/api/v2/__init__.py
+++ b/bc_obps/registration/api/v2/__init__.py
@@ -1,2 +1,3 @@
 # ruff: noqa: F401
 from . import sample
+from . import operations

--- a/bc_obps/registration/api/v2/operations.py
+++ b/bc_obps/registration/api/v2/operations.py
@@ -1,0 +1,29 @@
+from typing import Literal, Tuple
+from django.http import HttpRequest
+from registration.api.utils.current_user_utils import get_current_user_guid
+from registration.models import AppRole, UserOperator
+from registration.schema.v2.operation import OperationFilterSchema, OperationPaginatedOut
+from service.operation_service_v2 import OperationService
+from registration.decorators import authorize, handle_http_errors
+from ..router import router
+
+
+from registration.schema.generic import Message
+from ninja.responses import codes_4xx
+from ninja import Query
+from ninja.types import DictStrAny
+
+##### GET #####
+
+
+@router.get("/v2/operations", response={200: OperationPaginatedOut, codes_4xx: Message}, tags=["V2"])
+@authorize(AppRole.get_all_authorized_app_roles(), UserOperator.get_all_industry_user_operator_roles())
+@handle_http_errors()
+def list_operations_v2(
+    request: HttpRequest, filters: OperationFilterSchema = Query(...)
+) -> Tuple[Literal[200], DictStrAny]:
+
+    return 200, OperationService.list_operations(get_current_user_guid(request), filters)
+
+
+#

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -1,0 +1,34 @@
+from typing import List, Optional, Union
+from ninja import Field, FilterSchema, ModelSchema, Schema
+from registration.models import Operation
+
+#### Operation schemas
+
+
+class OperationFilterSchema(FilterSchema):
+    bcghg_id: Optional[str] = None
+    name: Optional[str] = None
+    operator: Optional[str] = None
+    type: Optional[str] = None
+    page: Union[int, float, str] = 1
+    sort_field: Optional[str] = "created_at"
+    sort_order: Optional[str] = "desc"
+
+
+class OperationListOut(ModelSchema):
+    operator: str = Field(..., alias="operator.legal_name")
+
+    class Config:
+        model = Operation
+        model_fields = [
+            'id',
+            'name',
+            'bcghg_id',
+            'type',
+        ]
+        from_attributes = True
+
+
+class OperationPaginatedOut(Schema):
+    data: List[OperationListOut]
+    row_count: int

--- a/bc_obps/registration/tests/endpoints/v2/_operations/test_operations_endpoint.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/test_operations_endpoint.py
@@ -1,0 +1,143 @@
+from model_bakery import baker
+from localflavor.ca.models import CAPostalCodeField
+from registration.models import (
+    NaicsCode,
+    Operation,
+)
+from registration.tests.utils.helpers import CommonTestSetup, TestUtils
+
+from registration.tests.utils.bakers import operator_baker
+from registration.utils import custom_reverse_lazy
+
+baker.generators.add(CAPostalCodeField, TestUtils.mock_postal_code)
+
+fake_timestamp_from_past = '2024-01-09 14:13:08.888903-0800'
+fake_timestamp_from_past_str_format = '%Y-%m-%d %H:%M:%S.%f%z'
+
+
+class TestOperationsEndpoint(CommonTestSetup):
+    endpoint = CommonTestSetup.base_endpoint + "v2/operations"
+
+    # AUTHORIZATION
+
+    # def test_unauthorized_roles_cannot_list_operations_v2(self):
+    #     response = TestUtils.mock_get_with_auth_role(
+    #         self, 'cas_pending', custom_reverse_lazy("list_operations_v2")
+    #     )
+    #     assert response.status_code == 401
+
+    # def test_operations_endpoint_list_operations_v2_paginated(self):
+    #     operator1 = operator_baker()
+    #     baker.make(
+    #         Operation,
+    #         operator_id=operator1.id,
+    #         status=Operation.Statuses.PENDING,
+    #         naics_code=baker.make(NaicsCode, naics_code=123456, naics_description='desc'),
+    #         _quantity=60,
+    #     )
+    #     # Get the default page 1 response
+    #     response = TestUtils.mock_get_with_auth_role(self, "cas_admin")
+    #     assert response.status_code == 200
+    #     response_data = response.json().get('data')
+    #     # save the id of the first paginated response item
+    #     page_1_response_id = response_data[0].get('id')
+    #     assert len(response_data) == PAGE_SIZE
+    #     # Get the page 2 response
+    #     response = TestUtils.mock_get_with_auth_role(
+    #         self, "cas_admin", custom_reverse_lazy('list_operations_v2') + "?page=2&sort_field=created_at&sort_order=desc"
+    #     )
+    #     assert response.status_code == 200
+    #     response_data = response.json().get('data')
+    #     # save the id of the first paginated response item
+    #     page_2_response_id = response_data[0].get('id')
+    #     assert len(response_data) == PAGE_SIZE
+    #     # assert that the first item in the page 1 response is not the same as the first item in the page 2 response
+    #     assert page_1_response_id != page_2_response_id
+
+    #     # Get the page 2 response but with a different sort order
+    #     response = TestUtils.mock_get_with_auth_role(
+    #         self, "cas_admin", custom_reverse_lazy('list_operations_v2') + "?page=2&sort_field=created_at&sort_order=asc"
+    #     )
+    #     assert response.status_code == 200
+    #     response_data = response.json().get('data')
+    #     # save the id of the first paginated response item
+    #     page_2_response_id_reverse = response_data[0].get('id')
+    #     assert len(response_data) == PAGE_SIZE
+    #     # assert that the first item in the page 2 response is not the same as the first item in the page 2 response with reversed order
+    #     assert page_2_response_id != page_2_response_id_reverse
+
+    def test_operations_endpoint_list_operations_v2_with_filter(self):
+        operator1 = operator_baker()
+        operator2 = operator_baker()
+
+        baker.make(
+            Operation,
+            operator_id=operator1.id,
+            name='Springfield Nuclear Power Plant',
+            naics_code=baker.make(NaicsCode, naics_code=123456, naics_description='desc'),
+            type='Gouda',
+            status=Operation.Statuses.PENDING,
+            _quantity=10,
+        )
+        baker.make(
+            Operation,
+            operator_id=operator2.id,
+            name='Krusty Burger',
+            naics_code=baker.make(NaicsCode, naics_code=123456, naics_description='desc'),
+            type='Cheddar',
+            status=Operation.Statuses.PENDING,
+            _quantity=10,
+        )
+        baker.make(
+            Operation,
+            operator_id=operator2.id,
+            name='Kwik-E-Mart',
+            status=Operation.Statuses.DECLINED,
+            bcghg_id=23219990023,
+            naics_code=baker.make(NaicsCode, naics_code=123456, naics_description='desc'),
+            type="Brie",
+        )
+
+        # Get the default page 1 response
+        response = TestUtils.mock_get_with_auth_role(
+            self, "cas_admin", custom_reverse_lazy('list_operations_v2') + "?type=gouda"
+        )
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        assert len(response_data) == 10
+        for item in response_data:
+            assert item.get('type') == 'Gouda'
+
+        # Test with a status filter that doesn't exist
+        response = TestUtils.mock_get_with_auth_role(
+            self, "cas_admin", custom_reverse_lazy('list_operations_v2') + "?type=havarti"
+        )
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        assert len(response_data) == 0
+
+        # Test with a name filter
+        response = TestUtils.mock_get_with_auth_role(
+            self, "cas_admin", custom_reverse_lazy('list_operations_v2') + "?name=kwik-e-mart"
+        )
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        assert len(response_data) == 1
+
+        # Test with a name filter that doesn't exist
+        response = TestUtils.mock_get_with_auth_role(
+            self, "cas_admin", custom_reverse_lazy('list_operations_v2') + "?name=abc"
+        )
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        assert len(response_data) == 0
+
+        # Test with multiple filters
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "cas_admin",
+            custom_reverse_lazy('list_operations_v2') + "?name=kwik&status=dec&bcghg_id=23219990023&type=brie",
+        )
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        assert len(response_data) == 1

--- a/bc_obps/registration/tests/endpoints/v2/_operations/test_operations_endpoint.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/test_operations_endpoint.py
@@ -1,3 +1,4 @@
+from registration.constants import PAGE_SIZE
 from model_bakery import baker
 from localflavor.ca.models import CAPostalCodeField
 from registration.models import (
@@ -20,51 +21,53 @@ class TestOperationsEndpoint(CommonTestSetup):
 
     # AUTHORIZATION
 
-    # def test_unauthorized_roles_cannot_list_operations_v2(self):
-    #     response = TestUtils.mock_get_with_auth_role(
-    #         self, 'cas_pending', custom_reverse_lazy("list_operations_v2")
-    #     )
-    #     assert response.status_code == 401
+    def test_unauthorized_roles_cannot_list_operations_v2(self):
+        response = TestUtils.mock_get_with_auth_role(self, 'cas_pending', custom_reverse_lazy("list_operations_v2"))
+        assert response.status_code == 401
 
-    # def test_operations_endpoint_list_operations_v2_paginated(self):
-    #     operator1 = operator_baker()
-    #     baker.make(
-    #         Operation,
-    #         operator_id=operator1.id,
-    #         status=Operation.Statuses.PENDING,
-    #         naics_code=baker.make(NaicsCode, naics_code=123456, naics_description='desc'),
-    #         _quantity=60,
-    #     )
-    #     # Get the default page 1 response
-    #     response = TestUtils.mock_get_with_auth_role(self, "cas_admin")
-    #     assert response.status_code == 200
-    #     response_data = response.json().get('data')
-    #     # save the id of the first paginated response item
-    #     page_1_response_id = response_data[0].get('id')
-    #     assert len(response_data) == PAGE_SIZE
-    #     # Get the page 2 response
-    #     response = TestUtils.mock_get_with_auth_role(
-    #         self, "cas_admin", custom_reverse_lazy('list_operations_v2') + "?page=2&sort_field=created_at&sort_order=desc"
-    #     )
-    #     assert response.status_code == 200
-    #     response_data = response.json().get('data')
-    #     # save the id of the first paginated response item
-    #     page_2_response_id = response_data[0].get('id')
-    #     assert len(response_data) == PAGE_SIZE
-    #     # assert that the first item in the page 1 response is not the same as the first item in the page 2 response
-    #     assert page_1_response_id != page_2_response_id
+    def test_operations_endpoint_list_operations_v2_paginated(self):
+        operator1 = operator_baker()
+        baker.make(
+            Operation,
+            operator_id=operator1.id,
+            status=Operation.Statuses.PENDING,
+            naics_code=baker.make(NaicsCode, naics_code=123456, naics_description='desc'),
+            _quantity=60,
+        )
+        # Get the default page 1 response
+        response = TestUtils.mock_get_with_auth_role(self, "cas_admin")
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        # save the id of the first paginated response item
+        page_1_response_id = response_data[0].get('id')
+        assert len(response_data) == PAGE_SIZE
+        # Get the page 2 response
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "cas_admin",
+            custom_reverse_lazy('list_operations_v2') + "?page=2&sort_field=created_at&sort_order=desc",
+        )
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        # save the id of the first paginated response item
+        page_2_response_id = response_data[0].get('id')
+        assert len(response_data) == PAGE_SIZE
+        # assert that the first item in the page 1 response is not the same as the first item in the page 2 response
+        assert page_1_response_id != page_2_response_id
 
-    #     # Get the page 2 response but with a different sort order
-    #     response = TestUtils.mock_get_with_auth_role(
-    #         self, "cas_admin", custom_reverse_lazy('list_operations_v2') + "?page=2&sort_field=created_at&sort_order=asc"
-    #     )
-    #     assert response.status_code == 200
-    #     response_data = response.json().get('data')
-    #     # save the id of the first paginated response item
-    #     page_2_response_id_reverse = response_data[0].get('id')
-    #     assert len(response_data) == PAGE_SIZE
-    #     # assert that the first item in the page 2 response is not the same as the first item in the page 2 response with reversed order
-    #     assert page_2_response_id != page_2_response_id_reverse
+        # Get the page 2 response but with a different sort order
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "cas_admin",
+            custom_reverse_lazy('list_operations_v2') + "?page=2&sort_field=created_at&sort_order=asc",
+        )
+        assert response.status_code == 200
+        response_data = response.json().get('data')
+        # save the id of the first paginated response item
+        page_2_response_id_reverse = response_data[0].get('id')
+        assert len(response_data) == PAGE_SIZE
+        # assert that the first item in the page 2 response is not the same as the first item in the page 2 response with reversed order
+        assert page_2_response_id != page_2_response_id_reverse
 
     def test_operations_endpoint_list_operations_v2_with_filter(self):
         operator1 = operator_baker()

--- a/bc_obps/service/operation_service_v2.py
+++ b/bc_obps/service/operation_service_v2.py
@@ -1,0 +1,47 @@
+from typing import Dict, Union
+from uuid import UUID
+from registration.schema.v2.operation import OperationFilterSchema
+from service.data_access_service.user_service import UserDataAccessService
+from service.data_access_service.operation_service import OperationDataAccessService
+from django.db.models import Q
+from django.core.paginator import Paginator
+from ninja import Query
+from registration.models import (
+    Operation,
+)
+from registration.constants import PAGE_SIZE
+
+
+class OperationService:
+    @classmethod
+    def list_operations(
+        cls, user_guid: UUID, filters: OperationFilterSchema = Query(...)
+    ) -> Dict[str, Union[list[Operation], int]]:
+        user = UserDataAccessService.get_by_guid(user_guid)
+        page = filters.page
+        bcghg_id = filters.bcghg_id
+        name = filters.name
+        type = filters.type
+        operator = filters.operator
+        sort_field = filters.sort_field
+        sort_order = filters.sort_order
+        sort_direction = "-" if sort_order == "desc" else ""
+        base_qs = OperationDataAccessService.get_all_operations_for_user(user)
+        list_of_filters = [
+            Q(bcghg_id__icontains=bcghg_id) if bcghg_id else Q(),
+            Q(name__icontains=name) if name else Q(),
+            Q(type__icontains=type) if type else Q(),
+            Q(operator__legal_name__icontains=operator) if operator else Q(),
+        ]
+        qs = base_qs.filter(*list_of_filters).order_by(f"{sort_direction}{sort_field}")
+
+        paginator = Paginator(qs, PAGE_SIZE)
+
+        try:
+            page = paginator.validate_number(page)
+        except Exception:
+            page = 1
+        return {
+            "data": [(operation) for operation in paginator.page(page).object_list],
+            "row_count": paginator.count,
+        }

--- a/bciers/apps/registration/app/components/datagrid/models/operationColumns.ts
+++ b/bciers/apps/registration/app/components/datagrid/models/operationColumns.ts
@@ -7,11 +7,13 @@ const operationColumns = (
   isInternalUser: boolean,
   ActionCell: (params: GridRenderCellParams) => JSX.Element,
 ) => {
-  const columns = [
+  const columns: GridColDef[] = [
     {
       field: "name",
       headerName: "Operation Name",
       width: isInternalUser ? 720 : 320,
+      // Set flex to 1 to make the column take up all the remaining width if user zooms out
+      flex: 1,
     },
     { field: "bcghg_id", headerName: "BC GHG ID", width: 200 },
     { field: "type", headerName: "Operation Type", width: 200 },
@@ -21,10 +23,8 @@ const operationColumns = (
       renderCell: ActionCell,
       sortable: false,
       width: 120,
-      // Set flex to 1 to make the column take up all the remaining width if user zooms out
-      flex: 1,
     },
-  ] as GridColDef[];
+  ];
 
   if (isInternalUser) {
     columns.splice(OPERATOR_COLUMN_INDEX, 0, {

--- a/bciers/apps/registration/app/components/datagrid/models/operationColumns.ts
+++ b/bciers/apps/registration/app/components/datagrid/models/operationColumns.ts
@@ -1,0 +1,40 @@
+import { GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
+import StatusStyleColumnCell from "@bciers/components/datagrid/cells/StatusStyleColumnCell";
+
+export const OPERATOR_COLUMN_INDEX = 1;
+
+const operationColumns = (
+  isInternalUser: boolean,
+  ActionCell: (params: GridRenderCellParams) => JSX.Element,
+) => {
+  const columns = [
+    {
+      field: "name",
+      headerName: "Operation Name",
+      width: isInternalUser ? 720 : 320,
+    },
+    { field: "bcghg_id", headerName: "BC GHG ID", width: 200 },
+    { field: "type", headerName: "Operation Type", width: 200 },
+    {
+      field: "action",
+      headerName: "Action",
+      renderCell: ActionCell,
+      sortable: false,
+      width: 120,
+      // Set flex to 1 to make the column take up all the remaining width if user zooms out
+      flex: 1,
+    },
+  ] as GridColDef[];
+
+  if (isInternalUser) {
+    columns.splice(OPERATOR_COLUMN_INDEX, 0, {
+      field: "operator",
+      headerName: "Operator Legal Name",
+      width: 400,
+    });
+  }
+
+  return columns;
+};
+
+export default operationColumns;

--- a/bciers/apps/registration/app/components/datagrid/models/operationGroupColumns.ts
+++ b/bciers/apps/registration/app/components/datagrid/models/operationGroupColumns.ts
@@ -9,7 +9,7 @@ const operationGroupColumns = (
   isInternalUser: boolean,
   SearchCell: (params: GridColumnGroupHeaderParams) => JSX.Element,
 ) => {
-  const columnGroupModel = [
+  const columnGroupModel: GridColumnGroupingModel = [
     {
       groupId: "bcghg_id",
       headerName: "BC GHG ID",
@@ -35,7 +35,7 @@ const operationGroupColumns = (
       renderHeaderGroup: EmptyGroupCell,
       children: [{ field: "action" }],
     },
-  ] as GridColumnGroupingModel;
+  ];
 
   if (isInternalUser) {
     columnGroupModel.splice(OPERATOR_COLUMN_INDEX, 0, {

--- a/bciers/apps/registration/app/components/datagrid/models/operationGroupColumns.ts
+++ b/bciers/apps/registration/app/components/datagrid/models/operationGroupColumns.ts
@@ -1,0 +1,52 @@
+import {
+  GridColumnGroupHeaderParams,
+  GridColumnGroupingModel,
+} from "@mui/x-data-grid";
+import EmptyGroupCell from "@bciers/components/datagrid/cells/EmptyGroupCell";
+import { OPERATOR_COLUMN_INDEX } from "@/app/components/datagrid/models/operationColumns";
+
+const operationGroupColumns = (
+  isInternalUser: boolean,
+  SearchCell: (params: GridColumnGroupHeaderParams) => JSX.Element,
+) => {
+  const columnGroupModel = [
+    {
+      groupId: "bcghg_id",
+      headerName: "BC GHG ID",
+      renderHeaderGroup: SearchCell,
+      children: [{ field: "bcghg_id" }],
+    },
+    {
+      groupId: "name",
+      headerName: "Operation Name",
+      renderHeaderGroup: SearchCell,
+      children: [{ field: "name" }],
+    },
+    {
+      groupId: "type",
+      headerName: "Operation Type",
+      renderHeaderGroup: SearchCell,
+      children: [{ field: "type" }],
+    },
+
+    {
+      groupId: "action",
+      headerName: "Action",
+      renderHeaderGroup: EmptyGroupCell,
+      children: [{ field: "action" }],
+    },
+  ] as GridColumnGroupingModel;
+
+  if (isInternalUser) {
+    columnGroupModel.splice(OPERATOR_COLUMN_INDEX, 0, {
+      groupId: "operator",
+      headerName: "Operator Legal Name",
+      renderHeaderGroup: SearchCell,
+      children: [{ field: "operator" }],
+    });
+  }
+
+  return columnGroupModel;
+};
+
+export default operationGroupColumns;

--- a/bciers/apps/registration/app/components/operations/OperationDataGrid.tsx
+++ b/bciers/apps/registration/app/components/operations/OperationDataGrid.tsx
@@ -22,8 +22,8 @@ const OperationSearchCell = ({
     const { groupId, headerName } = params;
     return (
       <HeaderSearchCell
-        field={groupId as string}
-        fieldLabel={headerName as string}
+        field={groupId ?? ""}
+        fieldLabel={headerName ?? ""}
         isFocused={lastFocusedField === groupId}
         setLastFocusedField={setLastFocusedField}
       />

--- a/bciers/apps/registration/app/components/operations/OperationDataGrid.tsx
+++ b/bciers/apps/registration/app/components/operations/OperationDataGrid.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import DataGrid from "@bciers/components/datagrid/DataGrid";
+import { GridColumnGroupHeaderParams } from "@mui/x-data-grid";
+import { useSession } from "next-auth/react";
+import OperationsActionCell from "@bciers/components/datagrid/cells/OperationsActionCell";
+import HeaderSearchCell from "@bciers/components/datagrid/cells/HeaderSearchCell";
+import { fetchOperationsPageData } from "./Operations";
+import operationColumns from "../datagrid/models/operationColumns";
+import operationGroupColumns from "../datagrid/models/operationGroupColumns";
+import { OperationRow } from "./types";
+
+const OperationSearchCell = ({
+  lastFocusedField,
+  setLastFocusedField,
+}: {
+  lastFocusedField: string | null;
+  setLastFocusedField: (value: string | null) => void;
+}) => {
+  const RenderCell = (params: GridColumnGroupHeaderParams) => {
+    const { groupId, headerName } = params;
+    return (
+      <HeaderSearchCell
+        field={groupId as string}
+        fieldLabel={headerName as string}
+        isFocused={lastFocusedField === groupId}
+        setLastFocusedField={setLastFocusedField}
+      />
+    );
+  };
+  return RenderCell;
+};
+
+const OperationDataGrid = ({
+  initialData,
+  isInternalUser = false,
+}: {
+  isInternalUser?: boolean;
+  initialData: {
+    rows: OperationRow[];
+    row_count: number;
+  };
+}) => {
+  const [lastFocusedField, setLastFocusedField] = useState<string | null>(null);
+
+  const SearchCell = useMemo(
+    () => OperationSearchCell({ lastFocusedField, setLastFocusedField }),
+    [lastFocusedField, setLastFocusedField],
+  );
+
+  const ActionCell = useMemo(
+    () => OperationsActionCell(!isInternalUser),
+    [!isInternalUser],
+  );
+
+  const columns = useMemo(
+    () => operationColumns(isInternalUser, ActionCell),
+    [ActionCell, isInternalUser],
+  );
+
+  const columnGroup = useMemo(
+    () => operationGroupColumns(isInternalUser, SearchCell),
+    [SearchCell, isInternalUser],
+  );
+
+  return (
+    <DataGrid
+      columns={columns}
+      columnGroupModel={columnGroup}
+      fetchPageData={fetchOperationsPageData}
+      paginationMode="server"
+      initialData={initialData}
+    />
+  );
+};
+
+export default OperationDataGrid;

--- a/bciers/apps/registration/app/components/operations/Operations.tsx
+++ b/bciers/apps/registration/app/components/operations/Operations.tsx
@@ -1,0 +1,74 @@
+import { GridRowsProp } from "@mui/x-data-grid";
+
+import buildQueryParams from "@/app/utils/buildQueryParams";
+import OperationDataGrid from "./OperationDataGrid";
+import { FrontEndRoles } from "@/app/utils/enums";
+import { OperationRow, OperationsSearchParams } from "./types";
+import { actionHandler } from "@/app/utils/actions";
+
+export const formatOperationRows = (rows: GridRowsProp) => {
+  if (!rows) {
+    return;
+  }
+  return rows.map(({ id, operator, name, bcghg_id, type }) => {
+    return {
+      id,
+      name,
+      bcghg_id,
+      operator: operator,
+      type,
+    };
+  });
+};
+
+// 🛠️ Function to fetch operations
+export const fetchOperationsPageData = async (
+  searchParams: OperationsSearchParams,
+) => {
+  try {
+    const queryParams = buildQueryParams(searchParams);
+    // fetch data from server
+    const pageData = await actionHandler(
+      `registration/v2/operations${queryParams}`,
+      "GET",
+      "",
+    );
+    return {
+      rows: formatOperationRows(pageData.data) as OperationRow[],
+      row_count: pageData.row_count,
+    };
+  } catch (error) {
+    throw error;
+  }
+};
+
+// 🧩 Main component
+export default async function Operations({
+  searchParams,
+  role,
+}: {
+  searchParams: OperationsSearchParams;
+  role: FrontEndRoles;
+}) {
+  // Fetch operations data
+  const operations: {
+    rows: OperationRow[];
+    row_count: number;
+  } = await fetchOperationsPageData(searchParams);
+  if (!operations) {
+    return <div>No operations data in database.</div>;
+  }
+
+  const isAuthorizedAdminUser =
+    role?.includes("cas") && !role?.includes("pending");
+
+  // Render the DataGrid component
+  return (
+    <div className="mt-5">
+      <OperationDataGrid
+        initialData={operations}
+        isInternalUser={isAuthorizedAdminUser}
+      />
+    </div>
+  );
+}

--- a/bciers/apps/registration/app/components/operations/Operations.tsx
+++ b/bciers/apps/registration/app/components/operations/Operations.tsx
@@ -6,21 +6,6 @@ import { FrontEndRoles } from "@/app/utils/enums";
 import { OperationRow, OperationsSearchParams } from "./types";
 import { actionHandler } from "@/app/utils/actions";
 
-export const formatOperationRows = (rows: GridRowsProp) => {
-  if (!rows) {
-    return;
-  }
-  return rows.map(({ id, operator, name, bcghg_id, type }) => {
-    return {
-      id,
-      name,
-      bcghg_id,
-      operator: operator,
-      type,
-    };
-  });
-};
-
 // 🛠️ Function to fetch operations
 export const fetchOperationsPageData = async (
   searchParams: OperationsSearchParams,
@@ -34,7 +19,7 @@ export const fetchOperationsPageData = async (
       "",
     );
     return {
-      rows: formatOperationRows(pageData.data) as OperationRow[],
+      rows: pageData.data,
       row_count: pageData.row_count,
     };
   } catch (error) {

--- a/bciers/apps/registration/app/components/operations/OperationsPage.tsx
+++ b/bciers/apps/registration/app/components/operations/OperationsPage.tsx
@@ -1,0 +1,45 @@
+// 🚩 flagging: the shared page route for */operations
+import Link from "next/link";
+import { Button } from "@mui/material";
+import { Suspense } from "react";
+import Loading from "@bciers/components/loading/SkeletonGrid";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { OperationsSearchParams } from "@/app/components/operations/types";
+import Note, {
+  registrationRequestNote,
+} from "@bciers/components/datagrid/Note";
+import Operations from "./Operations";
+
+export default async function OperationsPage({
+  searchParams,
+}: {
+  searchParams: OperationsSearchParams;
+}) {
+  // 👤 Use NextAuth.js hook to get information about the user's session
+  /* When calling from the server-side i.e., in Route Handlers, React Server Components, API routes,
+   * getServerSession requires passing the same object you would pass to NextAuth
+   */
+  const session = await getServerSession(authOptions);
+  const role = session?.user?.app_role;
+  const message = role?.includes("cas")
+    ? "View all the operations, which can be sorted or filtered by operator here."
+    : "View the operations owned by your operator here.";
+
+  return (
+    <>
+      <Note classNames="mb-4 mt-6" message={message} />
+      <h1>Operations</h1>
+      {/* Conditionally render the button based on user's role */}
+      {role?.includes("industry_user") && (
+        <Link href={"/dashboard/operations/create/1"}>
+          <Button variant="contained">Add Operation</Button>
+        </Link>
+      )}
+
+      <Suspense fallback={<Loading />}>
+        <Operations searchParams={searchParams} role={role} />
+      </Suspense>
+    </>
+  );
+}

--- a/bciers/apps/registration/app/components/operations/types.ts
+++ b/bciers/apps/registration/app/components/operations/types.ts
@@ -1,0 +1,18 @@
+export interface OperationRow {
+  id: number;
+  bcghg_id: string;
+  name: string;
+  operator: string;
+  type: string;
+}
+
+export interface OperationsSearchParams {
+  [key: string]: string | number | undefined;
+  bcghg_id?: string;
+  name?: string;
+  operator?: string;
+  page?: number;
+  sort_field?: string;
+  sort_order?: string;
+  type?: string;
+}

--- a/bciers/apps/registration/app/operations/layout.tsx
+++ b/bciers/apps/registration/app/operations/layout.tsx
@@ -1,0 +1,5 @@
+import Main from "@bciers/components/layout/Main";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <Main>{children}</Main>;
+}

--- a/bciers/apps/registration/app/operations/page.tsx
+++ b/bciers/apps/registration/app/operations/page.tsx
@@ -1,0 +1,11 @@
+// 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
+import { OperationsSearchParams } from "@/app/components/operations/types";
+import OperationsPage from "../components/operations/OperationsPage";
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: OperationsSearchParams;
+}) {
+  return <OperationsPage searchParams={searchParams} />;
+}

--- a/bciers/apps/registration1/app/utils/actions.ts
+++ b/bciers/apps/registration1/app/utils/actions.ts
@@ -64,7 +64,9 @@ export async function actionHandler(
         const userGuid =
           token?.user_guid || getUUIDFromEndpoint(endpoint) || "";
         // strip any guid param from endpoint url
-        endpoint = endpoint.replace(`/${userGuid}`, "");
+        if (userGuid) {
+          endpoint = endpoint.replace(`/${userGuid}`, ""); // if there's no userGuid, this replaces slashes
+        }
         // Add user_guid to Django API Authorization header
         const defaultOptions: RequestInit = {
           cache: "no-store", // Default cache option
@@ -80,7 +82,6 @@ export async function actionHandler(
           ...defaultOptions,
           ...options, // Merge the provided options, allowing cache to be overridden
         };
-
         const response = await fetch(
           `${process.env.API_URL}${endpoint}`,
           mergedOptions,

--- a/bciers/apps/registration1/tests/v2/operations/Operations.test.tsx
+++ b/bciers/apps/registration1/tests/v2/operations/Operations.test.tsx
@@ -1,0 +1,106 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import {
+  actionHandler,
+  useRouter,
+  useSearchParams,
+  useSession,
+} from "@bciers/testConfig/mocks";
+import { Session } from "@bciers/testConfig/types";
+import Operations from "apps/registration/app/components/operations/Operations";
+import { FrontEndRoles } from "@/app/utils/enums";
+
+useRouter.mockReturnValue({
+  query: {},
+  replace: vi.fn(),
+});
+
+useSearchParams.mockReturnValue({
+  get: vi.fn(),
+});
+
+const mockResponse = {
+  data: [
+    {
+      id: 1,
+      operator: "FakeOperator",
+      name: "Operation 1",
+      bcghg_id: "1-211113-0001",
+      type: "Single Facility Operation",
+    },
+    {
+      id: 2,
+      operator: "FakeOperator",
+      name: "Operation 2",
+      bcghg_id: "2",
+      type: "Linear Facility Operation",
+    },
+  ],
+  row_count: 2,
+};
+
+describe("Operations component", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    actionHandler.mockReturnValue(mockResponse);
+  });
+  it("renders the Operations grid for external users", async () => {
+    render(
+      await Operations({ searchParams: {}, role: FrontEndRoles.INDUSTRY_USER }),
+    );
+
+    // correct headers
+    expect(
+      screen.getByRole("columnheader", { name: "Operation Name" }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("columnheader", { name: "Operator Legal Name" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Operation Type" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("columnheader", { name: "BC GHG ID" }),
+    ).toBeVisible();
+    expect(screen.getByRole("columnheader", { name: "Action" })).toBeVisible();
+
+    // Check data displays
+    expect(screen.getByText(/Operation 1/i)).toBeVisible();
+    expect(screen.queryAllByText(/FakeOperator/i)).toHaveLength(0);
+    expect(screen.getByText(/1-211113-0001/i)).toBeVisible();
+    expect(screen.getAllByText(/Single Facility Operation/i)).toHaveLength(1);
+    expect(screen.getAllByRole("link", { name: /View Details/i })).toHaveLength(
+      2,
+    );
+  });
+
+  it("renders the Operations grid for internal users", async () => {
+    render(
+      await Operations({ searchParams: {}, role: FrontEndRoles.CAS_ADMIN }),
+    );
+
+    // correct headers
+    expect(
+      screen.getByRole("columnheader", { name: "Operation Name" }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("columnheader", { name: "Operator Legal Name" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("columnheader", { name: "Operation Type" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("columnheader", { name: "BC GHG ID" }),
+    ).toBeVisible();
+    expect(screen.getByRole("columnheader", { name: "Action" })).toBeVisible();
+
+    // Check data displays
+    expect(screen.getByText(/Operation 1/i)).toBeVisible();
+    expect(screen.queryAllByText(/FakeOperator/i)).toHaveLength(2);
+    expect(screen.getByText(/1-211113-0001/i)).toBeVisible();
+    expect(screen.getAllByText(/Single Facility Operation/i)).toHaveLength(1);
+    expect(screen.getAllByRole("link", { name: /View Details/i })).toHaveLength(
+      2,
+    );
+  });
+});


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=64781153

This one can't be fully completed until we have auth (can't confirm that only the allowed people can see stuff), so I'll do a follow up PR later.

This PR:
- new v2 operations endpoint to retrieve the p2 data
- new v2 schemas
- tests for ^
- new `page.tsx` file for p2
- new FE p2 files that handle operation grid columns. This resulted in new front-end components because I had to update the imports all the way up to the `page.tsx` file
- new version of the existing unit tests (coverage wasn't great, we have an epic to add more: https://github.com/bcgov/cas-registration/milestone/4)
- handles the internal grid as well because it ended up having almost the same requirements as the external one

Notes:
- there are some VS code errors related to not having auth but they don't seem to be breaking the build like TS errors, I'll address them in the follow up PR if they persist
- the operations page doesn't have the button/note because that's conditional on role (and related to auth). Again, if it still looks weirdly spaced after auth is in I'll address in the follow up
- test imports aren't working well atm so I put the tests in v1. Also to be addressed in follow up PR. Some work on this in commit  841d268894745f3195dcec82360f0fdc66ad677c, but will likely be solved by the auth pr)

Since we don't have auth yet, to test this PR you need to make a few temporary changes locally:
- in `bc_obps/registration/api/v2/operations.py`, comment out the `@authorize` decorator
- replace the return line with `return 200, OperationService.list_operations('ba2ba62a-1218-42e0-942a-ab9e92ce8822', filters)` (this is the uuid of bc-cas-dev in the fixtures)
- in `bciers/apps/registration1/app/utils/getUUIDFromEndpoint.ts`, add `"registration/v2/operations",` to the allow list

