### PR TITLE
Feat/286 reporting endpoint auth

### DIFF
--- a/bc_obps/reporting/api/activity_data.py
+++ b/bc_obps/reporting/api/activity_data.py
@@ -1,4 +1,5 @@
 from service.activity_service import ActivityService
+from common.permissions import authorize
 from .router import router
 from registration.decorators import handle_http_errors
 from django.http import HttpRequest
@@ -15,6 +16,7 @@ from ninja.responses import codes_4xx, codes_5xx
     "/initial-activity-data",
     response={200: str, codes_4xx: Message, codes_5xx: Message},
     url_name="get_initial_activity_data",
+    auth=authorize("approved_industry_user"),
 )
 @handle_http_errors()
 def get_initial_activity_data(

--- a/bc_obps/reporting/api/build_form_schema.py
+++ b/bc_obps/reporting/api/build_form_schema.py
@@ -1,4 +1,5 @@
 from service.form_builder_service import FormBuilderService
+from common.permissions import authorize
 from .router import router
 from registration.decorators import handle_http_errors
 from django.http import HttpRequest
@@ -11,7 +12,10 @@ from ninja.responses import codes_4xx, codes_5xx
 
 
 @router.get(
-    "/build-form-schema", response={200: str, codes_4xx: Message, codes_5xx: Message}, url_name="build_form_schema"
+    "/build-form-schema",
+    response={200: str, codes_4xx: Message, codes_5xx: Message},
+    url_name="build_form_schema",
+    auth=authorize("approved_authorized_roles"),
 )
 @handle_http_errors()
 def build_form_schema(

--- a/bc_obps/reporting/api/facility_report.py
+++ b/bc_obps/reporting/api/facility_report.py
@@ -1,5 +1,6 @@
 from typing import Literal, Tuple
 from uuid import UUID
+from common.permissions import authorize
 from django.http import HttpRequest
 from registration.decorators import handle_http_errors
 from reporting.constants import EMISSIONS_REPORT_TAGS
@@ -17,6 +18,7 @@ from registration.api.utils.current_user_utils import get_current_user_guid
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes `version_id` (primary key of the ReportVersion model) and `facility_id` to return a single matching `facility_report` object.
     Includes the associated activity IDs if found; otherwise, returns an error message if not found or in case of other issues.""",
+    auth=authorize("approved_authorized_roles"),
 )
 @handle_http_errors()
 def get_facility_report_form_data(
@@ -41,6 +43,7 @@ def get_facility_report_form_data(
     description="""Updates the report facility details by version_id and facility_id. The request body should include
     fields to be updated, such as facility name, type, BC GHG ID, activities, and products. Returns the updated report
     facility object or an error message if the update fails.""",
+    auth=authorize("approved_industry_user"),
 )
 @handle_http_errors()
 def save_facility_report(

--- a/bc_obps/reporting/api/operations.py
+++ b/bc_obps/reporting/api/operations.py
@@ -1,5 +1,6 @@
 from typing import List
 from uuid import UUID
+from common.permissions import authorize
 from django.http import HttpRequest
 from django.db.models import QuerySet
 from ninja import Query
@@ -26,6 +27,7 @@ from .router import router
     tags=DASHBOARD_TAGS,
     description="""Returns a list of operators for the current reporting year, for the current user. Populates
     the main reporting dashboard page.""",
+    auth=authorize("approved_authorized_roles"),
 )
 @handle_http_errors()
 @paginate(PageNumberPagination, page_size=PAGE_SIZE)

--- a/bc_obps/reporting/api/reports.py
+++ b/bc_obps/reporting/api/reports.py
@@ -1,4 +1,5 @@
 from typing import Literal, Tuple
+from common.permissions import authorize
 from django.http import HttpRequest
 from registration.decorators import handle_http_errors
 from reporting.constants import EMISSIONS_REPORT_TAGS
@@ -20,6 +21,7 @@ from ..models import ReportingYear
     description="""Starts a report for a given operation and reporting year, by creating the underlying data structures and
     pre-populating them with facility, operation and operator information. Returns the id of the report that was created.
     This endpoint only allows the creation of a report for an operation / operator to which the current user has access.""",
+    auth=authorize("approved_industry_user"),
 )
 @handle_http_errors()
 def start_report(request: HttpRequest, payload: StartReportIn) -> Tuple[Literal[201], int]:
@@ -32,6 +34,7 @@ def start_report(request: HttpRequest, payload: StartReportIn) -> Tuple[Literal[
     response={200: ReportOperationOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
+    auth=authorize("approved_authorized_roles"),
 )
 @handle_http_errors()
 def get_report_operation_by_version_id(
@@ -47,6 +50,7 @@ def get_report_operation_by_version_id(
     tags=EMISSIONS_REPORT_TAGS,
     description="""Updates given report operation with fields: Operator Legal Name, Operator Trade Name, Operation Name, Operation Type,
     Operation BC GHG ID, BC OBPS Regulated Operation ID, Operation Representative Name, and Activities.""",
+    auth=authorize("approved_industry_user"),
 )
 @handle_http_errors()
 def save_report(
@@ -61,6 +65,7 @@ def save_report(
     response={200: ReportingYearOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Returns json object with current reporting year and due date.""",
+    auth=authorize("all_roles"),
 )
 @handle_http_errors()
 def get_reporting_year(request: HttpRequest) -> Tuple[Literal[200], ReportingYear]:

--- a/bc_obps/reporting/tests/api/test_activity_data.py
+++ b/bc_obps/reporting/tests/api/test_activity_data.py
@@ -1,31 +1,11 @@
-from django.test import Client
-from model_bakery import baker
-from registration.models import User
 import json
-import pytest
-from registration.tests.utils.helpers import TestUtils
+from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.tests.utils.bakers import operator_baker
-
-client = Client()
-
-
-class TestSetup:
-    pytestmark = pytest.mark.django_db  # This is used to mark a test function as requiring the database
-    base_endpoint = "/api/reporting/"
-    pytest.endpoint = base_endpoint + "initial-activity-data"
-
-    def setup_method(self):
-        self.content_type = "application/json"
-        self.user = baker.make(
-            User, app_role_id="industry_user", _fill_optional=True
-        )  # Passing _fill_optional to fill all fields with random data
-        self.auth_header = {'user_guid': str(self.user.user_guid)}
-        self.auth_header_dumps = json.dumps(self.auth_header)
+from registration.utils import custom_reverse_lazy
 
 
-class TestActivityData(TestSetup):
-    endpoint = "/api/reporting/" + "initial-activity-data"
-    pytest.endpoint = "/api/reporting/" + "initial-activity-data"
+class TestActivityData(CommonTestSetup):
+    endpoint = custom_reverse_lazy("get_initial_activity_data")
 
     # AUTHORIZATION
     def test_unauthorized_users_cannot_get_activity_data(self):
@@ -35,16 +15,18 @@ class TestActivityData(TestSetup):
     def test_authorized_users_can_get_activity_data(self):
         operator = operator_baker()
         TestUtils.authorize_current_user_as_operator_user(self, operator=operator)
-        roles = ["industry_user"]
-        for role in roles:
-            response = TestUtils.mock_get_with_auth_role(
-                self,
-                role,
-                pytest.endpoint
-                + "?activity_name=General stationary combustion excluding line tracing&report_date=2024-05-01"
-                + "&report_date=2024-09-06",
-            )
-            assert response.status_code == 200
+
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "industry_user",
+            f'{self.endpoint}?activity_name=General stationary combustion excluding line tracing&report_date=2024-05-01',
+        )
+
+        assert response.status_code == 200
+        response_object = json.loads(response.json())
+        assert response_object['activityId'] == 1
+        # There are 2 source types in the map
+        assert len(response_object['sourceTypeMap'].keys()) == 2
 
     def test_invalid_without_report_date(self):
         operator = operator_baker()
