### PR TITLE
fix/reg1 nx affected e2e

### DIFF
--- a/.github/workflows/e2e-finalize.yaml
+++ b/.github/workflows/e2e-finalize.yaml
@@ -45,16 +45,3 @@ jobs:
             || contains(needs.*.result, 'cancelled')
             || contains(needs.*.result, 'skipped')
           }}
-  happo-finalize:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: dev env setup
-        uses: ./.github/actions/dev-env-setup
-      - name: finalize happo e2e tests
-        env:
-          HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
-          HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-          HAPPO_NONCE: ${{ github.sha }}
-        run: npx happo-e2e finalize
-        working-directory: ./bciers

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -120,7 +120,8 @@ jobs:
         test-registration-e2e,
         test-registration1-e2e,
       ]
-    # This wasn't wasn't being triggered if any tests were skipped
+    # Run this job only if all the e2e tests are successful or skipped but not on failure.
+    # This was needed as just the `needs` condition was skipping the entire job if any of the e2e tests were skipped.
     if: |
       always() &&
       (needs.test-administration-e2e.result == 'success' || needs.test-administration-e2e.result == 'skipped') &&

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,7 +93,6 @@ jobs:
       image_url: "ghcr.io/bcgov/cas-rep-frontend"
     secrets: inherit
   test-registration1-e2e:
-    # if: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'registration1')}}
     needs: [build-backend, build-registration1, check-nx-affected]
     uses: ./.github/workflows/test-registration1-e2e.yaml
     secrets: inherit
@@ -121,6 +120,14 @@ jobs:
         test-registration-e2e,
         test-registration1-e2e,
       ]
+    # This wasn't wasn't being triggered if any tests were skipped
+    if: |
+      always() &&
+      (needs.test-administration-e2e.result == 'success' || needs.test-administration-e2e.result == 'skipped') &&
+      (needs.test-coam-e2e.result == 'success' || needs.test-coam-e2e.result == 'skipped') &&
+      (needs.test-reporting-e2e.result == 'success' || needs.test-reporting-e2e.result == 'skipped') &&
+      (needs.test-registration-e2e.result == 'success' || needs.test-registration-e2e.result == 'skipped') &&
+      (needs.test-registration1-e2e.result == 'success' || needs.test-registration1-e2e.result == 'skipped')
     uses: ./.github/workflows/e2e-finalize.yaml
     secrets: inherit
   zap-owasp:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,7 +93,7 @@ jobs:
       image_url: "ghcr.io/bcgov/cas-rep-frontend"
     secrets: inherit
   test-registration1-e2e:
-    if: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'registration1')}}
+    # if: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'registration1')}}
     needs: [build-backend, build-registration1, check-nx-affected]
     uses: ./.github/workflows/test-registration1-e2e.yaml
     secrets: inherit

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,6 +72,7 @@ jobs:
       nx_project: administration
       nx_app_port: 4001
       image_url: "ghcr.io/bcgov/cas-admin-frontend"
+      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'administration')}}
     secrets: inherit
   test-coam-e2e:
     if: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'coam')}}
@@ -81,6 +82,7 @@ jobs:
       nx_project: coam
       nx_app_port: 7000
       image_url: "ghcr.io/bcgov/cas-coam-frontend"
+      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'coam')}}
     secrets: inherit
   test-reporting-e2e:
     if: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'reporting')}}
@@ -91,6 +93,7 @@ jobs:
       nx_project: reporting
       nx_app_port: 5000
       image_url: "ghcr.io/bcgov/cas-rep-frontend"
+      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'reporting')}}
     secrets: inherit
   test-registration1-e2e:
     needs: [build-backend, build-registration1, check-nx-affected]
@@ -110,6 +113,7 @@ jobs:
       nx_project: registration
       nx_app_port: 4000
       image_url: "ghcr.io/bcgov/cas-reg-frontend"
+      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'registration')}}
     secrets: inherit
   e2e-finalize:
     needs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,7 +59,6 @@ jobs:
     uses: ./.github/workflows/test-backend.yaml
     secrets: inherit
   test-administration-e2e:
-    if: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'administration')}}
     needs:
       [
         build-backend,
@@ -75,7 +74,6 @@ jobs:
       is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'administration')}}
     secrets: inherit
   test-coam-e2e:
-    if: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'coam')}}
     needs: [build-backend, build-dashboard-e2e, build-coam, check-nx-affected]
     uses: ./.github/workflows/test-nx-project-e2e.yaml
     with:
@@ -85,7 +83,6 @@ jobs:
       is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'coam')}}
     secrets: inherit
   test-reporting-e2e:
-    if: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'reporting')}}
     needs:
       [build-backend, build-dashboard-e2e, build-reporting, check-nx-affected]
     uses: ./.github/workflows/test-nx-project-e2e.yaml
