### PR TITLE
chore: add fuel classification field to gsc fuel fields

### DIFF
--- a/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/with_useful_energy.json
@@ -34,6 +34,11 @@
                   "type": "string",
                   "enum": []
                 },
+                "fuelClassification": {
+                  "title": "Fuel Classification",
+                  "maxLength": 200,
+                  "type": "string"
+                },
                 "fuelUnit": {
                   "title": "Fuel Unit",
                   "maxLength": 200,

--- a/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/without_useful_energy.json
@@ -34,6 +34,11 @@
                   "type": "string",
                   "enum": []
                 },
+                "fuelClassification": {
+                  "title": "Fuel Classification",
+                  "maxLength": 200,
+                  "type": "string"
+                },
                 "fuelUnit": {
                   "title": "Fuel Unit",
                   "maxLength": 200,

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/field_gas_process_vent_gas_at_lfo.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/field_gas_process_vent_gas_at_lfo.json
@@ -34,6 +34,11 @@
                   "type": "string",
                   "enum": []
                 },
+                "fuelClassification": {
+                  "title": "Fuel Classification",
+                  "maxLength": 200,
+                  "type": "string"
+                },
                 "fuelUnit": {
                   "title": "Fuel Unit",
                   "maxLength": 200,

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/with_useful_energy.json
@@ -34,6 +34,11 @@
                   "type": "string",
                   "enum": []
                 },
+                "fuelClassification": {
+                  "title": "Fuel Classification",
+                  "maxLength": 200,
+                  "type": "string"
+                },
                 "fuelUnit": {
                   "title": "Fuel Unit",
                   "maxLength": 200,

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/without_useful_energy.json
@@ -34,6 +34,11 @@
                   "type": "string",
                   "enum": []
                 },
+                "fuelClassification": {
+                  "title": "Fuel Classification",
+                  "maxLength": 200,
+                  "type": "string"
+                },
                 "fuelUnit": {
                   "title": "Fuel Unit",
                   "maxLength": 200,

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
@@ -34,6 +34,11 @@
                   "type": "string",
                   "enum": []
                 },
+                "fuelClassification": {
+                  "title": "Fuel Classification",
+                  "maxLength": 200,
+                  "type": "string"
+                },
                 "fuelUnit": {
                   "title": "Fuel Unit",
                   "maxLength": 200,

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
@@ -34,6 +34,11 @@
                   "type": "string",
                   "enum": []
                 },
+                "fuelClassification": {
+                  "title": "Fuel Classification",
+                  "maxLength": 200,
+                  "type": "string"
+                },
                 "fuelUnit": {
                   "title": "Fuel Unit",
                   "maxLength": 200,

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
@@ -34,6 +34,11 @@
                   "type": "string",
                   "enum": []
                 },
+                "fuelClassification": {
+                  "title": "Fuel Classification",
+                  "maxLength": 200,
+                  "type": "string"
+                },
                 "fuelUnit": {
                   "title": "Fuel Unit",
                   "maxLength": 200,

--- a/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/with_useful_energy.json
@@ -34,6 +34,11 @@
                   "type": "string",
                   "enum": []
                 },
+                "fuelClassification": {
+                  "title": "Fuel Classification",
+                  "maxLength": 200,
+                  "type": "string"
+                },
                 "fuelUnit": {
                   "title": "Fuel Unit",
                   "maxLength": 200,

--- a/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/without_useful_energy.json
@@ -34,6 +34,11 @@
                   "type": "string",
                   "enum": []
                 },
+                "fuelClassification": {
+                  "title": "Fuel Classification",
+                  "maxLength": 200,
+                  "type": "string"
+                },
                 "fuelUnit": {
                   "title": "Fuel Unit",
                   "maxLength": 200,


### PR DESCRIPTION
Add missing field to all gsc fuel fields in the schemas