@@ -53,7 +35,7 @@ class TestActivityData(TestSetup):
         response = TestUtils.mock_get_with_auth_role(
             self,
             "industry_user",
-            f'{pytest.endpoint}?activity_name=General stationary combustion excluding line tracing',
+            f'{self.endpoint}?activity_name=General stationary combustion excluding line tracing',
         )
 
         assert response.status_code == 422
@@ -65,23 +47,7 @@ class TestActivityData(TestSetup):
         response = TestUtils.mock_get_with_auth_role(
             self,
             "industry_user",
-            f'{pytest.endpoint}?report_date=2024-05-01',
+            f'{self.endpoint}?report_date=2024-05-01',
         )
 
         assert response.status_code == 422
-
-    def test_returns_activity_data(self):
-        operator = operator_baker()
-        TestUtils.authorize_current_user_as_operator_user(self, operator=operator)
-
-        response = TestUtils.mock_get_with_auth_role(
-            self,
-            "industry_user",
-            f'{pytest.endpoint}?activity_name=General stationary combustion excluding line tracing&report_date=2024-05-01',
-        )
-
-        assert response.status_code == 200
-        response_object = json.loads(response.json())
-        assert response_object['activityId'] == 1
-        # There are 2 source types in the map
-        assert len(response_object['sourceTypeMap'].keys()) == 2

