### PR TITLE
Fix form isCreating to manage POST or PUT

### DIFF
--- a/bciers/apps/administration/tests/components/facilities/FacilityForm.test.tsx
+++ b/bciers/apps/administration/tests/components/facilities/FacilityForm.test.tsx
@@ -14,14 +14,11 @@ import {
 } from "@bciers/testConfig/mocks";
 import FacilityForm from "apps/administration/app/components/facilities/FacilityForm";
 import {
-  facilitiesSfoSchema,
-  facilitiesSfoUiSchema,
+  facilitiesSchemaSfo,
+  facilitiesUiSchema,
 } from "../../../app/data/jsonSchema/facilitiesSfo";
+import { facilitiesSchemaLfo } from "../../../app/data/jsonSchema/facilitiesLfo";
 import { RJSFSchema } from "@rjsf/utils";
-import {
-  facilitiesLfoSchema,
-  facilitiesLfoUiSchema,
-} from "../../../app/data/jsonSchema/facilitiesLfo";
 
 const operationId = "8be4c7aa-6ab3-4aad-9206-0ef914fea063";
 const facilityId = "025328a0-f9e8-4e1a-888d-aa192cb053db";
@@ -39,7 +36,6 @@ useSession.mockReturnValue({
 });
 
 const mockReplace = vi.fn();
