### PR TITLE
chore: adjust bciers and registration1 helm dev and test values

### DIFF
--- a/helm/cas-bciers/values-dev.yaml
+++ b/helm/cas-bciers/values-dev.yaml
@@ -24,7 +24,7 @@ backend:
       memory: 256Mi
 
 administrationFrontend:
-  replicaCount: 2
+  replicaCount: 1
 
   image:
     tag: "latest"
@@ -44,7 +44,7 @@ administrationFrontend:
       memory: 256Mi
 
 registrationFrontend:
-  replicaCount: 2
+  replicaCount: 1
 
   image:
     tag: "latest"
@@ -57,11 +57,11 @@ registrationFrontend:
 
   resources:
     limits:
-      cpu: 150m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
 reportingFrontend:
   enabled: true
@@ -75,14 +75,14 @@ reportingFrontend:
 
   resources:
     limits:
-      cpu: 150m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
 coamFrontend:
-  replicaCount: 2
+  replicaCount: 1
 
   image:
     tag: "latest"
@@ -95,11 +95,11 @@ coamFrontend:
 
   resources:
     limits:
-      cpu: 150m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
 dashboardFrontend:
   enabled: true
@@ -113,11 +113,11 @@ dashboardFrontend:
 
   resources:
     limits:
-      cpu: 150m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
   auth:
     keycloakAuthUrl: https://dev.loginproxy.gov.bc.ca/auth

--- a/helm/cas-bciers/values-test.yaml
+++ b/helm/cas-bciers/values-test.yaml
@@ -19,7 +19,7 @@ backend:
       memory: 256Mi
 
 registrationFrontend:
-  replicaCount: 2
+  replicaCount: 1
 
   image:
     tag: "latest"
@@ -32,14 +32,14 @@ registrationFrontend:
 
   resources:
     limits:
-      cpu: 150m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
 reportingFrontend:
-  replicaCount: 2
+  replicaCount: 1
 
   image:
     tag: "latest"
@@ -52,14 +52,14 @@ reportingFrontend:
 
   resources:
     limits:
-      cpu: 150m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
 dashboardFrontend:
-  replicaCount: 2
+  replicaCount: 1
 
   image:
     tag: "latest"
@@ -76,11 +76,11 @@ dashboardFrontend:
 
   resources:
     limits:
-      cpu: 150m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
 growthbook:
   clientKey: sdk-9Vyna67jpIYdjMa

--- a/helm/cas-bciers/values.yaml
+++ b/helm/cas-bciers/values.yaml
@@ -62,8 +62,8 @@ registrationFrontend:
 
   resources:
     limits:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
       memory: 128Mi
@@ -96,8 +96,8 @@ reportingFrontend:
 
   resources:
     limits:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
       memory: 128Mi
@@ -130,11 +130,11 @@ administrationFrontend:
 
   resources:
     limits:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
   autoscaling:
     enabled: false
@@ -164,11 +164,11 @@ coamFrontend:
 
   resources:
     limits:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
   autoscaling:
     enabled: false
@@ -197,11 +197,11 @@ dashboardFrontend:
 
   resources:
     limits:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
   autoscaling:
     enabled: false

--- a/helm/cas-registration/values-dev.yaml
+++ b/helm/cas-registration/values-dev.yaml
@@ -2,7 +2,7 @@
 fullnameOverride: cas-reg1
 
 backend:
-  replicaCount: 2
+  replicaCount: 1
 
   image:
     tag: "latest"
@@ -16,14 +16,14 @@ backend:
 
   resources:
     limits:
-      cpu: 150m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
 registration1Frontend:
-  replicaCount: 2
+  replicaCount: 1
 
   image:
     tag: "latest"
@@ -39,11 +39,11 @@ registration1Frontend:
 
   resources:
     limits:
-      cpu: 150m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 128Mi
+      memory: 256Mi
 
 growthbook:
   clientKey: sdk-YMBcx9KglRDGzGTE

--- a/helm/cas-registration/values-test.yaml
+++ b/helm/cas-registration/values-test.yaml
@@ -2,7 +2,7 @@
 fullnameOverride: cas-reg1
 
 backend:
-  replicaCount: 2
+  replicaCount: 1
 
   image:
     tag: "latest"
@@ -21,7 +21,7 @@ backend:
       memory: 256Mi
 
 registration1Frontend:
-  replicaCount: 2
+  replicaCount: 1
 
   image:
     tag: "latest"
@@ -37,8 +37,8 @@ registration1Frontend:
 
   resources:
     limits:
-      cpu: 150m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
       memory: 128Mi

--- a/helm/cas-registration/values.yaml
+++ b/helm/cas-registration/values.yaml
@@ -64,11 +64,11 @@ registration1Frontend:
 
   resources:
     limits:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 60m
-      memory: 192Mi
+      memory: 256Mi
 
   autoscaling:
     enabled: false


### PR DESCRIPTION
Last week we reduced the requests and limits of our frontend pods to fix the broken deployments which were hanging due to lack of resources. However this caused the apps to have lots of errors and run sluggish. Until we get more resources we will have to run 1 replica even if it's not ideal for testing.  
  
- Reduce replicas to 1
- Restore previous requests and limits