### PR TITLE
feat: Add actions column to reporting operations dashboard

### DIFF
--- a/bc_obps/reporting/api/reports.py
+++ b/bc_obps/reporting/api/reports.py
@@ -5,6 +5,7 @@ from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from reporting.schema.report import StartReportIn
 from service.report_service import ReportService
+from service.reporting_year_service import ReportingYearService
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from reporting.schema.report_operation import ReportOperationOut, ReportOperationIn
 from .router import router
@@ -51,3 +52,14 @@ def save_report(
 ) -> Tuple[Literal[201], ReportOperationOut]:
     report_operation = ReportService.save_report_operation(version_id, payload)
     return 201, report_operation  # type: ignore
+
+
+@router.get(
+    "/reporting-year",
+    response={200: int, custom_codes_4xx: Message},
+    tags=EMISSIONS_REPORT_TAGS,
+    description="""Returns the current reporting year.""",
+)
+@handle_http_errors()
+def get_reporting_year(request: HttpRequest) -> Tuple[Literal[200], int]:
+    return 200, ReportingYearService.get_current_reporting_year().reporting_year

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user/operations/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user/operations/page.tsx
@@ -1,11 +1,16 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
 import { OperationsSearchParams } from "../../../components/operations/types";
 import OperationsPage from "../../../components/routes/operations/Page";
+import CurrentReportingYearContext from "@reporting/src/app/components/context/CurrentReportingYearContext";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
-  return <OperationsPage searchParams={searchParams} />;
+  return (
+    <CurrentReportingYearContext.Provider value={2024}>
+      <OperationsPage searchParams={searchParams} />
+    </CurrentReportingYearContext.Provider>
+  );
 }

--- a/bciers/apps/reporting/src/app/components/context/CurrentReportingYearContext.tsx
+++ b/bciers/apps/reporting/src/app/components/context/CurrentReportingYearContext.tsx
@@ -1,0 +1,5 @@
+"use client";
+import { createContext } from "react";
+
+const CurrentReportingYearContext = createContext(2024);
+export default CurrentReportingYearContext;

--- a/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
@@ -1,4 +1,4 @@
-import { GridColDef } from "@mui/x-data-grid";
+import { GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import Button from "@mui/material/Button";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
@@ -48,8 +48,15 @@ const MoreCell: React.FC = () => {
   );
 };
 
