### PR TITLE
Registration1 upload bug

### DIFF
--- a/bciers/apps/registration1/Dockerfile
+++ b/bciers/apps/registration1/Dockerfile
@@ -18,10 +18,16 @@ ENTRYPOINT ["dumb-init", "--"]
 ENV NODE_ENV production
 ENV PORT 3000
 WORKDIR /usr/src/app
+
 COPY --from=deps /usr/src/app/node_modules node_modules
 COPY --from=deps /usr/src/app/package.json package.json
-COPY ./public ./public
-COPY --chown=node:node ./.next ./.next
+COPY ./public public
+COPY ./.next .next
+COPY ./next.config.js next.config.js
+COPY ./.nx-helpers .nx-helpers
+COPY ./yarn.lock yarn.lock
+
+RUN chown -R node:node .
 
 USER node
 EXPOSE 3000

--- a/bciers/apps/registration1/next.config.js
+++ b/bciers/apps/registration1/next.config.js
@@ -2,10 +2,7 @@
 const { withSentryConfig } = require("@sentry/nextjs");
 const { composePlugins, withNx } = require("@nx/next");
 
-const nextConfigBase = require("../../next.config.base");
-
 const nextConfig = {
-  ...nextConfigBase,
   reactStrictMode: true,
   swcMinify: true,
   //use modularizeImports properties to optimize the imports in the application


### PR DESCRIPTION
[#1964](https://github.com/bcgov/cas-registration/issues/1964)

Finally got this working by copying some missing build files in registration1 Dockerfile, most importantly `next.config.js`. Also removed the inherited settings from the shared `next.config` that is in the `bciers` directory as I couldn't get this to work in e2e with the next config setting [output: standalone](https://nextjs.org/docs/pages/api-reference/next-config-js/output) that the rest of our apps use to containerize the app.

While we will need to figure out why that wasn't working in the near future, it was important to get this bug fixed in prod so I just modified the original Dockerfile so we could get this issue unblocked.

I've been trying to fix the unrelated nextjs permissions error when we noticed in the pod but can't seem to get it fixed for some reason even though we fixed it in the bciers shared Dockerfile. Seems like some people are having similar issues here:  
https://github.com/vercel/next.js/discussions/51164