### PR TITLE
chore: shipit will ignore Happo 

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -12,3 +12,4 @@ deploy:
 ci:
   allow_failures:
     - "yarn-audit"
+    - "Happo"


### PR DESCRIPTION
Ignoring the happo check in shipit to avoid blocking automated deploy when snapshots are flaky.
Snapshots would already have been approved in PR review.