### PR TITLE
2140 retry owasp zap

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,7 +52,7 @@ jobs:
     secrets: inherit
   zap-owasp:
     # We will need to set up registration part 2 and reporting to get zap scanned
-    needs: [build-backend, build-registration1, install-dev-tools]
+    # needs: [build-backend, build-registration1, install-dev-tools]
     uses: ./.github/workflows/zap-owasp.yaml
   trivy:
     uses: ./.github/workflows/trivy.yaml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,7 +52,7 @@ jobs:
     secrets: inherit
   zap-owasp:
     # We will need to set up registration part 2 and reporting to get zap scanned
-    # needs: [build-backend, build-registration1, install-dev-tools]
+    needs: [build-backend, build-registration1, install-dev-tools]
     uses: ./.github/workflows/zap-owasp.yaml
   trivy:
     uses: ./.github/workflows/trivy.yaml

--- a/.github/workflows/retry-workflow.yaml
+++ b/.github/workflows/retry-workflow.yaml
@@ -1,0 +1,18 @@
+name: Retry workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed

--- a/.github/workflows/retry-workflow.yaml
+++ b/.github/workflows/retry-workflow.yaml
@@ -6,7 +6,7 @@ on:
       run_id:
         required: true
 jobs:
-  rerun:
+  retry-on-failure:
     runs-on: ubuntu-latest
     steps:
       - name: rerun ${{ inputs.run_id }}

--- a/.github/workflows/zap-owasp.yaml
+++ b/.github/workflows/zap-owasp.yaml
@@ -41,14 +41,14 @@ jobs:
           issue_title: OWASP Baseline - Backend
           fail_action: false
 
-  # retry-on-failure:
-  #   needs: zap-scan
-  #   if: failure() && fromJSON(github.run_attempt) < 3
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - env:
-  #         GH_REPO: ${{ github.repository }}
-  #         GH_TOKEN: ${{ github.token }}
-  #         GH_DEBUG: api
-  #       This will fail to fetch the workflow from gh api until merged into develop
-  #       run: gh workflow run retry-workflow.yaml -F run_id=${{ github.run_id }}
+  retry-on-failure:
+    needs: zap-scan
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        # This will fail to fetch the workflow from gh api until merged into develop
+        run: gh workflow run retry-workflow.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/zap-owasp.yaml
+++ b/.github/workflows/zap-owasp.yaml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: test failure
-        run: exit 1
+      # - name: test failure
+      #   run: exit 1
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - name: run app locally
@@ -41,14 +41,14 @@ jobs:
           issue_title: OWASP Baseline - Backend
           fail_action: false
 
-  retry-on-failure:
-    needs: zap-scan
-    if: failure() && fromJSON(github.run_attempt) < 3
-    runs-on: ubuntu-latest
-    steps:
-      - env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-          GH_DEBUG: api
-        # This will fail to fetch the workflow from gh api until merged into develop
-        run: gh workflow run retry-workflow.yaml -F run_id=${{ github.run_id }}
+  # retry-on-failure:
+  #   needs: zap-scan
+  #   if: failure() && fromJSON(github.run_attempt) < 3
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - env:
+  #         GH_REPO: ${{ github.repository }}
+  #         GH_TOKEN: ${{ github.token }}
+  #         GH_DEBUG: api
+  #       # This will fail to fetch the workflow from gh api until merged into develop
+  #       run: gh workflow run retry-workflow.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/zap-owasp.yaml
+++ b/.github/workflows/zap-owasp.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: test failure
+        run: exit 1
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - name: run app locally
@@ -38,3 +40,15 @@ jobs:
           cmd_options: "-a -d -T 5 -m 2"
           issue_title: OWASP Baseline - Backend
           fail_action: false
+
+  # retry-on-failure:
+  #   needs: zap-scan
+  #   if: failure() && fromJSON(github.run_attempt) < 3
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - env:
+  #         GH_REPO: ${{ github.repository }}
+  #         GH_TOKEN: ${{ github.token }}
+  #         GH_DEBUG: api
+  #       This will fail to fetch the workflow from gh api until merged into develop
+  #       run: gh workflow run retry-workflow.yaml -F run_id=${{ github.run_id }}


### PR DESCRIPTION
#2140 

This method seems to be commonly recommended as a way to re-run workflows on failure:
https://github.com/orgs/community/discussions/67654#discussioncomment-8038649
https://medium.com/@aarne.laur/retry-failed-github-actions-8661e7601c66
https://dev.to/logto/automatically-rerun-your-github-workflow-after-failure-26hi

However I discovered that you can't manually trigger workflows that don't exist yet in the default branch so I get a 404 error:
https://stackoverflow.com/a/78765950

<img width="860" alt="Screenshot 2024-09-12 at 10 45 58 AM" src="https://github.com/user-attachments/assets/0519f75c-afd5-4585-843e-b1bb7c6bf8ec">


Tried the same command with a workflow that exists in `develop`:
<img width="860" alt="Screenshot 2024-09-12 at 11 01 35 AM" src="https://github.com/user-attachments/assets/48aab148-4daa-4025-b837-b15212d3dc05">