--- a/bc_obps/reporting/tests/api/test_activity_data.py
+++ b/bc_obps/reporting/tests/api/test_activity_data.py
@@ -1,25 +1,85 @@
 from django.test import Client
+from model_bakery import baker
+from registration.models import User
 import json
 import pytest
+from registration.tests.utils.helpers import TestUtils
+from registration.tests.utils.bakers import operator_baker
 
-pytestmark = pytest.mark.django_db
 client = Client()
-pytest.endpoint = "/api/reporting/initial-activity-data"
 
 
-class TestActivityData:
+class TestSetup:
+    pytestmark = pytest.mark.django_db  # This is used to mark a test function as requiring the database
+    base_endpoint = "/api/reporting/"
+    pytest.endpoint = base_endpoint + "initial-activity-data"
+
+    def setup_method(self):
+        self.content_type = "application/json"
+        self.user = baker.make(
+            User, app_role_id="industry_user", _fill_optional=True
+        )  # Passing _fill_optional to fill all fields with random data
+        self.auth_header = {'user_guid': str(self.user.user_guid)}
+        self.auth_header_dumps = json.dumps(self.auth_header)
+
+
+class TestActivityData(TestSetup):
+    endpoint = "/api/reporting/" + "initial-activity-data"
+    pytest.endpoint = "/api/reporting/" + "initial-activity-data"
+
+    # AUTHORIZATION
+    def test_unauthorized_users_cannot_get_activity_data(self):
+        response = TestUtils.mock_get_with_auth_role(self, "cas_pending")
+        assert response.status_code == 401
+
+    def test_authorized_users_can_get_activity_data(self):
+        operator = operator_baker()
+        TestUtils.authorize_current_user_as_operator_user(self, operator=operator)
+        roles = ["industry_user"]
+        for role in roles:
+            response = TestUtils.mock_get_with_auth_role(
+                self,
+                role,
+                pytest.endpoint
+                + "?activity_name=General stationary combustion excluding line tracing&report_date=2024-05-01"
+                + "&report_date=2024-09-06",
+            )
+            assert response.status_code == 200
+
     def test_invalid_without_report_date(self):
-        response = client.get(f'{pytest.endpoint}?activity_name=General stationary combustion excluding line tracing')
+        operator = operator_baker()
+        TestUtils.authorize_current_user_as_operator_user(self, operator=operator)
+
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "industry_user",
+            f'{pytest.endpoint}?activity_name=General stationary combustion excluding line tracing',
+        )
+
         assert response.status_code == 422
 
     def test_invalid_without_activity(self):
-        response = client.get(f'{pytest.endpoint}?report_date=2024-05-01')
+        operator = operator_baker()
+        TestUtils.authorize_current_user_as_operator_user(self, operator=operator)
+
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "industry_user",
+            f'{pytest.endpoint}?report_date=2024-05-01',
+        )
+
         assert response.status_code == 422
 
     def test_returns_activity_data(self):
-        response = client.get(
-            '/api/reporting/initial-activity-data?activity_name=General stationary combustion excluding line tracing&report_date=2024-05-01'
+        operator = operator_baker()
+        TestUtils.authorize_current_user_as_operator_user(self, operator=operator)
+
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "industry_user",
+            f'{pytest.endpoint}?activity_name=General stationary combustion excluding line tracing&report_date=2024-05-01',
         )
+
         assert response.status_code == 200
         response_object = json.loads(response.json())
         assert response_object['activityId'] == 1

--- a/bc_obps/reporting/tests/api/test_facility_report_api.py
+++ b/bc_obps/reporting/tests/api/test_facility_report_api.py
@@ -1,37 +1,53 @@
-import json
 import pytest
 from django.test import Client
+from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from reporting.models import FacilityReport
-from registration.tests.utils.bakers import user_baker
 from model_bakery import baker
-
-client = Client()
 
 
 @pytest.mark.django_db
-class TestFacilityReportEndpoints:
+class TestFacilityReportEndpoints(CommonTestSetup):
     # GET
