### PR TITLE
2167 fix bug cas_pending dashboard

### DIFF
--- a/bciers/apps/administration/app/components/profile/ProfileForm.tsx
+++ b/bciers/apps/administration/app/components/profile/ProfileForm.tsx
@@ -5,7 +5,6 @@ import { actionHandler } from "@bciers/actions";
 import FormBase from "@bciers/components/form/FormBase";
 import { Button } from "@mui/material";
 import { useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
 import { RJSFSchema } from "@rjsf/utils";
 import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
 import {
@@ -60,7 +59,6 @@ export default function ProfileForm({ formData, isCreate }: Props) {
   //  Destructuring assignment from data property of the object returned by useSession()
   const { data: session, update } = useSession();
   const idp = session?.identity_provider || "";
-  const router = useRouter();
   // 🛠️ Function to update the session, without reloading the page
   const handleUpdate = async () => {
     // With NextAuth strategy: "jwt" , update() method will trigger a jwt callback where app_role will be augmented to the jwt and session objects
@@ -72,8 +70,8 @@ export default function ProfileForm({ formData, isCreate }: Props) {
       setIsSuccess(false);
     }, 3000);
     if (isCreate) {
-      // 🛸 Routing: after the update is complete, navigate to the dashboard
-      router.push("/");
+      // 🛸 Redirect: after the update is complete, navigate to the dashboard
+      window.location.href = "./";
     }
   };
 

--- a/bciers/apps/dashboard/app/dashboard/page.tsx
+++ b/bciers/apps/dashboard/app/dashboard/page.tsx
@@ -15,14 +15,18 @@ export default async function Page() {
   const role = session?.user?.app_role || "";
   const isIndustryUser = role.includes("industry");
 
-  // 🚀 API fetch dashboard tiles
-  // 🚩 Source: bc_obps/common/fixtures/dashboard/bciers/[IdProviderType]
-  let data = (await fetchDashboardData(
-    "common/dashboard-data?dashboard=bciers",
-  )) as ContentItem[];
+  let data: ContentItem[] = [];
 
-  // Evaluate display conditions in the dashboard data
-  data = await evalDashboardRules(data);
+  // Check role before fetching data
+  if (role && role !== FrontEndRoles.CAS_PENDING) {
+    // 🚀 API fetch dashboard tiles
+    // 🚩 Source: bc_obps/common/fixtures/dashboard/bciers/[IdProviderType]
+    data = (await fetchDashboardData(
+      "common/dashboard-data?dashboard=bciers",
+    )) as ContentItem[];
+    // Evaluate display rules in the dashboard data
+    data = await evalDashboardRules(data);
+  }
 
   return (
     <div>

--- a/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.ts
+++ b/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.ts
@@ -24,7 +24,7 @@ const paths = {
   profile: "profile",
 };
 export const authAllowedPaths = [paths.dashboard, paths.profile];
-const unauthAllowedPaths = [paths.auth, paths.auth];
+const unauthAllowedPaths = [paths.auth, paths.unauth];
 
 // Middleware for authorization
 export const withAuthorizationDashboard: MiddlewareFactory = (

--- a/bciers/libs/utils/evalDashboardRules.ts
+++ b/bciers/libs/utils/evalDashboardRules.ts
@@ -9,8 +9,12 @@ import { actionHandler } from "../actions/src/actions";
  * @returns Filtered array of ContentItem objects.
  */
 const evalDashboardRules = async (
-  items: ContentItem[],
+  items: ContentItem[] | null | undefined, // Allow null or undefined
 ): Promise<ContentItem[]> => {
+  // Ensure items is an array, if not default to an empty array
+  if (!Array.isArray(items)) {
+    items = [];
+  }
   const result = await Promise.all(
     items.map(async (item) => {
       // 🧩 Check if the tile (item) has a condition

--- a/bciers/libs/utils/isInAllowedList.ts
+++ b/bciers/libs/utils/isInAllowedList.ts
@@ -1,0 +1,6 @@
+// 🛠️ Function to serialize search params
+const isInAllowedPath = (pathname: string, allowedList: string[]): boolean => {
+  return allowedList.some((allowedPath) => pathname.includes(allowedPath));
+};
+
+export default isInAllowedPath;


### PR DESCRIPTION
Addresses [2167](https://github.com/bcgov/cas-registration/issues/2167)

### 🚀 Impact:
-  Authenticated Internal User, without a user profile,  gets redirected to dashboard with pending message after submitting profile page



### 🔬 Local Testing:

1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd client && yarn dev-all

```
3. Ensure your user id is not in the db
```
psql
\c registration
DELETE FROM erc.user where user_guid='your-idir-user_guid"
```
### Test Dashboard Pending Message:

1. Navigate to `http://localhost:3000`
2. Click button "Log in with IDIR"
3. Sign in to Keycloak using `your-idir-id`
**Expected results:** 
- Redirection to `http://localhost:3000/administration/profile`
![image](https://github.com/user-attachments/assets/a1bd5123-b2a2-421a-be06-a71a20947242)
4. Submit profile page
**Expected results:** 
-BCIERS dashboard displays pending message:
![image](https://github.com/user-attachments/assets/74842e60-32cb-4e3f-a84c-6c8c739c3d8d)
