### PR TITLE
chore: refactor breadcrumbs for uuid and number

### DIFF
--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -91,7 +91,7 @@ export default function ContactForm({
           window.history.replaceState(
             null,
             "",
-            `/administration/contacts/${response.id}?contactsTitle=${response.first_name} ${response.last_name}`,
+            `/administration/contacts/${response.id}?contacts_title=${response.first_name} ${response.last_name}`,
           );
         } else {
           setKey(Math.random());

--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -91,7 +91,7 @@ export default function ContactForm({
           window.history.replaceState(
             null,
             "",
-            `/administration/contacts/${response.id}`,
+            `/administration/contacts/${response.id}?contactsTitle=${response.first_name} ${response.last_name}`,
           );
         } else {
           setKey(Math.random());

--- a/bciers/apps/administration/app/components/contacts/ContactsDataGrid.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactsDataGrid.tsx
@@ -12,7 +12,7 @@ import { GridRenderCellParams } from "@mui/x-data-grid";
 
 const ContactsActionCell = ActionCellFactory({
   generateHref: (params: GridRenderCellParams) => {
-    return `contacts/${params.row.id}?contactsTitle=${params.row.first_name} ${params.row.last_name}`;
+    return `contacts/${params.row.id}?contacts_title=${params.row.first_name} ${params.row.last_name}`;
   },
   cellText: "View Details",
 });

--- a/bciers/apps/administration/app/components/contacts/ContactsDataGrid.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactsDataGrid.tsx
@@ -12,7 +12,7 @@ import { GridRenderCellParams } from "@mui/x-data-grid";
 
 const ContactsActionCell = ActionCellFactory({
   generateHref: (params: GridRenderCellParams) => {
-    return `contacts/${params.row.id}`;
+    return `contacts/${params.row.id}?contactsTitle=${params.row.first_name} ${params.row.last_name}`;
   },
   cellText: "View Details",
 });

--- a/bciers/apps/administration/app/components/facilities/FacilitiesForm.tsx
+++ b/bciers/apps/administration/app/components/facilities/FacilitiesForm.tsx
@@ -58,7 +58,7 @@ export default function FacilitiesForm({
         }
         if (isCreating) {
           router.replace(
-            `/operations/${params.operationId}/facilities/${response.id}?facilitiesTitle=${response.name}`,
+            `/operations/${params.operationId}/facilities/${response.id}?facilities_title=${response.name}`,
             // @ts-ignore
             { shallow: true },
           );

--- a/bciers/apps/administration/app/components/facilities/FacilityDataGrid.tsx
+++ b/bciers/apps/administration/app/components/facilities/FacilityDataGrid.tsx
@@ -26,7 +26,7 @@ const FacilityDataGrid = ({
   const createFacilitiesActionCell = () =>
     ActionCellFactory({
       generateHref: (params: GridRenderCellParams) => {
-        return `/operations/${operationId}/facilities/${params.row.id}?operationsTitle=${operationsTitle}&facilitiesTitle=${params.row.name}`;
+        return `/operations/${operationId}/facilities/${params.row.id}?operations_title=${operationsTitle}&facilities_title=${params.row.name}`;
       },
       cellText: "View Details",
     });

--- a/bciers/apps/administration/app/components/facilities/FacilityDataGrid.tsx
+++ b/bciers/apps/administration/app/components/facilities/FacilityDataGrid.tsx
@@ -26,7 +26,7 @@ const FacilityDataGrid = ({
   const createFacilitiesActionCell = () =>
     ActionCellFactory({
       generateHref: (params: GridRenderCellParams) => {
-        return `/operations/${operationId}/facilities/${params.row.id}?operations_title=${operations_title}&facilities_title=${params.row.name}`;
+        return `/operations/${operationId}/facilities/${params.row.id}?operations_title=${operationsTitle}&facilities_title=${params.row.name}`;
       },
       cellText: "View Details",
     });

--- a/bciers/apps/administration/app/components/facilities/FacilityDataGrid.tsx
+++ b/bciers/apps/administration/app/components/facilities/FacilityDataGrid.tsx
@@ -22,11 +22,11 @@ const FacilityDataGrid = ({
   };
 }) => {
   const searchParams = useSearchParams();
-  const operationsTitle = searchParams.get("operationsTitle") as string;
+  const operationsTitle = searchParams.get("operations_title") as string;
   const createFacilitiesActionCell = () =>
     ActionCellFactory({
       generateHref: (params: GridRenderCellParams) => {
-        return `/operations/${operationId}/facilities/${params.row.id}?operations_title=${operationsTitle}&facilities_title=${params.row.name}`;
+        return `/operations/${operationId}/facilities/${params.row.id}?operations_title=${operations_title}&facilities_title=${params.row.name}`;
       },
       cellText: "View Details",
     });

--- a/bciers/apps/administration/app/components/operations/OperationDataGrid.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationDataGrid.tsx
@@ -13,7 +13,7 @@ import { GridRenderCellParams } from "@mui/x-data-grid";
 
 const FacilitiesActionCell = ActionCellFactory({
   generateHref: (params: GridRenderCellParams) => {
-    return `operations/${params.row.id}/facilities?operationsTitle=${params.row.name}`;
+    return `operations/${params.row.id}/facilities?operations_title=${params.row.name}`;
   },
   cellText: "View Facilities",
 });

--- a/bciers/apps/administration/app/components/routes/facilities/Page.tsx
+++ b/bciers/apps/administration/app/components/routes/facilities/Page.tsx
@@ -25,7 +25,7 @@ export default async function FacilitiesPage({
       {isExternalUser && (
         <div className="text-right">
           <Link
-            href={`/operations/${operationId}/facilities/add-facility?operationsTitle=${searchParams.operationsTitle}`}
+            href={`/operations/${operationId}/facilities/add-facility?operations_title=${searchParams.operationsTitle}`}
           >
             <Button variant="contained">Add Facility</Button>
           </Link>

--- a/bciers/apps/administration/app/components/routes/facilities/Page.tsx
+++ b/bciers/apps/administration/app/components/routes/facilities/Page.tsx
@@ -25,7 +25,7 @@ export default async function FacilitiesPage({
       {isExternalUser && (
         <div className="text-right">
           <Link
-            href={`/operations/${operationId}/facilities/add-facility?operations_title=${searchParams.operationsTitle}`}
+            href={`/operations/${operationId}/facilities/add-facility?operations_title=${searchParams.operations_title}`}
           >
             <Button variant="contained">Add Facility</Button>
           </Link>

--- a/bciers/apps/administration/tests/components/contacts/ContactsDataGrid.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactsDataGrid.test.tsx
@@ -106,7 +106,7 @@ describe("ContactsDataGrid component", () => {
     );
     expect(
       screen.getAllByRole("link", { name: /View Details/i })[0],
-    ).toHaveAttribute("href", "contacts/1");
+    ).toHaveAttribute("href", "contacts/1?contactsTitle=John Doe");
   });
   it("makes API call with correct params when sorting", async () => {
     render(

--- a/bciers/apps/administration/tests/components/contacts/ContactsDataGrid.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactsDataGrid.test.tsx
@@ -106,7 +106,7 @@ describe("ContactsDataGrid component", () => {
     );
     expect(
       screen.getAllByRole("link", { name: /View Details/i })[0],
-    ).toHaveAttribute("href", "contacts/1?contactsTitle=John Doe");
+    ).toHaveAttribute("href", "contacts/1?contacts_title=John Doe");
   });
   it("makes API call with correct params when sorting", async () => {
     render(

--- a/bciers/apps/administration/tests/components/facilities/FacilitiesForm.test.tsx
+++ b/bciers/apps/administration/tests/components/facilities/FacilitiesForm.test.tsx
@@ -407,7 +407,7 @@ describe("FacilitiesForm component", () => {
 
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith(
-        `/operations/${operationId}/facilities/${facilityId}?facilitiesTitle=${facilityName}`,
+        `/operations/${operationId}/facilities/${facilityId}?facilities_title=${facilityName}`,
         {
           shallow: true,
         },
@@ -503,7 +503,7 @@ describe("FacilitiesForm component", () => {
 
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith(
-        `/operations/${operationId}/facilities/${facilityId}?facilitiesTitle=${facilityName}`,
+        `/operations/${operationId}/facilities/${facilityId}?facilities_title=${facilityName}`,
         {
           shallow: true,
         },

--- a/bciers/apps/administration/tests/components/operations/OperationDataGrid.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationDataGrid.test.tsx
@@ -123,11 +123,11 @@ describe("OperationsDataGrid component", () => {
 
     expect(facilitiesLinks[0]).toHaveAttribute(
       "href",
-      "operations/1/facilities?operationsTitle=Operation 1",
+      "operations/1/facilities?operations_title=Operation 1",
     );
     expect(facilitiesLinks[1]).toHaveAttribute(
       "href",
-      "operations/2/facilities?operationsTitle=Operation 2",
+      "operations/2/facilities?operations_title=Operation 2",
     );
   });
 
@@ -142,11 +142,11 @@ describe("OperationsDataGrid component", () => {
 
     expect(operationInfoLinks[0]).toHaveAttribute(
       "href",
-      "operations/1?operationsTitle=Operation+1",
+      "operations/1?operations_title=Operation+1",
     );
     expect(operationInfoLinks[1]).toHaveAttribute(
       "href",
-      "operations/2?operationsTitle=Operation+2",
+      "operations/2?operations_title=Operation+2",
     );
   });
 });

--- a/bciers/apps/administration/tests/routes/FacilitiesPage.test.tsx
+++ b/bciers/apps/administration/tests/routes/FacilitiesPage.test.tsx
@@ -18,7 +18,7 @@ describe("Facilities page", () => {
       await FacilitiesPage({
         operationId: "random UUID",
         searchParams: {
-          operationsTitle: "Operation Title",
+          operations_title: "Operation Title",
         },
         isExternalUser: true,
       }),

--- a/bciers/apps/administration/tests/routes/FacilitiesPage.test.tsx
+++ b/bciers/apps/administration/tests/routes/FacilitiesPage.test.tsx
@@ -28,7 +28,7 @@ describe("Facilities page", () => {
     expect(screen.getByRole("button", { name: "Add Facility" })).toBeVisible();
     expect(screen.getByRole("link", { name: "Add Facility" })).toHaveAttribute(
       "href",
-      "/operations/random UUID/facilities/add-facility?operationsTitle=Operation Title",
+      "/operations/random UUID/facilities/add-facility?operations_title=Operation Title",
     );
   });
   it("Not displaying `Add Facility` button for internal users", async () => {

--- a/bciers/libs/components/src/datagrid/cells/OperationsActionCell.tsx
+++ b/bciers/libs/components/src/datagrid/cells/OperationsActionCell.tsx
@@ -24,7 +24,7 @@ const OperationsActionCell = () => {
           href={{
             pathname: `operations/${params.row.id}`,
             query: {
-              operationsTitle: `${params.row.name}`,
+              operations_title: `${params.row.name}`,
             },
           }}
         >

--- a/bciers/libs/components/src/navigation/Bread.tsx
+++ b/bciers/libs/components/src/navigation/Bread.tsx
@@ -74,9 +74,9 @@ export default function Bread({
         : "";
       if (
         precedingSegment &&
-        crumbTitles[`${precedingSegment.toLowerCase()}Title`]
+        crumbTitles[`${precedingSegment.toLowerCase()}_title`]
       ) {
-        return crumbTitles[`${precedingSegment.toLowerCase()}Title`];
+        return crumbTitles[`${precedingSegment.toLowerCase()}_title`];
       }
       return crumbTitles.title;
     }

--- a/bciers/libs/components/src/navigation/Bread.tsx
+++ b/bciers/libs/components/src/navigation/Bread.tsx
@@ -21,6 +21,11 @@ function unslugifyAndCapitalize(segment: string): string {
     .join(" ");
 }
 
+// 🛠️ Function to check if a given value is numeric
+function isNumeric(value: string): boolean {
+  return !isNaN(Number(value));
+}
+
 // 🛠️ Function to determine valid crumb link
 function isValidLink(segment: string): boolean {
   // Define invalid links
@@ -63,7 +68,7 @@ export default function Bread({
   const crumbTitles = Object.fromEntries(searchParams.entries());
 
   function translateNumericPart(segment: string, index: number): string {
-    if (isValidUUID(segment)) {
+    if (isValidUUID(segment) || isNumeric(segment)) {
       const precedingSegment = pathNames[index - 1]
         ? unslugifyAndCapitalize(pathNames[index - 1])
         : "";


### PR DESCRIPTION
Addresses: 
[2026](https://github.com/bcgov/cas-registration/issues/2026)

### 🚀 Impact
- Updated breadcrumbs for UUID and numeric path segments



### 🔬 Local Testing:

1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd client && yarn dev-all
```  

### Test Contact Breadcrumbs:
1. Navigate to `http://localhost:3000`
3. Click button "Log in with Business BCeID"
4. Sign in to Keycloak using `bc-cas-dev`
5. Navigate to http://localhost:3000/administration/contacts
**Expected Results**   
   - `Contacts` displays
   - `Add Contact` button displays
![image](https://github.com/user-attachments/assets/468ba1fd-a4e6-492e-a0f1-a9f37eee5ced)
6. Click button `Add Contact`
**Expected Results**   
   - Contact form in edit mode displays
![image](https://github.com/user-attachments/assets/3cc34936-537a-4811-b5bd-4f6cbcbdf8d5)
7. Complete the required form fields. 
8. Click button `Submit` 
**Expected Results**   
   - Breadcrumbs displays the value in fields `First Name`  `Last Name`
![image](https://github.com/user-attachments/assets/ebbfe366-792c-4eb4-a47d-975e9feeebe1)
9. Click breadcrumb `Contacts`
**Expected Results**   
   - `Contacts` displays
   - Grid rows display `View Details` cell action
![image](https://github.com/user-attachments/assets/7ecf7012-2381-4563-bd16-ee78f479e3ea)
10. Click grid link `View Details`
**Expected Results**   
   - Breadcrumbs displays the value in fields `First Name`  `Last Name`
![image](https://github.com/user-attachments/assets/3c2e031a-8c2b-41bc-8347-e56100c1eff0)
