### PR TITLE
Fix new form uses POST on subsequent edit\submit

### DIFF
--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -60,6 +60,9 @@ export default function ContactForm({
       allowEdit={allowEdit}
       inlineMessage={isCreatingState && <NewOperationMessage />}
       onSubmit={async (data: { formData?: any }) => {
+        const updatedFormData = { ...formState, ...data.formData };
+        setFormState(updatedFormData);
+
         const method = isCreatingState ? "POST" : "PUT";
         const endpoint = isCreatingState
           ? "registration/contacts"
@@ -84,26 +87,26 @@ export default function ContactForm({
           setError(response.error);
           return { error: response.error };
         } else {
-          // Update formState with the new ID from the response
-          const updatedFormState = {
-            ...formState, // Retain the current form state
-            ...data.formData, // Merge in the form data
-            id: response.id, // add the id from the response
-          };
-          // Set the updated form state
-          setFormState(updatedFormState);
+          if (method === "POST") {
+            // Update formState with the new ID from the response
+            const updatedFormState = {
+              ...formState, // Retain the current form state
+              id: response.id, // add the id from the response
+            };
+            // Set the updated form state
+            setFormState(updatedFormState);
+          }
         }
 
         if (isCreatingState) {
           setIsCreatingState(false);
-          window.history.replaceState(
-            null,
-            "",
-            `/administration/contacts/${response.id}?contacts_title=${response.first_name} ${response.last_name}`,
-          );
         } else {
           setKey(Math.random());
         }
+        const replaceUrl = `/administration/contacts/${
+          method === "POST" ? response.id : formState.id
+        }?contacts_title=${response.first_name} ${response.last_name}`;
+        window.history.replaceState(null, "", replaceUrl);
       }}
       onChange={(e: IChangeEvent) => {
         let newSelectedUser = e.formData?.section1?.selected_user;

--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -86,20 +86,14 @@ export default function ContactForm({
         if (response.error) {
           setError(response.error);
           return { error: response.error };
-        } else {
-          if (method === "POST") {
-            // Update formState with the new ID from the response
-            const updatedFormState = {
-              ...formState, // Retain the current form state
-              id: response.id, // add the id from the response
-            };
-            // Set the updated form state
-            setFormState(updatedFormState);
-          }
         }
 
         if (isCreatingState) {
           setIsCreatingState(false);
+          setFormState((prevState) => ({
+            ...prevState,
+            id: response.id,
+          }));
         } else {
           setKey(Math.random());
         }

--- a/bciers/apps/administration/app/components/facilities/FacilitiesDataGrid.tsx
+++ b/bciers/apps/administration/app/components/facilities/FacilitiesDataGrid.tsx
@@ -30,7 +30,7 @@ const FacilitiesDataGrid = ({
   const createFacilitiesActionCell = () =>
     ActionCellFactory({
       generateHref: (params: GridRenderCellParams) => {
-        return `/administration/operations/${operationId}/facilities/${params.row.id}?operationsTitle=${operationsTitle}&facilitiesTitle=${params.row.name}`;
+        return `/administration/operations/${operationId}/facilities/${params.row.id}?operations_title=${operationsTitle}&facilities_title=${params.row.name}`;
       },
       cellText: "View Details",
       useWindowLocation: true,

--- a/bciers/apps/administration/app/components/facilities/FacilityForm.tsx
+++ b/bciers/apps/administration/app/components/facilities/FacilityForm.tsx
@@ -43,11 +43,6 @@ export default function FacilityForm({
         const updatedFormData = { ...formState, ...data.formData };
         setFormState(updatedFormData);
 
-        const body = {
-          ...updatedFormData,
-          operation_id: params.operationId,
-        };
-
         const method = isCreatingState ? "POST" : "PUT";
         const endpoint = isCreatingState
           ? "registration/facilities"
@@ -55,6 +50,10 @@ export default function FacilityForm({
         const pathToRevalidate = isCreatingState
           ? `/operations/${params.operationId}/facilities`
           : `/operations/${params.operationId}/facilities/${formState.id}`;
+        const body = {
+          ...data.formData,
+          operation_id: params.operationId,
+        };
 
         const response = await actionHandler(
           endpoint,
@@ -71,11 +70,11 @@ export default function FacilityForm({
         }
 
         if (isCreatingState) {
+          setIsCreatingState(false);
           setFormState((prevState) => ({
             ...prevState,
             id: response[0].id,
           }));
-          setIsCreatingState(false);
         }
 
         const facilityId = isCreatingState ? response[0].id : formState.id;

--- a/bciers/apps/administration/app/components/facilities/types.ts
+++ b/bciers/apps/administration/app/components/facilities/types.ts
@@ -12,7 +12,7 @@ export interface FacilityInitialData {
 
 export interface FacilitiesSearchParams {
   [key: string]: string | number | undefined;
-  operationsTitle?: string;
+  operations_title?: string;
   bcghg_id?: string;
   type?: string;
   name?: string;

--- a/bciers/apps/administration/tests/components/facilities/FacilityForm.test.tsx
+++ b/bciers/apps/administration/tests/components/facilities/FacilityForm.test.tsx
@@ -705,6 +705,42 @@ describe("FacilityForm component", () => {
   );
 
   it(
+    "creates a new facility, edits it, and submits the updated facility",
+    {
+      timeout: 20000,
+    },
+    async () => {
+      render(
+        <FacilityForm
+          isCreating
+          schema={facilitiesSfoSchema}
+          uiSchema={facilitiesSfoUiSchema}
+          formData={{
+            name: "test facility name",
+            type: "Single Facility",
+          }}
+        />,
+      );
+
+      //fill fields
+      await fillMandatoryFields(facilitiesSfoSchema);
+      await checkMandatoryFieldValues(facilitiesSfoSchema);
+
+      // assert first invocation: POST
+      await assertFormPost(sfoResponsePost);
+
+      // edit the form
+      const editButton = screen.getByRole("button", { name: /edit/i });
+      act(() => {
+        editButton.click();
+      });
+      await editFormFields(facilitiesSfoSchema);
+
+      // assert first invocation: PUT
+      await assertFormPut();
+    },
+  );
+  it(
     "it edits a SFO Facility form, submits form, and displays success",
     {
       timeout: 20000,
@@ -737,7 +773,6 @@ describe("FacilityForm component", () => {
       // submit valid form data, assert response
       await assertFormPut();
     },
-    30000,
   );
   it(
     "it edits a LFO Facility form, submits form, and displays success",
@@ -771,7 +806,6 @@ describe("FacilityForm component", () => {
       // submit valid form data, assert response
       await assertFormPut();
     },
-    30000,
   );
   it("redirects to the operation's facilities grid on cancel", async () => {
     render(

--- a/bciers/apps/registration/tests/components/operations/OperationRegistrationPage.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/OperationRegistrationPage.test.tsx
@@ -57,7 +57,7 @@ describe("the OperationRegistrationPage component", () => {
     useSearchParams.mockReturnValue({
       searchParams: {
         operation: "002d5a9e-32a6-4191-938c-2c02bfec592d",
-        operationsTitle: "Test Operation",
+        operations_title: "Test Operation",
         step: 3,
       },
       get: vi.fn(),

--- a/bciers/apps/registration/tests/components/operations/registration/FacilityInformationForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/FacilityInformationForm.test.tsx
@@ -32,7 +32,7 @@ useSession.mockReturnValue({
 useSearchParams.mockReturnValue({
   searchParams: {
     operation: "002d5a9e-32a6-4191-938c-2c02bfec592d",
-    operationsTitle: "Test Operation",
+    operations_title: "Test Operation",
     step: 3,
   },
   get: vi.fn(),

--- a/bciers/apps/registration/tests/components/operations/registration/FacilityInformationPage.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/FacilityInformationPage.test.tsx
@@ -18,7 +18,7 @@ useSession.mockReturnValue({
 useSearchParams.mockReturnValue({
   searchParams: {
     operation: "002d5a9e-32a6-4191-938c-2c02bfec592d",
-    operationsTitle: "Test Operation",
+    operations_title: "Test Operation",
     step: 3,
   },
   get: vi.fn(),

--- a/docs/frontend/developer-guide.md
+++ b/docs/frontend/developer-guide.md
@@ -142,7 +142,7 @@ The Bread.tsx component in the `bciers/libs/components/src/navigation` directory
 
 For instance, when dealing with UUID breadcrumbs from dynamic folders, the component passes the name associated with the UUID record via the query string. The Bread component utilizes the translateNumericPart function to handle UUID segments, identifying the correct query string parameter and rendering the name instead of the UUID number.
 
-The pattern for the query string parameter should follow the format `{name-of-preceding-folder}Title`. For example, the OperationDataGridPage is displayed from the route `bciers/apps/administration/app/bceidbusiness/industry_user_admin/operations`, and the View Details link includes the parameter `?operationsTitle` for the route `bciers/apps/administration/app/bceidbusiness/industry_user_admin/operations/[operatorId]`.
+The pattern for the query string parameter should follow the format `{name-of-preceding-folder}Title`. For example, the OperationDataGridPage is displayed from the route `bciers/apps/administration/app/bceidbusiness/industry_user_admin/operations`, and the View Details link includes the parameter `?operations_title` for the route `bciers/apps/administration/app/bceidbusiness/industry_user_admin/operations/[operatorId]`.
 
 ## Styling
 


### PR DESCRIPTION
Addresses [2088](https://github.com/bcgov/cas-registration/issues/2088)



### 🚀 Impact:
- Fixes `bciers/apps/administration/app/components/contacts/ContactForm.tsx`  to use PUT on subsequent edits after POST
- Added test `creates a new contact, edits it, and submits the updated contact` in `bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx`
- Fixes `bciers/apps/administration/app/components/facilities/FacilityForm.tsx`  to use PUT on subsequent edits after POST
- Added test `creates a new facility, edits it, and submits the updated facility` in `bciers/apps/administration/tests/components/facilities/FacilityForm.test.tsx`
- Fixes `bciers/apps/administration/app/components/facilities/FacilityForm.tsx` replace url in FacilityForm to contain all breadcrumb parameters
- Fixes `bciers/apps/administration/app/components/facilities/FacilitiesDataGrid.tsx` breadcrumb parameter syntax

### 📝 To Do
- Fix bug [Admin\ContactForm - Field existing_bciers_user displays after creating a new contact ](https://github.com/bcgov/cas-registration/issues/2092)

### 🔬 Local Testing:

1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd client && yarn dev-all
```  
 
### Test Contact Form - Create-Update:

1. Navigate to `http://localhost:3000`
3. Click button "Log in with Business BCeID"
4. Sign in to Keycloak using `bc-cas-dev`
5. Navigate to http://localhost:3000/administration/contacts
**Expected Results**   
   - `Contacts` displays
   - `Add Contact` button displays
![image](https://github.com/user-attachments/assets/468ba1fd-a4e6-492e-a0f1-a9f37eee5ced)
6. Click button `Add Contact`
**Expected Results**   
   - Contact form in edit mode displays
   - `Submit` button displays
   - Breadcrumbs display as expected
![image](https://github.com/user-attachments/assets/3cc34936-537a-4811-b5bd-4f6cbcbdf8d5)
7. Complete the required form fields
8. Click button `Submit` 
**Expected Results**   
   - Sandbox displays: `Your edits were saved successfully`
   - `Edit` button displays
   - Breadcrumbs display as expected
![image](https://github.com/user-attachments/assets/adfe7254-95cb-47b5-a723-a706566aaf95)
   - Form is submitted using POST method
![image](https://github.com/user-attachments/assets/0be4d58d-16d6-4bf5-875b-26b7a5be3165)
9. Click button `Edit` 
**Expected Results**   
   - Form fields are editable
   - `Submit` button displays
7. Update `First Name` and any other form field(s)
8. Click button `Submit` 
**Expected Results**   
   - `Edit` button displays
   - Breadcrumbs display as expected
![image](https://github.com/user-attachments/assets/c5076e86-3bae-4af5-8fc3-6b4077ae5634)
   - Form is submitted using PUT method
![image](https://github.com/user-attachments/assets/6ad3a071-1c5a-4dfb-b3d2-1ef25ad6be02)



 
### Test Facility Form - Create-Update:
1. Navigate to `http://localhost:3000`
3. Click button "Log in with Business BCeID"
4. Sign in to Keycloak using `bc-cas-dev`
5. Navigate to `http://localhost:3000/administration/operations`
**Expected Results**   
   - `Operation` displays
![image](https://github.com/user-attachments/assets/11c057db-55a0-4311-bbaa-d2df285f5bd3)
6. Click grid link `Operation 2\View Facilities`
**Expected Results**   
   - `Operation 2 > Facilities` grid displays
   - `Add Facilty` button displays
   - Breadcrumbs display as expected
![image](https://github.com/user-attachments/assets/ffdb60ad-072d-4152-9d8d-57f22f9aedf5)
7. Click `Add Facilty` button
**Expected Results**   
   - Form in edit mode displays
   - `Submit` button displays
   -  Breadcrumbs display as expected
![image](https://github.com/user-attachments/assets/06a21f1b-4245-4b09-b9a6-923136ea7d30)
8. Complete the required form fields
9. Click button `Submit` 
**Expected Results**   
   - Sandbox displays: `Your edits were saved successfully`
   - `Edit` button displays
   -  Breadcrumbs display as expected
 ![image](https://github.com/user-attachments/assets/4159bc63-21ca-41f9-9a30-4d196be9a66a)
   - Form is submitted using POST method
![image](https://github.com/user-attachments/assets/8a8508d4-89b1-4e15-bc12-3bd77360da6d)
10. Click button `Edit` 
**Expected Results**   
   - Form fields are editable
   - `Submit` button displays
11. Update form `Facility Name` and other field(s)
12. Click button `Submit` 
**Expected Results**   
   - `Edit` button displays
   -  Breadcrumbs display as expected
![image](https://github.com/user-attachments/assets/3ac545a3-badf-4ee3-9393-ce3c21d342bd)
   - Form is submitted using PUT method
![image](https://github.com/user-attachments/assets/9add1ac9-e73c-46ac-bd98-59b8a6b72ae8)
