### PR TITLE
chore: 315 - load correct activity schema for gsc line tracing activity

### DIFF
--- a/bc_obps/reporting/migrations/0010_combustion_for_line_tracing_data.py
+++ b/bc_obps/reporting/migrations/0010_combustion_for_line_tracing_data.py
@@ -1804,7 +1804,7 @@ def init_activity_schema_data(apps, schema_monitor):
     import os
 
     cwd = os.getcwd()
-    with open(f'{cwd}/reporting/json_schemas/2024/gsc_excluding_line_tracing/activity.json') as gsc_st1:
+    with open(f'{cwd}/reporting/json_schemas/2024/gsc_solely_for_line_tracing/activity.json') as gsc_st1:
         schema = json.load(gsc_st1)
 
     ActivitySchema = apps.get_model('reporting', 'ActivityJsonSchema')


### PR DESCRIPTION
One-line fix. Looks like a leftover copy-paste error in the migration