### PR TITLE
chore: fix coam helm deployment.yaml indentation

### DIFF
--- a/helm/cas-bciers/Chart.lock
+++ b/helm/cas-bciers/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: terraform-bucket-provision
   repository: https://bcgov.github.io/cas-pipeline/
-  version: 0.1.3
-digest: sha256:a364b7f2d3c760ee659c5997064deff4503630e2ead84aca5ecae3c78e1489cf
-generated: "2024-06-20T16:20:26.020903145-06:00"
+  version: 0.1.4
+digest: sha256:f063f79b166b43429e05c8433d8818e133e49923104a05644addca302df8774f
+generated: "2024-07-18T12:11:40.370439-07:00"

--- a/helm/cas-bciers/templates/NetworkPolicy/admin-frontend-allow-from-openshift-ingress.yaml
+++ b/helm/cas-bciers/templates/NetworkPolicy/admin-frontend-allow-from-openshift-ingress.yaml
@@ -1,0 +1,17 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-administration-frontend-allow-from-openshift-ingress
+  labels: {{ include "cas-bciers.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cas-bciers.fullname" . }}
+      component: administration-frontend
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress

--- a/helm/cas-bciers/templates/NetworkPolicy/caom-frontend-allow-from-openshift-ingress.yaml
+++ b/helm/cas-bciers/templates/NetworkPolicy/caom-frontend-allow-from-openshift-ingress.yaml
@@ -1,0 +1,17 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-coam-frontend-allow-from-openshift-ingress
+  labels: {{ include "cas-bciers.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cas-bciers.fullname" . }}
+      component: coam-frontend
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress

--- a/helm/cas-bciers/templates/coam/deployment.yaml
+++ b/helm/cas-bciers/templates/coam/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         component: coam-frontend
         layer: frontend
     spec:
-    automountServiceAccountToken: false
+      automountServiceAccountToken: false
       containers:
         - name: {{ template "cas-bciers.fullname" . }}-coam-frontend
           envFrom:


### PR DESCRIPTION
I noticed that this failed in shipit, also updated dependencies as I got an error testing this with `helm template`