### PR TITLE
2051 fix undefined rows

### DIFF
--- a/bciers/apps/registration1/app/components/datagrid/DataGrid.tsx
+++ b/bciers/apps/registration1/app/components/datagrid/DataGrid.tsx
@@ -48,7 +48,7 @@ const DataGrid: React.FC<Props> = ({
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const { replace } = useRouter();
-  const isRowsEmpty = rows.length === 0;
+  const isRowsEmpty = !rows || rows.length === 0;
 
   useEffect(() => {
     setIsComponentMounted(true);
@@ -70,7 +70,7 @@ const DataGrid: React.FC<Props> = ({
         // fetch data from server
         const pageData = await fetchPageData(params);
         setRows(pageData.rows);
-        setRowCount(pageData.row_count);
+        setRowCount(pageData?.row_count);
       };
 
       fetchData().then(() => setLoading(false));

--- a/bciers/apps/registration1/tests/components/datagrid/DataGrid.test.tsx
+++ b/bciers/apps/registration1/tests/components/datagrid/DataGrid.test.tsx
@@ -92,6 +92,18 @@ describe("The DataGrid component", () => {
     expect(screen.getByText(/No records found/i)).toBeInTheDocument();
   });
 
+  it("renders an empty grid with overlay when data is undefined", async () => {
+    render(
+      <DataGrid
+        columns={defaultColumns}
+        initialData={{ rows: undefined, row_count: undefined }}
+      />,
+    );
+    expect(screen.getAllByRole("columnheader")).toHaveLength(3);
+    expect(screen.getAllByRole("row")).toHaveLength(1);
+    expect(screen.getByText(/No records found/i)).toBeInTheDocument();
+  });
+
   it("sorts the column data and updates the URL", async () => {
     render(
       <DataGrid columns={defaultColumns} initialData={defaultInitialData} />,

--- a/bciers/libs/components/src/datagrid/DataGrid.test.tsx
+++ b/bciers/libs/components/src/datagrid/DataGrid.test.tsx
@@ -88,6 +88,18 @@ describe("The DataGrid component", () => {
     expect(screen.getByText(/No records found/i)).toBeInTheDocument();
   });
 
+  it("renders an empty grid with overlay when data is undefined", async () => {
+    render(
+      <DataGrid
+        columns={defaultColumns}
+        initialData={{ rows: undefined, row_count: undefined }}
+      />,
+    );
+    expect(screen.getAllByRole("columnheader")).toHaveLength(3);
+    expect(screen.getAllByRole("row")).toHaveLength(1);
+    expect(screen.getByText(/No records found/i)).toBeInTheDocument();
+  });
+
   it("sorts the column data and updates the URL", async () => {
     render(
       <DataGrid columns={defaultColumns} initialData={defaultInitialData} />,

--- a/bciers/libs/components/src/datagrid/DataGrid.tsx
+++ b/bciers/libs/components/src/datagrid/DataGrid.tsx
@@ -67,7 +67,7 @@ const DataGrid: React.FC<Props> = ({
   const [rowCount, setRowCount] = useState(initialData.row_count ?? undefined);
   const [loading, setLoading] = useState(false);
   const [isComponentMounted, setIsComponentMounted] = useState(false);
-  const isRowsEmpty = rows.length === 0;
+  const isRowsEmpty = !rows || rows.length === 0;
   const searchParams = useSearchParams();
   const [sortModel, setSortModel] = useState<GridSortItem[]>([]);
 


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?filterQuery=&pane=issue&itemId=73893336

This PR:
- fixes bug in both reg1 and 2
- regression test with vitest

To test this, delete rows from database and then look at the data grid in the app.

Happo looks like flake to me, I'll re-run after rebasing/before merging.