-
 useRouter.mockReturnValue({
   query: {},
   replace: mockReplace,
@@ -47,7 +43,7 @@ useRouter.mockReturnValue({
 
 const sfoFormData = {
   name: "Monkeyfuzz",
-  type: "Single Facility",
+  type: "Single Facility Operation",
   latitude_of_largest_emissions: "3.000000",
   longitude_of_largest_emissions: "4.000000",
   street_address: "adf",
@@ -61,7 +57,7 @@ const sfoFormData = {
 
 const lfoFormData = {
   name: "Monkeyfuzz",
-  type: "Single Facility",
+  type: "Single Facility Operation",
   well_authorization_numbers: [24546, 54321],
   latitude_of_largest_emissions: "3.000000",
   longitude_of_largest_emissions: "4.000000",
@@ -75,8 +71,8 @@ const lfoFormData = {
 };
 
 const defaultFillFormValues = {
-  name: "test facility name",
-  type_sfo: "Single Facility",
+  name: "test",
+  type_sfo: "Single Facility Operation",
   type_lfo: "Large Facility",
   well_authorization_numbers: [355],
   street_address: "address",
@@ -102,46 +98,44 @@ const defaultUpdateFormValues = {
   starting_date: "2024-07-11 02:00:00.000 -0700",
 };
 
-const sfoResponsePost = [
-  {
-    name: "test facility name",
-    type: "Single Facility",
-    is_current_year: false,
-    latitude_of_largest_emissions: 48.3,
-    longitude_of_largest_emissions: 123.32,
-    operation_id: "8be4c7aa-6ab3-4aad-9206-0ef914fea063",
-  },
-];
+const sfoResponsePost = {
+  name: "test",
+  type: "Single Facility",
+  is_current_year: false,
+  latitude_of_largest_emissions: 48.3,
+  longitude_of_largest_emissions: 123.32,
+  operation_id: "8be4c7aa-6ab3-4aad-9206-0ef914fea063",
+};
 
-const lfoResponsePost = [
-  {
-    name: "test facility name",
-    type: "Large Facility",
-    well_authorization_numbers: [355],
-    is_current_year: true,
-    starting_date: "2024-07-07T09:00:00.000Z",
-    street_address: "address",
-    municipality: "city",
-    province: "AB",
-    postal_code: "H0H0H0",
-    latitude_of_largest_emissions: 48.3,
-    longitude_of_largest_emissions: 123.32,
-    operation_id: "8be4c7aa-6ab3-4aad-9206-0ef914fea063",
-  },
-];
+const lfoResponsePost = {
+  name: "test",
+  type: "Large Facility",
+  well_authorization_numbers: [355],
+  is_current_year: true,
+  starting_date: "2024-07-07T09:00:00.000Z",
+  street_address: "address",
+  municipality: "city",
+  province: "AB",
+  postal_code: "H0H0H0",
+  latitude_of_largest_emissions: 48.3,
+  longitude_of_largest_emissions: 123.32,
+  operation_id: "8be4c7aa-6ab3-4aad-9206-0ef914fea063",
+};
 
 // ⛏️ Helper function to check mandatory field values
 const checkMandatoryFieldValues = async (schema: RJSFSchema) => {
-  const isLfoFacility = schema === facilitiesLfoSchema;
-  if (isLfoFacility) {
-    expect(screen.getByLabelText(/Facility Name+/i)).toHaveValue(
-      defaultFillFormValues.name,
-    );
+  expect(screen.getByLabelText(/Facility Name+/i)).toHaveValue(
+    defaultFillFormValues.name,
+  );
+  if (schema === facilitiesSchemaLfo) {
     expect(screen.getByLabelText(/Facility Type+/i)).toHaveValue(
       defaultFillFormValues.type_lfo,
     );
+  } else {
+    expect(screen.getByLabelText(/Facility Type+/i)).toHaveValue(
+      defaultFillFormValues.type_sfo,
+    );
   }
-
   expect(
     screen.getByLabelText(/Latitude of Largest Point of Emissions+/i),
   ).toHaveValue(defaultFillFormValues.latitude_of_largest_emissions);
@@ -172,22 +166,18 @@ const checkOptionalFieldValues = ({
 
 // ⛏️ Helper function to edit form fields
 export const editFormFields = async (schema: RJSFSchema) => {
-  const isLfoFacility = schema === facilitiesLfoSchema;
-  if (isLfoFacility) {
-    // edit the facility name
-    const nameInput = screen.getByLabelText(/Facility Name+/i);
-    await userEvent.clear(nameInput);
-    await userEvent.type(nameInput, defaultUpdateFormValues.name);
+  const nameInput = screen.getByLabelText(/Facility Name+/i);
+  await userEvent.clear(nameInput);
+  await userEvent.type(nameInput, defaultUpdateFormValues.name);
 
-    const typeInput = screen.getByLabelText(/Facility Type+/i);
-    await userEvent.click(typeInput);
-    // Select the last option in the dropdown
-    const typeOptions = screen.getAllByRole("option");
-    const lastTypeOption = typeOptions[typeOptions.length - 1];
-    await userEvent.click(lastTypeOption);
-  }
+  const typeInput = screen.getByLabelText(/Facility Type+/i);
+  await userEvent.click(typeInput);
+  // Select the last option in the dropdown
+  const typeOptions = screen.getAllByRole("option");
+  const lastTypeOption = typeOptions[typeOptions.length - 1];
+  await userEvent.click(lastTypeOption);
 
-  if (isLfoFacility) {
+  if (schema === facilitiesSchemaLfo) {
     // edit the well authorization number
     const firstWellAuthInput = screen.getAllByRole("spinbutton")[0];
     await userEvent.clear(firstWellAuthInput); // clear the existing value
@@ -234,24 +224,21 @@ export const editFormFields = async (schema: RJSFSchema) => {
 
 // ⛏️ Helper function to fill form mandatory fields
 const fillMandatoryFields = async (schema: RJSFSchema) => {
-  const isLfoFacility = schema === facilitiesLfoSchema;
-  if (isLfoFacility) {
-    await userEvent.type(
-      screen.getByLabelText(/Facility Name+/i),
-      defaultFillFormValues.name,
-    );
-    // fill type
-    const comboBoxInput = screen.getAllByRole("combobox");
-    const openFacilityTypeDropdownButton = comboBoxInput[0]?.parentElement
-      ?.children[1]?.children[0] as HTMLInputElement;
-    await userEvent.click(openFacilityTypeDropdownButton);
-    const selectText =
-      schema === facilitiesLfoSchema
-        ? defaultFillFormValues.type_lfo
-        : defaultFillFormValues.type_sfo;
-    const typeOption = screen.getByText(selectText);
-    await userEvent.click(typeOption);
-  }
+  await userEvent.type(
+    screen.getByLabelText(/Facility Name+/i),
+    defaultFillFormValues.name,
+  );
+  // fill type
+  const comboBoxInput = screen.getAllByRole("combobox");
+  const openFacilityTypeDropdownButton = comboBoxInput[0]?.parentElement
+    ?.children[1]?.children[0] as HTMLInputElement;
+  await userEvent.click(openFacilityTypeDropdownButton);
+  const selectText =
+    schema === facilitiesSchemaLfo
+      ? defaultFillFormValues.type_lfo
+      : defaultFillFormValues.type_sfo;
+  const typeOption = screen.getByText(selectText);
+  await userEvent.click(typeOption);
 
   fireEvent.change(
     screen.getByLabelText(/Latitude of Largest Point of Emissions+/i),
@@ -265,7 +252,7 @@ const fillMandatoryFields = async (schema: RJSFSchema) => {
 
 // ⛏️ Helper function to fill optional fields
 const fillOptionalFields = async (schema: RJSFSchema) => {
-  if (schema === facilitiesLfoSchema) {
+  if (schema === facilitiesSchemaLfo) {
     // fill well authorization numbers
     await userEvent.click(screen.getByText("Add"));
     const firstWellAuthInput = screen.getAllByRole("spinbutton")[0];
@@ -308,26 +295,23 @@ const assertFormPost = async (
   responseData: Record<string, any>,
 ): Promise<void> => {
   // Set up the mock before the click event
-  const response = [
-    {
-      id: facilityId,
-      name: facilityName,
-      error: null,
-    },
-  ];
+  const response = {
+    id: facilityId,
+    name: facilityName,
+    error: null,
+  };
   actionHandler.mockReturnValueOnce(response);
 
   // Find and click the submit button
   const submitButton = screen.getByRole("button", { name: /submit/i });
-  act(() => {
-    userEvent.click(submitButton);
-  });
+  userEvent.click(submitButton);
 
   // Add some delay to allow async processes to complete
   await new Promise((r) => setTimeout(r, 100));
 
   // Assertion to check if actionHandler was called correctly
-  expect(actionHandler).toHaveBeenCalledWith(
+  expect(actionHandler).toHaveBeenNthCalledWith(
+    1,
     endPoint,
     "POST",
     revalidatePathPost,
@@ -341,9 +325,7 @@ const assertFormPost = async (
 const assertFormPut = async (): Promise<void> => {
   // Submit valid form data
   const submitButton = screen.getByRole("button", { name: /submit/i });
-  act(() => {
-    userEvent.click(submitButton);
-  });
+  userEvent.click(submitButton);
   actionHandler.mockReturnValue({ error: null });
   await waitFor(() => {
     expect(
@@ -358,10 +340,10 @@ describe("FacilityForm component", () => {
   });
 
   it("renders the empty SFO facility form when creating a new facility", async () => {
-    const { container } = render(
+    render(
       <FacilityForm
-        schema={facilitiesSfoSchema}
-        uiSchema={facilitiesSfoUiSchema}
+        schema={facilitiesSchemaSfo}
+        uiSchema={facilitiesUiSchema}
         formData={{}}
         isCreating
       />,
@@ -370,13 +352,8 @@ describe("FacilityForm component", () => {
     expect(
       screen.getByRole("heading", { name: /Facility Information/i }),
     ).toBeVisible();
-    // Can't get read only fields by label
-    expect(container.querySelector("#root_section1_name")).toHaveTextContent(
-      "",
-    );
-    expect(container.querySelector("#root_section1_type")).toHaveTextContent(
-      "",
-    );
+    expect(screen.getByLabelText(/Facility Name+/i)).toHaveValue("");
+    expect(screen.getByLabelText(/Facility Type+/i)).toHaveValue("");
     expect(
       screen.getByLabelText(/Did this facility begin operations in+/i),
     ).not.toBeChecked();
@@ -401,10 +378,10 @@ describe("FacilityForm component", () => {
     expect(submitButton).toBeEnabled();
   });
   it("renders the empty LFO facility form when creating a new facility", async () => {
-    const { container } = render(
+    render(
       <FacilityForm
-        schema={facilitiesLfoSchema}
-        uiSchema={facilitiesLfoUiSchema}
+        schema={facilitiesSchemaLfo}
+        uiSchema={facilitiesUiSchema}
         formData={{}}
         isCreating
       />,
@@ -413,13 +390,8 @@ describe("FacilityForm component", () => {
     expect(
       screen.getByRole("heading", { name: /Facility Information/i }),
     ).toBeVisible();
-    // Can't get read only fields by label
-    expect(container.querySelector("#root_section1_name")).toHaveTextContent(
-      "",
-    );
-    expect(container.querySelector("#root_section1_type")).toHaveTextContent(
-      "",
-    );
+    expect(screen.getByLabelText(/Facility Name+/i)).toHaveValue("");
+    expect(screen.getByLabelText(/Facility Type+/i)).toHaveValue("");
 
     expect(screen.getByText(/Authorization+/i)).toBeVisible();
     expect(screen.getByRole("button", { name: "Add" })).toBeVisible();
@@ -449,8 +421,8 @@ describe("FacilityForm component", () => {
   it("loads existing readonly SFO form data", async () => {
     const { container } = render(
       <FacilityForm
-        schema={facilitiesSfoSchema}
-        uiSchema={facilitiesSfoUiSchema}
+        schema={facilitiesSchemaSfo}
+        uiSchema={facilitiesUiSchema}
         formData={sfoFormData}
       />,
     );
@@ -459,7 +431,7 @@ describe("FacilityForm component", () => {
       "Monkeyfuzz",
     );
     expect(container.querySelector("#root_section1_type")).toHaveTextContent(
-      "Single Facility",
+      "Single Facility Operation",
     );
     expect(
       container.querySelector("#root_section1_is_current_year"),
@@ -494,8 +466,8 @@ describe("FacilityForm component", () => {
   it("loads existing readonly LFO form data", async () => {
     const { container } = render(
       <FacilityForm
-        schema={facilitiesLfoSchema}
-        uiSchema={facilitiesLfoUiSchema}
+        schema={facilitiesSchemaLfo}
+        uiSchema={facilitiesUiSchema}
         formData={lfoFormData}
       />,
     );
@@ -504,7 +476,7 @@ describe("FacilityForm component", () => {
       "Monkeyfuzz",
     );
     expect(container.querySelector("#root_section1_type")).toHaveTextContent(
-      "Single Facility",
+      "Single Facility Operation",
     );
     expect(screen.getByText("Well Authorization Number(s)")).toBeVisible();
     expect(screen.getByText(24546)).toBeVisible();
@@ -542,8 +514,8 @@ describe("FacilityForm component", () => {
   it("does not allow SFO submission if there are validation errors (empty form data)", async () => {
     render(
       <FacilityForm
-        schema={facilitiesSfoSchema}
-        uiSchema={facilitiesSfoUiSchema}
+        schema={facilitiesSchemaSfo}
+        uiSchema={facilitiesUiSchema}
         formData={{}}
         isCreating
       />,
@@ -567,8 +539,8 @@ describe("FacilityForm component", () => {
   it("does not allow LFO submission if there are validation errors (bad form data)", async () => {
     render(
       <FacilityForm
-        schema={facilitiesLfoSchema}
-        uiSchema={facilitiesLfoUiSchema}
+        schema={facilitiesSchemaLfo}
+        uiSchema={facilitiesUiSchema}
         formData={{
           latitude_of_largest_emissions: -600,
           longitude_of_largest_emissions: 1800,
@@ -590,8 +562,8 @@ describe("FacilityForm component", () => {
   it("does not allow LFO submission if there is a starting date validation error", async () => {
     render(
       <FacilityForm
-        schema={facilitiesLfoSchema}
-        uiSchema={facilitiesLfoUiSchema}
+        schema={facilitiesSchemaLfo}
+        uiSchema={facilitiesUiSchema}
         formData={{}}
         isCreating
       />,
@@ -652,132 +624,131 @@ describe("FacilityForm component", () => {
     ).toHaveLength(1);
   });
 
-  it(
-    "fills the mandatory form fields, creates new SFO facility, and redirects on success",
-    {
-      timeout: 20000,
-    },
-    async () => {
-      render(
-        <FacilityForm
-          isCreating
-          schema={facilitiesSfoSchema}
-          uiSchema={facilitiesSfoUiSchema}
-          formData={{
-            name: "test facility name",
-            type: "Single Facility",
-          }}
-        />,
-      );
+  it("fills the mandatory form fields, creates new SFO facility, and redirects on success", async () => {
+    render(
+      <FacilityForm
+        isCreating
+        schema={facilitiesSchemaSfo}
+        uiSchema={facilitiesUiSchema}
+        formData={{}}
+      />,
+    );
 
-      //fill fields
-      await fillMandatoryFields(facilitiesSfoSchema);
-      await checkMandatoryFieldValues(facilitiesSfoSchema);
+    //fill fields
+    await fillMandatoryFields(facilitiesSchemaSfo);
+    await checkMandatoryFieldValues(facilitiesSchemaSfo);
 
-      // submit valid form data, assert response
-      await assertFormPost(sfoResponsePost);
-    },
-  );
-  it(
-    "fills all form fields, creates new LFO facility, and redirects on success",
-    {
-      timeout: 20000,
-    },
-    async () => {
-      render(
-        <FacilityForm
-          isCreating
-          schema={facilitiesLfoSchema}
-          uiSchema={facilitiesLfoUiSchema}
-          formData={{}}
-        />,
-      );
+    // submit valid form data, assert response
+    await assertFormPost(sfoResponsePost);
+  });
+  it("fills all form fields, creates new LFO facility, and redirects on success", async () => {
+    render(
+      <FacilityForm
+        isCreating
+        schema={facilitiesSchemaLfo}
+        uiSchema={facilitiesUiSchema}
+        formData={{}}
+      />,
+    );
 
-      //fill fields
-      await fillMandatoryFields(facilitiesLfoSchema);
-      await checkMandatoryFieldValues(facilitiesLfoSchema);
-      await fillOptionalFields(facilitiesLfoSchema);
-      await checkOptionalFieldValues();
+    //fill fields
+    await fillMandatoryFields(facilitiesSchemaLfo);
+    await checkMandatoryFieldValues(facilitiesSchemaLfo);
+    await fillOptionalFields(facilitiesSchemaLfo);
+    await checkOptionalFieldValues();
 
-      // submit valid form data, assert response
-      await assertFormPost(lfoResponsePost);
-    },
-  );
+    // submit valid form data, assert response
+    await assertFormPost(lfoResponsePost);
+  });
 
-  it(
-    "it edits a SFO Facility form, submits form, and displays success",
-    {
-      timeout: 20000,
-    },
-    async () => {
-      render(
-        <FacilityForm
-          schema={facilitiesSfoSchema}
-          uiSchema={facilitiesSfoUiSchema}
-          formData={sfoFormData}
-        />,
-      );
+  it("it edits a SFO Facility form, submits form, and displays success", async () => {
+    render(
+      <FacilityForm
+        schema={facilitiesSchemaSfo}
+        uiSchema={facilitiesUiSchema}
+        formData={sfoFormData}
+      />,
+    );
 
-      // Buttons
-      expect(screen.getByRole("button", { name: /edit/i })).toBeEnabled();
-      expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
+    // Buttons
+    expect(screen.getByRole("button", { name: /edit/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
 
-      const editButton = screen.getByRole("button", { name: /edit/i });
-      act(() => {
-        editButton.click();
-      });
+    const editButton = screen.getByRole("button", { name: /edit/i });
+    act(() => {
+      editButton.click();
+    });
 
-      // Buttons
-      expect(screen.getByRole("button", { name: /submit/i })).toBeEnabled();
-      expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
+    // Buttons
+    expect(screen.getByRole("button", { name: /submit/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
 
-      // Edit form fields
-      await editFormFields(facilitiesSfoSchema);
+    // Edit form fields
+    await editFormFields(facilitiesSchemaSfo);
 
-      // submit valid form data, assert response
-      await assertFormPut();
-    },
-    30000,
-  );
-  it(
-    "it edits a LFO Facility form, submits form, and displays success",
-    {
-      timeout: 20000,
-    },
-    async () => {
-      render(
-        <FacilityForm
-          schema={facilitiesLfoSchema}
-          uiSchema={facilitiesLfoUiSchema}
-          formData={lfoFormData}
-        />,
-      );
+    // submit valid form data, assert response
+    await assertFormPut();
+  }, 30000);
+  it("it edits a LFO Facility form, submits form, and displays success", async () => {
+    render(
+      <FacilityForm
+        schema={facilitiesSchemaLfo}
+        uiSchema={facilitiesUiSchema}
+        formData={lfoFormData}
+      />,
+    );
 
-      // Buttons
-      expect(screen.getByRole("button", { name: /edit/i })).toBeEnabled();
-      expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
+    // Buttons
+    expect(screen.getByRole("button", { name: /edit/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
 
-      const editButton = screen.getByRole("button", { name: /edit/i });
-      act(() => {
-        editButton.click();
-      });
+    const editButton = screen.getByRole("button", { name: /edit/i });
+    act(() => {
+      editButton.click();
+    });
 
-      // Buttons
-      expect(screen.getByRole("button", { name: /submit/i })).toBeEnabled();
-      expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
-      // Edit form fields
-      await editFormFields(facilitiesLfoSchema);
+    // Buttons
+    expect(screen.getByRole("button", { name: /submit/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
+    // Edit form fields
+    await editFormFields(facilitiesSchemaLfo);
 
-      // submit valid form data, assert response
-      await assertFormPut();
-    },
-    30000,
-  );
+    // submit valid form data, assert response
+    await assertFormPut();
+  }, 30000);
+
+  it("creates a new facility, edits it, and submits the updated facility", async () => {
+    render(
+      <FacilityForm
+        isCreating
+        schema={facilitiesSchemaSfo}
+        uiSchema={facilitiesUiSchema}
+        formData={{}}
+      />,
+    );
+
+    //fill fields
+    await fillMandatoryFields(facilitiesSchemaSfo);
+
+    // submit valid form data, assert response
+    await assertFormPost(sfoResponsePost);
+
+    // edit the form fields
+
+    const editButton = screen.getByRole("button", { name: /edit/i });
+    act(() => {
+      editButton.click();
+    });
+    await editFormFields(facilitiesSchemaSfo);
+
+    // submit the form to update the facility
+    await assertFormPut();
+  });
   it("redirects to the operation's facilities grid on cancel", async () => {
     render(
       <FacilityForm
-        schema={facilitiesSfoSchema}
-        uiSchema={facilitiesSfoUiSchema}
+        schema={facilitiesSchemaSfo}
+        uiSchema={facilitiesUiSchema}
         formData={{}}
         isCreating
       />,


### PR DESCRIPTION
Addresses [2088](https://github.com/bcgov/cas-registration/issues/2088)



### 🚀 Impact:
- Fixes new form to use PUT on subsequent edits after POST
- Fixes replace url in FacilityForm


### 🔬 Local Testing:

1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd client && yarn dev-all
```  
 
### Test Contact:

1. Navigate to `http://localhost:3000`
3. Click button "Log in with Business BCeID"
4. Sign in to Keycloak using `bc-cas-dev`
5. Navigate to http://localhost:3000/administration/contacts
**Expected Results**   
   - `Contacts` displays
   - `Add Contact` button displays
![image](https://github.com/user-attachments/assets/468ba1fd-a4e6-492e-a0f1-a9f37eee5ced)
6. Click button `Add Contact`
**Expected Results**   
   - Contact form in edit mode displays
![image](https://github.com/user-attachments/assets/3cc34936-537a-4811-b5bd-4f6cbcbdf8d5)
7. Complete the required form fields. 
8. Click button `Submit` 
**Expected Results**   
   - Form is submitted using POST method
![image](https://github.com/user-attachments/assets/5bfb7daa-d771-4786-a198-05eeda1c54ef)

9. Click button `Edit` 
**Expected Results**   
   - Form fields are editable
   - `Submit` button displays

### Test Contact:

- http://localhost:3000/registration/