### PR TITLE
chore: update test-setup endpoint with load_only boolean

### DIFF
--- a/bc_obps/registration/api/v1/e2e_test_setup.py
+++ b/bc_obps/registration/api/v1/e2e_test_setup.py
@@ -14,14 +14,16 @@ from django.core.cache import cache
     description="""Sets up the test environment by either truncating data tables or loading fixtures based on the specified workflow.
     This endpoint is only available in the development environment.""",
 )
-def setup(request: HttpRequest, workflow: Optional[str] = None, truncate_only: bool = False) -> HttpResponse:
+def setup(request: HttpRequest, workflow: Optional[str] = None, truncate_only: bool = False, load_only: bool = False) -> HttpResponse:
     if settings.ENVIRONMENT == "dev":
         cache.clear()  # clear cache to avoid stale data (specifically for the current_user_middleware.py middleware)
         try:
             if truncate_only:  # only truncate the tables
                 call_command('truncate_dev_data_tables')
                 return HttpResponse("Test setup complete.", status=200)
-
+            if load_only:  # only load the data
+                call_command('load_fixtures', workflow)
+                return HttpResponse("Test setup complete.", status=200)
             call_command('truncate_dev_data_tables')
             call_command('load_fixtures', workflow)
             return HttpResponse("Test setup complete.", status=200)

--- a/bc_obps/registration/api/v1/e2e_test_setup.py
+++ b/bc_obps/registration/api/v1/e2e_test_setup.py
@@ -14,7 +14,9 @@ from django.core.cache import cache
     description="""Sets up the test environment by either truncating data tables or loading fixtures based on the specified workflow.
     This endpoint is only available in the development environment.""",
 )
-def setup(request: HttpRequest, workflow: Optional[str] = None, truncate_only: bool = False, load_only: bool = False) -> HttpResponse:
+def setup(
+    request: HttpRequest, workflow: Optional[str] = None, truncate_only: bool = False, load_only: bool = False
+) -> HttpResponse:
     if settings.ENVIRONMENT == "dev":
         cache.clear()  # clear cache to avoid stale data (specifically for the current_user_middleware.py middleware)
         try:

--- a/helm/cas-bciers/templates/backend/job/load-dev-data.yaml
+++ b/helm/cas-bciers/templates/backend/job/load-dev-data.yaml
@@ -25,6 +25,6 @@ spec:
           command:
             - /bin/sh
             - -ec
-            - "curl https://$(BACKEND_HOST)/api/registration/test-setup"
+            - "curl https://$(BACKEND_HOST)/api/registration/test-setup?load_only=True"
       restartPolicy: Never
 {{ end }}

--- a/helm/cas-registration/templates/backend/job/load-dev-data.yaml
+++ b/helm/cas-registration/templates/backend/job/load-dev-data.yaml
@@ -25,6 +25,6 @@ spec:
           command:
             - /bin/sh
             - -ec
-            - "curl https://$(BACKEND_HOST)/api/registration/test-setup"
+            - "curl https://$(BACKEND_HOST)/api/registration/test-setup?load_only=True"
       restartPolicy: Never
 {{ end }}


### PR DESCRIPTION
The test-setup endpoint was truncating tables in the dev environment resulting in losing data that we expected to exist after deploy to dev. Truncating the data should be unnecessary here since we reset the db before deploy.

- Added a load_only boolean to the test-setup endpoint & set it to True in the call from helm