### PR TITLE
2189 dashboard operations tile

### DIFF
--- a/bc_obps/common/fixtures/dashboard/administration/external.json
+++ b/bc_obps/common/fixtures/dashboard/administration/external.json
@@ -35,7 +35,13 @@
             "title": "Operations",
             "icon": "Layers",
             "content": "View the operations owned by your operator, or to add and register new operation to your operator here.",
-            "href": "/administration/operations"
+            "href": "/administration/operations",
+            "condition": {
+              "api": "registration/v2/user-operators/current/operator",
+              "field": "error",
+              "operator": "notExists",
+              "value": true
+            }
           },
           {
             "title": "Contacts",

--- a/bc_obps/common/fixtures/dashboard/administration/external.json
+++ b/bc_obps/common/fixtures/dashboard/administration/external.json
@@ -59,7 +59,13 @@
             "title": "Users and Access Requests",
             "icon": "Users",
             "content": "View, approve or decline Business BCeID user access requests to your operator, or to assign access type to users here.",
-            "href": "/administration/tbd"
+            "href": "/administration/tbd",
+            "condition": {
+              "api": "registration/v2/user-operators/current/operator",
+              "field": "error",
+              "operator": "notExists",
+              "value": true
+            }
           }
         ]
       }

--- a/bc_obps/common/fixtures/dashboard/bciers/external.json
+++ b/bc_obps/common/fixtures/dashboard/bciers/external.json
@@ -35,7 +35,13 @@
               },
               {
                 "title": "Operations",
-                "href": "/administration/operations"
+                "href": "/administration/operations",
+                "condition": {
+                  "api": "registration/v2/user-operators/current/operator",
+                  "field": "error",
+                  "operator": "notExists",
+                  "value": true
+                }
               },
               {
                 "title": "Contacts",

--- a/bc_obps/common/fixtures/dashboard/bciers/external.json
+++ b/bc_obps/common/fixtures/dashboard/bciers/external.json
@@ -55,7 +55,13 @@
               },
               {
                 "title": "Users and Access Requests",
-                "href": "/administration/tbd"
+                "href": "/administration/tbd",
+                "condition": {
+                  "api": "registration/v2/user-operators/current/operator",
+                  "field": "error",
+                  "operator": "notExists",
+                  "value": true
+                }
               }
             ]
           },


### PR DESCRIPTION
#2189

Conditionally show the Operations and Users & Access Requests tiles based on the User Operator status. The Users & Access Requests weren't part of this issue though it was suggested to take care of that in this as well.

Make sure to reset the db/load the new fixtures to test:
`make reset_db && make run`

#### User has User Operator

- Log in as `bc-cas-user`
- BCIERS dashboard Administration tile has `Operations` & `Users and access requests` link
<img width="1330" alt="Screenshot 2024-09-19 at 8 10 26 AM" src="https://github.com/user-attachments/assets/5d533656-6d83-4705-b3ef-b5bcab364c92">

- Click `Administration` tile
- Administration dashboard has `Operations` tile & `Users and access requests` tile:

<img width="1330" alt="Screenshot 2024-09-19 at 8 15 18 AM" src="https://github.com/user-attachments/assets/af6da235-dabe-4655-a059-91107669d87d">

#### User does no have User Operator
- Log in as `bc-cas-dev-secondary`
- BCIERS dashboard Administration tile does not have `Operations` & `Users and access requests` link

<img width="1330" alt="Screenshot 2024-09-19 at 8 18 15 AM" src="https://github.com/user-attachments/assets/21178ec6-a7d8-431d-b655-36681876fc87">

- Click `Administration` tile
-- Administration dashboard does not have `Operations` & `Users and access requests` tile:

<img width="1330" alt="Screenshot 2024-09-19 at 8 18 36 AM" src="https://github.com/user-attachments/assets/991ec01c-0378-4fd5-b710-a4037ef9ee66">


- Click `Select an Operator`
- Search for and select `Operator 3`
- Request access to this operator
- Approve User Operator in the database:
```
psql
\c registration
UPDATE erc.user_operator SET status='Approved' WHERE user_id='279c80cf-5781-4c28-8727-40a133d17c0d' AND operator_id='438eff6c-d2e7-40ab-8220-29d3a86ef314';
```

- Navigate to BCIERS dashboard
- `Administration` tile has `Operations` and `Users and access requests`:

<img width="1330" alt="Screenshot 2024-09-19 at 8 23 32 AM" src="https://github.com/user-attachments/assets/2cdedd40-ccb9-47be-8c57-c2e675993bd9">

- Click `Administration` tile
- `Administration` dashboard has `Operations` and `Users and access requests` tile:

<img width="1330" alt="Screenshot 2024-09-19 at 8 23 26 AM" src="https://github.com/user-attachments/assets/79a5bfd4-cf7c-4081-b4cc-fa5e3f763f2c">



