### PR TITLE
fix: docker build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,9 @@ helm/**/charts
 !.yarn/sdks
 !.yarn/versions
 
-
 # JetBrains
 .idea/
+
+# Vite(st) temporary config files
+vite.config.**s.timestamp-*
+vitest.config.**s.timestamp-*

--- a/bciers/.gitignore
+++ b/bciers/.gitignore
@@ -60,3 +60,7 @@ out
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Vite(st) temporary config files
+vite.config.**s.timestamp-*
+vitest.config.**s.timestamp-*

--- a/bciers/.nxignore
+++ b/bciers/.nxignore
@@ -1,5 +1,3 @@
-node_modules
-
 # Vite(st) temporary config files
 vite.config.**s.timestamp-*
 vitest.config.**s.timestamp-*

--- a/bciers/.prettierignore
+++ b/bciers/.prettierignore
@@ -2,3 +2,7 @@
 /dist
 /coverage
 /.nx/cache
+
+# Vite(st) temporary config files
+vite.config.**s.timestamp-*
+vitest.config.**s.timestamp-*

--- a/bciers/apps/registration/Dockerfile
+++ b/bciers/apps/registration/Dockerfile
@@ -18,10 +18,11 @@ ENTRYPOINT ["dumb-init", "--"]
 ENV NODE_ENV production
 ENV PORT 3000
 WORKDIR /usr/src/app
-COPY --from=deps --chown=node:node /usr/src/app/node_modules node_modules
-COPY --from=deps --chown=node:node /usr/src/app/package.json package.json
-COPY --chown=node:node ./public ./public
+COPY --from=deps /usr/src/app/node_modules node_modules
+COPY --from=deps /usr/src/app/package.json package.json
+COPY ./public ./public
 COPY --chown=node:node ./.next ./.next
+
 USER node
 EXPOSE 3000
 # COPY --chown=node:node ./tools/scripts/entrypoints/api.sh /usr/local/bin/docker-entrypoint.sh

--- a/bciers/apps/registration/Dockerfile
+++ b/bciers/apps/registration/Dockerfile
@@ -1,8 +1,7 @@
 # Install dependencies only when needed
 FROM docker.io/node:20.11 as deps
 WORKDIR /usr/src/app
-COPY ./package*.json ./
-RUN corepack enable
+COPY ./package.json ./
 RUN corepack enable
 RUN yarn set version 4.2.0
 # Force Yarn to use standard node-modules folder

--- a/bciers/apps/registration1/Dockerfile
+++ b/bciers/apps/registration1/Dockerfile
@@ -3,6 +3,7 @@ FROM docker.io/node:20.11 as deps
 WORKDIR /usr/src/app
 COPY ./package.json .
 RUN corepack enable
+RUN yarn set version 4.2.0
 # Force Yarn to use standard node-modules folder
 RUN echo 'nodeLinker: "node-modules"' >> ./.yarnrc.yml
 RUN yarn install

--- a/bciers/apps/registration1/Dockerfile
+++ b/bciers/apps/registration1/Dockerfile
@@ -18,9 +18,9 @@ ENTRYPOINT ["dumb-init", "--"]
 ENV NODE_ENV production
 ENV PORT 3000
 WORKDIR /usr/src/app
-COPY --from=deps --chown=node:node /usr/src/app/node_modules node_modules
-COPY --from=deps --chown=node:node /usr/src/app/package.json package.json
-COPY --chown=node:node ./public ./public
+COPY --from=deps /usr/src/app/node_modules node_modules
+COPY --from=deps /usr/src/app/package.json package.json
+COPY ./public ./public
 COPY --chown=node:node ./.next ./.next
 
 USER node

--- a/bciers/apps/registration1/Dockerfile
+++ b/bciers/apps/registration1/Dockerfile
@@ -1,9 +1,11 @@
 # Install dependencies only when needed
 FROM docker.io/node:20.11 as deps
 WORKDIR /usr/src/app
-COPY ./package*.json ./
+COPY ./package.json .
 RUN corepack enable
-RUN yarn install --immutable --production==false --ignore-scripts
+# Force Yarn to use standard node-modules folder
+RUN echo 'nodeLinker: "node-modules"' >> ./.yarnrc.yml
+RUN yarn install
 
 # Production image, copy all the files and run next
 FROM docker.io/node:20.11 as runner
@@ -15,11 +17,11 @@ ENTRYPOINT ["dumb-init", "--"]
 ENV NODE_ENV production
 ENV PORT 3000
 WORKDIR /usr/src/app
