### PR TITLE
Facility Review Information Page

### DIFF
--- a/bc_obps/reporting/api/activity_data.py
+++ b/bc_obps/reporting/api/activity_data.py
@@ -7,6 +7,7 @@ from typing import Tuple
 from registration.schema.generic import Message
 from ninja.responses import codes_4xx, codes_5xx
 
+
 ##### GET #####
 
 
@@ -22,3 +23,13 @@ def get_initial_activity_data(
     report_date: str,
 ) -> Tuple[int, str]:
     return 200, ActivityService.get_initial_activity_data(activity_name, report_date)
+
+
+@router.get(
+    "/activities",
+    response={200: list, codes_4xx: Message, codes_5xx: Message},
+    url_name="get_activities",
+)
+@handle_http_errors()
+def get_activities(request: HttpRequest) -> Tuple[int, list]:
+    return 200, ActivityService.get_all_activities()

--- a/bc_obps/reporting/api/reports.py
+++ b/bc_obps/reporting/api/reports.py
@@ -1,4 +1,4 @@
-from typing import Literal, Tuple
+from typing import Literal, Tuple, Dict, Union
 from django.http import HttpRequest
 from registration.decorators import handle_http_errors
 from reporting.constants import EMISSIONS_REPORT_TAGS
@@ -10,6 +10,8 @@ from service.error_service.custom_codes_4xx import custom_codes_4xx
 from reporting.schema.report_operation import ReportOperationOut, ReportOperationIn
 from reporting.schema.reporting_year import ReportingYearOut
 from .router import router
