### PR TITLE
2140 retry workflow

### DIFF
--- a/.github/workflows/zap-owasp.yaml
+++ b/.github/workflows/zap-owasp.yaml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # - name: test failure
-      #   run: exit 1
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - name: run app locally
@@ -21,6 +19,7 @@ jobs:
         with:
           django_secret_key: ${{ env.DJANGO_SECRET_KEY }}
       - name: ZAP Frontend Scan
+        id: zap-frontend-scan
         uses: zaproxy/action-baseline@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,6 +30,7 @@ jobs:
           issue_title: OWASP Baseline - Frontend
           fail_action: false
       - name: ZAP Backend Scan
+        id: zap-backend-scan
         uses: zaproxy/action-baseline@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -41,14 +41,13 @@ jobs:
           issue_title: OWASP Baseline - Backend
           fail_action: false
 
-  # retry-on-failure:
-  #   needs: zap-scan
-  #   if: failure() && fromJSON(github.run_attempt) < 3
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - env:
-  #         GH_REPO: ${{ github.repository }}
-  #         GH_TOKEN: ${{ github.token }}
-  #         GH_DEBUG: api
-  #       # This will fail to fetch the workflow from gh api until merged into develop
-  #       run: gh workflow run retry-workflow.yaml -F run_id=${{ github.run_id }}
+  retry-on-failure:
+    needs: zap-scan
+    if: failure() || needs.zap-scan.result != 'success' && fromJSON(github.run_attempt) < 3 && !cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: gh workflow run retry-workflow.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/zap-owasp.yaml
+++ b/.github/workflows/zap-owasp.yaml
@@ -39,6 +39,7 @@ jobs:
           issue_title: OWASP Baseline - Backend
           fail_action: false
 
+  # Retry the workflow due to secondary rate limiting errors causing frequent failures
   retry-on-failure:
     needs: zap-scan
     if: failure() || needs.zap-scan.result != 'success' && fromJSON(github.run_attempt) < 3 && !cancelled()

--- a/.github/workflows/zap-owasp.yaml
+++ b/.github/workflows/zap-owasp.yaml
@@ -19,7 +19,6 @@ jobs:
         with:
           django_secret_key: ${{ env.DJANGO_SECRET_KEY }}
       - name: ZAP Frontend Scan
-        id: zap-frontend-scan
         uses: zaproxy/action-baseline@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -30,7 +29,6 @@ jobs:
           issue_title: OWASP Baseline - Frontend
           fail_action: false
       - name: ZAP Backend Scan
-        id: zap-backend-scan
         uses: zaproxy/action-baseline@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#2140

This took me awhile to figure out since the secondary rate limiting error was seemingly causing the job to fail, however it wasn't triggering the `failure()` condition. So after some trial and error I got the retry working well. The `!cancelled()` condition had to be added as the retry workflow was being called if I pushed an update which cancels the in progress pr.

If you want to test this it's pretty easy, though a little time consuming depending on how many tries it takes to trigger the rate limiting error. Just retry the `zap-scan` job. It will fail eventually, then you will see the retry job being called. It will also appear as a second workflow in our Action tab:

<img width="1095" alt="Screenshot 2024-09-13 at 11 45 41 AM" src="https://github.com/user-attachments/assets/ffbe6477-1768-4550-ab17-402f1be0f77f">

After that completes you will see the failed workflow restart:
<img width="533" alt="Screenshot 2024-09-13 at 11 45 26 AM" src="https://github.com/user-attachments/assets/62ac071a-adfd-4507-9250-043bcc3dc10e">