-const ActionCell: React.FC = () => {
-  return <div>I am an action cell.</div>;
+const ActionCell = (params: GridRenderCellParams) => {
+  const reportId = params.value;
+
+  console.log(reportId);
+  if (reportId) {
+    return <a href={`/reporting/report/${reportId}`}>Continue</a>;
+  }
+
+  return <a href="/reporting/report">Start</a>;
 };
 
 const operationColumns = (): GridColDef[] => {

--- a/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
@@ -48,6 +48,10 @@ const MoreCell: React.FC = () => {
   );
 };
 
+const ActionCell: React.FC = () => {
+  return <div>I am an action cell.</div>;
+};
+
 const operationColumns = (): GridColDef[] => {
   const columns: GridColDef[] = [
     { field: "bcghg_id", headerName: "BC GHG ID", width: 160 },
@@ -55,6 +59,13 @@ const operationColumns = (): GridColDef[] => {
       field: "name",
       headerName: "Operation",
       width: 560,
+    },
+    {
+      field: "actions",
+      headerName: "Actions",
+      renderCell: () => <ActionCell />,
+      sortable: false,
+      width: 120,
     },
     {
       field: "more",

--- a/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
@@ -4,6 +4,7 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import * as React from "react";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
+import { actionHandler } from "@bciers/actions";
 
 export const OPERATOR_COLUMN_INDEX = 1;
 
@@ -48,15 +49,38 @@ const MoreCell: React.FC = () => {
   );
 };
 
+const handleStartReport = async (
+  operationId: string,
+  reportingYear: number,
+) => {
+  try {
+    const reportId = await actionHandler("reporting/reports", "POST", "", {
+      body: JSON.stringify({
+        operation_id: operationId,
+        reporting_year: reportingYear,
+      }),
+    });
+
+    return reportId;
+  } catch (error) {
+    throw error;
+  }
+};
+
 const ActionCell = (params: GridRenderCellParams) => {
   const reportId = params.value;
+  const reportingYear = 2024;
 
-  console.log(reportId);
   if (reportId) {
     return <a href={`/reporting/report/${reportId}`}>Continue</a>;
   }
 
-  return <a href="/reporting/report">Start</a>;
+  const OperationId = params.row.id;
+  return (
+    <Button onClick={() => handleStartReport(OperationId, reportingYear)}>
+      Start
+    </Button>
+  );
 };
 
 const operationColumns = (): GridColDef[] => {
@@ -68,9 +92,9 @@ const operationColumns = (): GridColDef[] => {
       width: 560,
     },
     {
-      field: "actions",
+      field: "report_id",
       headerName: "Actions",
-      renderCell: () => <ActionCell />,
+      renderCell: ActionCell,
       sortable: false,
       width: 120,
     },

--- a/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
@@ -72,12 +72,19 @@ const ActionCell = (params: GridRenderCellParams) => {
   const reportingYear = 2024;
 
   if (reportId) {
-    return <a href={`/reporting/report/${reportId}`}>Continue</a>;
+    return (
+      <Button color="primary" href={`/reporting/report/${reportId}`}>
+        Continue
+      </Button>
+    );
   }
 
   const OperationId = params.row.id;
   return (
-    <Button onClick={() => handleStartReport(OperationId, reportingYear)}>
+    <Button
+      color="primary"
+      onClick={() => handleStartReport(OperationId, reportingYear)}
+    >
       Start
     </Button>
   );

--- a/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
@@ -7,8 +7,7 @@ import * as React from "react";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { actionHandler } from "@bciers/actions";
 import { useRouter } from "next/navigation";
-import CurrentReportingYearContext from '../../context/CurrentReportingYearContext';
-import { useContext } from 'react';
+import { getReportingYear } from "@reporting/src/app/utils/getReportingYear";
 
 export const OPERATOR_COLUMN_INDEX = 1;
 
@@ -73,7 +72,6 @@ const handleStartReport = async (
 
 const ActionCell = (params: GridRenderCellParams) => {
   const reportId = params.value;
-  const reportingYear = useContext(CurrentReportingYearContext);
   const router = useRouter();
   const OperationId = params.row.id;
 
@@ -81,7 +79,9 @@ const ActionCell = (params: GridRenderCellParams) => {
     return (
       <Button
         color="primary"
-        href={`operations/${reportId}/review-operator-data`}
+        onClick={() =>
+          router.push(`operations/${reportId}/review-operator-data`)
+        }
       >
         Continue
       </Button>
@@ -92,6 +92,7 @@ const ActionCell = (params: GridRenderCellParams) => {
     <Button
       color="primary"
       onClick={async () => {
+        const reportingYear = await getReportingYear();
         const newReportId = await handleStartReport(OperationId, reportingYear);
         router.push(`operations/${newReportId}/review-operator-data`);
       }}

--- a/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
@@ -7,6 +7,8 @@ import * as React from "react";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { actionHandler } from "@bciers/actions";
 import { useRouter } from "next/navigation";
+import CurrentReportingYearContext from '../../context/CurrentReportingYearContext';
+import { useContext } from 'react';
 
 export const OPERATOR_COLUMN_INDEX = 1;
 
@@ -54,7 +56,7 @@ const MoreCell: React.FC = () => {
 const handleStartReport = async (
   operationId: string,
   reportingYear: number,
-) => {
+): Promise<string> => {
   try {
     const reportId = await actionHandler("reporting/reports", "POST", "", {
       body: JSON.stringify({
@@ -71,8 +73,9 @@ const handleStartReport = async (
 
 const ActionCell = (params: GridRenderCellParams) => {
   const reportId = params.value;
-  const reportingYear = 2024;
+  const reportingYear = useContext(CurrentReportingYearContext);
   const router = useRouter();
+  const OperationId = params.row.id;
 
   if (reportId) {
     return (
@@ -85,7 +88,6 @@ const ActionCell = (params: GridRenderCellParams) => {
     );
   }
 
-  const OperationId = params.row.id;
   return (
     <Button
       color="primary"

--- a/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/operationColumns.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import Button from "@mui/material/Button";
 import Menu from "@mui/material/Menu";
@@ -5,6 +6,7 @@ import MenuItem from "@mui/material/MenuItem";
 import * as React from "react";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { actionHandler } from "@bciers/actions";
+import { useRouter } from "next/navigation";
 
 export const OPERATOR_COLUMN_INDEX = 1;
 
@@ -70,10 +72,14 @@ const handleStartReport = async (
 const ActionCell = (params: GridRenderCellParams) => {
   const reportId = params.value;
   const reportingYear = 2024;
+  const router = useRouter();
 
   if (reportId) {
     return (
-      <Button color="primary" href={`/reporting/report/${reportId}`}>
+      <Button
+        color="primary"
+        href={`operations/${reportId}/review-operator-data`}
+      >
         Continue
       </Button>
     );
@@ -83,7 +89,10 @@ const ActionCell = (params: GridRenderCellParams) => {
   return (
     <Button
       color="primary"
-      onClick={() => handleStartReport(OperationId, reportingYear)}
+      onClick={async () => {
+        const newReportId = await handleStartReport(OperationId, reportingYear);
+        router.push(`operations/${newReportId}/review-operator-data`);
+      }}
     >
       Start
     </Button>

--- a/bciers/apps/reporting/src/app/utils/getReportingYear.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportingYear.ts
@@ -1,0 +1,7 @@
+import { actionHandler } from "@bciers/actions";
+
+export const getReportingYear = async (): Promise<number> => {
+  const reportingYear = await actionHandler("reporting/reporting-year", "GET");
+
+  return reportingYear;
+};

--- a/bciers/apps/reporting/tests/pages/operationsColumns.test.tsx
+++ b/bciers/apps/reporting/tests/pages/operationsColumns.test.tsx
@@ -6,7 +6,7 @@ describe("operationColumns function", () => {
   it("returns an array of column definitions", () => {
     const columns: GridColDef[] = operationColumns();
 
-    assert(columns.length === 3, "Expected 3 columns");
+    assert(columns.length === 4, "Expected 4 columns");
 
     assert(
       columns[0].field === "bcghg_id",
@@ -25,13 +25,66 @@ describe("operationColumns function", () => {
     );
     assert(columns[1].width === 560, "Column 2 width should be 560");
 
-    assert(columns[2].field === "more", 'Column 3 field should be "action"');
     assert(
-      columns[2].headerName === "More",
-      'Column 3 headerName should be "More"',
+      columns[2].field === "report_id",
+      'Column 3 field should be "report_id"',
     );
-    assert(columns[2].sortable === false, "Column 3 sortable should be false");
+    assert(
+      columns[2].headerName === "Actions",
+      'Column 3 headerName should be "Actions"',
+    );
     assert(columns[2].width === 120, "Column 3 width should be 120");
-    assert(columns[2].flex === 1, "Column 3 flex should be 1");
+
+    assert(columns[3].field === "more", 'Column 4 field should be "action"');
+    assert(
+      columns[3].headerName === "More",
+      'Column 4 headerName should be "More"',
+    );
+    assert(columns[3].sortable === false, "Column 4 sortable should be false");
+    assert(columns[3].width === 120, "Column 4 width should be 120");
+    assert(columns[3].flex === 1, "Column 4 flex should be 1");
   });
+
+  it("has a 'start' button in the 'Actions' column when report_id is null", () => {
+    const columns: GridColDef[] = operationColumns();
+
+    const row = {
+      id: "1",
+      bcghg_id: "1",
+      name: "Operation without report",
+      report_id: null,
+      report_version_id: null,
+      report_status: null,
+    };
+
+    const params = {
+      row,
+      value: null,
+    };
+
+    const cell = columns[2].renderCell(params);
+    expect(cell.props.children).toBe("Start");
+  });
+
+  it("has a 'continue' button in the 'Actions' column when report_id exists", () => {
+    const columns: GridColDef[] = operationColumns();
+
+    const row = {
+      id: "1",
+      bcghg_id: "1",
+      name: "Operation with report",
+      report_id: 1,
+      report_version_id: 1,
+      report_status: "draft",
+    };
+
+    const params = {
+      row,
+      value: 1,
+    };
+
+    const cell = columns[2].renderCell(params);
+    expect(cell.props.children).toBe("Continue");
+  });
+
 });


### PR DESCRIPTION
Addresses bcgov/cas-reporting#274. Adds the "Actions" column in the Reporting Dashboard with an action to Start or Continue a report.

## Changes 🚧

- Adds _Action_ column to operations table.
- Adds a _CurrentReportingYear_ context provider.

## To test 🔬

0. Run `make reset_db` in your backend folder if required. 
1. Spin up your local server, log in. 
2. Navigate to `/reporting/operations`. You should see a list of operations. 
3. Click the **Start** action for _Operation 3_. After a few moments, you should be taken to a 404'd page with the address `operations/1/review-operator-data`, with `/1/` being the report number. 
4. Navigate to the previous page, then click the **Start** action for _Operation 5_. After a few moments, you should be taken to a 404'd page with the address `operations/2/review-operator-data`, with `/2/` being the report number. 
5. Navigate to the previous page, then click the **Continue** action for _Operation 3_. After a few moments, you should be taken to a 404'd page with the address `operations/1/review-operator-data`, with `/1/` being the report number from step 3. 

## Notes 📝

`CurrentReportingYear` context should be usable for bcgov/cas-reporting#238, but should be expanded to cover all the needs of that ticket. This ticket was more focussed on supply the year to the Report generation service on the backend.