+from ..models import FacilityReport
+from ..schema.facility_report import FacilityReportOut, FacilityReportIn
 
 
 @router.post(
@@ -62,5 +64,101 @@ def save_report(
     description="""Returns json object with current reporting year and due date.""",
 )
 @handle_http_errors()
-def get_reporting_year(request: HttpRequest) -> Tuple[Literal[200], ReportingYearOut]:
-    return 200, ReportingYearService.get_current_reporting_year()  # type: ignore
+def get_reporting_year(request: HttpRequest) -> Tuple[Literal[200], int]:
+    return 200, ReportingYearService.get_current_reporting_year().reporting_year
+
+
+@router.get(
+    "/report-version/{version_id}/facility-report/{facility_id}",
+    response={200: FacilityReportOut, 404: Message, 400: Message, 500: Message},
+    tags=EMISSIONS_REPORT_TAGS,
+    description="""Takes `version_id` (primary key of the ReportVersion model) and `facility_id` to return a single matching `facility_report` object.
+    Includes the associated activity IDs if found; otherwise, returns an error message if not found or in case of other issues.""",
+)
+@handle_http_errors()
+def get_facility_report_by_version_and_id(
+    request: HttpRequest, version_id: int, facility_id: int
+) -> Union[
+    Tuple[Literal[200], FacilityReportOut],
+    Tuple[Literal[404], Dict[str, str]],
+    Tuple[Literal[400], Dict[str, str]],
+    Tuple[Literal[500], Dict[str, str]],
+]:
+    try:
+        facility_report = ReportService.get_facility_report_by_version_and_id(version_id, facility_id)
+
+        if facility_report:
+            activity_ids = ReportService.get_activity_ids_for_facility(facility_report) or []
+            response_data = FacilityReportOut(
+                id=facility_report.id,
+                report_version_id=facility_report.report_version.id,
+                facility_name=facility_report.facility_name,
+                facility_type=facility_report.facility_type,
+                facility_bcghgid=facility_report.facility_bcghgid,
+                activities=activity_ids,
+                products=[],
+            )
+            return 200, response_data
+
+        else:
+            return 404, {"message": "Facility not found"}
+
+    except ValueError as ve:
+        return 400, {"message": f"Invalid input: {str(ve)}"}
+
+    except Exception as e:
+        return 500, {"message": "An unexpected error occurred", "details": str(e)}
+
+
+@router.post(
+    "/report-version/{version_id}/facility-report/{facility_id}",
+    response={201: FacilityReportOut, custom_codes_4xx: Message},
+    tags=EMISSIONS_REPORT_TAGS,
+    description="""Updates the report facility details by version_id and facility_id. The request body should include
+    fields to be updated, such as facility name, type, BC GHG ID, activities, and products. Returns the updated report
+    facility object or an error message if the update fails.""",
+)
+@handle_http_errors()
+def save_facility_report(
+    request: HttpRequest, version_id: int, payload: FacilityReportIn
+) -> Union[
+    Tuple[Literal[201], FacilityReportOut],
+    Tuple[Literal[400], Dict[str, str]],
+    Tuple[Literal[404], Dict[str, str]],
+    Tuple[Literal[500], Dict[str, str]],
+]:
+    """
+    Save or update a report facility and its related activities.
+
+    Args:
+        request (HttpRequest): The HTTP request object.
+        version_id (int): The ID of the report version.
+        payload (FacilityReportIn): The input data for the report facility.
+
+    Returns:
+        Tuple: HTTP status code and the response data or an error message.
+    """
+    try:
+        # Save or update the report facility using the service layer
+        facility_report = ReportService.save_facility_report(version_id, payload)
+
+        # Prepare the response data
+        response_data = FacilityReportOut(
+            id=facility_report.id,
+            report_version_id=facility_report.report_version.id,
+            facility_name=facility_report.facility_name,
+            facility_type=facility_report.facility_type,
+            facility_bcghgid=facility_report.facility_bcghgid,
+            activities=list(facility_report.activities.values_list('id', flat=True)),
+            products=list(facility_report.products.values_list('id', flat=True)) or [],
+        )
+        return 201, response_data
+
+    except ValueError as ve:
+        return 400, {"message": f"Invalid input: {str(ve)}"}
+
+    except FacilityReport.DoesNotExist:
+        return 404, {"message": "Report facility not found"}
+
+    except Exception as e:
+        return 500, {"message": "An unexpected error occurred", "details": str(e)}

--- a/bc_obps/reporting/fixtures/mock/facility_report.json
+++ b/bc_obps/reporting/fixtures/mock/facility_report.json
@@ -1,0 +1,13 @@
+[
+  {
+    "model": "reporting.facilityreport",
+    "fields": {
+      "id": 1,
+      "facility_id": "f486f2fb-62ed-438d-bb3e-0819b51e3aeb",
+      "facility_name": "Facility1",
+      "facility_type": "SFO",
+      "facility_bcghgid": "BCGHGID12345",
+      "report_version_id": 1
+    }
+  }
+]

--- a/bc_obps/reporting/fixtures/mock/report.json
+++ b/bc_obps/reporting/fixtures/mock/report.json
@@ -1,0 +1,20 @@
+[
+  {
+    "model": "reporting.report",
+    "fields": {
+      "id": 1,
+      "operation_id": "e1300fd7-2dee-47d1-b655-2ad3fd10f052",
+      "operator_id": "685d581b-5698-411f-ae00-de1d97334a71",
+      "reporting_year_id": 2024
+    }
+  },
+  {
+    "model": "reporting.report",
+    "fields": {
+      "id": 2,
+      "operation_id": "e1300fd7-2dee-47d1-b655-2ad3fd10f052",
+      "operator_id": "685d581b-5698-411f-ae00-de1d97334a71",
+      "reporting_year_id": 2024
+    }
+  }
+]

--- a/bc_obps/reporting/fixtures/mock/report_version.json
+++ b/bc_obps/reporting/fixtures/mock/report_version.json
@@ -1,0 +1,20 @@
+[
+  {
+    "model": "reporting.reportversion",
+    "pk": 1,
+    "fields": {
+      "is_latest_submitted": true,
+      "status": "active",
+      "report_id": 1
+    }
+  },
+  {
+    "model": "reporting.reportversion",
+    "pk": 2,
+    "fields": {
+      "is_latest_submitted": false,
+      "status": "draft",
+      "report_id": 2
+    }
+  }
+]

--- a/bc_obps/reporting/management/commands/load_reporting_fixtures.py
+++ b/bc_obps/reporting/management/commands/load_reporting_fixtures.py
@@ -10,6 +10,9 @@ class Command(BaseCommand):
 
         fixtures = [
             f'{fixture_base_dir}/reporting_year.json',
+            f'{fixture_base_dir}/report.json',
+            f'{fixture_base_dir}/report_version.json',
+            f'{fixture_base_dir}/facility_report.json',
         ]
 
         for fixture in fixtures:

--- a/bc_obps/reporting/schema/facility_report.py
+++ b/bc_obps/reporting/schema/facility_report.py
@@ -1,0 +1,41 @@
+from ninja import ModelSchema
+from pydantic import alias_generators
+from typing import List
+
+from reporting.models import FacilityReport
+
+
+def to_camel(string: str) -> str:
+    return alias_generators.to_camel(string)
+
+
+def to_snake(string: str) -> str:
+    return alias_generators.to_snake(string)
+
+
+class FacilityReportOut(ModelSchema):
+    """
+    Schema for the get report facility endpoint request output
+    """
+
+    class Meta:
+        alias_generator = to_snake
+        model = FacilityReport
+        fields = ['facility_name', 'facility_type', 'facility_bcghgid', 'activities', 'products']
+
+
+class FacilityReportIn(ModelSchema):
+    """
+    Schema for the save report activity endpoint request input
+    """
+
+    facility_name: str
+    facility_type: str
+    facility_bcghgid: str
+    activities: List[str]
+    products: List[str]
+
+    class Meta:
+        alias_generator = to_snake
+        model = FacilityReport
+        fields = ['facility_name', 'facility_type', 'facility_bcghgid', 'activities', 'products']

--- a/bc_obps/service/activity_service.py
+++ b/bc_obps/service/activity_service.py
@@ -1,6 +1,7 @@
 import json
 from reporting.models import Configuration, ConfigurationElement
 from registration.models import ReportingActivity
+from typing import List, Dict, Any
 
 
 class ActivityService:
@@ -24,3 +25,8 @@ class ActivityService:
         for s in source_type_data:
             source_type_map[s.source_type.id] = s.source_type.json_key
         return json.dumps({"activityId": activity_id, "sourceTypeMap": source_type_map})
+
+    @classmethod
+    def get_all_activities(cls) -> List[Dict[str, Any]]:
+        activities = ReportingActivity.objects.all().values("id", "name", "applicable_to")
+        return [dict(activity) for activity in activities]

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/[version_id]/facilities/[facility_id]/review/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/[version_id]/facilities/[facility_id]/review/page.tsx
@@ -1,0 +1,14 @@
+import FacilityReviewFormData from "@reporting/src/app/components/facility/FacilityReviewFormData";
+
+export default async function Page({
+  params,
+}: {
+  params: { version_id: number; facility_id: number };
+}) {
+  return (
+    <FacilityReviewFormData
+      version_id={params.version_id}
+      facility_id={params.facility_id}
+    />
+  );
+}

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReview.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReview.tsx
@@ -1,0 +1,236 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Alert,
+  Checkbox,
+  Typography,
+  FormControlLabel,
+  CircularProgress,
+} from "@mui/material";
+import MultiStepHeader from "@bciers/components/form/components/MultiStepHeader";
+import FormBase from "@bciers/components/form/FormBase";
+import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/ReportingTaskList";
+import { tasklistData } from "@reporting/src/app/components/facility/TaskListElements";
+import {
+  facilityReviewUiSchema,
+  facilitySchema,
+} from "@reporting/src/data/jsonSchema/facilities";
+import { RJSFSchema } from "@rjsf/utils";
+import { actionHandler } from "@bciers/actions";
+import { IChangeEvent } from "@rjsf/core";
+
+interface Props {
+  version_id: number;
+  facility_id: number;
+}
+
+interface Activity {
+  name: string;
+  id: number;
+}
+
+const getFacilityReport = async (version_id: number, facility_id: number) => {
+  return actionHandler(
+    `reporting/report-version/${version_id}/facility-report/${facility_id}`,
+    "GET",
+    `reporting/report-version/${version_id}/facility-report/${facility_id}`,
+  );
+};
+
+const getAllActivities = async () => {
+  return actionHandler(`reporting/activities`, "GET", `reporting/activities`);
+};
+
+const FacilityReview: React.FC<Props> = ({ version_id, facility_id }) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorList, setErrorList] = useState<string[]>([]);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [formData, setFormData] = useState<any>({});
+  const [activities, setActivities] = useState<Record<number, boolean>>({});
+  const [facilityReviewSchema, setFacilityReviewSchema] = useState<RJSFSchema>({
+    type: "object",
+    properties: {},
+  });
+  const [activityList, setActivityList] = useState<Activity[]>([]);
+
+  const customStepNames = [
+    "Operation Information",
+    "Facilities Information",
+    "Compliance Summary",
+    "Sign-off & Submit",
+  ];
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const facilityData = await getFacilityReport(version_id, facility_id);
+        const activitiesData = await getAllActivities();
+        const validActivitiesData = Array.isArray(activitiesData)
+          ? activitiesData
+          : [];
+
+        setFormData(facilityData);
+        setFacilityReviewSchema(facilitySchema);
+
+        const activityMap: Record<number, boolean> = {};
+        validActivitiesData.forEach((activity: Activity) => {
+          activityMap[activity.id] = facilityData.activities?.includes(
+            activity.id,
+          );
+        });
+        setActivities(activityMap);
+        setActivityList(validActivitiesData);
+      } catch (error: any) {
+        console.error("Error fetching data:", error);
+        setErrorList([error.message || "An error occurred"]);
+      }
+    };
+
+    fetchData().then(() => console.log());
+  }, [version_id, facility_id]);
+
+  const handleCheckboxChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    id: number,
+  ) => {
+    const isChecked = event.target.checked;
+    setActivities((prevActivities) => ({
+      ...prevActivities,
+      [id]: isChecked,
+    }));
+
+    setFormData((prevFormData: any) => ({
+      ...prevFormData,
+      activities: isChecked
+        ? [...(prevFormData.activities || []), id]
+        : prevFormData.activities?.filter(
+            (activityId: number) => activityId !== id,
+          ),
+    }));
+  };
+
+  const handleFormChange = (event: IChangeEvent) => {
+    setFormData(event.formData);
+  };
+
+  const handleSave = async () => {
+    setIsLoading(true); // Start loading when save is clicked
+    const updatedFacility = {
+      ...formData,
+      activities: Object.keys(activities).filter((id) => activities[+id]),
+    };
+
+    const method = "POST";
+    const endpoint = `reporting/report-version/${version_id}/facility-report/${facility_id}`;
+    const pathToRevalidate = `reporting/report-version/${version_id}/facility-report/${facility_id}`;
+    const formDataObject = JSON.parse(JSON.stringify(updatedFacility));
+
+    try {
+      await actionHandler(endpoint, method, pathToRevalidate, {
+        body: JSON.stringify(formDataObject),
+        headers: {
+          "Content-Type": "application/json",
+          accept: "application/json",
+        },
+      });
+
+      setIsSuccess(true);
+    } catch (error: any) {
+      console.error("Error updating facility:", error);
+      setErrorList([error.message || "An error occurred"]);
+    } finally {
+      setIsLoading(false);
+      setTimeout(() => {
+        setIsSuccess(false);
+      }, 3000);
+    }
+  };
+
+  const buttonContent = isLoading ? (
+    <CircularProgress data-testid="progressbar" role="progress" size={24} />
+  ) : isSuccess ? (
+    "✅ Success"
+  ) : (
+    "Save"
+  );
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <div className="container mx-auto p-4" data-testid="facility-review">
+        <MultiStepHeader stepIndex={1} steps={customStepNames} />
+      </div>
+      <div className="w-full flex">
+        <ReportingTaskList elements={tasklistData} />
+        <div className="w-full md:max-w-[60%]">
+          <FormBase
+            schema={facilityReviewSchema}
+            uiSchema={facilityReviewUiSchema}
+            formData={formData}
+            onSubmit={handleSave}
+            onChange={handleFormChange}
+          >
+            {errorList.length > 0 &&
+              errorList.map((error, index) => (
+                <Alert key={index} severity="error">
+                  {error}
+                </Alert>
+              ))}
+            {activityList.length > 0 && (
+              <div>
+                <Typography
+                  variant="h6"
+                  sx={{
+                    width: "84px",
+                    height: "22px",
+                    fontFamily: "'Inter', sans-serif",
+                    fontStyle: "normal",
+                    fontWeight: 700,
+                    fontSize: "18px",
+                    lineHeight: "22px",
+                    color: "#38598A",
+                    flex: "none",
+                    order: 0,
+                    flexGrow: 0,
+                  }}
+                >
+                  Activities
+                </Typography>
+                <Box sx={{ display: "block" }}>
+                  {activityList.map((activity) => (
+                    <FormControlLabel
+                      key={activity.id}
+                      control={
+                        <Checkbox
+                          checked={activities[activity.id] || false}
+                          onChange={(event) =>
+                            handleCheckboxChange(event, activity.id)
+                          }
+                        />
+                      }
+                      label={activity.name || `Activity ${activity.id}`}
+                      sx={{ display: "block", marginBottom: 0.1 }}
+                    />
+                  ))}
+                </Box>
+              </div>
+            )}
+            <div className="flex justify-end gap-3">
+              <Button
+                variant="contained"
+                type="submit"
+                aria-disabled={isLoading}
+                disabled={isLoading}
+              >
+                {buttonContent}
+              </Button>
+            </div>
+          </FormBase>
+        </div>
+      </div>
+    </Box>
+  );
+};
+
+export default FacilityReview;

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewFormData.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewFormData.tsx
@@ -1,0 +1,13 @@
+import FacilityReview from "./FacilityReview";
+
+type FacilityReviewFormDataProps = Readonly<{
+  version_id: number;
+  facility_id: number;
+}>;
+
+export default function FacilityReviewFormData({
+  version_id,
+  facility_id,
+}: FacilityReviewFormDataProps) {
+  return <FacilityReview version_id={version_id} facility_id={facility_id} />;
+}

