### PR TITLE
Make registration purpose conditional

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -10,7 +10,7 @@ sonar.python.version=3.12
 # Path is relative to the sonar-project.properties file. Defaults to .
 sonar.sources=.
 
-sonar.exclusions=**/Makefile, **/migrations/**, **bc_obps/registration1/tests/**, **/bciers/apps/registration1/tests/**, **/bciers/apps/registration1/e2e/**
+sonar.exclusions=**/Makefile, **/migrations/**, **bc_obps/registration1/tests/**, **/bciers/apps/registration1/tests/**, **/bciers/apps/registration1/e2e/**, **/bciers/apps/registration/tests/**,
 
 # Ignore duplication scanning for registration part 2 (will be removed once part 2 is merged into part 1)
 # Adding COAM as well for its middleware and middleware testing

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -72,6 +72,11 @@ class OperationOutV2(ModelSchema):
     process_flow_diagram: Optional[str] = None
     equipment_list: Optional[str] = None
     multiple_operators_array: Optional[List[MultipleOperatorIn]] = None
+    registration_purposes: Optional[list] = []
+
+    @staticmethod
+    def resolve_registration_purposes(obj: Operation) -> List[str]:
+        return list(obj.registration_purposes.all().values_list('registration_purpose', flat=True))
 
     @staticmethod
     def resolve_operator(obj: Operation, context: DictStrAny) -> Optional[Operator]:

--- a/bciers/apps/registration/app/components/operations/OperationRegistrationPage.tsx
+++ b/bciers/apps/registration/app/components/operations/OperationRegistrationPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/registration/app/components/operations/registration";
 import {
   OperationRegistrationSteps,
+  RegistrationPurposes,
   initialOperationRegistrationSteps,
 } from "@/registration/app/components/operations/registration/enums";
 import { getOperationV2 } from "@bciers/actions/api";
@@ -31,11 +32,11 @@ const OperationRegistrationPage = async ({
     const purposes = operationData?.registration_purposes;
     if (
       // Note: the purposes have slightly different names than the step names
-      purposes.includes("Opted-in Operation")
+      purposes.includes(RegistrationPurposes.OPTED_IN_OPERATION)
     ) {
       steps.splice(2, 0, OperationRegistrationSteps.OPT_IN_APPLICATION);
     }
-    if (purposes.includes("New Entrant Operation"))
+    if (purposes.includes(RegistrationPurposes.NEW_ENTRANT_OPERATION))
       steps.splice(2, 0, OperationRegistrationSteps.NEW_ENTRANT_APPLICATION);
   } else {
     steps = [...initialOperationRegistrationSteps];

--- a/bciers/apps/registration/app/components/operations/OperationRegistrationPage.tsx
+++ b/bciers/apps/registration/app/components/operations/OperationRegistrationPage.tsx
@@ -8,7 +8,10 @@ import {
   RegistrationSubmissionPage,
   OptedInOperationPage,
 } from "@/registration/app/components/operations/registration";
-import { allOperationRegistrationSteps } from "@/registration/app/components/operations/registration/enums";
+import {
+  OperationRegistrationSteps,
+  initialOperationRegistrationSteps,
+} from "@/registration/app/components/operations/registration/enums";
 import { getOperationV2 } from "@bciers/actions/api";
 import { FacilitiesSearchParams } from "@/administration/app/components/facilities/types";
 
@@ -21,22 +24,21 @@ const OperationRegistrationPage = async ({
   operation: UUID;
   searchParams: FacilitiesSearchParams;
 }) => {
-  // const purpose = operationFormData?.registration_purpose;
-  // hardcoding a value for development; remove value and ts-ignores when feature is implemented
-  const purpose = "New Entrant Operation";
-
-  // Remove steps that aren't applicable to the registration based on purpose
-  let steps = allOperationRegistrationSteps;
-  // @ts-ignore
-  if (purpose !== "New Entrant Operation")
-    steps = steps.filter((e) => e !== "New Entrant Application");
-  // @ts-ignore
-  if (purpose !== "Opted-in Operation")
-    steps = steps.filter((e) => e !== "Opt-in Application");
   let operationData;
-
+  let steps = [...initialOperationRegistrationSteps];
   if (operation && isValidUUID(operation)) {
     operationData = await getOperationV2(operation);
+    const purposes = operationData?.registration_purposes;
+    if (
+      // Note: the purposes have slightly different names than the step names
+      purposes.includes("Opted-in Operation")
+    ) {
+      steps.splice(2, 0, OperationRegistrationSteps.OPT_IN_APPLICATION);
+    }
+    if (purposes.includes("New Entrant Operation"))
+      steps.splice(2, 0, OperationRegistrationSteps.NEW_ENTRANT_APPLICATION);
+  } else {
+    steps = [...initialOperationRegistrationSteps];
   }
 
   const stepIndex = step - 1;
@@ -47,7 +49,6 @@ const OperationRegistrationPage = async ({
     step,
     steps,
   };
-
   switch (formSectionName) {
     case "Operation Information":
       return OperationInformationPage(defaultProps);

--- a/bciers/apps/registration/app/components/operations/registration/enums.ts
+++ b/bciers/apps/registration/app/components/operations/registration/enums.ts
@@ -7,6 +7,13 @@ export enum OperationRegistrationSteps {
   SUBMISSION = "Submission",
 }
 
+export const initialOperationRegistrationSteps: string[] = [
+  OperationRegistrationSteps.OPERATION_INFORMATION,
+  OperationRegistrationSteps.FACILITY_INFORMATION,
+  OperationRegistrationSteps.OPERATION_REPRESENTATIVE,
+  OperationRegistrationSteps.SUBMISSION,
+];
+
 export const allOperationRegistrationSteps: string[] = Object.values(
   OperationRegistrationSteps,
 );

--- a/bciers/apps/registration/tests/components/operations/OperationRegistrationPage.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/OperationRegistrationPage.test.tsx
@@ -81,7 +81,7 @@ describe("the OperationRegistrationPage component", () => {
     );
   });
 
-  it("should render the Facility Information Form", async () => {
+  it("should render the Facility Information Form with 4 steps", async () => {
     useSearchParams.mockReturnValue({
       searchParams: {
         operation: "002d5a9e-32a6-4191-938c-2c02bfec592d",
@@ -93,6 +93,9 @@ describe("the OperationRegistrationPage component", () => {
     actionHandler.mockReturnValue({
       items: [],
       count: 0,
+    });
+    actionHandler.mockResolvedValueOnce({
+      registration_purposes: ["OBPS Regulated Operation"],
     });
     render(
       await OperationRegistrationPage({
@@ -107,18 +110,55 @@ describe("the OperationRegistrationPage component", () => {
     );
   });
 
-  // add tests for new entrant and opt-in pages when created
+  it("should render 5 steps and the Opt-in Application Form if the registration purpose is Opt-in", async () => {
+    actionHandler.mockResolvedValueOnce({
+      registration_purposes: ["Opted-in Operation"],
+    });
+    render(
+      await OperationRegistrationPage({
+        operation: "002d5a9e-32a6-4191-938c-2c02bfec592d",
+        step: 3,
+        searchParams: {},
+      }),
+    );
 
-  it("should render the Operation Representative Form", async () => {
+    expect(screen.getByTestId("field-template-label")).toHaveTextContent(
+      "Opt-In Application",
+    );
+  });
+
+  it("should render 5 steps and the New Entrant Application Form if the registration purpose is New Entrant", async () => {
+    actionHandler.mockResolvedValueOnce({
+      registration_purposes: ["New Entrant Operation"],
+    });
+    render(
+      await OperationRegistrationPage({
+        operation: "002d5a9e-32a6-4191-938c-2c02bfec592d",
+        step: 3,
+        searchParams: {},
+      }),
+    );
+
+    expect(screen.getByTestId("field-template-label")).toHaveTextContent(
+      "New Entrant Operation",
+    );
+  });
+
+  it("should render the Operation Representative Form and 4 steps", async () => {
+    // purpose
+    actionHandler.mockResolvedValueOnce({
+      registration_purposes: ["OBPS Regulated Operation"],
+    });
     // contacts
     actionHandler.mockResolvedValueOnce([]);
 
     // users
     actionHandler.mockResolvedValueOnce([]);
+
     render(
       await OperationRegistrationPage({
         operation: "002d5a9e-32a6-4191-938c-2c02bfec592d",
-        step: 4,
+        step: 3,
         searchParams: {},
       }),
     );
@@ -128,7 +168,10 @@ describe("the OperationRegistrationPage component", () => {
     );
   });
 
-  it("should render the Submission Form", async () => {
+  it("should render the Submission Form and 5 steps", async () => {
+    actionHandler.mockResolvedValueOnce({
+      registration_purposes: ["New Entrant Operation"],
+    });
     render(
       await OperationRegistrationPage({
         operation: "002d5a9e-32a6-4191-938c-2c02bfec592d",


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?filterQuery=&pane=issue&itemId=76712500

This PR:
- removes the hardcoded "New Entrant" purpose and pulls the purpose (if there is one) from the db instead
- vitest
- endpoint test
- excludes our vitest directory from sonarcloud scan (this PR's tests set off a bunch of duplication warnings)

Note: There's an existing bug with the "Save and Continue" button for LFOs: https://github.com/orgs/bcgov/projects/122/views/2?filterQuery=facility&pane=issue&itemId=79778537. Operation 2 is our only mock LFO, so test with a different mock operation or make your own.