### PR TITLE
chore: fix profile urls

### DIFF
--- a/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.test.ts
+++ b/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.test.ts
@@ -71,7 +71,7 @@ describe("withAuthorizationDashboard middleware", () => {
 
     expect(NextResponse.redirect).toHaveBeenCalledOnce();
     expect(NextResponse.redirect).toHaveBeenCalledWith(
-      new URL("/registration/profile", domain),
+      new URL("/administration/profile", domain),
     );
     expect(result).toBeInstanceOf(NextResponse);
 

--- a/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.ts
+++ b/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.ts
@@ -65,7 +65,7 @@ export const withAuthorizationDashboard: MiddlewareFactory = (
           return next(request, _next);
         } else {
           return NextResponse.redirect(
-            new URL(`/registration/profile`, request.url),
+            new URL(`/administration/profile`, request.url),
           );
         }
       }

--- a/bciers/libs/components/src/navigation/Profile.tsx
+++ b/bciers/libs/components/src/navigation/Profile.tsx
@@ -11,7 +11,7 @@ export default function Profile() {
     <div className="flex items-center">
       <Link
         data-testid="nav-user-profile"
-        href="/registration/profile"
+        href="/administration/profile"
         sx={{ color: "white", marginRight: "10px" }}
       >
         <div


### PR DESCRIPTION
Fixing IDIR login for new users. At some point the profile page was moved from `Registration` to `Administration`. The team decided that it was good to stay there. 

To test log in with IDIR using a fresh database, the profile redirect works and the user can fill out their information.