### PR TITLE
238 reporting year

### DIFF
--- a/bc_obps/reporting/fixtures/mock/reporting_year.json
+++ b/bc_obps/reporting/fixtures/mock/reporting_year.json
@@ -6,5 +6,13 @@
       "reporting_window_start": "2025-01-01T00:00:00.000Z",
       "reporting_window_end": "2025-12-31T23:59:59.999Z"
     }
+  },
+  {
+    "model": "reporting.reportingyear",
+    "fields": {
+      "reporting_year": 2023,
+      "reporting_window_start": "2024-01-01T00:00:00.000Z",
+      "reporting_window_end": "2024-12-31T23:59:59.999Z"
+    }
   }
 ]

--- a/bc_obps/reporting/tests/service/test_reporting_year_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_year_service.py
@@ -1,0 +1,28 @@
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import patch
+from service.reporting_year_service import ReportingYearService
+from reporting.models import ReportingYear
+
+pytestmark = pytest.mark.django_db
+
+
+@patch('service.reporting_year_service.datetime')
+class TestReportingYearService:
+
+    def setup_method(self):
+        self.reporting_year = ReportingYear.objects.create(
+            reporting_year=2000,
+            reporting_window_start='2001-01-01T00:00:00.000Z',
+            reporting_window_end='2001-12-31T23:59:59.999Z',
+            description='Test reporting year',
+        )
+
+    def test_get_current_reporting_year(self, mock_datetime):
+        expected_reporting_year = 2000
+        fake_now = datetime(2001, 1, 1, tzinfo=timezone.utc)
+
+        mock_datetime.now.return_value = fake_now
+        current_reporting_year = ReportingYearService.get_current_reporting_year()
+
+        assert current_reporting_year.reporting_year == expected_reporting_year

--- a/bc_obps/reporting/tests/service/test_reporting_year_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_year_service.py
@@ -9,7 +9,6 @@ pytestmark = pytest.mark.django_db
 
 @patch('service.reporting_year_service.datetime')
 class TestReportingYearService:
-
     def setup_method(self):
         self.reporting_year = ReportingYear.objects.create(
             reporting_year=2000,

--- a/bc_obps/service/reporting_year_service.py
+++ b/bc_obps/service/reporting_year_service.py
@@ -1,7 +1,11 @@
 from reporting.models.reporting_year import ReportingYear
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 
 class ReportingYearService:
     @classmethod
     def get_current_reporting_year(cls) -> ReportingYear:
-        return ReportingYear.objects.get(reporting_year=2024)
+        now = datetime.now(ZoneInfo("America/Vancouver"))
+
+        return ReportingYear.objects.get(reporting_window_start__lte=now, reporting_window_end__gte=now)

--- a/bciers/apps/reporting/src/app/components/routes/operations/Page.tsx
+++ b/bciers/apps/reporting/src/app/components/routes/operations/Page.tsx
@@ -1,3 +1,4 @@
+import { getReportingYear } from "@reporting/src/app/utils/getReportingYear";
 import Operations from "../../operations/Operations";
 import { OperationsSearchParams } from "../../operations/types";
 
@@ -6,8 +7,11 @@ export default async function OperationsPage({
 }: {
   searchParams: OperationsSearchParams;
 }) {
+  const reportingYear = await getReportingYear();
+
   return (
     <>
+      <h2 className="text-2xl font-bold">Reporting year {reportingYear}</h2>
       <Operations searchParams={searchParams} />
     </>
   );


### PR DESCRIPTION
 Addresses bcgov/cas-reporting#238. This adds the _current_ reporting year to the reporting operations page. 

## Changes 🚧

- Updates ReportingYearService to get current reporting year based on start/end reporting windows.
  - Add fixture for 2023 (to cover for testing in current year) 
- Fetch from service and populate a header on the operations page.

## To test 🔬

0. Run `bc_obps/make reset_db` to ensure the new fixtures are loaded. 
1. Spin up a local instance (`bc_obps/make start_db && bc_obps/make run` + `yarn dev-all`). Login with `bc-cas-dev`. Navigate to `/reporting/operations` using your browser address bar. 
2. Check the header above the table, it should read `Reporting Year 2023` (unless you test this a year from now)