-COPY --from=deps /usr/src/app/node_modules ./node_modules
-COPY --from=deps /usr/src/app/package.json ./package.json
-COPY ./public ./public
-COPY ./.next ./.next
-RUN chown -R node:node .
+COPY --from=deps --chown=node:node /usr/src/app/node_modules node_modules
+COPY --from=deps --chown=node:node /usr/src/app/package.json package.json
+COPY --chown=node:node ./public ./public
+COPY --chown=node:node ./.next ./.next
+
 USER node
 EXPOSE 3000
 # COPY --chown=node:node ./tools/scripts/entrypoints/api.sh /usr/local/bin/docker-entrypoint.sh

--- a/bciers/apps/registration1/project.json
+++ b/bciers/apps/registration1/project.json
@@ -10,7 +10,8 @@
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "dev",
       "options": {
-        "outputPath": "dist/registration1"
+        "outputPath": "dist/registration1",
+        "generateLockfile": true
       }
     },
     "start": {

--- a/bciers/apps/reporting/Dockerfile
+++ b/bciers/apps/reporting/Dockerfile
@@ -3,6 +3,7 @@ FROM docker.io/node:20.11 as deps
 WORKDIR /usr/src/app
 COPY ./package.json .
 RUN corepack enable
+RUN yarn set version 4.2.0
 # Force Yarn to use standard node-modules folder
 RUN echo 'nodeLinker: "node-modules"' >> ./.yarnrc.yml
 RUN yarn install

--- a/bciers/apps/reporting/Dockerfile
+++ b/bciers/apps/reporting/Dockerfile
@@ -18,9 +18,9 @@ ENTRYPOINT ["dumb-init", "--"]
 ENV NODE_ENV production
 ENV PORT 3000
 WORKDIR /usr/src/app
-COPY --from=deps --chown=node:node /usr/src/app/node_modules node_modules
-COPY --from=deps --chown=node:node /usr/src/app/package.json package.json
-COPY --chown=node:node ./public ./public
+COPY --from=deps /usr/src/app/node_modules node_modules
+COPY --from=deps /usr/src/app/package.json package.json
+COPY ./public ./public
 COPY --chown=node:node ./.next ./.next
 
 USER node

--- a/bciers/apps/reporting/Dockerfile
+++ b/bciers/apps/reporting/Dockerfile
@@ -1,9 +1,11 @@
 # Install dependencies only when needed
 FROM docker.io/node:20.11 as deps
 WORKDIR /usr/src/app
-COPY ./package*.json ./
+COPY ./package.json .
 RUN corepack enable
-RUN yarn install --immutable --production==false --ignore-scripts
+# Force Yarn to use standard node-modules folder
+RUN echo 'nodeLinker: "node-modules"' >> ./.yarnrc.yml
+RUN yarn install
 
 # Production image, copy all the files and run next
 FROM docker.io/node:20.11 as runner
@@ -15,11 +17,11 @@ ENTRYPOINT ["dumb-init", "--"]
 ENV NODE_ENV production
 ENV PORT 3000
 WORKDIR /usr/src/app
-COPY --from=deps /usr/src/app/node_modules ./node_modules
-COPY --from=deps /usr/src/app/package.json ./package.json
-COPY ./public ./public
-COPY ./.next ./.next
-RUN chown -R node:node .
+COPY --from=deps --chown=node:node /usr/src/app/node_modules node_modules
+COPY --from=deps --chown=node:node /usr/src/app/package.json package.json
+COPY --chown=node:node ./public ./public
+COPY --chown=node:node ./.next ./.next
+
 USER node
 EXPOSE 3000
 # COPY --chown=node:node ./tools/scripts/entrypoints/api.sh /usr/local/bin/docker-entrypoint.sh

--- a/bciers/apps/reporting/project.json
+++ b/bciers/apps/reporting/project.json
@@ -15,7 +15,8 @@
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "dev",
       "options": {
-        "outputPath": "dist/reporting"
+        "outputPath": "dist/reporting",
+        "generateLockfile": true
       }
     },
     "container": {


### PR DESCRIPTION
Addresses build issues in Dockerfiles. Yarn was not pulling files as expected, defaulting to PnP rather than the module folder. 

## Changes 🚧

- Adds any vitest config ephemeral files to `ignore` files.
- Enforce `node_modules` for Yarn in docker build files.

## To test 🔬

- You can run `yarn nx run registration1:container`, while Docker is running, and ensure the build of the container completes.