### PR TITLE
Disable Datagrid e2e screenshots

### DIFF
--- a/bciers/apps/registration1/e2e/workflows/bceidbusiness/industry_user_admin.spec.ts
+++ b/bciers/apps/registration1/e2e/workflows/bceidbusiness/industry_user_admin.spec.ts
@@ -229,7 +229,6 @@ test.describe("Test Workflow industry_user_admin", () => {
   }) => {
     const dashboardPage = new DashboardPOM(page);
     const userPage = new UsersPOM(page);
-    const pageContent = page.locator("html");
     // 🛸 Navigate to dashboard
     await dashboardPage.route();
     // 🛸 Navigates to user access management tile page
@@ -257,10 +256,13 @@ test.describe("Test Workflow industry_user_admin", () => {
     // 🔍 Assert updated row is Pending
     await userPage.rowHasCorrectStatusValue(rowId, UserOperatorStatus.PENDING);
     // 📷 Cheese!
-    await happoPlaywright.screenshot(userPage.page, pageContent, {
-      component: "User Access Management",
-      variant: UserRole.INDUSTRY_USER_ADMIN,
-    });
+    // Disabled due to flakiness - tech debt to resolve:
+    // https://github.com/bcgov/cas-registration/issues/2181
+    // const pageContent = page.locator("html");
+    // await happoPlaywright.screenshot(userPage.page, pageContent, {
+    //   component: "User Access Management",
+    //   variant: UserRole.INDUSTRY_USER_ADMIN,
+    // });
     // ♿️ Analyze accessibility
     await analyzeAccessibility(page);
   });

--- a/bciers/apps/registration1/e2e/workflows/bceidbusiness/industry_user_admin.spec.ts
+++ b/bciers/apps/registration1/e2e/workflows/bceidbusiness/industry_user_admin.spec.ts
@@ -15,9 +15,7 @@ import {
   filterTableByFieldId,
   setupTestEnvironment,
   sortTableByColumnLabel,
-  stabilizeGrid,
   tableRowCount,
-  takeStabilizedScreenshot,
 } from "@/e2e/utils/helpers";
 import * as dotenv from "dotenv";
 dotenv.config({ path: "./e2e/.env.local" });
@@ -113,13 +111,15 @@ test.describe("Test Workflow industry_user_admin", () => {
     await operationsPage.tableIsVisible();
     await operationsPage.tableHasExpectedColumns(UserRole.INDUSTRY_USER_ADMIN);
     // 📷 Cheese!
-    await stabilizeGrid(page, 14);
-    await takeStabilizedScreenshot(happoPlaywright, operationPage.page, {
-      component: "Operation grid",
-      variant: UserRole.INDUSTRY_USER_ADMIN,
-      targets: ["chrome", "firefox", "safari"], // this screenshot is flaky in edge
-    });
-
+    // Disabled due to flakiness - tech debt to resolve:
+    // https://github.com/bcgov/cas-registration/issues/2181
+    // await stabilizeGrid(page, 14);
+    // await takeStabilizedScreenshot(happoPlaywright, operationPage.page, {
+    //   component: "Operation grid",
+    //   variant: UserRole.INDUSTRY_USER_ADMIN,
+    //   targets: ["chrome", "firefox", "safari"], // this screenshot is flaky in edge
+    // });
+    //
     // ♿️ Analyze accessibility
     await analyzeAccessibility(page);
     // 🛸 Navigate to new operation form

--- a/bciers/apps/registration1/e2e/workflows/idir/cas_admin.spec.ts
+++ b/bciers/apps/registration1/e2e/workflows/idir/cas_admin.spec.ts
@@ -71,11 +71,13 @@ test.describe("Test Workflow cas_admin", () => {
       );
 
       // 📷 Cheese!
-      const pageContent = page.locator("html");
-      await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
-        component: "Operators Grid cas_admin",
-        variant: "default",
-      });
+      // Disabled due to flakiness - tech debt to resolve:
+      // https://github.com/bcgov/cas-registration/issues/2181
+      // const pageContent = page.locator("html");
+      // await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
+      //   component: "Operators Grid cas_admin",
+      //   variant: "default",
+      // });
     });
 
     test("Test details view by status", async ({ page }) => {

--- a/bciers/apps/registration1/e2e/workflows/idir/cas_admin.spec.ts
+++ b/bciers/apps/registration1/e2e/workflows/idir/cas_admin.spec.ts
@@ -12,7 +12,6 @@ import {
   tableRowCount,
   waitForElementToStabilize,
   takeStabilizedScreenshot,
-  stabilizeGrid,
   stabilizeAccordion,
 } from "@/e2e/utils/helpers";
 // ☰ Enums
@@ -161,12 +160,14 @@ test.describe("Test Workflow cas_admin", () => {
         TableDataField.STATUS,
       );
       // 📷 Cheese!
-      await stabilizeGrid(page, 20);
-      await takeStabilizedScreenshot(happoPlaywright, operationsPage.page, {
-        component: "Operations Grid cas_admin",
-        variant: "default",
-        targets: ["chrome", "firefox", "safari"], // edge screenshot is flaky
-      });
+      // Disabled due to flakiness - tech debt to resolve:
+      // https://github.com/bcgov/cas-registration/issues/2181
+      // await stabilizeGrid(page, 20);
+      // await takeStabilizedScreenshot(happoPlaywright, operationsPage.page, {
+      //   component: "Operations Grid cas_admin",
+      //   variant: "default",
+      //   targets: ["chrome", "firefox", "safari"], // edge screenshot is flaky
+      // });
     });
 
     test("Test details view by status", async ({ page }) => {

--- a/bciers/apps/registration1/e2e/workflows/idir/cas_analyst.spec.ts
+++ b/bciers/apps/registration1/e2e/workflows/idir/cas_analyst.spec.ts
@@ -8,7 +8,6 @@ import { OperatorsPOM } from "@/e2e/poms/operators";
 import {
   setupTestEnvironment,
   stabilizeAccordion,
-  stabilizeGrid,
   takeStabilizedScreenshot,
 } from "@/e2e/utils/helpers";
 // ☰ Enums
@@ -66,12 +65,14 @@ test.describe("Test Workflow cas_analyst", () => {
         TableDataField.STATUS,
       );
       // 📷 Cheese!
-      await stabilizeGrid(page, 20);
-      const pageContent = page.locator("html");
-      await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
-        component: "Operators Grid cas_analyst",
-        variant: "default",
-      });
+      // Disabled due to flakiness - tech debt to resolve:
+      // https://github.com/bcgov/cas-registration/issues/2181
+      // await stabilizeGrid(page, 20);
+      // const pageContent = page.locator("html");
+      // await happoPlaywright.screenshot(operatorsPage.page, pageContent, {
+      //   component: "Operators Grid cas_analyst",
+      //   variant: "default",
+      // });
     });
 
     test("Test details view by status", async ({ page }) => {
@@ -155,12 +156,14 @@ test.describe("Test Workflow cas_analyst", () => {
         TableDataField.STATUS,
       );
       // 📷 Cheese!
-      await stabilizeGrid(page, 20);
-      await takeStabilizedScreenshot(happoPlaywright, operationsPage.page, {
-        component: "Operations Grid cas_analyst",
-        variant: "default",
-        targets: ["chrome", "firefox", "safari"], // this screenshot is flaky in edge
-      });
+      // Disabled due to flakiness - tech debt to resolve:
+      // https://github.com/bcgov/cas-registration/issues/2181
+      // await stabilizeGrid(page, 20);
+      // await takeStabilizedScreenshot(happoPlaywright, operationsPage.page, {
+      //   component: "Operations Grid cas_analyst",
+      //   variant: "default",
+      //   targets: ["chrome", "firefox", "safari"], // this screenshot is flaky in edge
+      // });
     });
 
     test("Test details view by status", async ({ page }) => {


### PR DESCRIPTION
#2182

#### Note: the Happo run for this PR still needs to be approved for all the deleted screenshots

Disables Datagrid e2e screenshots since they are very flaky. This won't completely solve our flaky screenshots but should significantly reduce them. There is a reg1 breadcrumb bug occasionally causes flakes: https://github.com/bcgov/cas-registration/issues/2116

Tech debt ticket for flaky Datagrid screenshots: https://github.com/bcgov/cas-registration/issues/2181


