### PR TITLE
273 Pathing fix

### DIFF
--- a/bciers/Dockerfile
+++ b/bciers/Dockerfile
@@ -11,6 +11,9 @@ RUN yarn install
 # Production image, copy all the files and run next
 FROM docker.io/node:20.15 AS runner
 
+# nx/nextjs builds some files into subfolders based on project name. For a unified container, we supply the project name as a path.
+ARG application_path
+
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 ENTRYPOINT ["dumb-init", "--"]
@@ -20,8 +23,9 @@ ENV PORT 3000
 WORKDIR /usr/src/app
 COPY --from=deps /usr/src/app/node_modules node_modules
 COPY --from=deps /usr/src/app/package.json package.json
+COPY ./.next/standalone .
 COPY ./public ./public
-COPY --chown=node:node ./.next ./.next
+COPY ./.next/static ./dist/${application_path}/.next/static
 
 USER node
 EXPOSE 3000
@@ -31,4 +35,8 @@ EXPOSE 3000
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry.
 ENV NEXT_TELEMETRY_DISABLED 1
-CMD ["node_modules/.bin/next", "start"]
+
+# Add an ENV to preserve the build ARG
+ENV app_server=apps/${application_path}/server.js
+
+CMD node ${app_server}

--- a/bciers/apps/dashboard/next.config.js
+++ b/bciers/apps/dashboard/next.config.js
@@ -41,6 +41,7 @@ const nextConfig = {
       ...localRoutes,
     ];
   },
+  output: "standalone",
   nx: {
     // Set this to true if you would like to use SVGR
     // See: https://github.com/gregberge/svgr

--- a/bciers/apps/dashboard/next.config.js
+++ b/bciers/apps/dashboard/next.config.js
@@ -5,11 +5,14 @@ const { composePlugins, withNx } = require("@nx/next");
 
 // The hosts are only available at build time. Routing locally is handled by Next.js while routing on OpenShift is handled by ingress rules.
 const { HOST_REGISTRATION, HOST_REPORTING } = process.env;
+// Next.js doesn't use TS's paths, so we need to use the relative path
+const nextConfigBase = require("../../next.config.base");
 
 /**
  * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
  **/
 const nextConfig = {
+  ...nextConfigBase,
   async rewrites() {
     const localRoutes =
       HOST_REGISTRATION && HOST_REPORTING
@@ -41,7 +44,6 @@ const nextConfig = {
       ...localRoutes,
     ];
   },
-  output: "standalone",
   nx: {
     // Set this to true if you would like to use SVGR
     // See: https://github.com/gregberge/svgr

--- a/bciers/apps/dashboard/project.json
+++ b/bciers/apps/dashboard/project.json
@@ -27,6 +27,7 @@
         "engine": "docker",
         "context": "dist/dashboard",
         "file": "Dockerfile",
+        "build-args": ["application_path=dashboard"],
         "tags": ["cas-dashboard:latest"]
       }
     },

--- a/bciers/apps/registration/next.config.js
+++ b/bciers/apps/registration/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
   ...nextConfigBase,
   // To deploy a Next.js application under a sub-path of a domain you can use the basePath config option
   basePath: "/registration",
+  assetPrefix: "/registration/",
   reactStrictMode: true,
   swcMinify: true,
   //use modularizeImports properties to optimize the imports in the application

--- a/bciers/apps/registration/next.config.js
+++ b/bciers/apps/registration/next.config.js
@@ -24,7 +24,6 @@ const nextConfig = {
       bodySizeLimit: "20mb",
     },
   },
-  output: "standalone",
   nx: {
     // Set this to true if you would like to use SVGR
     // See: https://github.com/gregberge/svgr

--- a/bciers/apps/registration/next.config.js
+++ b/bciers/apps/registration/next.config.js
@@ -24,6 +24,7 @@ const nextConfig = {
       bodySizeLimit: "20mb",
     },
   },
+  output: "standalone",
   nx: {
     // Set this to true if you would like to use SVGR
     // See: https://github.com/gregberge/svgr

--- a/bciers/apps/registration/project.json
+++ b/bciers/apps/registration/project.json
@@ -40,6 +40,7 @@
         "engine": "docker",
         "context": "dist/registration",
         "file": "Dockerfile",
+        "build-args": ["application_path=registration"],
         "tags": ["cas-registration:latest"]
       }
     },

