### PR TITLE
reg1 auth always redirects back to landing page after login

### DIFF
--- a/bciers/apps/registration1/app/api/auth/token/route.ts
+++ b/bciers/apps/registration1/app/api/auth/token/route.ts
@@ -1,10 +1,13 @@
 import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
 
-const cookieName =
-  process.env.NODE_ENV === "production"
-    ? "__Secure-authjs.session-token"
-    : "authjs.session-token";
+const isLocalDevelopment = process.env?.NEXTAUTH_URL?.includes(
+  "http://localhost:3000",
+);
+
+const cookieName = isLocalDevelopment
+  ? "authjs.session-token"
+  : "__Secure-authjs.session-token";
 
 export async function GET(request: NextRequest) {
   const token = await getToken({

--- a/bciers/apps/registration1/app/api/auth/token/route.ts
+++ b/bciers/apps/registration1/app/api/auth/token/route.ts
@@ -1,11 +1,17 @@
 import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
 
+const cookieName =
+  process.env.NODE_ENV === "production"
+    ? "__Secure-authjs.session-token"
+    : "authjs.session-token";
+
 export async function GET(request: NextRequest) {
   const token = await getToken({
     req: request,
     secret: `${process.env.NEXTAUTH_SECRET}`,
-    salt: "authjs.session-token",
+    salt: cookieName,
+    cookieName: cookieName,
   });
   return NextResponse.json(token, { status: 200 });
 }


### PR DESCRIPTION
Fix for [#1981](https://github.com/bcgov/cas-registration/issues/1981)

Thanks to a suggestion from Josh I updated the registration1 `route.ts` file to specify a cookie name and opened this PR to build an image. I then grabbed the `sha` of the image, changed the image file in the deployment from `latest` to the sha and cycled the pods so it would use this image. 

Now login seems to be working again in `/dev`. I'd like to get this merged in and do a proper deployment and double check that it's working as expected.