### PR TITLE
chore: fix stale form state on edit

### DIFF
--- a/bciers/libs/components/src/form/components/TaskList.tsx
+++ b/bciers/libs/components/src/form/components/TaskList.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import CheckCircle from "@bciers/components/icons/CheckCircle";
 
 export interface TaskListProps {
   className?: string;
@@ -7,16 +6,9 @@ export interface TaskListProps {
     section: string;
     title: string;
   }[];
-  taskListItemStatus: {
-    [section: string]: boolean;
-  };
 }
 
-const TaskList: React.FC<TaskListProps> = ({
-  className,
-  taskListItems,
-  taskListItemStatus,
-}) => {
+const TaskList: React.FC<TaskListProps> = ({ className, taskListItems }) => {
   const [activeTask, setActiveTask] = useState(taskListItems[0].section);
 
   const handleTaskClick = (e: React.MouseEvent, section: string) => {
@@ -34,7 +26,6 @@ const TaskList: React.FC<TaskListProps> = ({
     >
       {taskListItems.map((task) => {
         const { section, title } = task;
-        const taskStatus = taskListItemStatus?.[section];
         const isActive = activeTask === section;
         return (
           <button
@@ -46,12 +37,6 @@ const TaskList: React.FC<TaskListProps> = ({
             } hover:bg-bc-light-grey-200`}
             onClick={(e) => handleTaskClick(e, section)}
           >
-            <div
-              className={`min-w-4 mr-2.5 flex align-middle `}
-              data-testid={`${section}-tasklist-check`}
-            >
-              {taskStatus && <CheckCircle />}
-            </div>
             <span
               className={`no-underline whitespace-nowrap ${
                 isActive ? "text-bc-link-blue" : "text-bc-text"


### PR DESCRIPTION
Fix for stale form data on edit. We ran into this issue with the contacts form as well, though I put the fix in the single step task list as I don' think this was caught when editing was added to that component. 

I believe what is happening is that submitting causes a full re-render and the initial `formData` gets passed back to the component causing this buggy behaviour. The fix is simple - saving the initial form data in `formState`. We are not turning this into a controlled component and updating the form state onChange, though we update the `formState` `onSubmit` which ensures the latest data on re-render.

Also cleaned up the commented code in the single step task list.