--- a/bciers/apps/reporting/next.config.js
+++ b/bciers/apps/reporting/next.config.js
@@ -13,7 +13,6 @@ const nextConfig = {
   // To deploy a Next.js application under a sub-path of a domain you can use the basePath config option
   basePath: "/reporting",
   assetPrefix: "/reporting/",
-  output: "standalone",
   nx: {
     // Set this to true if you would like to use SVGR
     // See: https://github.com/gregberge/svgr

--- a/bciers/apps/reporting/next.config.js
+++ b/bciers/apps/reporting/next.config.js
@@ -12,6 +12,7 @@ const nextConfig = {
   ...nextConfigBase,
   // To deploy a Next.js application under a sub-path of a domain you can use the basePath config option
   basePath: "/reporting",
+  assetPrefix: "/reporting/",
   nx: {
     // Set this to true if you would like to use SVGR
     // See: https://github.com/gregberge/svgr

--- a/bciers/apps/reporting/next.config.js
+++ b/bciers/apps/reporting/next.config.js
@@ -13,6 +13,7 @@ const nextConfig = {
   // To deploy a Next.js application under a sub-path of a domain you can use the basePath config option
   basePath: "/reporting",
   assetPrefix: "/reporting/",
+  output: "standalone",
   nx: {
     // Set this to true if you would like to use SVGR
     // See: https://github.com/gregberge/svgr

--- a/bciers/apps/reporting/project.json
+++ b/bciers/apps/reporting/project.json
@@ -27,6 +27,7 @@
         "engine": "docker",
         "context": "dist/reporting",
         "file": "Dockerfile",
+        "build-args": ["application_path=reporting"],
         "tags": ["cas-reporting:latest"]
       }
     },

--- a/bciers/next.config.base.js
+++ b/bciers/next.config.base.js
@@ -2,6 +2,7 @@
 module.exports = {
   reactStrictMode: true,
   swcMinify: true,
+  output: "standalone",
   //use modularizeImports properties to optimize the imports in the application
   modularizeImports: {
     "@mui/icons-material": {

--- a/helm/cas-bciers/templates/common/frontend-env-configmap.yaml
+++ b/helm/cas-bciers/templates/common/frontend-env-configmap.yaml
@@ -4,8 +4,6 @@ metadata:
   name: {{ template "cas-bciers.fullname" . }}-frontend-env-configmap
 data:
   API_URL: http://{{ include "cas-bciers.fullname" . }}-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.backend.service.port }}/api/
-  HOST_REGISTRATION: http://{{ include "cas-bciers.fullname" . }}-frontend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.registrationFrontend.service.port }}
-  HOST_REPORTING: http://{{ include "cas-bciers.fullname" . }}-frontend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.reportingFrontend.service.port }}
   KEYCLOAK_AUTH_URL: {{ .Values.dashboardFrontend.auth.keycloakAuthUrl }}
   KEYCLOAK_REALMS: {{ .Values.dashboardFrontend.auth.keycloakRealms }}
   KEYCLOAK_OIDC: {{ .Values.dashboardFrontend.auth.keycloakOidc }}

--- a/helm/cas-bciers/templates/registration/route.yaml
+++ b/helm/cas-bciers/templates/registration/route.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "cas-bciers.labels" . | indent 4 }}
   annotations:
     haproxy.router.openshift.io/balance: roundrobin
-    haproxy.router.openshift.io/rewrite-target: /
+    haproxy.router.openshift.io/rewrite-target: {{ .Values.registrationFrontend.route.path }}
 
 spec:
   host: {{ .Values.registrationFrontend.route.host }}

--- a/helm/cas-bciers/templates/reporting/route.yaml
+++ b/helm/cas-bciers/templates/reporting/route.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "cas-bciers.labels" . | indent 4 }}
   annotations:
     haproxy.router.openshift.io/balance: roundrobin
-    haproxy.router.openshift.io/rewrite-target: {{ .Values.registrationFrontend.route.path }}
+    haproxy.router.openshift.io/rewrite-target: {{ .Values.reportingFrontend.route.path }}
 
 spec:
   host: {{ .Values.reportingFrontend.route.host }}

--- a/helm/cas-bciers/templates/reporting/route.yaml
+++ b/helm/cas-bciers/templates/reporting/route.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "cas-bciers.labels" . | indent 4 }}
   annotations:
     haproxy.router.openshift.io/balance: roundrobin
-    haproxy.router.openshift.io/rewrite-target: /
+    haproxy.router.openshift.io/rewrite-target: {{ .Values.registrationFrontend.route.path }}
 
 spec:
   host: {{ .Values.reportingFrontend.route.host }}


### PR DESCRIPTION
Addresses final part of bcgov/cas-reporting#273. Ensure that the Registration and Reporting applications deploy to and read from the correct paths in OpenShift. 

## Changes 🚧

- Sets NextJS to build in standalone mode.
  - This was found to set the proper paths when next applications fetch their first-fetches and assets, static or otherwise.
- Use standalone as container runtime.
- Update OpenShift routes to match internal service routes.
  - NextJS handles routing to Reg and Rep when deployed locally, but we utilize OpenShift Routes (ingress) to handle routing to services and therefore pods.

## To test 🔬

> I've hand-changed Reporting and Registration's container image target in OpenShift to use this PR, and updated the routes to match.

1. Navigate to https://cas-bciers-frontend-dev.apps.silver.devops.gov.bc.ca/, login with IDIR, then click on the profile link in the header. It should display properly (all styles, etc) show the relevant profile information. 
2. From the logged-in root dashboard, click Registration>Operators.

## Notes 📝

When COAM is containerized/deployed, it will need the same ARG set in the `project.json` and `assetPath`/`basePath` in `next.config` (also, it might need to pull in `next.base.config` as well). Routes will need to follow the same pattern in the helm template deployment.
