### PR TITLE
1964 upload bug

### DIFF
--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -172,7 +172,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 CORS_ALLOWED_ORIGINS = ["http://localhost:3000"]
 
-DATA_UPLOAD_MAX_MEMORY_SIZE = 20000000
+DATA_UPLOAD_MAX_MEMORY_SIZE = 25000000
+FILE_UPLOAD_MAX_MEMORY_SIZE = 20000000
 
 
 # Only enable sentry in production

--- a/bciers/apps/registration1/next.config.js
+++ b/bciers/apps/registration1/next.config.js
@@ -19,7 +19,7 @@ const nextConfig = {
   },
   experimental: {
     serverActions: {
-      bodySizeLimit: "20mb",
+      bodySizeLimit: "25mb",
     },
   },
   nx: {

--- a/bciers/next.config.base.js
+++ b/bciers/next.config.base.js
@@ -12,9 +12,4 @@ module.exports = {
       transform: "@mui/material/{{member}}",
     },
   },
-  experimental: {
-    serverActions: {
-      bodySizeLimit: "20mb",
-    },
-  },
 };

--- a/bciers/next.config.base.js
+++ b/bciers/next.config.base.js
@@ -1,8 +1,13 @@
 /** @type {import('next').NextConfig} */
-module.exports = {
+const logAndReturnConfig = (config) => {
+  console.log("Next.js base config is being loaded");
+  return config;
+};
+module.exports = logAndReturnConfig({
   reactStrictMode: true,
   swcMinify: true,
   output: "standalone",
+
   //use modularizeImports properties to optimize the imports in the application
   modularizeImports: {
     "@mui/icons-material": {
@@ -12,4 +17,4 @@ module.exports = {
       transform: "@mui/material/{{member}}",
     },
   },
-};
+});


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=71304153

There are two issues here:
1. Files are below the size limit (currently 20mb locally and 1mb in dev/test/prod) but can't be submitted. This is because we had a limit on the body size, not the file size specifically, and sometimes the body has extra stuff in it (probably the dataurl?) that increases the size. This is fixed in this PR: I set a file size limit and increased the body size to give us a buffer.
2. Dev/test/prod has a body size limit of 1mb even though we've got it set much higher in the next config. I ~think the problem may be that the next configs aren't loaded properly in dev/test/prod (it's fine in local). There's a console.log in the next config for testing