### PR TITLE
chore: replace all JSON.parse() calls with safeJsonParse

### DIFF
--- a/bciers/apps/administration/app/components/contacts/createContactSchema.ts
+++ b/bciers/apps/administration/app/components/contacts/createContactSchema.ts
@@ -1,6 +1,6 @@
 import { contactsSchema } from "./../../data/jsonSchema/contact";
 import { UserOperatorUser } from "./types";
-import safeJsonParse from "libs/utils/safeJsonParse"
+import safeJsonParse from "libs/utils/safeJsonParse";
 
 // 🛠️ Function to create a contact schema with updated enum values
 export const createContactSchema = (

--- a/bciers/apps/administration/app/components/contacts/createContactSchema.ts
+++ b/bciers/apps/administration/app/components/contacts/createContactSchema.ts
@@ -1,12 +1,13 @@
 import { contactsSchema } from "./../../data/jsonSchema/contact";
 import { UserOperatorUser } from "./types";
+import safeJsonParse from 'libs/utils/safeJsonParse'
 
 // 🛠️ Function to create a contact schema with updated enum values
 export const createContactSchema = (
   userOperatorUsers: UserOperatorUser[],
   isCreating?: boolean,
 ) => {
-  const localSchema = JSON.parse(JSON.stringify(contactsSchema)); // deep copy
+  const localSchema = safeJsonParse(JSON.stringify(contactsSchema)); // deep copy
 
   // For now, we show the `existing_bciers_user` toggle and `selected_user` combobox only when creating a new contact
   if (isCreating) {

--- a/bciers/apps/administration/app/components/contacts/createContactSchema.ts
+++ b/bciers/apps/administration/app/components/contacts/createContactSchema.ts
@@ -1,6 +1,6 @@
 import { contactsSchema } from "./../../data/jsonSchema/contact";
 import { UserOperatorUser } from "./types";
-import safeJsonParse from 'libs/utils/safeJsonParse'
+import safeJsonParse from "libs/utils/safeJsonParse"
 
 // 🛠️ Function to create a contact schema with updated enum values
 export const createContactSchema = (

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -9,7 +9,7 @@ import {
 import { RJSFSchema } from "@rjsf/utils";
 import { operationInformationSchema } from "../../data/jsonSchema/operationInformation";
 import { validate as isValidUUID } from "uuid";
-import safeJsonParse from "libs/utils/safeJsonParse"
+import safeJsonParse from "libs/utils/safeJsonParse";
 
 // 🛠️ Function to create an operation schema with updated enum values
 export const createOperationSchema = (

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -9,6 +9,7 @@ import {
 import { RJSFSchema } from "@rjsf/utils";
 import { operationInformationSchema } from "../../data/jsonSchema/operationInformation";
 import { validate as isValidUUID } from "uuid";
+import safeJsonParse from 'libs/utils/safeJsonParse'
 
 // 🛠️ Function to create an operation schema with updated enum values
 export const createOperationSchema = (
@@ -25,7 +26,7 @@ export const createOperationSchema = (
     name: string;
   }[],
 ) => {
-  const localSchema = JSON.parse(JSON.stringify(schema));
+  const localSchema = safeJsonParse(JSON.stringify(schema));
   const section1 = localSchema.properties.section1.properties;
   const section2Dependencies = localSchema.properties.section2.dependencies;
   const section3 = localSchema.properties.section3.properties;

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -9,7 +9,7 @@ import {
 import { RJSFSchema } from "@rjsf/utils";
 import { operationInformationSchema } from "../../data/jsonSchema/operationInformation";
 import { validate as isValidUUID } from "uuid";
-import safeJsonParse from 'libs/utils/safeJsonParse'
+import safeJsonParse from "libs/utils/safeJsonParse"
 
 // 🛠️ Function to create an operation schema with updated enum values
 export const createOperationSchema = (

--- a/bciers/apps/administration/app/components/operators/Operator.tsx
+++ b/bciers/apps/administration/app/components/operators/Operator.tsx
@@ -4,7 +4,7 @@ import { operatorSchema } from "../../data/jsonSchema/operator";
 import { RJSFSchema } from "@rjsf/utils";
 import getCurrentOperator from "./getCurrentOperator";
 import getBusinessStructures from "./getBusinessStructures";
-import safeJsonParse from 'libs/utils/safeJsonParse'
+import safeJsonParse from "libs/utils/safeJsonParse"
 
 export const createOperatorSchema = (
   schema: RJSFSchema,

--- a/bciers/apps/administration/app/components/operators/Operator.tsx
+++ b/bciers/apps/administration/app/components/operators/Operator.tsx
@@ -4,12 +4,13 @@ import { operatorSchema } from "../../data/jsonSchema/operator";
 import { RJSFSchema } from "@rjsf/utils";
 import getCurrentOperator from "./getCurrentOperator";
 import getBusinessStructures from "./getBusinessStructures";
+import safeJsonParse from 'libs/utils/safeJsonParse'
 
 export const createOperatorSchema = (
   schema: RJSFSchema,
   businessStructures: { name: string }[],
 ): RJSFSchema => {
-  const localSchema = JSON.parse(JSON.stringify(schema));
+  const localSchema = safeJsonParse(JSON.stringify(schema));
 
   const businessStructureOptions = businessStructures?.map(
     (businessStructure) => ({

--- a/bciers/apps/administration/app/components/operators/Operator.tsx
+++ b/bciers/apps/administration/app/components/operators/Operator.tsx
@@ -4,7 +4,7 @@ import { operatorSchema } from "../../data/jsonSchema/operator";
 import { RJSFSchema } from "@rjsf/utils";
 import getCurrentOperator from "./getCurrentOperator";
 import getBusinessStructures from "./getBusinessStructures";
-import safeJsonParse from "libs/utils/safeJsonParse"
+import safeJsonParse from "libs/utils/safeJsonParse";
 
 export const createOperatorSchema = (
   schema: RJSFSchema,

--- a/bciers/apps/registration/app/components/operations/registration/FacilityInformationPage.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/FacilityInformationPage.tsx
@@ -5,13 +5,14 @@ import { facilityInformationSchema } from "apps/registration/app/data/jsonSchema
 import { facilitiesSchemaLfo } from "apps/administration/app/data/jsonSchema/facilitiesLfo";
 import { RJSFSchema } from "@rjsf/utils";
 import { FacilitiesSearchParams } from "apps/administration/app/components/facilities/types";
+import safeJsonParse from 'libs/utils/safeJsonParse'
 
 // 🛠️ Function to create a facility information schema with updated enum values
 export const createFacilityInformationSchema = (
   schema: RJSFSchema,
   lfoSchema: RJSFSchema,
 ) => {
-  const localSchema = JSON.parse(JSON.stringify(schema));
+  const localSchema = safeJsonParse(JSON.stringify(schema));
 
   localSchema.properties.facility_information_array.items.properties =
     lfoSchema.properties;

--- a/bciers/apps/registration/app/components/operations/registration/FacilityInformationPage.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/FacilityInformationPage.tsx
@@ -5,7 +5,7 @@ import { facilityInformationSchema } from "apps/registration/app/data/jsonSchema
 import { facilitiesSchemaLfo } from "apps/administration/app/data/jsonSchema/facilitiesLfo";
 import { RJSFSchema } from "@rjsf/utils";
 import { FacilitiesSearchParams } from "apps/administration/app/components/facilities/types";
-import safeJsonParse from "libs/utils/safeJsonParse"
+import safeJsonParse from "libs/utils/safeJsonParse";
 
 // 🛠️ Function to create a facility information schema with updated enum values
 export const createFacilityInformationSchema = (

--- a/bciers/apps/registration/app/components/operations/registration/FacilityInformationPage.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/FacilityInformationPage.tsx
@@ -5,7 +5,7 @@ import { facilityInformationSchema } from "apps/registration/app/data/jsonSchema
 import { facilitiesSchemaLfo } from "apps/administration/app/data/jsonSchema/facilitiesLfo";
 import { RJSFSchema } from "@rjsf/utils";
 import { FacilitiesSearchParams } from "apps/administration/app/components/facilities/types";
-import safeJsonParse from 'libs/utils/safeJsonParse'
+import safeJsonParse from "libs/utils/safeJsonParse"
 
 // 🛠️ Function to create a facility information schema with updated enum values
 export const createFacilityInformationSchema = (

--- a/bciers/apps/registration/app/components/operations/registration/RegistrationPurposePage.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/RegistrationPurposePage.tsx
@@ -4,7 +4,7 @@ import RegistrationPurposeForm from "apps/registration/app/components/operations
 import { registrationPurposeSchema } from "apps/registration/app/data/jsonSchema/operationRegistration/registrationPurpose";
 import { getRegulatedProducts } from "@bciers/actions/api";
 import { RJSFSchema } from "@rjsf/utils";
-import safeJsonParse from "libs/utils/safeJsonParse"
+import safeJsonParse from "libs/utils/safeJsonParse";
 
 // 🛠️ Function to create an operation schema with updated enum values
 export const createRegistrationPurposeSchema = (

--- a/bciers/apps/registration/app/components/operations/registration/RegistrationPurposePage.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/RegistrationPurposePage.tsx
@@ -4,7 +4,7 @@ import RegistrationPurposeForm from "apps/registration/app/components/operations
 import { registrationPurposeSchema } from "apps/registration/app/data/jsonSchema/operationRegistration/registrationPurpose";
 import { getRegulatedProducts } from "@bciers/actions/api";
 import { RJSFSchema } from "@rjsf/utils";
-import safeJsonParse from 'libs/utils/safeJsonParse'
+import safeJsonParse from "libs/utils/safeJsonParse"
 
 // 🛠️ Function to create an operation schema with updated enum values
 export const createRegistrationPurposeSchema = (

--- a/bciers/apps/registration/app/components/operations/registration/RegistrationPurposePage.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/RegistrationPurposePage.tsx
@@ -4,6 +4,7 @@ import RegistrationPurposeForm from "apps/registration/app/components/operations
 import { registrationPurposeSchema } from "apps/registration/app/data/jsonSchema/operationRegistration/registrationPurpose";
 import { getRegulatedProducts } from "@bciers/actions/api";
 import { RJSFSchema } from "@rjsf/utils";
+import safeJsonParse from 'libs/utils/safeJsonParse'
 
 // 🛠️ Function to create an operation schema with updated enum values
 export const createRegistrationPurposeSchema = (
@@ -13,7 +14,7 @@ export const createRegistrationPurposeSchema = (
     name: string;
   }[],
 ) => {
-  const localSchema = JSON.parse(JSON.stringify(schema));
+  const localSchema = safeJsonParse(JSON.stringify(schema));
 
   const regulatedProductsSchema =
     localSchema.dependencies.registration_purpose.allOf[0].then.properties

--- a/bciers/apps/registration1/app/components/operations/Operation.tsx
+++ b/bciers/apps/registration1/app/components/operations/Operation.tsx
@@ -19,6 +19,7 @@ import {
   operationInternalUserSchema,
   operationSchema,
 } from "@/app/utils/jsonSchema/operations";
+import safeJsonParse from 'libs/utils/safeJsonParse'
 
 // 🚀 API call: GET user's data
 async function getUserFormData(): Promise<
@@ -105,7 +106,7 @@ export const createOperationSchema = (
   // }[],
   businessStructureList: { id: string; label: string }[],
 ) => {
-  const localSchema = JSON.parse(JSON.stringify(schema));
+  const localSchema = safeJsonParse(JSON.stringify(schema));
   // naics codes
   if (Array.isArray(naicsCodes)) {
     // add to nested operation page1 schema

--- a/bciers/apps/registration1/app/components/operations/Operation.tsx
+++ b/bciers/apps/registration1/app/components/operations/Operation.tsx
@@ -19,7 +19,7 @@ import {
   operationInternalUserSchema,
   operationSchema,
 } from "@/app/utils/jsonSchema/operations";
-import safeJsonParse from "libs/utils/safeJsonParse"
+import safeJsonParse from "libs/utils/safeJsonParse";
 
 // 🚀 API call: GET user's data
 async function getUserFormData(): Promise<

--- a/bciers/apps/registration1/app/components/operations/Operation.tsx
+++ b/bciers/apps/registration1/app/components/operations/Operation.tsx
@@ -19,7 +19,7 @@ import {
   operationInternalUserSchema,
   operationSchema,
 } from "@/app/utils/jsonSchema/operations";
-import safeJsonParse from 'libs/utils/safeJsonParse'
+import safeJsonParse from "libs/utils/safeJsonParse"
 
 // 🚀 API call: GET user's data
 async function getUserFormData(): Promise<

--- a/bciers/apps/registration1/app/components/userOperators/UserOperator.tsx
+++ b/bciers/apps/registration1/app/components/userOperators/UserOperator.tsx
@@ -11,6 +11,7 @@ import { validate as isValidUUID } from "uuid";
 import { BusinessStructure } from "./types";
 import UserOperatorReviewForm from "./UserOperatorReviewForm";
 import UserOperatorForm from "./UserOperatorForm";
+import safeJsonParse from 'libs/utils/safeJsonParse'
 
 async function getBusinessStructures() {
   return actionHandler(
@@ -34,7 +35,7 @@ const createUserOperatorSchema = (
   schema: RJSFSchema,
   businessStructureList: { id: string; label: string }[],
 ): RJSFSchema => {
-  const localSchema = JSON.parse(JSON.stringify(schema));
+  const localSchema = safeJsonParse(JSON.stringify(schema));
 
   const businessStructureOptions = businessStructureList?.map(
     (businessStructure) => ({

--- a/bciers/apps/registration1/app/components/userOperators/UserOperator.tsx
+++ b/bciers/apps/registration1/app/components/userOperators/UserOperator.tsx
@@ -11,7 +11,7 @@ import { validate as isValidUUID } from "uuid";
 import { BusinessStructure } from "./types";
 import UserOperatorReviewForm from "./UserOperatorReviewForm";
 import UserOperatorForm from "./UserOperatorForm";
-import safeJsonParse from 'libs/utils/safeJsonParse'
+import safeJsonParse from "libs/utils/safeJsonParse"
 
 async function getBusinessStructures() {
   return actionHandler(

--- a/bciers/apps/registration1/app/components/userOperators/UserOperator.tsx
+++ b/bciers/apps/registration1/app/components/userOperators/UserOperator.tsx
@@ -11,7 +11,7 @@ import { validate as isValidUUID } from "uuid";
 import { BusinessStructure } from "./types";
 import UserOperatorReviewForm from "./UserOperatorReviewForm";
 import UserOperatorForm from "./UserOperatorForm";
-import safeJsonParse from "libs/utils/safeJsonParse"
+import safeJsonParse from "libs/utils/safeJsonParse";
 
 async function getBusinessStructures() {
   return actionHandler(

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user/activities/general_stationary_combustion/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user/activities/general_stationary_combustion/page.tsx
@@ -1,7 +1,7 @@
 import GeneralStationaryCombustion from "../../../../components/activities/generalStationaryCombustion";
 import { Suspense } from "react";
 import { actionHandler } from "@bciers/actions";
-import safeJsonParse from "libs/utils/safeJsonParse"
+import safeJsonParse from "libs/utils/safeJsonParse";
 
 export default async function Page() {
   const reportDate = "2024-04-01"; // This should be passed in once we have a path to this page from starting a report

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user/activities/general_stationary_combustion/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user/activities/general_stationary_combustion/page.tsx
@@ -1,7 +1,7 @@
 import GeneralStationaryCombustion from "../../../../components/activities/generalStationaryCombustion";
 import { Suspense } from "react";
 import { actionHandler } from "@bciers/actions";
-import safeJsonParse from 'libs/utils/safeJsonParse'
+import safeJsonParse from "libs/utils/safeJsonParse"
 
 export default async function Page() {
   const reportDate = "2024-04-01"; // This should be passed in once we have a path to this page from starting a report

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user/activities/general_stationary_combustion/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user/activities/general_stationary_combustion/page.tsx
@@ -1,6 +1,7 @@
 import GeneralStationaryCombustion from "../../../../components/activities/generalStationaryCombustion";
 import { Suspense } from "react";
 import { actionHandler } from "@bciers/actions";
+import safeJsonParse from 'libs/utils/safeJsonParse'
 
 export default async function Page() {
   const reportDate = "2024-04-01"; // This should be passed in once we have a path to this page from starting a report
@@ -9,7 +10,7 @@ export default async function Page() {
     "GET",
     "",
   );
-  const activityDataObject = JSON.parse(activityData);
+  const activityDataObject = safeJsonParse(activityData);
 
   return (
     <Suspense fallback="Loading Schema">

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/activities/general_stationary_combustion/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/activities/general_stationary_combustion/page.tsx
@@ -1,7 +1,7 @@
 import GeneralStationaryCombustion from "../../../../components/activities/generalStationaryCombustion";
 import { Suspense } from "react";
 import { actionHandler } from "@bciers/actions";
-import safeJsonParse from "libs/utils/safeJsonParse"
+import safeJsonParse from "libs/utils/safeJsonParse";
 
 export default async function Page() {
   const reportDate = "2024-04-01"; // This should be passed in once we have a path to this page from starting a report

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/activities/general_stationary_combustion/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/activities/general_stationary_combustion/page.tsx
@@ -1,7 +1,7 @@
 import GeneralStationaryCombustion from "../../../../components/activities/generalStationaryCombustion";
 import { Suspense } from "react";
 import { actionHandler } from "@bciers/actions";
-import safeJsonParse from 'libs/utils/safeJsonParse'
+import safeJsonParse from "libs/utils/safeJsonParse"
 
 export default async function Page() {
   const reportDate = "2024-04-01"; // This should be passed in once we have a path to this page from starting a report

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/activities/general_stationary_combustion/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/activities/general_stationary_combustion/page.tsx
@@ -1,6 +1,7 @@
 import GeneralStationaryCombustion from "../../../../components/activities/generalStationaryCombustion";
 import { Suspense } from "react";
 import { actionHandler } from "@bciers/actions";
+import safeJsonParse from 'libs/utils/safeJsonParse'
 
 export default async function Page() {
   const reportDate = "2024-04-01"; // This should be passed in once we have a path to this page from starting a report
@@ -9,7 +10,7 @@ export default async function Page() {
     "GET",
     "",
   );
-  const activityDataObject = JSON.parse(activityData);
+  const activityDataObject = safeJsonParse(activityData);
 
   return (
     <Suspense fallback="Loading Schema">

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -6,6 +6,7 @@ import { actionHandler } from "@bciers/actions";
 import { Alert, Button } from "@mui/material";
 import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/ReportingTaskList";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
+import safeJsonParse from "@bciers/utils/safeJsonParse";
 
 const tasklistData: TaskListElement[] = [
   {
@@ -99,7 +100,7 @@ export default function ActivityForm({
         "GET",
         "",
       );
-      setJsonSchema(JSON.parse(schemaData).schema);
+      setJsonSchema(safeJsonParse(schemaData).schema);
       const sourceTypeFormData = (formState?.sourceTypes as any) || {};
       // Add an empty sourceType for each selected Source Type (show first item by default)
       selectedKeys.forEach((k: number) => {

--- a/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
@@ -20,6 +20,7 @@ import {
   operationReviewSchema,
   operationReviewUiSchema,
 } from "@reporting/src/data/jsonSchema/operations";
+import safeJsonParse from "@bciers/utils/safeJsonParse";
 
 interface Props {
   formData: any;
@@ -30,7 +31,7 @@ const submitHandler = async (data: { formData?: any }, version_id: number) => {
   const method = "POST";
   const endpoint = `reporting/report-version/${version_id}/report-operation`;
   const pathToRevalidate = `reporting/report-version/${version_id}/report-operation`;
-  const formDataObject = JSON.parse(JSON.stringify(data.formData));
+  const formDataObject = safeJsonParse(JSON.stringify(data.formData));
   await actionHandler(endpoint, method, pathToRevalidate, {
     body: JSON.stringify(formDataObject),
     headers: {

--- a/bciers/libs/actions/src/actions.ts
+++ b/bciers/libs/actions/src/actions.ts
@@ -12,7 +12,7 @@ import { ContentItem } from "@bciers/types/tiles";
 import getUUIDFromEndpoint from "@bciers/utils/getUUIDFromEndpoint";
 import { revalidatePath } from "next/cache";
 import * as Sentry from "@sentry/nextjs";
-import safeJsonParse from "libs/utils/safeJsonParse"
+import safeJsonParse from "libs/utils/safeJsonParse";
 
 // 🛠️ Function to get the encrypted JWT from NextAuth getToken route function
 export async function getToken() {

--- a/bciers/libs/actions/src/actions.ts
+++ b/bciers/libs/actions/src/actions.ts
@@ -12,7 +12,7 @@ import { ContentItem } from "@bciers/types/tiles";
 import getUUIDFromEndpoint from "@bciers/utils/getUUIDFromEndpoint";
 import { revalidatePath } from "next/cache";
 import * as Sentry from "@sentry/nextjs";
-import safeJsonParse from 'libs/utils/safeJsonParse'
+import safeJsonParse from "libs/utils/safeJsonParse"
 
 // 🛠️ Function to get the encrypted JWT from NextAuth getToken route function
 export async function getToken() {

--- a/bciers/libs/actions/src/actions.ts
+++ b/bciers/libs/actions/src/actions.ts
@@ -12,6 +12,7 @@ import { ContentItem } from "@bciers/types/tiles";
 import getUUIDFromEndpoint from "@bciers/utils/getUUIDFromEndpoint";
 import { revalidatePath } from "next/cache";
 import * as Sentry from "@sentry/nextjs";
+import safeJsonParse from 'libs/utils/safeJsonParse'
 
 // 🛠️ Function to get the encrypted JWT from NextAuth getToken route function
 export async function getToken() {
@@ -52,7 +53,7 @@ export async function actionHandler(
   // Create a FormData object from the body if it's a string to pass to Sentry
   const formData = new FormData();
   if (options?.body && typeof options.body === "string")
-    for (const [key, value] of Object.entries(JSON.parse(options.body)))
+    for (const [key, value] of Object.entries(safeJsonParse(options.body)))
       formData.append(key, value as any);
 
   return Sentry.withServerActionInstrumentation(
@@ -148,7 +149,7 @@ export async function fetchDashboardData(url: string) {
     // Pretty-print the data
     const data = JSON.stringify(response[0].data.tiles, null, 2);
     // Parse data to object
-    const object = JSON.parse(data);
+    const object = safeJsonParse(data);
     // Assert the object as ContentType
     return object as ContentItem[];
   } catch (error) {

--- a/bciers/libs/utils/safeJsonParse.ts
+++ b/bciers/libs/utils/safeJsonParse.ts
@@ -1,0 +1,9 @@
+// Function takes a string as a parameter & returns a parsed JSON object if valid JSON, {} if not valid.
+// Prevents app crash on invalid querystring.
+export default function safeJsonParse(toParse: string) {
+  try {
+    return JSON.parse(toParse);
+  } catch (e) {
+    return {};
+  }
+}


### PR DESCRIPTION
Getting a null or invalid JSON will currently crash the app. safeJsonParse handles the error more gracefully & just returns an empty set.