@@ -100,7 +97,6 @@ jobs:
     uses: ./.github/workflows/test-registration1-e2e.yaml
     secrets: inherit
   test-registration-e2e:
-    if: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'registration')}}
     needs:
       [
         build-backend,

--- a/.github/workflows/test-nx-project-e2e.yaml
+++ b/.github/workflows/test-nx-project-e2e.yaml
@@ -123,3 +123,17 @@ jobs:
       - name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v2
+
+  happo-finalize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: dev env setup
+        uses: ./.github/actions/dev-env-setup
+      - name: finalize happo e2e tests
+        env:
+          HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+          HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
+          HAPPO_NONCE: ${{ github.sha }}
+        run: npx happo-e2e finalize
+        working-directory: ./bciers/apps/${{ inputs.nx_project }}-e2e

--- a/.github/workflows/test-nx-project-e2e.yaml
+++ b/.github/workflows/test-nx-project-e2e.yaml
@@ -149,6 +149,7 @@ jobs:
         run: npx happo-e2e finalize
         working-directory: ./bciers/apps/${{ inputs.nx_project }}-e2e
 
+  # Call Happo api and skip the project if it wasn't affected
   happo-skip-not-affected:
     if: ${{ !inputs.is_nx_affected }}
     runs-on: ubuntu-latest
@@ -165,5 +166,4 @@ jobs:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           cd bciers
-          yarn add jsonwebtoken
           node libs/e2e/src/utils/happo-skip.js

--- a/.github/workflows/test-nx-project-e2e.yaml
+++ b/.github/workflows/test-nx-project-e2e.yaml
@@ -108,7 +108,8 @@ jobs:
           E2E_NEW_USER_STORAGE_STATE: ${{ secrets.E2E_NEW_USER_STORAGE_STATE}}
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-          HAPPO_NONCE: ${{ github.sha }}
+          HAPPO_NONCE: ${{ github.sha }}-${{ inputs.nx_project }}
+          HAPPO_PROJECT: cas-${{ inputs.nx_project }}
           SMTP_CONNECTION_STRING: smtp://@localhost:1025
         working-directory: ./bciers
       - name: 💾 save ${{ matrix.project }} report artifact
@@ -126,6 +127,7 @@ jobs:
 
   happo-finalize:
     runs-on: ubuntu-latest
+    needs: [e2e-tests]
     steps:
       - uses: actions/checkout@v4
       - name: dev env setup
@@ -134,6 +136,7 @@ jobs:
         env:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-          HAPPO_NONCE: ${{ github.sha }}
+          HAPPO_NONCE: ${{ github.sha }}-${{ inputs.nx_project }}
+          HAPPO_PROJECT: cas-${{ inputs.nx_project }}
         run: npx happo-e2e finalize
         working-directory: ./bciers/apps/${{ inputs.nx_project }}-e2e

--- a/.github/workflows/test-nx-project-e2e.yaml
+++ b/.github/workflows/test-nx-project-e2e.yaml
@@ -18,6 +18,10 @@ on:
         description: "Docker image URL minus the tag which will be the pull request sha"
         required: true
         type: string
+      is_nx_affected:
+        description: "Whether the project is affected by the PR"
+        required: true
+        type: boolean
 
 env:
   PGUSER: postgres
@@ -28,6 +32,7 @@ env:
 
 jobs:
   e2e-tests:
+    if: ${{ inputs.is_nx_affected }}
     name: 🧪 e2e tests ${{ matrix.project }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -127,6 +132,7 @@ jobs:
         uses: jwalton/gh-docker-logs@v2
 
   happo-finalize:
+    if: ${{ inputs.is_nx_affected }}
     runs-on: ubuntu-latest
     needs: [e2e-tests]
     steps:
@@ -142,3 +148,22 @@ jobs:
           HAPPO_PROJECT: cas-${{ inputs.nx_project }}
         run: npx happo-e2e finalize
         working-directory: ./bciers/apps/${{ inputs.nx_project }}-e2e
+
+  happo-skip-not-affected:
+    if: ${{ !inputs.is_nx_affected }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: dev env setup
+        uses: ./.github/actions/dev-env-setup
+      - name: run happo skip node script
+        shell: bash
+        env:
+          HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+          HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
+          HAPPO_PROJECT: cas-${{ inputs.nx_project }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          cd bciers
+          yarn add jsonwebtoken
+          node libs/e2e/src/utils/happo-skip.js

--- a/.github/workflows/test-nx-project-e2e.yaml
+++ b/.github/workflows/test-nx-project-e2e.yaml
@@ -108,7 +108,8 @@ jobs:
           E2E_NEW_USER_STORAGE_STATE: ${{ secrets.E2E_NEW_USER_STORAGE_STATE}}
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-          HAPPO_NONCE: ${{ github.sha }}-${{ inputs.nx_project }}
+          # HAPPO_NONCE has 50 char limit, so using nx_project caused failures for projects with long names so using the unique nx_app_port instead
+          HAPPO_NONCE: ${{ github.sha }}-${{ inputs.nx_app_port }}
           HAPPO_PROJECT: cas-${{ inputs.nx_project }}
           SMTP_CONNECTION_STRING: smtp://@localhost:1025
         working-directory: ./bciers
@@ -136,7 +137,8 @@ jobs:
         env:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-          HAPPO_NONCE: ${{ github.sha }}-${{ inputs.nx_project }}
+          # HAPPO_NONCE has 50 char limit, so using nx_project caused failures for projects with long names so using the unique nx_app_port instead
+          HAPPO_NONCE: ${{ github.sha }}-${{ inputs.nx_app_port }}
           HAPPO_PROJECT: cas-${{ inputs.nx_project }}
         run: npx happo-e2e finalize
         working-directory: ./bciers/apps/${{ inputs.nx_project }}-e2e

--- a/.github/workflows/test-registration1-e2e.yaml
+++ b/.github/workflows/test-registration1-e2e.yaml
@@ -89,7 +89,8 @@ jobs:
           E2E_NEW_USER_STORAGE_STATE: ${{ secrets.E2E_NEW_USER_STORAGE_STATE}}
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-          HAPPO_NONCE: ${{ github.sha }}
+          HAPPO_NONCE: ${{ github.sha }}-registration1
+          HAPPO_PROJECT: cas-registration1
           SMTP_CONNECTION_STRING: smtp://@localhost:1025
         working-directory: ./bciers/apps/registration1
       - name: 💾 save ${{ matrix.project }} report artifact
@@ -113,6 +114,6 @@ jobs:
         env:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-          HAPPO_NONCE: ${{ github.sha }}
+          HAPPO_NONCE: ${{ github.sha }}-registration1
         run: npx happo-e2e finalize
         working-directory: ./bciers/apps/registration1

--- a/.github/workflows/test-registration1-e2e.yaml
+++ b/.github/workflows/test-registration1-e2e.yaml
@@ -89,7 +89,7 @@ jobs:
           E2E_NEW_USER_STORAGE_STATE: ${{ secrets.E2E_NEW_USER_STORAGE_STATE}}
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-          HAPPO_NONCE: ${{ github.sha }}-registration1
+          HAPPO_NONCE: ${{ github.sha }}-reg1
           HAPPO_PROJECT: cas-registration1
           SMTP_CONNECTION_STRING: smtp://@localhost:1025
         working-directory: ./bciers/apps/registration1
@@ -114,6 +114,6 @@ jobs:
         env:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-          HAPPO_NONCE: ${{ github.sha }}-registration1
+          HAPPO_NONCE: ${{ github.sha }}-reg1
         run: npx happo-e2e finalize
         working-directory: ./bciers/apps/registration1

--- a/.github/workflows/test-registration1-e2e.yaml
+++ b/.github/workflows/test-registration1-e2e.yaml
@@ -101,3 +101,18 @@ jobs:
           name: blob-report-${{ matrix.project }}
           path: bciers/blob-report
           retention-days: 1
+
+  happo-finalize:
+    runs-on: ubuntu-latest
+    needs: [e2e-tests]
+    steps:
+      - uses: actions/checkout@v4
+      - name: dev env setup
+        uses: ./.github/actions/dev-env-setup
+      - name: finalize happo e2e tests
+        env:
+          HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+          HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
+          HAPPO_NONCE: ${{ github.sha }}
+        run: npx happo-e2e finalize
+        working-directory: ./bciers/apps/registration1

--- a/bciers/.happo.js
+++ b/bciers/.happo.js
@@ -7,7 +7,7 @@ const MAXHEIGHT = 20000;
 module.exports = {
   apiKey: process.env.HAPPO_API_KEY,
   apiSecret: process.env.HAPPO_API_SECRET,
-  project: "cas-registration",
+  project: process.env.HAPPO_PROJECT || "cas-registration",
   targets: {
     chrome: new RemoteBrowserTarget("chrome", {
       viewport: VIEWPORT,

--- a/bciers/apps/administration-e2e/.happo.js
+++ b/bciers/apps/administration-e2e/.happo.js
@@ -1,3 +1,6 @@
 const happoConfig = require("../../.happo");
 
-module.exports = happoConfig;
+module.exports = {
+  ...happoConfig,
+  project: "cas-administration",
+};

--- a/bciers/apps/administration-e2e/.happo.js
+++ b/bciers/apps/administration-e2e/.happo.js
@@ -2,5 +2,5 @@ const happoConfig = require("../../.happo");
 
 module.exports = {
   ...happoConfig,
-  project: "cas-administration",
+  project: "cas-registration",
 };

--- a/bciers/apps/administration-e2e/.happo.js
+++ b/bciers/apps/administration-e2e/.happo.js
@@ -2,5 +2,5 @@ const happoConfig = require("../../.happo");
 
 module.exports = {
   ...happoConfig,
-  project: "cas-registration",
+  project: "cas-administration",
 };

--- a/bciers/apps/coam-e2e/.happo.js
+++ b/bciers/apps/coam-e2e/.happo.js
@@ -1,3 +1,6 @@
 const happoConfig = require("../../.happo");
 
-module.exports = happoConfig;
+module.exports = {
+  ...happoConfig,
+  project: "cas-coam",
+};

--- a/bciers/apps/dashboard-e2e/.happo.js
+++ b/bciers/apps/dashboard-e2e/.happo.js
@@ -1,3 +1,6 @@
 const happoConfig = require("../../.happo");
 
-module.exports = happoConfig;
+module.exports = {
+  ...happoConfig,
+  project: "cas-dashboard",
+};

--- a/bciers/apps/registration-e2e/.happo.js
+++ b/bciers/apps/registration-e2e/.happo.js
@@ -1,3 +1,6 @@
 const happoConfig = require("../../.happo");
 
-module.exports = happoConfig;
+module.exports = {
+  ...happoConfig,
+  project: "cas-registration",
+};

--- a/bciers/apps/registration1/.happo.js
+++ b/bciers/apps/registration1/.happo.js
@@ -7,7 +7,7 @@ const MAXHEIGHT = 20000;
 module.exports = {
   apiKey: process.env.HAPPO_API_KEY,
   apiSecret: process.env.HAPPO_API_SECRET,
-  project: "cas-registration",
+  project: "cas-registration1",
   targets: {
     chrome: new RemoteBrowserTarget("chrome", {
       viewport: VIEWPORT,

--- a/bciers/apps/reporting-e2e/.happo.js
+++ b/bciers/apps/reporting-e2e/.happo.js
@@ -1,3 +1,6 @@
 const happoConfig = require("../../.happo");
 
-module.exports = happoConfig;
+module.exports = {
+  ...happoConfig,
+  project: "cas-reporting",
+};

--- a/bciers/libs/e2e/src/utils/happo-skip.js
+++ b/bciers/libs/e2e/src/utils/happo-skip.js
@@ -1,0 +1,52 @@
+/* eslint-disable */
+const jwt = require("jsonwebtoken");
+const fetch = require("node-fetch");
+
+function makeRequest(requestAttributes, { apiKey, apiSecret }) {
+  const signed = jwt.sign({ key: apiKey }, apiSecret, {
+    header: { kid: apiKey },
+  });
+
+  const { url, method, json, body } = requestAttributes;
+
+  return fetch(url, {
+    method: method || "GET",
+    headers: {
+      Authorization: `Bearer ${signed}`,
+      "Content-Type": "application/json",
+    },
+    body: json ? JSON.stringify(body) : body,
+  }).then((response) => {
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+    return response;
+  });
+}
+
+const apiKey = process.env.HAPPO_API_KEY;
+const apiSecret = process.env.HAPPO_API_SECRET;
+const project = process.env.HAPPO_PROJECT;
+const commitSha = process.env.COMMIT_SHA;
+
+// This helper will skip the current commit/project in happo
+// https://happo.io/docs/api
+
+async function skipHappo() {
+  const response = await makeRequest(
+    {
+      url: `https://happo.io/api/skip/${commitSha}`,
+      method: "POST",
+      json: true,
+      body: { project },
+    },
+    { apiKey, apiSecret, retryCount: 5 },
+  );
+
+  if (response.ok) {
+    return response;
+  }
+}
+
+// Run skipHappo() to skip the current commit in Happo.
+skipHappo().then(() => console.log("Skipped Happo for this commit"));


### PR DESCRIPTION
Some issues cropped up from the e2e PR when there are no nx affected projects. Changes in this PR:

- `registration1` runs every time to be safe since it is in production (we should run the full e2e suite on merge to main in the future)
- fixes the `e2e-finalize` conditional so it doesn't get skipped when other projects are skipped
- adds separate Happo projects for each app. If projects were skipped the other screenshots were showing as deleted. This will also make it easier to figure out where the issues are if we have diffs.
- Adds `happo-skip` helper to call the Happo api and skip projects that aren't in `nx affected`. This way we can add them  as a required status check.

Adding `happo-skip` was slightly more involved than expected since it's not part of the `happo-e2e` cli:
https://github.com/happo/happo-e2e/issues/27

The `cas-coam` Happo project was manually skipped here running `happo-script.js` locally:
<img width="849" alt="Screenshot 2024-09-16 at 4 14 42 PM" src="https://github.com/user-attachments/assets/a4ee4855-020c-488d-94e1-8560d4d41710">