--- a/bciers/apps/reporting/src/app/components/facility/TaskListElements.ts
+++ b/bciers/apps/reporting/src/app/components/facility/TaskListElements.ts
@@ -1,0 +1,21 @@
+import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
+
+export const tasklistData: TaskListElement[] = [
+  {
+    type: "Section",
+    title: "Facility1 information",
+    elements: [
+      { type: "Page", title: "Review facility information", isActive: true },
+      {
+        type: "Subsection",
+        title: "Activities information",
+        isExpanded: true,
+        elements: [{ type: "Page", title: "Mobile combustion" }],
+      },
+      { type: "Page", title: "Non-attributable emissions" },
+      { type: "Page", title: "Emissions Summary" },
+      { type: "Page", title: "Production data" },
+      { type: "Page", title: "Allocation of emissions" },
+    ],
+  },
+];

--- a/bciers/apps/reporting/src/data/jsonSchema/facilities.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/facilities.ts
@@ -1,0 +1,28 @@
+import { RJSFSchema } from "@rjsf/utils";
+import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
+
+export const facilitySchema: RJSFSchema = {
+  type: "object",
+  title: "Review facility information",
+  properties: {
+    facility_name: { type: "string", title: "Facility name" },
+    facility_type: { type: "string", title: "Facility type" },
+    facility_bcghgid: { type: "string", title: "Facility BCGHG ID" },
+  },
+};
+
+export const facilityReviewUiSchema = {
+  "ui:FieldTemplate": FieldTemplate,
+  "ui:classNames": "form-heading-label",
+
+  facility_name: {
+    "ui:options": { style: { width: "100%", textAlign: "left" } },
+  },
+  facility_type: {
+    "ui:options": { style: { width: "100%", textAlign: "left" } },
+  },
+  facility_bcghgid: {
+    "ui:readonly": true,
+    "ui:options": { style: { width: "100%", textAlign: "left" } },
+  },
+};

