### PR TITLE
testing: e2e flaky matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -308,9 +308,9 @@ jobs:
           - project: chromium
             os: ubuntu-latest
             cache_dir: ~/.cache/ms-playwright
-          - project: firefox
-            os: ubuntu-latest
-            cache_dir: ~/.cache/ms-playwright
+          # - project: firefox
+          #   os: ubuntu-latest
+          #   cache_dir: ~/.cache/ms-playwright
           # Commented out because of flakey issues with webkit in CI
           # - project: webkit
           #   os: macos-latest
@@ -336,8 +336,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.project }}-ms-playwright-registration
 
       - name: 📥 install Playwright ${{ matrix.project }}
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps ${{ matrix.project }}
+        run: npx playwright install --with-deps
         working-directory: ./bciers/apps/registration1
 
       - name: 🎭 Run Playwright Tests

--- a/bciers/apps/registration1/playwright.config.ts
+++ b/bciers/apps/registration1/playwright.config.ts
@@ -43,10 +43,10 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
       },
     },
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
+    // {
+    //   name: "firefox",
+    //   use: { ...devices["Desktop Firefox"] },
+    // },
     // {
     //   name: "webkit",
     //   use: { ...devices["Desktop Safari"] },


### PR DESCRIPTION
We commented out the Webkit tests since they kept flaking out and now Firefox e2e test is intermittently failing. This is just a test PR to see if disabling Firefox will fix anything or if Chromium will be flakey -  perhaps something to do with finalizing the test matrix. 

Will try and re-run CI multiple times.