+    def test_unauthorized_users_cannot_get_facility_report(self):
+        endpoint_under_test = '/api/reporting/report-version/1/facility-report/101'
+
+        response = TestUtils.mock_get_with_auth_role(self, "cas_pending", endpoint_under_test)
+        assert response.status_code == 401
+
     def test_error_if_no_facility_report_exists(self):
-        response = client.get('/api/reporting/report-version/9999/facility-report/00000000-0000-0000-0000-000000000000')
+        facility_report = baker.make_recipe('reporting.tests.utils.facility_report')
+        TestUtils.authorize_current_user_as_operator_user(self, operator=facility_report.report_version.report.operator)
+
+        endpoint_under_test = '/api/reporting/report-version/9999/facility-report/00000000-0000-0000-0000-000000000000'
+        response = TestUtils.mock_get_with_auth_role(self, 'cas_admin', endpoint_under_test)
+
         assert response.status_code == 404
         assert response.json()["message"] == "Not Found"
 
     def test_error_if_no_invalid_facility_id(self):
-        response = client.get('/api/reporting/report-version/9999/facility-report/1')
+        facility_report = baker.make_recipe('reporting.tests.utils.facility_report')
+        TestUtils.authorize_current_user_as_operator_user(self, operator=facility_report.report_version.report.operator)
+
+        endpoint_under_test = f'/api/reporting/report-version/{facility_report.report_version.id}/facility-report/1'
+        response = TestUtils.mock_get_with_auth_role(self, 'cas_admin', endpoint_under_test)
         assert response.status_code == 422
         assert "Input should be a valid UUID" in response.json()["detail"][0]["msg"]
 
     def test_returns_correct_data(self):
         facility_report = baker.make_recipe('reporting.tests.utils.facility_report')
-        response = client.get(
-            f'/api/reporting/report-version/{facility_report.report_version_id}/facility-report/{facility_report.facility_id}'
-        )
+        TestUtils.authorize_current_user_as_operator_user(self, operator=facility_report.report_version.report.operator)
+
+        endpoint_under_test = f'/api/reporting/report-version/{facility_report.report_version_id}/facility-report/{facility_report.facility_id}'
+        response = TestUtils.mock_get_with_auth_role(self, 'cas_admin', endpoint_under_test)
         assert response.status_code == 200
         assert response.json()['facility_name'] == facility_report.facility_name
 
     # POST
     def test_saves_facility_data(self):
         facility_report = baker.make_recipe('reporting.tests.utils.facility_report')
+        TestUtils.authorize_current_user_as_operator_user(self, operator=facility_report.report_version.report.operator)
+
+        endpoint_under_test = f'/api/reporting/report-version/{facility_report.report_version_id}/facility-report/{facility_report.facility_id}'
         request_data = {
             "facility_name": "CHANGED",
             "facility_type": "Single Facility Operation",
@@ -39,12 +55,13 @@ class TestFacilityReportEndpoints:
             "activities": ["1", "2", "3"],
             "products": [],
         }