--- a/bciers/apps/reporting/tests/components/FacilityReview.test.tsx
+++ b/bciers/apps/reporting/tests/components/FacilityReview.test.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import FacilityReview from "@reporting/src/app/components/facility/FacilityReview";
+import { vi, Mock } from "vitest"; // If you are using Vitest for mocking
+
+import { actionHandler } from "@bciers/actions";
+
+vi.mock("@bciers/actions", () => ({
+  actionHandler: vi.fn(),
+}));
+
+const mockFacilityData = {
+  id: 1,
+  bcghg_id: "BCGHGID12345",
+  name: "Facility1",
+  facility_type: "SFO",
+  activities: [7, 10],
+  products: [],
+};
+
+const mockActivitiesData = [
+  { id: 7, name: "Activity7" },
+  { id: 10, name: "Activity10" },
+  { id: 12, name: "Activity12" },
+];
+
+beforeEach(() => {
+  window.alert = vi.fn(); // or vi.fn() if using Vitest
+});
+
+describe("FacilityReview", () => {
+  beforeEach(() => {
+    (actionHandler as Mock).mockClear();
+  });
+
+  it("should render and display labels correctly for activities", async () => {
+    (actionHandler as Mock)
+      .mockResolvedValueOnce(mockFacilityData) // Mock facility data
+      .mockResolvedValueOnce(mockActivitiesData); // Mock activities data
+
+    render(<FacilityReview version_id={1} facility_id={1} />);
+
+    await waitFor(() => {
+      expect(actionHandler).toHaveBeenCalledTimes(2); // Ensure initial fetches occurred
+    });
+
+    expect(screen.getByText("Activity7")).toBeInTheDocument();
+    expect(screen.getByText("Activity10")).toBeInTheDocument();
+    expect(screen.getByLabelText("Activity7")).toBeChecked();
+    expect(screen.getByLabelText("Activity10")).toBeChecked();
+    expect(screen.queryByLabelText("Activity12")).not.toBeChecked();
+  });
+
+  it("should handle loading state correctly", async () => {
+    (actionHandler as Mock).mockImplementationOnce(
+      () => new Promise(() => {}), // Mock loading indefinitely
+    );
+
+    render(<FacilityReview version_id={1} facility_id={1} />);
+
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("progressbar")).toBeInTheDocument();
+    });
+    await new Promise((r) => setTimeout(r, 1000));
+  });
+
+  it("should handle form submission successfully", async () => {
+    (actionHandler as Mock)
+      .mockResolvedValueOnce(mockFacilityData) // Mock facility data
+      .mockResolvedValueOnce(mockActivitiesData) // Mock activities data
+      .mockResolvedValueOnce({}); // Mock successful save
+
+    render(<FacilityReview version_id={1} facility_id={1} />);
+
+    await waitFor(() => {
+      expect(actionHandler).toHaveBeenCalledTimes(2); // Ensure initial fetches occurred
+    });
+
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(actionHandler).toHaveBeenCalledWith(
+        `reporting/report-version/1/facility-report/1`,
+        "POST",
+        `reporting/report-version/1/facility-report/1`,
+        expect.objectContaining({
+          body: JSON.stringify({
+            ...mockFacilityData,
+            activities: ["7", "10"], // Ensure this matches your implementation
+          }),
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            accept: "application/json",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("should handle form submission error", async () => {
+    (actionHandler as Mock)
+      .mockResolvedValueOnce(mockFacilityData) // Mock facility data
+      .mockResolvedValueOnce(mockActivitiesData) // Mock activities data
+      .mockRejectedValueOnce(new Error("Failed to save")); // Mock save error
+
+    render(<FacilityReview version_id={1} facility_id={1} />);
+
+    await waitFor(() => {
+      expect(actionHandler).toHaveBeenCalledTimes(2); // Ensure initial fetches occurred
+    });
+
+    fireEvent.click(screen.getByLabelText("Activity7"));
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to save")).toBeInTheDocument();
+    });
+  });
+
+  it("should render with no activities", async () => {
+    const mockFacilityDataNoActivities = {
+      ...mockFacilityData,
+      activities: [], // No activities
+    };
+
+    (actionHandler as Mock)
+      .mockResolvedValueOnce(mockFacilityDataNoActivities) // Mock facility data with no activities
+      .mockResolvedValueOnce([]); // Mock no activities data
+
+    render(<FacilityReview version_id={1} facility_id={1} />);
+
+    await waitFor(() => {
+      expect(actionHandler).toHaveBeenCalledTimes(2); // Ensure initial fetches occurred
+    });
+
+    expect(screen.queryByText("Activity7")).not.toBeInTheDocument();
+    expect(screen.queryByText("Activity10")).not.toBeInTheDocument();
+  });
+
+  it("should handle error state correctly", async () => {
+    // Mock the API calls to simulate an error
+    (actionHandler as Mock)
+      .mockRejectedValueOnce(new Error("Failed to fetch facility data")) // Simulate error fetching facility data
+      .mockRejectedValueOnce(new Error("Failed to fetch activities data")); // Simulate error fetching activities data
+
+    render(<FacilityReview version_id={1} facility_id={1} />);
+
+    // Check if error messages are displayed
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Failed to fetch facility data/),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/195
Added: Review Facility Information Page

Summary of Changes:

Created the ReviewFacilityData component.
Added new API routes:
Fetch facility data for a specific facility_id and report version.
Fetch all activities related to a specific facility_id.
Save facility data.
Updated activity_service to include get_all_activities method.
Updated report_service.
Created report_facility schema.
Added mock fixtures:
report
report_facility
report_version
Added APIs for:
Fetching all activities.
Getting report facility data by facility_id and report version.
Saving report facility data.
Local Testing Instructions:

Navigate to /bc_obps and run:
make reset_db
make run
to apply changes to the database.

Run the frontend using: yarn dev-all

Insert data into the report_facility_activities table to see selected activities:
INSERT INTO erc.report_facility_activities (reportfacility_id, reportingactivity_id) VALUES (1, 10), (1, 7), (1, 31);
Alternatively, you can add data by selecting activities in the UI.

4.Log in with BCeID to bc-cas-dev and navigate to:  /reporting/1/facilities/1/review