### PR TITLE
chore: fix indentation in deployment yaml files

### DIFF
--- a/helm/cas-bciers/templates/administration/deployment.yaml
+++ b/helm/cas-bciers/templates/administration/deployment.yaml
@@ -28,15 +28,15 @@ spec:
         - name: {{ template "cas-bciers.fullname" . }}-administration-frontend
           env:
             - name: KEYCLOAK_CLIENT_SECRET
-                valueFrom:
-                  secretKeyRef:
-                    name: keycloak-gold-client-secret
-                    key: kcClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-gold-client-secret
+                  key: kcClientSecret
             - name: NEXTAUTH_SECRET
               valueFrom:
-                  secretKeyRef:
-                    name: cas-bciers-nextauth
-                    key: nextauth-secret
+                secretKeyRef:
+                  name: cas-bciers-nextauth
+                  key: nextauth-secret
           envFrom:
             - configMapRef:
                 name: {{ template "cas-bciers.fullname" . }}-frontend-env-configmap

--- a/helm/cas-bciers/templates/registration/deployment.yaml
+++ b/helm/cas-bciers/templates/registration/deployment.yaml
@@ -33,9 +33,9 @@ spec:
                   key: kcClientSecret
             - name: NEXTAUTH_SECRET
               valueFrom:
-                  secretKeyRef:
-                    name: cas-bciers-nextauth
-                    key: nextauth-secret
+                secretKeyRef:
+                  name: cas-bciers-nextauth
+                  key: nextauth-secret
           envFrom:
             - configMapRef:
                 name: {{ template "cas-bciers.fullname" . }}-frontend-env-configmap


### PR DESCRIPTION
some bad indents made it into a couple deployment yaml files, preventing helm from deploying properly. This should fix it, I tested the deploy with a --dry-run flag.