### PR TITLE
chore: fix root layout metadata

### DIFF
--- a/bciers/apps/administration/app/layout.tsx
+++ b/bciers/apps/administration/app/layout.tsx
@@ -8,14 +8,16 @@ import "@bciers/styles/globals.css";
 
 import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
 
+const title = "Administration";
+
 const defaultLinks = [
   { label: "Dashboard", href: "/" },
-  { label: "Administration", href: "/administration" },
+  { label: title, href: "/administration" },
 ];
 
 export const metadata = {
   ...rootMetadata,
-  title: `${rootMetadata.title} | Administration`,
+  title: `${rootMetadata.title} | ${title}`,
 };
 
 export default function AdministrationLayout({
@@ -24,7 +26,7 @@ export default function AdministrationLayout({
   children: React.ReactNode;
 }) {
   return (
-    <RootLayout defaultLinks={defaultLinks} zone="administration">
+    <RootLayout defaultLinks={defaultLinks} zone={title.toLowerCase()}>
       {children}
     </RootLayout>
   );

--- a/bciers/apps/administration/app/layout.tsx
+++ b/bciers/apps/administration/app/layout.tsx
@@ -15,7 +15,7 @@ const defaultLinks = [
 
 export const metadata = {
   ...rootMetadata,
-  title: "CAS OBPS | Administration",
+  title: `${rootMetadata.title} | Administration`,
 };
 
 export default function AdministrationLayout({

--- a/bciers/apps/administration/app/layout.tsx
+++ b/bciers/apps/administration/app/layout.tsx
@@ -6,12 +6,17 @@ The app directory must include a root app/layout.js.
 // eslint-disable-next-line import/extensions
 import "@bciers/styles/globals.css";
 
-import RootLayout from "@bciers/components/layout/RootLayout";
+import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
 
 const defaultLinks = [
   { label: "Dashboard", href: "/" },
   { label: "Administration", href: "/administration" },
 ];
+
+export const metadata = {
+  ...rootMetadata,
+  title: "CAS OBPS | Administration",
+};
 
 export default function AdministrationLayout({
   children,

--- a/bciers/apps/administration/app/layout.tsx
+++ b/bciers/apps/administration/app/layout.tsx
@@ -6,7 +6,9 @@ The app directory must include a root app/layout.js.
 // eslint-disable-next-line import/extensions
 import "@bciers/styles/globals.css";
 
-import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
+import RootLayout, {
+  generateMetadata,
+} from "@bciers/components/layout/RootLayout";
 
 const title = "Administration";
 
@@ -15,10 +17,7 @@ const defaultLinks = [
   { label: title, href: "/administration" },
 ];
 
-export const metadata = {
-  ...rootMetadata,
-  title: `${rootMetadata.title} | ${title}`,
-};
+export const metadata = generateMetadata(title);
 
 export default function AdministrationLayout({
   children,

--- a/bciers/apps/administration/app/not-found.tsx
+++ b/bciers/apps/administration/app/not-found.tsx
@@ -1,0 +1,3 @@
+import NotFound from "@bciers/components/error/NotFound";
+
+export default NotFound;

--- a/bciers/apps/coam/app/layout.tsx
+++ b/bciers/apps/coam/app/layout.tsx
@@ -5,7 +5,9 @@ The app directory must include a root app/layout.js.
 
 // eslint-disable-next-line import/extensions
 import "@bciers/styles/globals.css";
-import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
+import RootLayout, {
+  generateMetadata,
+} from "@bciers/components/layout/RootLayout";
 
 const title = "COAM";
 
@@ -14,10 +16,7 @@ const defaultLinks = [
   { label: title, href: "/coam" },
 ];
 
-export const metadata = {
-  ...rootMetadata,
-  title: `${rootMetadata.title} | ${title}`,
-};
+export const metadata = generateMetadata(title);
 
 export default function COAMLayout({
   children,

--- a/bciers/apps/coam/app/layout.tsx
+++ b/bciers/apps/coam/app/layout.tsx
@@ -14,7 +14,7 @@ const defaultLinks = [
 
 export const metadata = {
   ...rootMetadata,
-  title: "CAS OBPS | COAM",
+  title: `${rootMetadata.title} | COAM`,
 };
 
 export default function COAMLayout({

--- a/bciers/apps/coam/app/layout.tsx
+++ b/bciers/apps/coam/app/layout.tsx
@@ -7,14 +7,16 @@ The app directory must include a root app/layout.js.
 import "@bciers/styles/globals.css";
 import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
 
+const title = "COAM";
+
 const defaultLinks = [
   { label: "Dashboard", href: "/" },
-  { label: "COAM", href: "/coam" },
+  { label: title, href: "/coam" },
 ];
 
 export const metadata = {
   ...rootMetadata,
-  title: `${rootMetadata.title} | COAM`,
+  title: `${rootMetadata.title} | ${title}`,
 };
 
 export default function COAMLayout({
@@ -23,7 +25,7 @@ export default function COAMLayout({
   children: React.ReactNode;
 }) {
   return (
-    <RootLayout defaultLinks={defaultLinks} zone="coam">
+    <RootLayout defaultLinks={defaultLinks} zone={title.toLowerCase()}>
       {children}
     </RootLayout>
   );

--- a/bciers/apps/coam/app/layout.tsx
+++ b/bciers/apps/coam/app/layout.tsx
@@ -5,11 +5,18 @@ The app directory must include a root app/layout.js.
 
 // eslint-disable-next-line import/extensions
 import "@bciers/styles/globals.css";
-import { RootLayout } from "@bciers/components/server";
+import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
+
 const defaultLinks = [
   { label: "Dashboard", href: "/" },
   { label: "COAM", href: "/coam" },
 ];
+
+export const metadata = {
+  ...rootMetadata,
+  title: "CAS OBPS | COAM",
+};
+
 export default function COAMLayout({
   children,
 }: {

--- a/bciers/apps/coam/app/not-found.tsx
+++ b/bciers/apps/coam/app/not-found.tsx
@@ -1,0 +1,3 @@
+import NotFound from "@bciers/components/error/NotFound";
+
+export default NotFound;

--- a/bciers/apps/dashboard/app/layout.tsx
+++ b/bciers/apps/dashboard/app/layout.tsx
@@ -7,11 +7,10 @@ You should not manually add <head> tags such as <title> and <meta> to root layou
 
 // eslint-disable-next-line import/extensions
 import "@bciers/styles/globals.css";
-import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
+import RootLayout, {
+  generateMetadata,
+} from "@bciers/components/layout/RootLayout";
 
-export const metadata = {
-  ...rootMetadata,
-  title: `${rootMetadata.title} | Dashboard`,
-};
+export const metadata = generateMetadata("Dashboard");
 
 export default RootLayout;

--- a/bciers/apps/dashboard/app/layout.tsx
+++ b/bciers/apps/dashboard/app/layout.tsx
@@ -7,6 +7,11 @@ You should not manually add <head> tags such as <title> and <meta> to root layou
 
 // eslint-disable-next-line import/extensions
 import "@bciers/styles/globals.css";
-import RootLayout from "@bciers/components/layout/RootLayout";
+import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
+
+export const metadata = {
+  ...rootMetadata,
+  title: "CAS OBPS | Dashboard",
+};
 
 export default RootLayout;

--- a/bciers/apps/dashboard/app/layout.tsx
+++ b/bciers/apps/dashboard/app/layout.tsx
@@ -11,7 +11,7 @@ import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
 
 export const metadata = {
   ...rootMetadata,
-  title: "CAS OBPS | Dashboard",
+  title: `${rootMetadata.title} | Dashboard`,
 };
 
 export default RootLayout;

--- a/bciers/apps/dashboard/app/not-found.tsx
+++ b/bciers/apps/dashboard/app/not-found.tsx
@@ -1,0 +1,3 @@
+import NotFound from "@bciers/components/error/NotFound";
+
+export default NotFound;

--- a/bciers/apps/registration/app/layout.tsx
+++ b/bciers/apps/registration/app/layout.tsx
@@ -5,7 +5,9 @@ The app directory must include a root app/layout.js.
 
 // eslint-disable-next-line import/extensions
 import "@bciers/styles/globals.css";
-import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
+import RootLayout, {
+  generateMetadata,
+} from "@bciers/components/layout/RootLayout";
 
 const title = "Registration";
 
@@ -14,10 +16,7 @@ const defaultLinks = [
   { label: title, href: "/registration" },
 ];
 
-export const metadata = {
-  ...rootMetadata,
-  title: `${rootMetadata.title} | ${title}`,
-};
+export const metadata = generateMetadata(title);
 
 export default function ReportingLayout({
   children,

--- a/bciers/apps/registration/app/layout.tsx
+++ b/bciers/apps/registration/app/layout.tsx
@@ -5,11 +5,18 @@ The app directory must include a root app/layout.js.
 
 // eslint-disable-next-line import/extensions
 import "@bciers/styles/globals.css";
-import { RootLayout } from "@bciers/components/server";
+import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
+
 const defaultLinks = [
   { label: "Dashboard", href: "/" },
   { label: "Registration", href: "/registration" },
 ];
+
+export const metadata = {
+  ...rootMetadata,
+  title: "CAS OBPS | Registration",
+};
+
 export default function ReportingLayout({
   children,
 }: {

--- a/bciers/apps/registration/app/layout.tsx
+++ b/bciers/apps/registration/app/layout.tsx
@@ -14,7 +14,7 @@ const defaultLinks = [
 
 export const metadata = {
   ...rootMetadata,
-  title: "CAS OBPS | Registration",
+  title: `${rootMetadata.title} | Registration`,
 };
 
 export default function ReportingLayout({

--- a/bciers/apps/registration/app/layout.tsx
+++ b/bciers/apps/registration/app/layout.tsx
@@ -7,14 +7,16 @@ The app directory must include a root app/layout.js.
 import "@bciers/styles/globals.css";
 import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
 
+const title = "Registration";
+
 const defaultLinks = [
   { label: "Dashboard", href: "/" },
-  { label: "Registration", href: "/registration" },
+  { label: title, href: "/registration" },
 ];
 
 export const metadata = {
   ...rootMetadata,
-  title: `${rootMetadata.title} | Registration`,
+  title: `${rootMetadata.title} | ${title}`,
 };
 
 export default function ReportingLayout({
@@ -23,7 +25,7 @@ export default function ReportingLayout({
   children: React.ReactNode;
 }) {
   return (
-    <RootLayout defaultLinks={defaultLinks} zone="registration">
+    <RootLayout defaultLinks={defaultLinks} zone={title.toLowerCase()}>
       {children}
     </RootLayout>
   );

--- a/bciers/apps/registration/app/not-found.tsx
+++ b/bciers/apps/registration/app/not-found.tsx
@@ -1,0 +1,3 @@
+import NotFound from "@bciers/components/error/NotFound";
+
+export default NotFound;

--- a/bciers/apps/reporting/src/app/layout.tsx
+++ b/bciers/apps/reporting/src/app/layout.tsx
@@ -5,7 +5,9 @@ The app directory must include a root app/layout.js.
 
 // eslint-disable-next-line import/extensions
 import "@bciers/styles/globals.css";
-import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
+import RootLayout, {
+  generateMetadata,
+} from "@bciers/components/layout/RootLayout";
 
 const title = "Reporting";
 
@@ -14,10 +16,7 @@ const defaultLinks = [
   { label: title, href: "/reporting" },
 ];
 
-export const metadata = {
-  ...rootMetadata,
-  title: `${rootMetadata.title} | ${title}`,
-};
+export const metadata = generateMetadata(title);
 
 export default function ReportingLayout({
   children,

--- a/bciers/apps/reporting/src/app/layout.tsx
+++ b/bciers/apps/reporting/src/app/layout.tsx
@@ -5,11 +5,18 @@ The app directory must include a root app/layout.js.
 
 // eslint-disable-next-line import/extensions
 import "@bciers/styles/globals.css";
-import { RootLayout } from "@bciers/components/server";
+import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
+
 const defaultLinks = [
   { label: "Dashboard", href: "/" },
   { label: "Reporting", href: "/reporting" },
 ];
+
+export const metadata = {
+  ...rootMetadata,
+  title: "CAS OBPS | Reporting",
+};
+
 export default function ReportingLayout({
   children,
 }: {

--- a/bciers/apps/reporting/src/app/layout.tsx
+++ b/bciers/apps/reporting/src/app/layout.tsx
@@ -14,7 +14,7 @@ const defaultLinks = [
 
 export const metadata = {
   ...rootMetadata,
-  title: "CAS OBPS | Reporting",
+  title: `${rootMetadata.title} | Reporting`,
 };
 
 export default function ReportingLayout({

--- a/bciers/apps/reporting/src/app/layout.tsx
+++ b/bciers/apps/reporting/src/app/layout.tsx
@@ -7,14 +7,16 @@ The app directory must include a root app/layout.js.
 import "@bciers/styles/globals.css";
 import RootLayout, { rootMetadata } from "@bciers/components/layout/RootLayout";
 
+const title = "Reporting";
+
 const defaultLinks = [
   { label: "Dashboard", href: "/" },
-  { label: "Reporting", href: "/reporting" },
+  { label: title, href: "/reporting" },
 ];
 
 export const metadata = {
   ...rootMetadata,
-  title: `${rootMetadata.title} | Reporting`,
+  title: `${rootMetadata.title} | ${title}`,
 };
 
 export default function ReportingLayout({
@@ -23,7 +25,7 @@ export default function ReportingLayout({
   children: React.ReactNode;
 }) {
   return (
-    <RootLayout defaultLinks={defaultLinks} zone="reporting">
+    <RootLayout defaultLinks={defaultLinks} zone={title.toLowerCase()}>
       {children}
     </RootLayout>
   );

--- a/bciers/apps/reporting/src/app/not-found.tsx
+++ b/bciers/apps/reporting/src/app/not-found.tsx
@@ -1,0 +1,3 @@
+import NotFound from "@bciers/components/error/NotFound";
+
+export default NotFound;

--- a/bciers/libs/components/src/error/NotFound.tsx
+++ b/bciers/libs/components/src/error/NotFound.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+const NotFound = () => {
+  return (
+    <div className="flex flex-col items-center text-bc-gov-links-color">
+      <h2>Not found</h2>
+      <p>Could not find requested resource</p>
+      <Link href="/">Return Home</Link>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/bciers/libs/components/src/error/NotFound.tsx
+++ b/bciers/libs/components/src/error/NotFound.tsx
@@ -2,9 +2,9 @@ import Link from "next/link";
 
 const NotFound = () => {
   return (
-    <div className="flex flex-col items-center text-bc-gov-links-color">
+    <div className="flex flex-col items-center text-bc-gov-links-color mt-8">
       <h2>Not found</h2>
-      <p>Could not find requested resource</p>
+      <p className="mt-0">Could not find requested resource</p>
       <Link href="/">Return Home</Link>
     </div>
   );

--- a/bciers/libs/components/src/layout/RootLayout.tsx
+++ b/bciers/libs/components/src/layout/RootLayout.tsx
@@ -13,7 +13,7 @@ import { Header } from "@bciers/components";
 import { Bread } from "@bciers/components";
 import { Main } from "@bciers/components/server";
 
-export const metadata: Metadata = {
+export const rootMetadata: Metadata = {
   title: "CAS OBPS",
   description:
     "The OBPS is designed to ensure there is a price incentive for industrial emitters to reduce their greenhouse gas emissions and spur innovation while maintaining competitiveness and protecting against carbon leakage.",

--- a/bciers/libs/components/src/layout/RootLayout.tsx
+++ b/bciers/libs/components/src/layout/RootLayout.tsx
@@ -13,13 +13,20 @@ import { Header } from "@bciers/components";
 import { Bread } from "@bciers/components";
 import { Main } from "@bciers/components/server";
 
-export const rootMetadata: Metadata = {
+const rootMetadata: Metadata = {
   title: "CAS OBPS",
   description:
     "The OBPS is designed to ensure there is a price incentive for industrial emitters to reduce their greenhouse gas emissions and spur innovation while maintaining competitiveness and protecting against carbon leakage.",
   icons: {
     icon: "/favicon.ico",
   },
+};
+
+export const generateMetadata = (zone: string): Metadata => {
+  return {
+    ...rootMetadata,
+    title: `${rootMetadata.title} | ${zone}`,
+  };
 };
 
 export const viewport: Viewport = {

--- a/bciers/libs/components/src/layout/RootLayout.tsx
+++ b/bciers/libs/components/src/layout/RootLayout.tsx
@@ -18,7 +18,7 @@ export const rootMetadata: Metadata = {
   description:
     "The OBPS is designed to ensure there is a price incentive for industrial emitters to reduce their greenhouse gas emissions and spur innovation while maintaining competitiveness and protecting against carbon leakage.",
   icons: {
-    icon: "/img/favicon.ico",
+    icon: "/favicon.ico",
   },
 };
 


### PR DESCRIPTION
#2060 

The metadata in the `RootLayout` wasn't working correctly as it was exporting from that file instead of being exported from the `layout`. 

To test this first run `yarn dev-all` in `develop` and see that the title isn't working:

<img width="844" alt="Screenshot 2024-08-09 at 7 47 04 AM" src="https://github.com/user-attachments/assets/8fdb93e3-f5d2-40e8-b2c1-f58f7543ce71">


Checkout this branch and run `yarn dev-all` and now the title is working:  
<img width="844" alt="Screenshot 2024-08-09 at 7 46 20 AM" src="https://github.com/user-attachments/assets/16e6e260-8126-4c08-8f83-888ad58caf2c">

