### PR TITLE
1322 confirmation message

### DIFF
--- a/bciers/apps/registration1/app/components/operations/OperationsForm.tsx
+++ b/bciers/apps/registration1/app/components/operations/OperationsForm.tsx
@@ -41,13 +41,14 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
 
   // used as href query parameter for breadcrumb toggle of UUID segment to a title segment
   let paramTitle = "Create";
-  return (
-    <>
-      {operationName ? (
-        <section
-          data-testid="operation-boro-id-message"
-          className="w-full text-center text-2xl mt-20"
-        >
+
+  const confirmationMessage = (
+    <section
+      data-testid="operation-boro-id-message"
+      className="w-full text-center text-2xl mt-20"
+    >
+      {!formData?.bc_obps_regulated_operation ? (
+        <>
           <p>
             Your application for the B.C. OBPS Regulated Operation ID for{" "}
             <b>{operationName}</b> has been received.
@@ -60,14 +61,27 @@ export default function OperationsForm({ formData, schema }: Readonly<Props>) {
           <p>
             <Link href="#">Have not received the confirmation email yet?</Link>
           </p>
-          <Link
-            className="m-auto link-button-blue"
-            href="/dashboard/operations"
-            aria-label="Return to Operations List"
-          >
-            Return to Operations List{" "}
-          </Link>
-        </section>
+        </>
+      ) : (
+        <>
+          <p>Your changes have been saved.</p>
+        </>
+      )}
+
+      <Link
+        className="m-auto link-button-blue"
+        href="/dashboard/operations"
+        aria-label="Return to Operations List"
+      >
+        Return to Operations List{" "}
+      </Link>
+    </section>
+  );
+
+  return (
+    <>
+      {operationName ? (
+        confirmationMessage
       ) : (
         <MultiStepFormBase
           baseUrl={`/dashboard/operations/${operationId}`}

--- a/bciers/apps/registration1/tests/components/form/OperationsForm.test.tsx
+++ b/bciers/apps/registration1/tests/components/form/OperationsForm.test.tsx
@@ -138,7 +138,7 @@ describe("Operations component", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows the success message when operationName is defined", async () => {
+  it("shows the received message when operationName is defined", async () => {
     useParams.mockReturnValue({
       formSection: "3",
       operation: "test-id",
@@ -166,6 +166,41 @@ describe("Operations component", () => {
           (_, element) =>
             element?.textContent ===
             "Your application for the B.C. OBPS Regulated Operation ID for Operation 1 has been received.",
+        ),
+      ).toBeVisible();
+    });
+  });
+
+  it("shows the saved message when an operation that already has a BORO ID and is updated", async () => {
+    useParams.mockReturnValue({
+      formSection: "3",
+      operation: "test-id",
+    } as QueryParams);
+
+    render(
+      <OperationsForm
+        schema={testOperationSchema}
+        formData={{ ...mockFormData, bc_obps_regulated_operation: "21-0005" }}
+      />,
+    );
+
+    const submitButton = screen.getByText(/Submit/i);
+
+    act(() => {
+      submitButton.click();
+      actionHandler.mockReturnValueOnce({
+        id: "025328a0-f9e8-4e1a-888d-aa192cb053db",
+        name: "Operation 1",
+        error: null,
+      });
+    });
+
+    // Get the success message using the text content since it returns broken up text error
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.textContent === "Your changes have been saved.",
         ),
       ).toBeVisible();
     });


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=59180231

This PR:
- shows a different confirmation message if the operation already has a BORO ID
- no changes needed to the email service--emails were already being sent conditionally based on application status (see cas-registration/bc_obps/service/operation_service.py)

To test:
- Make a new operation. You should get the original message.
- Edit an approved operation. You should get the new message.