-        user = user_baker()
-        client.post(
-            f'/api/reporting/report-version/{facility_report.report_version_id}/facility-report/{facility_report.facility_id}',
-            data=json.dumps(request_data),
-            HTTP_AUTHORIZATION=json.dumps({"user_guid": f'{user.user_guid}'}),
-            content_type="application/json",
+
+        TestUtils.mock_post_with_auth_role(
+            self,
+            'industry_user',
+            self.content_type,
+            request_data,
+            endpoint_under_test,
         )
         assert FacilityReport.objects.get(pk=facility_report.id).facility_name == "CHANGED"
         assert FacilityReport.objects.get(pk=facility_report.id).activities.count() == 3

--- a/bc_obps/reporting/tests/api/test_facility_report_api.py
+++ b/bc_obps/reporting/tests/api/test_facility_report_api.py
@@ -1,5 +1,4 @@
 import pytest
-from django.test import Client
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from reporting.models import FacilityReport
 from model_bakery import baker

--- a/bc_obps/reporting/tests/api/test_report_version_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_version_endpoint.py
@@ -1,0 +1,78 @@
+from registration.tests.utils.helpers import CommonTestSetup, TestUtils
+from reporting.tests.utils.bakers import report_version_baker
+from model_bakery import baker
+
+class TestReportVersionEndpoint(CommonTestSetup):
+    # GET report-operation
+    def test_unauthorized_users_cannot_get_report_version(self):
+        endpoint_under_test = f'/api/reporting/report-version/1/report-operation'
+
+        response = TestUtils.mock_get_with_auth_role(self, "cas_pending", endpoint_under_test)
+        assert response.status_code == 401
+
+    def test_authorized_users_can_get_report_version(self):
+        report_version = report_version_baker()
+        TestUtils.authorize_current_user_as_operator_user(self, operator=report_version.report.operator)
+
+        endpoint_under_test = f'/api/reporting/report-version/{report_version.id}/report-operation'
+
+        for role in ['cas_admin', 'cas_analyst', 'industry_user']:
+            response = TestUtils.mock_get_with_auth_role(
+                self,
+                role,
+                f'{endpoint_under_test}',
+            )
+
+            assert response.status_code == 200
+
+        # Test that the endpoint returns the correct data
+        response_json = response.json()
+        assert response_json['operator_legal_name'] == str(report_version.report_operation.operator_legal_name)
+
+    # POST report-operation
+    def test_unauthorized_users_cannot_post_report_version(self):
+        report_version = report_version_baker()
+        endpoint_under_test = f'/api/reporting/report-version/{report_version.id}/report-operation'
+
+        data = {}
+        response = TestUtils.mock_post_with_auth_role(self, "cas_pending", self.content_type, data, endpoint_under_test)
+        assert response.status_code == 401
+
+    def test_authorized_users_can_post_updates_to_report_version(self):
+        report_version = report_version_baker()
+        TestUtils.authorize_current_user_as_operator_user(self, operator=report_version.report.operator)
+
+        endpoint_under_test = f'/api/reporting/report-version/{report_version.id}/report-operation'
+
+        data = {
+            "operator_legal_name": "new legal name",
+            "operator_trade_name": "new trade name",
+            "operation_name": "new operation name",
+            "operation_type": "LFO",
+            "operation_bcghgid": "new operation bcghgid",
+            "bc_obps_regulated_operation_id": "new bc obps regulated operation id",
+            "activities": [],
+            "regulated_products": [],
+            "operation_representative_name": "new operation representative name",
+        }
+
+        assert report_version.report_operation.operator_legal_name != data['operator_legal_name']
+        assert report_version.report_operation.operator_trade_name != data['operator_trade_name']
+        assert report_version.report_operation.operation_name != data['operation_name']
+        assert report_version.report_operation.operation_bcghgid != data['operation_bcghgid']
+        assert report_version.report_operation.bc_obps_regulated_operation_id != data['bc_obps_regulated_operation_id']
+        assert report_version.report_operation.operation_representative_name != data['operation_representative_name']
+
+        response = TestUtils.mock_post_with_auth_role(
+            self, 'industry_user', self.content_type, data, endpoint_under_test
+        )
+
+        assert response.status_code == 201
+        response_json = response.json()
+
+        assert response_json['operator_legal_name'] == data['operator_legal_name']
+        assert response_json['operator_trade_name'] == data['operator_trade_name']
+        assert response_json['operation_name'] == data['operation_name']
+        assert response_json['operation_bcghgid'] == data['operation_bcghgid']
+        assert response_json['bc_obps_regulated_operation_id'] == data['bc_obps_regulated_operation_id']
+        assert response_json['operation_representative_name'] == data['operation_representative_name']

--- a/bc_obps/reporting/tests/api/test_report_version_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_version_endpoint.py
@@ -1,11 +1,11 @@
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from reporting.tests.utils.bakers import report_version_baker
-from model_bakery import baker
+
 
 class TestReportVersionEndpoint(CommonTestSetup):
     # GET report-operation
     def test_unauthorized_users_cannot_get_report_version(self):
-        endpoint_under_test = f'/api/reporting/report-version/1/report-operation'
+        endpoint_under_test = '/api/reporting/report-version/1/report-operation'
 
         response = TestUtils.mock_get_with_auth_role(self, "cas_pending", endpoint_under_test)
         assert response.status_code == 401

--- a/bc_obps/reporting/tests/api/test_reporting_year_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_reporting_year_endpoint.py
@@ -1,0 +1,11 @@
+from registration.tests.utils.helpers import CommonTestSetup, TestUtils
+
+client = TestUtils.client
+
+
+class TestReportingYearEndpoint(CommonTestSetup):
+    endpoint_under_test = "/api/reporting/reporting-year"
+
+    def test_unauthenticated_users_can_get_reporting_year(self):
+        response = TestUtils.mock_get_with_auth_role(self, "cas_pending", self.endpoint_under_test)
+        assert response.status_code == 200

--- a/bc_obps/reporting/tests/api/test_reports.py
+++ b/bc_obps/reporting/tests/api/test_reports.py
@@ -2,20 +2,32 @@ import json
 import pytest
 from typing import Any
 from django.http import HttpResponse
-from django.test import Client
-from registration.tests.utils.bakers import operation_baker
+from registration.tests.utils.bakers import operation_baker, operator_baker
 from reporting.models import Report, ReportVersion
 from reporting.tests.utils.bakers import report_baker, reporting_year_baker
+from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 
 
-@pytest.mark.django_db
-class TestReportsEndpoint:
+class TestReportsEndpoint(CommonTestSetup):
     endpoint_under_test = "/api/reporting/create-report"
-    client = Client()
 
-    def send_post_request(self, request_data: dict[str, Any]) -> HttpResponse:
-        return self.client.post(
-            self.endpoint_under_test, data=json.dumps(request_data), content_type="application/json"
+    def test_unauthorized_users_cannot_create_report(self):
+        data = {}
+        response = TestUtils.mock_post_with_auth_role(
+            self, "cas_pending", self.content_type, data, self.endpoint_under_test
+        )
+        assert response.status_code == 401
+
+    def send_authorized_post_request(self, request_data: dict[str, Any]) -> HttpResponse:
+        operator = operator_baker()
+        TestUtils.authorize_current_user_as_operator_user(self, operator=operator)
+
+        return TestUtils.mock_post_with_auth_role(
+            self,
+            "industry_user",
+            self.content_type,
+            json.dumps(request_data),
+            self.endpoint_under_test,
         )
 
     def test_error_if_no_operation_exists(self):
@@ -25,7 +37,7 @@ class TestReportsEndpoint:
             "operation_id": "00000000-0000-0000-0000-000000000000",
             "reporting_year": reporting_year.reporting_year,
         }
-        response = self.send_post_request(request_data)
+        response = self.send_authorized_post_request(request_data)
 
         assert response.status_code == 404
         assert response.json()["message"] == "Not Found"
@@ -34,7 +46,7 @@ class TestReportsEndpoint:
         operation = operation_baker()
 
         request_data = {"operation_id": str(operation.id), "reporting_year": 2000}
-        response = self.send_post_request(request_data)
+        response = self.send_authorized_post_request(request_data)
 
         assert response.status_code == 404
         assert response.json()["message"] == "Not Found"
@@ -46,7 +58,7 @@ class TestReportsEndpoint:
             "operation_id": str(report.operation.id),
             "reporting_year": report.reporting_year.reporting_year,
         }
