### PR TITLE
fix: terraform job's template to be time-bound

### DIFF
--- a/helm/cas-registration/templates/backend/job/terraform-apply.yaml
+++ b/helm/cas-registration/templates/backend/job/terraform-apply.yaml
@@ -9,12 +9,12 @@ metadata:
     "helm.sh/hook": pre-install, pre-upgrade
 spec:
   backoffLimit: 0
-  activeDeadlineSeconds: 900
   parallelism: 1
   completions: 1
   template:
     spec:
       serviceAccountName: "terraform-kubernetes-service-account"
+      activeDeadlineSeconds: 600
       containers:
         - name: terraform-apply
           resources: {{ toYaml .Values.devops.resources | nindent 12 }}


### PR DESCRIPTION
Fix to address the issue identified by Sepehr in the Terraform Job deployment. _Should_ have been counted against time-based quota rather than long-running.