### PR TITLE
BCIERS\Dashboard - Internal user, pending approval, sees pending message

### DIFF
--- a/bciers/apps/administration/app/page.tsx
+++ b/bciers/apps/administration/app/page.tsx
@@ -1,15 +1,8 @@
 import Tiles from "@bciers/components/navigation/Tiles";
-import { FrontEndRoles } from "@bciers/utils/enums";
-import Card from "@mui/material/Card";
-import Typography from "@mui/material/Typography";
 import { fetchDashboardData } from "@bciers/actions";
 import { ContentItem } from "@bciers/types/tiles";
-import { auth } from "@/dashboard/auth";
 
 export default async function Page() {
-  const session = await auth();
-  const role = session?.user?.app_role || "";
-
   // 🚀 API fetch dashboard tiles
   // 🚩 Source: bc_obps/common/fixtures/dashboard/administration/[IdProviderType]/role?
   const data = (await fetchDashboardData(
@@ -18,25 +11,7 @@ export default async function Page() {
 
   return (
     <div>
-      {role === FrontEndRoles.CAS_PENDING ? (
-        <Card
-          data-testid="dashboard-pending-message"
-          sx={{ padding: 2, margin: 2, border: "none", boxShadow: "none" }}
-        >
-          <Typography variant="h5" component="div">
-            Welcome to B.C. Industrial Emissions Reporting System
-          </Typography>
-          <Typography variant="body1" color="textSecondary" component="div">
-            Your access request is pending approval.
-          </Typography>
-          <Typography variant="body1" color="textSecondary" component="div">
-            Once approved, you can log back in with access to the system.
-          </Typography>
-        </Card>
-      ) : (
-        // Display role based tiles here
-        <Tiles tiles={data} />
-      )}
+      <Tiles tiles={data} />
     </div>
   );
 }

--- a/bciers/apps/dashboard/app/dashboard/page.tsx
+++ b/bciers/apps/dashboard/app/dashboard/page.tsx
@@ -4,10 +4,15 @@ import { fetchDashboardData } from "@bciers/actions";
 import { ContentItem } from "@bciers/types/tiles";
 import { auth } from "@/dashboard/auth";
 
+import { FrontEndRoles } from "@bciers/utils/enums";
+import Card from "@mui/material/Card";
+import Typography from "@mui/material/Typography";
+
 export default async function Page() {
   const session = await auth();
 
-  const isIndustryUser = session?.user?.app_role?.includes("industry");
+  const role = session?.user?.app_role || "";
+  const isIndustryUser = role.includes("industry");
 
   // 🚀 API fetch dashboard tiles
   // 🚩 Source: bc_obps/common/fixtures/dashboard/bciers/[IdProviderType]
@@ -15,17 +20,35 @@ export default async function Page() {
     "common/dashboard-data?dashboard=bciers",
   )) as ContentItem[];
 
-  // Build the navigation tiles
   return (
-    <>
-      {isIndustryUser && (
-        <Note variant="important">
-          <b>Important:</b> Please always ensure that the information in{" "}
-          <b>Registration</b> is complete and accurate before submit or amend
-          reports in <b>Reporting.</b>
-        </Note>
+    <div>
+      {role === FrontEndRoles.CAS_PENDING ? (
+        <Card
+          data-testid="dashboard-pending-message"
+          sx={{ padding: 2, margin: 2, border: "none", boxShadow: "none" }}
+        >
+          <Typography variant="h5" component="div">
+            Welcome to B.C. Industrial Emissions Reporting System
+          </Typography>
+          <Typography variant="body1" color="textSecondary" component="div">
+            Your access request is pending approval.
+          </Typography>
+          <Typography variant="body1" color="textSecondary" component="div">
+            Once approved, you can log back in with access to the system.
+          </Typography>
+        </Card>
+      ) : (
+        <>
+          {isIndustryUser && (
+            <Note variant="important">
+              <b>Important:</b> Please always ensure that the information in{" "}
+              <b>Registration</b> is complete and accurate before submitting or
+              amending reports in <b>Reporting.</b>
+            </Note>
+          )}
+          <Tiles tiles={data} />
+        </>
       )}
-      <Tiles tiles={data} />
-    </>
+    </div>
   );
 }

--- a/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.ts
+++ b/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.ts
@@ -70,12 +70,12 @@ export const withAuthorizationDashboard: MiddlewareFactory = (
         }
       }
 
-      // Should the user be redirected to the onboarding page?
       if (token.app_role.includes("pending")) {
-        const url = request.nextUrl.clone();
-        url.pathname = "/registration";
-
-        return NextResponse.rewrite(url);
+        if (pathname.endsWith("/dashboard")) {
+          return next(request, _next);
+        } else {
+          return NextResponse.redirect(new URL(`/dashboard`, request.url));
+        }
       }
 
       if (pathname === "/" || pathname === `/${onboarding}`) {

--- a/bciers/apps/dashboard/tests/routes/dashboard/page.test.tsx
+++ b/bciers/apps/dashboard/tests/routes/dashboard/page.test.tsx
@@ -2,6 +2,12 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, vi } from "vitest";
 import DashboardPage from "../../../app/dashboard/page";
 import { auth } from "@bciers/testConfig/mocks";
+const roles = [
+  "cas_admin",
+  "cas_analyst",
+  "industry_user",
+  "industry_user_admin",
+];
 
 const tiles = [
   {
@@ -89,7 +95,9 @@ const tiles = [
 ];
 
 const noteContent =
-  "Important: Please always ensure that the information in Registration is complete and accurate before submit or amend reports in Reporting.";
+  "Important: Please always ensure that the information in Registration is complete and accurate before submitting or amending reports in Reporting.";
+
+const msgContent = "Welcome to B.C. Industrial Emissions Reporting System";
 
 vi.mock("@bciers/actions", () => ({
   fetchDashboardData: vi.fn(() => tiles),
@@ -238,4 +246,31 @@ describe("Registration dashboard page", () => {
 
     expect(screen.queryByTestId("note")).not.toBeInTheDocument();
   });
+
+  it("renders the dashboard-pending-message card for cas_pending role", async () => {
+    auth.mockReturnValueOnce({
+      user: { app_role: "cas_pending" },
+    });
+
+    render(await DashboardPage());
+
+    const msg = screen.getByTestId("dashboard-pending-message");
+    expect(msg).toBeVisible();
+    expect(msg).toHaveTextContent(msgContent);
+  });
+
+  it.each(roles)(
+    "does not render the dashboard-pending-message card for role: %s",
+    async (role) => {
+      auth.mockReturnValueOnce({
+        user: { app_role: role },
+      });
+
+      render(await DashboardPage());
+
+      expect(
+        screen.queryByTestId("dashboard-pending-message"),
+      ).not.toBeInTheDocument();
+    },
+  );
 });

--- a/bciers/package.json
+++ b/bciers/package.json
@@ -8,6 +8,7 @@
     "dev": "nx dev reporting",
     "dash": "nx dev dashboard -p 3000",
     "dash:build": "nx build dashboard",
+    "dash:test": "nx run dashboard:test",
     "admin": "nx dev administration -p 4001",
     "admin:build": "nx build administration",
     "admin:e2e": "nx run administration:e2e",


### PR DESCRIPTION
Addresses [2058](https://github.com/bcgov/cas-registration/issues/2058)

### 🚀 Impact:
- Internal cas user with `cas_pending` role is redirected to common dashboard displaying "pending approval" message.


### 🔬 Local Testing:

1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd client && yarn dev-all
```  
3.  From terminal  update your idir id to status "Pending"
 ```
psql
\c registration
UPDATE erc.user SET  app_role_id='cas_pending' WHERE  user_guid='your-guid-here';
```  
 
### Test Login IDIR\cas_pending
1. Navigate to `http://localhost:3000`
3. Click button "Log in with IDIR"
4. Sign in to Keycloak using your IDIR
**Expected Results**   
   - Common dashboard with `Pending approval...` displays.
   - Bread crumbs display `Dashboard`
![image](https://github.com/user-attachments/assets/662b66ba-dcac-4f7e-a5b8-545c7c7d26d1)

 
### Test app urls
- http://localhost:3000/
- http://localhost:3000/dashboard
- http://localhost:3000/onboarding
- http://localhost:3000/administration/
- http://localhost:3000/coam/
- http://localhost:3000/registration/
- http://localhost:3000/reporting
**Expected Results**   
   - Common dashboard with `Pending approval...` displays.
   - Bread crumbs display `Dashboard`
![image](https://github.com/user-attachments/assets/662b66ba-dcac-4f7e-a5b8-545c7c7d26d1)