### PR TITLE
chore: add deploy.sh script for shipit

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Get the current git branch
+echo "Branch: $BRANCH"
+# Check if the shipit environment includes 'reg1'
+if [[ "$ENVIRONMENT" == *"reg1"* ]]; then
+    ENVIRONMENT="${ENVIRONMENT//reg1-/}"
+    echo "Running reg1 make target for $ENVIRONMENT environment..."
+    make install_reg1
+else
+    echo "Running default make target..."
+    make install
+fi

--- a/shipit.yml
+++ b/shipit.yml
@@ -6,7 +6,7 @@ review:
 
 deploy:
   override:
-    - make install:
+    - ./deploy.sh:
         timeout: 1800
 
 ci:


### PR DESCRIPTION
Added a deploy script to fix `reg1` shipit deployment. Now we will be able to deploy both our original `reg1` helm chart as well as the `bciers` helm chart through shipit.

To test this you can add `--dry-run` to the `make install` and `make install_reg1` commands then:

`sudo chmod +x deploy.sh`

Replace `prefix` here with our namespace prefix:
`OBPS_NAMESPACE_PREFIX=prefix ENVIRONMENT=reg1-dev ./deploy.sh`

The terminal should say `Running reg1 make target for dev environment...` and run the `make install_reg1` script.