-        response = self.send_post_request(request_data)
+        response = self.send_authorized_post_request(request_data)
 
         assert response.status_code == 400
         assert (
@@ -65,7 +77,7 @@ class TestReportsEndpoint:
             "operation_id": str(operation.id),
             "reporting_year": reporting_year.reporting_year,
         }
-        response = self.send_post_request(request_data)
+        response = self.send_authorized_post_request(request_data)
 
         assert Report.objects.count() == 1
         assert ReportVersion.objects.count() == 1

--- a/bc_obps/reporting/tests/api/test_reports.py
+++ b/bc_obps/reporting/tests/api/test_reports.py
@@ -1,5 +1,4 @@
 import json
-import pytest
 from typing import Any
 from django.http import HttpResponse
 from registration.tests.utils.bakers import operation_baker, operator_baker


### PR DESCRIPTION
Addresses bcgov/cas-reporting#286 [project link](https://github.com/orgs/bcgov/projects/123/views/1?pane=issue&itemId=71018751). Adds auth checks to Reporting endpoints. 

## Changes 🚧

- Added auth to reporting activity_data, build_form_schema, operations, and reports endpoints. 
  - GET /initial-activity-data
  - GET /build-form-schema
  - GET /operations
  - POST /reports
  - GET /report-version/{version_id}/report-operation
  - POST /report-version/{version_id}/report-operation
  - GET /report-version/{version_id}/facility-report/{facility_id}
  - POST /report-version/{version_id}/facility-report/{facility_id}
  - GET /reporting-year: All users - no auth required


- Expanded tests to include coverage for auth. 

## To test 🔬

1. Start up postgres `make start_pg` and the django server `make run`.
2. Run Pytests `make pythontests`. Tests should pass.
_Optionally_, you can also run API calls against the endpoints with Insomnia/Postman/cURL and a copy of logged-in auth headers from your browser. 