### PR TITLE
238 reporting year migrations

### DIFF
--- a/bc_obps/common/management/commands/load_fixtures.py
+++ b/bc_obps/common/management/commands/load_fixtures.py
@@ -10,7 +10,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         fixture_base_dir = 'registration/fixtures/mock'
-        reporting_fixture_base_dir = 'reporting/fixtures/mock'
 
         workflow_fixtures = {
             "cas_admin": [
@@ -45,7 +44,6 @@ class Command(BaseCommand):
                 f'{fixture_base_dir}/event.json',
                 f'{fixture_base_dir}/parent_operator.json',
                 f'{fixture_base_dir}/partner_operator.json',
-                f'{reporting_fixture_base_dir}/reporting_year.json',
             ]
 
         for fixture in fixtures:

--- a/bc_obps/reporting/migrations/0007_prod_data.py
+++ b/bc_obps/reporting/migrations/0007_prod_data.py
@@ -614,6 +614,18 @@ def reverse_init_methodology_data(apps, schema_monitor):
     ).delete()
 
 
+def load_reporting_fixtures(apps, schema_editor):
+    from django.core.management import call_command
+
+    fixture_files = [
+        'reporting/fixtures/mock/reporting_year.json',
+    ]
+
+    # Load the fixtures
+    for fixture in fixture_files:
+        call_command('loaddata', fixture)
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -626,4 +638,5 @@ class Migration(migrations.Migration):
         migrations.RunPython(init_fuel_type_data, reverse_init_fuel_type_data),
         migrations.RunPython(init_methodology_data, reverse_init_methodology_data),
         migrations.RunPython(init_configuration_data, reverse_init_configuration_data),
+        migrations.RunPython(load_reporting_fixtures),
     ]


### PR DESCRIPTION
Moves the `reporting`.`reporting_year` fixture mocks from `common`.`load_fixtures` into a `reporting` migration.