### PR TITLE
chore: shared error boundary

### DIFF
--- a/bciers/apps/administration/app/error.tsx
+++ b/bciers/apps/administration/app/error.tsx
@@ -1,0 +1,3 @@
+"use client";
+import ErrorPage from "@bciers/components/error/ErrorPage";
+export default ErrorPage;

--- a/bciers/apps/coam/app/error.tsx
+++ b/bciers/apps/coam/app/error.tsx
@@ -1,0 +1,3 @@
+"use client";
+import ErrorPage from "@bciers/components/error/ErrorPage";
+export default ErrorPage;

--- a/bciers/apps/dashboard/app/error.tsx
+++ b/bciers/apps/dashboard/app/error.tsx
@@ -1,0 +1,3 @@
+"use client";
+import ErrorPage from "@bciers/components/error/ErrorPage";
+export default ErrorPage;

--- a/bciers/apps/registration/app/error.tsx
+++ b/bciers/apps/registration/app/error.tsx
@@ -1,0 +1,3 @@
+"use client";
+import ErrorPage from "@bciers/components/error/ErrorPage";
+export default ErrorPage;

--- a/bciers/apps/reporting/src/app/error.tsx
+++ b/bciers/apps/reporting/src/app/error.tsx
@@ -1,0 +1,3 @@
+"use client";
+import ErrorPage from "@bciers/components/error/ErrorPage";
+export default ErrorPage;

--- a/bciers/libs/components/src/error/ErrorBoundary.tsx
+++ b/bciers/libs/components/src/error/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+
+import { Alert, AlertTitle } from "@mui/material";
+
+interface Props {
+  error: Error & { digest?: string };
+}
+export default function ErrorBoundary({ error }: Props) {
+  useEffect(() => {
+    if (error) {
+      try {
+        // Attempt to log the error to Sentry
+        Sentry.captureException(error);
+      } catch (sentryError) {
+        // If there's an error logging to Sentry, log it to the console
+        // eslint-disable-next-line no-console
+        console.error("Error logging to Sentry:", sentryError);
+      }
+      // Log the original error to the console
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center text-bc-gov-links-color">
+      <h2>Something went wrong...</h2>
+      <Alert
+        severity="error"
+        sx={{
+          width: "100%",
+          maxWidth: "600px",
+          marginBottom: "1rem",
+        }}
+      >
+        <AlertTitle>Error</AlertTitle>
+        <strong>{error.message}</strong>
+      </Alert>
+    </div>
+  );
+}

--- a/bciers/libs/components/src/error/ErrorPage.test.tsx
+++ b/bciers/libs/components/src/error/ErrorPage.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @file ErrorPage.test.tsx
+ * @description Unit tests for the ErrorPage and ErrorBoundary components.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ErrorPage from "./ErrorPage";
+import ErrorBoundary from "./ErrorBoundary";
+import * as Sentry from "@sentry/nextjs";
+
+// Mock the Sentry module to avoid actual error logging during tests
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+describe("ErrorPage", () => {
+  /**
+   * Test to ensure that the ErrorPage component renders the ErrorBoundary component
+   * and passes the error prop correctly.
+   */
+  it("renders the ErrorBoundary with the error prop", () => {
+    const error = new Error("Test error");
+    render(<ErrorPage error={error} />);
+
+    expect(screen.getByText("Something went wrong...")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.getByText("Test error")).toBeInTheDocument();
+  });
+});
+
+describe("ErrorBoundary", () => {
+  /**
+   * Test to ensure that the error is logged to Sentry and the console when the ErrorBoundary
+   * component mounts with an error prop.
+   */
+  it("logs error to Sentry and console", () => {
+    const error = new Error("Test error");
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(<ErrorBoundary error={error} />);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  /**
+   * Test to ensure that the error message is displayed correctly within the Alert component
+   * when the ErrorBoundary component mounts with an error prop.
+   */
+  it("displays error message in Alert", () => {
+    const error = new Error("Test error");
+    render(<ErrorBoundary error={error} />);
+
+    expect(screen.getByText("Something went wrong...")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.getByText("Test error")).toBeInTheDocument();
+  });
+});

--- a/bciers/libs/components/src/error/ErrorPage.tsx
+++ b/bciers/libs/components/src/error/ErrorPage.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import ErrorBoundary from "@bciers/components/error/ErrorBoundary";
+
+export default function ErrorPage({
+  error,
+}: Readonly<{
+  error: Error & { digest?: string };
+}>) {
+  return <ErrorBoundary error={error} />;
+}


### PR DESCRIPTION
Addresses: 
[1982](https://github.com/bcgov/cas-registration/issues/1982)

### 🚀 Impact:

- Shared ErrorBoundary across apps
   - `bciers/libs/components/src/error/ErrorBoundary.tsx`
   - `bciers/libs/components/src/error/Error.tsx`
   - `bciers/apps/administration/app/error.tsx`
   - `bciers/apps/coam/app/error.tsx`   
   - `bciers/apps/dashboard/app/error.tsx`
   - `bciers/apps/registration/app/error.tsx`
   - `bciers/apps/reporting/app/error.tsx`
   
### 📝 Notes
- `global-error.tsx` will be addressed [here](https://github.com/bcgov/cas-registration/issues/2044)


### 🔬 Local Testing:

1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd client && yarn dev-all
```  

### Test Error in app components:

1.  In `bciers/apps/administration/app/page.tsx` add temporary code `... export default async function Page() {  throw new Error("This is a test of error.tsx");...` 
2.  In `bciers/apps/coam/app/page.tsx` add temporary code `... export default async function Page() {  throw new Error("This is a test of error.tsx");...` 
3. In `bciers/apps/dashboard/app/dashboard/page.tsx` add temporary code `... export default async function Page() {  throw new Error("This is a test of error.tsx");...` 
4. In `bciers/apps/registration/app/page.tsx` add temporary code `... export default async function Page() {  throw new Error("This is a test of error.tsx");...` 
5. Navigate to `http://localhost:3000`
6. Click button "Log in with Business BCeID"
7. Sign in to Keycloak using `bc-cas-dev`
**Expected Results**   
   - `ErrorBoundary` displays
![image](https://github.com/user-attachments/assets/bb22e95c-82b1-4b25-aeed-66e62cca7d99)
8. Navigate to `Administration`: http://localhost:3000/administration
**Expected Results**   
   - `ErrorBoundary` displays
![image](https://github.com/user-attachments/assets/fbbbd51b-8ed7-43dd-adc4-3da20ff2d1f6)
9. Navigate to `COAM`: http://localhost:3000/coam
**Expected Results**   
   - `ErrorBoundary` displays
![image](https://github.com/user-attachments/assets/85ad0af2-1fd5-4385-a8bc-1e80fd4835c4)
10. Navigate to`Registraion`: http://localhost:3000/registration
**Expected Results**   
   - `ErrorBoundary` displays
![image](https://github.com/user-attachments/assets/8af92983-382a-46b2-97b2-57fbff6089cc)

