### PR TITLE
Chore/349 autofill dependent fuel fields

### DIFF
--- a/bc_obps/reporting/api/__init__.py
+++ b/bc_obps/reporting/api/__init__.py
@@ -5,3 +5,4 @@ from .build_form_schema import build_form_schema
 from .operations import get_dashboard_operations_list
 from .activity_data import get_initial_activity_data
 from .facility_report import get_facility_report_form_data
+from .fuel import get_fuel_data

--- a/bc_obps/reporting/api/fuel.py
+++ b/bc_obps/reporting/api/fuel.py
@@ -1,0 +1,25 @@
+from service.data_access_service.fuel_service import FuelTypeDataAccessService
+from .router import router
+from registration.decorators import handle_http_errors
+from django.http import HttpRequest
+from typing import Tuple
+from reporting.models import FuelType
+
+from registration.schema.generic import Message
+from ninja.responses import codes_4xx, codes_5xx
+
+
+##### GET #####
+
+
+@router.get(
+    "/fuel",
+    response={200: str, codes_4xx: Message, codes_5xx: Message},
+    url_name="get_fuel",
+)
+@handle_http_errors()
+def get_fuel_data(
+    request: HttpRequest,
+    fuel_name: str,
+) -> Tuple[int, FuelType]:
+    return 200, FuelTypeDataAccessService.get_fuel(fuel_name)

--- a/bc_obps/reporting/api/fuel.py
+++ b/bc_obps/reporting/api/fuel.py
@@ -4,6 +4,7 @@ from registration.decorators import handle_http_errors
 from django.http import HttpRequest
 from typing import Tuple
 from reporting.models import FuelType
+from reporting.schema.fuel import FuelTypeSchema
 
 from registration.schema.generic import Message
 from ninja.responses import codes_4xx, codes_5xx
@@ -14,8 +15,8 @@ from ninja.responses import codes_4xx, codes_5xx
 
 @router.get(
     "/fuel",
-    response={200: str, codes_4xx: Message, codes_5xx: Message},
-    url_name="get_fuel",
+    response={200: FuelTypeSchema, codes_4xx: Message, codes_5xx: Message},
+    url_name="fuel",
 )
 @handle_http_errors()
 def get_fuel_data(

--- a/bc_obps/reporting/json_schemas/2024/fuel_combustion_mobile/combustion_by_equipment.json
+++ b/bc_obps/reporting/json_schemas/2024/fuel_combustion_mobile/combustion_by_equipment.json
@@ -19,12 +19,14 @@
               "fuelClassification": {
                 "title": "Fuel Classification",
                 "maxLength": 200,
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "fuelUnit": {
                 "title": "Fuel Unit",
                 "maxLength": 200,
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               }
             }
           },

--- a/bc_obps/reporting/json_schemas/2024/fuel_combustion_mobile/combustion_by_equipment.json
+++ b/bc_obps/reporting/json_schemas/2024/fuel_combustion_mobile/combustion_by_equipment.json
@@ -8,15 +8,25 @@
       "items": {
         "type": "object",
         "properties": {
-          "fuelName": {
-            "title": "Fuel Name",
-            "type": "string",
-            "enum": []
-          },
-          "fuelClassification": {
-            "title": "Fuel Classification",
-            "maxLength": 200,
-            "type": "string"
+          "fuelType": {
+            "type": "object",
+            "properties": {
+              "fuelName": {
+                "title": "Fuel Name",
+                "type": "string",
+                "enum": []
+              },
+              "fuelClassification": {
+                "title": "Fuel Classification",
+                "maxLength": 200,
+                "type": "string"
+              },
+              "fuelUnit": {
+                "title": "Fuel Unit",
+                "maxLength": 200,
+                "type": "string"
+              }
+            }
           },
           "fuelDescription": {
             "title": "Fuel Description",

--- a/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/with_useful_energy.json
@@ -29,20 +29,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "fuelName": {
-                  "title": "Fuel Name",
-                  "type": "string",
-                  "enum": []
-                },
-                "fuelClassification": {
-                  "title": "Fuel Classification",
-                  "maxLength": 200,
-                  "type": "string"
-                },
-                "fuelUnit": {
-                  "title": "Fuel Unit",
-                  "maxLength": 200,
-                  "type": "string"
+                "fuelType": {
+                  "type": "object",
+                  "properties": {
+                    "fuelName": {
+                      "title": "Fuel Name",
+                      "type": "string",
+                      "enum": []
+                    },
+                    "fuelClassification": {
+                      "title": "Fuel Classification",
+                      "maxLength": 200,
+                      "type": "string"
+                    },
+                    "fuelUnit": {
+                      "title": "Fuel Unit",
+                      "maxLength": 200,
+                      "type": "string"
+                    }
+                  }
                 },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",

--- a/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/with_useful_energy.json
@@ -40,12 +40,14 @@
                     "fuelClassification": {
                       "title": "Fuel Classification",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     },
                     "fuelUnit": {
                       "title": "Fuel Unit",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     }
                   }
                 },

--- a/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/without_useful_energy.json
@@ -29,20 +29,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "fuelName": {
-                  "title": "Fuel Name",
-                  "type": "string",
-                  "enum": []
-                },
-                "fuelClassification": {
-                  "title": "Fuel Classification",
-                  "maxLength": 200,
-                  "type": "string"
-                },
-                "fuelUnit": {
-                  "title": "Fuel Unit",
-                  "maxLength": 200,
-                  "type": "string"
+                "fuelType": {
+                  "type": "object",
+                  "properties": {
+                    "fuelName": {
+                      "title": "Fuel Name",
+                      "type": "string",
+                      "enum": []
+                    },
+                    "fuelClassification": {
+                      "title": "Fuel Classification",
+                      "maxLength": 200,
+                      "type": "string"
+                    },
+                    "fuelUnit": {
+                      "title": "Fuel Unit",
+                      "maxLength": 200,
+                      "type": "string"
+                    }
+                  }
                 },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",

--- a/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/without_useful_energy.json
@@ -40,12 +40,14 @@
                     "fuelClassification": {
                       "title": "Fuel Classification",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     },
                     "fuelUnit": {
                       "title": "Fuel Unit",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     }
                   }
                 },

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/field_gas_process_vent_gas_at_lfo.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/field_gas_process_vent_gas_at_lfo.json
@@ -29,20 +29,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "fuelName": {
-                  "title": "Fuel Name",
-                  "type": "string",
-                  "enum": []
-                },
-                "fuelClassification": {
-                  "title": "Fuel Classification",
-                  "maxLength": 200,
-                  "type": "string"
-                },
-                "fuelUnit": {
-                  "title": "Fuel Unit",
-                  "maxLength": 200,
-                  "type": "string"
+                "fuelType": {
+                  "type": "object",
+                  "properties": {
+                    "fuelName": {
+                      "title": "Fuel Name",
+                      "type": "string",
+                      "enum": []
+                    },
+                    "fuelClassification": {
+                      "title": "Fuel Classification",
+                      "maxLength": 200,
+                      "type": "string"
+                    },
+                    "fuelUnit": {
+                      "title": "Fuel Unit",
+                      "maxLength": 200,
+                      "type": "string"
+                    }
+                  }
                 },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/field_gas_process_vent_gas_at_lfo.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/field_gas_process_vent_gas_at_lfo.json
@@ -40,12 +40,14 @@
                     "fuelClassification": {
                       "title": "Fuel Classification",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     },
                     "fuelUnit": {
                       "title": "Fuel Unit",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     }
                   }
                 },

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/with_useful_energy.json
@@ -29,20 +29,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "fuelName": {
-                  "title": "Fuel Name",
-                  "type": "string",
-                  "enum": []
-                },
-                "fuelClassification": {
-                  "title": "Fuel Classification",
-                  "maxLength": 200,
-                  "type": "string"
-                },
-                "fuelUnit": {
-                  "title": "Fuel Unit",
-                  "maxLength": 200,
-                  "type": "string"
+                "fuelType": {
+                  "type": "object",
+                  "properties": {
+                    "fuelName": {
+                      "title": "Fuel Name",
+                      "type": "string",
+                      "enum": []
+                    },
+                    "fuelClassification": {
+                      "title": "Fuel Classification",
+                      "maxLength": 200,
+                      "type": "string"
+                    },
+                    "fuelUnit": {
+                      "title": "Fuel Unit",
+                      "maxLength": 200,
+                      "type": "string"
+                    }
+                  }
                 },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/with_useful_energy.json
@@ -40,12 +40,14 @@
                     "fuelClassification": {
                       "title": "Fuel Classification",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     },
                     "fuelUnit": {
                       "title": "Fuel Unit",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     }
                   }
                 },

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/without_useful_energy.json
@@ -29,20 +29,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "fuelName": {
-                  "title": "Fuel Name",
-                  "type": "string",
-                  "enum": []
-                },
-                "fuelClassification": {
-                  "title": "Fuel Classification",
-                  "maxLength": 200,
-                  "type": "string"
-                },
-                "fuelUnit": {
-                  "title": "Fuel Unit",
-                  "maxLength": 200,
-                  "type": "string"
+                "fuelType": {
+                  "type": "object",
+                  "properties": {
+                    "fuelName": {
+                      "title": "Fuel Name",
+                      "type": "string",
+                      "enum": []
+                    },
+                    "fuelClassification": {
+                      "title": "Fuel Classification",
+                      "maxLength": 200,
+                      "type": "string"
+                    },
+                    "fuelUnit": {
+                      "title": "Fuel Unit",
+                      "maxLength": 200,
+                      "type": "string"
+                    }
+                  }
                 },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/without_useful_energy.json
@@ -40,12 +40,14 @@
                     "fuelClassification": {
                       "title": "Fuel Classification",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     },
                     "fuelUnit": {
                       "title": "Fuel Unit",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     }
                   }
                 },

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
@@ -29,20 +29,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "fuelName": {
-                  "title": "Fuel Name",
-                  "type": "string",
-                  "enum": []
-                },
-                "fuelClassification": {
-                  "title": "Fuel Classification",
-                  "maxLength": 200,
-                  "type": "string"
-                },
-                "fuelUnit": {
-                  "title": "Fuel Unit",
-                  "maxLength": 200,
-                  "type": "string"
+                "fuelType": {
+                  "type": "object",
+                  "properties": {
+                    "fuelName": {
+                      "title": "Fuel Name",
+                      "type": "string",
+                      "enum": []
+                    },
+                    "fuelClassification": {
+                      "title": "Fuel Classification",
+                      "maxLength": 200,
+                      "type": "string"
+                    },
+                    "fuelUnit": {
+                      "title": "Fuel Unit",
+                      "maxLength": 200,
+                      "type": "string"
+                    }
+                  }
                 },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
@@ -40,12 +40,14 @@
                     "fuelClassification": {
                       "title": "Fuel Classification",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     },
                     "fuelUnit": {
                       "title": "Fuel Unit",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     }
                   }
                 },

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
@@ -29,20 +29,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "fuelName": {
-                  "title": "Fuel Name",
-                  "type": "string",
-                  "enum": []
-                },
-                "fuelClassification": {
-                  "title": "Fuel Classification",
-                  "maxLength": 200,
-                  "type": "string"
-                },
-                "fuelUnit": {
-                  "title": "Fuel Unit",
-                  "maxLength": 200,
-                  "type": "string"
+                "fuelType": {
+                  "type": "object",
+                  "properties": {
+                    "fuelName": {
+                      "title": "Fuel Name",
+                      "type": "string",
+                      "enum": []
+                    },
+                    "fuelClassification": {
+                      "title": "Fuel Classification",
+                      "maxLength": 200,
+                      "type": "string"
+                    },
+                    "fuelUnit": {
+                      "title": "Fuel Unit",
+                      "maxLength": 200,
+                      "type": "string"
+                    }
+                  }
                 },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
@@ -40,12 +40,14 @@
                     "fuelClassification": {
                       "title": "Fuel Classification",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     },
                     "fuelUnit": {
                       "title": "Fuel Unit",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     }
                   }
                 },

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
@@ -29,20 +29,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "fuelName": {
-                  "title": "Fuel Name",
-                  "type": "string",
-                  "enum": []
-                },
-                "fuelClassification": {
-                  "title": "Fuel Classification",
-                  "maxLength": 200,
-                  "type": "string"
-                },
-                "fuelUnit": {
-                  "title": "Fuel Unit",
-                  "maxLength": 200,
-                  "type": "string"
+                "fuelType": {
+                  "type": "object",
+                  "properties": {
+                    "fuelName": {
+                      "title": "Fuel Name",
+                      "type": "string",
+                      "enum": []
+                    },
+                    "fuelClassification": {
+                      "title": "Fuel Classification",
+                      "maxLength": 200,
+                      "type": "string"
+                    },
+                    "fuelUnit": {
+                      "title": "Fuel Unit",
+                      "maxLength": 200,
+                      "type": "string"
+                    }
+                  }
                 },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
@@ -40,12 +40,14 @@
                     "fuelClassification": {
                       "title": "Fuel Classification",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     },
                     "fuelUnit": {
                       "title": "Fuel Unit",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     }
                   }
                 },

--- a/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/with_useful_energy.json
@@ -29,20 +29,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "fuelName": {
-                  "title": "Fuel Name",
-                  "type": "string",
-                  "enum": []
-                },
-                "fuelClassification": {
-                  "title": "Fuel Classification",
-                  "maxLength": 200,
-                  "type": "string"
-                },
-                "fuelUnit": {
-                  "title": "Fuel Unit",
-                  "maxLength": 200,
-                  "type": "string"
+                "fuelType": {
+                  "type": "object",
+                  "properties": {
+                    "fuelName": {
+                      "title": "Fuel Name",
+                      "type": "string",
+                      "enum": []
+                    },
+                    "fuelClassification": {
+                      "title": "Fuel Classification",
+                      "maxLength": 200,
+                      "type": "string"
+                    },
+                    "fuelUnit": {
+                      "title": "Fuel Unit",
+                      "maxLength": 200,
+                      "type": "string"
+                    }
+                  }
                 },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",

--- a/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/with_useful_energy.json
@@ -40,12 +40,14 @@
                     "fuelClassification": {
                       "title": "Fuel Classification",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     },
                     "fuelUnit": {
                       "title": "Fuel Unit",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     }
                   }
                 },

--- a/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/without_useful_energy.json
@@ -29,20 +29,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "fuelName": {
-                  "title": "Fuel Name",
-                  "type": "string",
-                  "enum": []
-                },
-                "fuelClassification": {
-                  "title": "Fuel Classification",
-                  "maxLength": 200,
-                  "type": "string"
-                },
-                "fuelUnit": {
-                  "title": "Fuel Unit",
-                  "maxLength": 200,
-                  "type": "string"
+                "fuelType": {
+                  "type": "object",
+                  "properties": {
+                    "fuelName": {
+                      "title": "Fuel Name",
+                      "type": "string",
+                      "enum": []
+                    },
+                    "fuelClassification": {
+                      "title": "Fuel Classification",
+                      "maxLength": 200,
+                      "type": "string"
+                    },
+                    "fuelUnit": {
+                      "title": "Fuel Unit",
+                      "maxLength": 200,
+                      "type": "string"
+                    }
+                  }
                 },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",

--- a/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/without_useful_energy.json
@@ -40,12 +40,14 @@
                     "fuelClassification": {
                       "title": "Fuel Classification",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     },
                     "fuelUnit": {
                       "title": "Fuel Unit",
                       "maxLength": 200,
-                      "type": "string"
+                      "type": "string",
+                      "readOnly": true
                     }
                   }
                 },

--- a/bc_obps/reporting/json_schemas/2024/refinery_fuel_gas/combustion_of_refinery_gas.json
+++ b/bc_obps/reporting/json_schemas/2024/refinery_fuel_gas/combustion_of_refinery_gas.json
@@ -19,12 +19,14 @@
               "fuelClassification": {
                 "title": "Fuel Classification",
                 "maxLength": 200,
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               },
               "fuelUnit": {
                 "title": "Fuel Unit",
                 "maxLength": 200,
-                "type": "string"
+                "type": "string",
+                "readOnly": true
               }
             }
           },

--- a/bc_obps/reporting/json_schemas/2024/refinery_fuel_gas/combustion_of_refinery_gas.json
+++ b/bc_obps/reporting/json_schemas/2024/refinery_fuel_gas/combustion_of_refinery_gas.json
@@ -8,20 +8,25 @@
       "items": {
         "type": "object",
         "properties": {
-          "fuelName": {
-            "title": "Fuel Name",
-            "type": "string",
-            "enum": []
-          },
-          "fuelClassification": {
-            "title": "Fuel Classification",
-            "maxLength": 200,
-            "type": "string"
-          },
-          "fuelUnits": {
-            "title": "Fuel Units",
-            "maxLength": 500,
-            "type": "string"
+          "fuelType": {
+            "type": "object",
+            "properties": {
+              "fuelName": {
+                "title": "Fuel Name",
+                "type": "string",
+                "enum": []
+              },
+              "fuelClassification": {
+                "title": "Fuel Classification",
+                "maxLength": 200,
+                "type": "string"
+              },
+              "fuelUnit": {
+                "title": "Fuel Unit",
+                "maxLength": 200,
+                "type": "string"
+              }
+            }
           },
           "annualFuelAmount": {
             "title": "Annual Fuel Amount",

--- a/bc_obps/reporting/tests/api/test_build_form_schema.py
+++ b/bc_obps/reporting/tests/api/test_build_form_schema.py
@@ -10,25 +10,25 @@ pytest.endpoint = "/api/reporting/build-form-schema"
 
 class TestBuildFormSchema:
     def test_invalid_without_report_date(self):
-        response = client.get(f'{pytest.endpoint}?activity=1')
+        response = client.get('/api/reporting/build-form-schema?activity=1')
         assert response.status_code == 422
 
     def test_invalid_without_activity(self):
-        response = client.get(f'{pytest.endpoint}?report_date=2024-05-01')
+        response = client.get('/api/reporting/build-form-schema?report_date=2024-05-01')
         assert response.status_code == 422
 
     def test_except_if_no_valid_configuration(self):
-        response = client.get(f'{pytest.endpoint}?activity=1&report_date=5024-05-01')
+        response = client.get('/api/reporting/build-form-schema?activity=1&report_date=5024-05-01')
         assert response.status_code == 400
         assert response.json().get('message') == "No Configuration found for report_date 5024-05-01"
 
     def test_except_if_no_valid_activity_schema(self):
-        response = client.get(f'{pytest.endpoint}?activity=0&report_date=2024-05-01')
+        response = client.get('/api/reporting/build-form-schema?activity=0&report_date=2024-05-01')
         assert response.status_code == 400
         assert response.json().get('message') == "No schema found for activity_id 0 & report_date 2024-05-01"
 
     def test_except_if_no_valid_source_type_schema(self):
-        response = client.get(f'{pytest.endpoint}?activity=1&source_types[]=0&report_date=2024-05-01')
+        response = client.get('/api/reporting/build-form-schema?activity=1&source_types[]=0&report_date=2024-05-01')
         assert response.status_code == 400
         assert (
             response.json().get('message')
@@ -36,7 +36,7 @@ class TestBuildFormSchema:
         )
 
     def test_returns_activity_schema(self):
-        response = client.get(f'{pytest.endpoint}?activity=1&report_date=2024-05-01')
+        response = client.get('/api/reporting/build-form-schema?activity=1&report_date=2024-05-01')
         assert response.status_code == 200
         response_object = json.loads(response.json())
         assert response_object['schema']['title'] == 'General stationary combustion excluding line tracing'
@@ -46,7 +46,7 @@ class TestBuildFormSchema:
         assert len(response_object['schema']['properties'].keys()) == 2
 
     def test_returns_source_type_schema(self):
-        response = client.get(f'{pytest.endpoint}?activity=1&source_types[]=1&report_date=2024-05-01')
+        response = client.get('/api/reporting/build-form-schema?activity=1&source_types[]=1&report_date=2024-05-01')
         assert response.status_code == 200
         response_object = json.loads(response.json())
         # Source Types object has been created
@@ -71,7 +71,7 @@ class TestBuildFormSchema:
             len(
                 response_object['schema']['properties']['sourceTypes']['properties'][source_type_key]['properties'][
                     'units'
-                ]['items']['properties']['fuels']['items']['properties']['fuelName']['enum']
+                ]['items']['properties']['fuels']['items']['properties']['fuelType']['properties']['fuelName']['enum']
             )
             == FuelType.objects.count()
         )
@@ -94,19 +94,21 @@ class TestBuildFormSchema:
         ]
 
     def test_returns_multiple_source_type_schemas(self):
-        response = client.get(f'{pytest.endpoint}?activity=1&source_types[]=1&source_types[]=2&report_date=2024-05-01')
+        response = client.get(
+            '/api/reporting/build-form-schema?activity=1&source_types[]=1&source_types[]=2&report_date=2024-05-01'
+        )
         assert response.status_code == 200
         # 2 schemas in the sourceTypes object
         assert len(json.loads(response.json())['schema']['properties']['sourceTypes']['properties'].keys()) == 2
 
     def test_single_mandatory_source_type(self):
-        response = client.get(f'{pytest.endpoint}?activity=3&report_date=2024-05-01')
+        response = client.get('/api/reporting/build-form-schema?activity=3&report_date=2024-05-01')
         assert response.status_code == 200
         # 1 schema is automatically added to the sourceTypes object when there is only 1 valid sourceType for the activity
         assert len(json.loads(response.json())['schema']['properties']['sourceTypes']['properties'].keys()) == 1
 
     def test_source_type_schema_no_units(self):
-        response = client.get(f'{pytest.endpoint}?activity=3&report_date=2024-05-01')
+        response = client.get('/api/reporting/build-form-schema?activity=3&report_date=2024-05-01')
         assert response.status_code == 200
         response_object = json.loads(response.json())
         source_type_key = list(response_object['schema']['properties']['sourceTypes']['properties'].keys())[0]

--- a/bc_obps/reporting/tests/api/test_fuel.py
+++ b/bc_obps/reporting/tests/api/test_fuel.py
@@ -1,0 +1,24 @@
+from django.test import Client
+import pytest
+
+pytestmark = pytest.mark.django_db
+client = Client()
+pytest.endpoint = "/api/reporting/fuel"
+
+
+class TestActivityData:
+    def test_invalid_without_fuel_name(self):
+        response = client.get(f'{pytest.endpoint}')
+        assert response.status_code == 422
+
+    def test_invalid_fuel(self):
+        response = client.get(f'{pytest.endpoint}?fuel_name=non-existent')
+        assert response.status_code == 404
+
+    def test_returns_fuel_data(self):
+        response = client.get('/api/reporting/fuel?fuel_name=Acetylene')
+        print(response.json())
+        assert response.status_code == 200
+        assert response.json().get('name') == 'Acetylene'
+        assert response.json().get('classification') == 'Exempted Non-biomass'
+        assert response.json().get('unit') == 'Sm^3'

--- a/bc_obps/service/data_access_service/fuel_service.py
+++ b/bc_obps/service/data_access_service/fuel_service.py
@@ -17,3 +17,13 @@ class FuelTypeDataAccessService:
             fuels = FuelType.objects.only(*FuelTypeSchema.Meta.fields).order_by('id')
             cache.set("fuels", fuels, 60 * 60 * 24 * 1)  # 1 day
             return fuels
+
+    @classmethod
+    def get_fuel(cls, fuel_name: str) -> FuelType:
+        cached_data: Optional[FuelType] = cache.get("fuel")
+        if cached_data:
+            return cached_data
+        else:
+            fuel = FuelType.objects.get(name=fuel_name)
+            cache.set("fuel", fuel, 60 * 60 * 24 * 1)  # 1 day
+            return fuel

--- a/bc_obps/service/data_access_service/fuel_service.py
+++ b/bc_obps/service/data_access_service/fuel_service.py
@@ -20,10 +20,5 @@ class FuelTypeDataAccessService:
 
     @classmethod
     def get_fuel(cls, fuel_name: str) -> FuelType:
-        cached_data: Optional[FuelType] = cache.get("fuel")
-        if cached_data:
-            return cached_data
-        else:
-            fuel = FuelType.objects.get(name=fuel_name)
-            cache.set("fuel", fuel, 60 * 60 * 24 * 1)  # 1 day
-            return fuel
+        fuel = FuelType.objects.get(name=fuel_name)
+        return fuel

--- a/bc_obps/service/form_builder_service.py
+++ b/bc_obps/service/form_builder_service.py
@@ -177,9 +177,9 @@ def handle_source_type_schema(
     if source_type_schema.has_unit and source_type_schema.has_fuel:
         # Fetch the list of fuels & add them to the fuelName enum
         fuel_list = list(FuelTypeDataAccessService.get_fuels().values_list("name", flat=True))
-        st_schema['properties']['units']['items']['properties']['fuels']['items']['properties']['fuelName'][
-            'enum'
-        ] = fuel_list
+        st_schema['properties']['units']['items']['properties']['fuels']['items']['properties']['fuelType'][
+            'properties'
+        ]['fuelName']['enum'] = fuel_list
         st_schema['properties']['units']['items']['properties']['fuels']['items']['properties']['emissions']['items'][
             'properties'
         ]['gasType']['enum'] = gas_type_enum
@@ -188,7 +188,9 @@ def handle_source_type_schema(
         ] = gas_type_one_of
     elif not source_type_schema.has_unit and source_type_schema.has_fuel:
         fuel_list = list(FuelTypeDataAccessService.get_fuels().values_list("name", flat=True))
-        st_schema['properties']['fuels']['items']['properties']['fuelName']['enum'] = fuel_list
+        st_schema['properties']['fuels']['items']['properties']['fuelType']['properties']['fuelName'][
+            'enum'
+        ] = fuel_list
         st_schema['properties']['fuels']['items']['properties']['emissions']['items']['properties']['gasType'][
             'enum'
         ] = gas_type_enum

--- a/bc_obps/service/tests/data_access_service/test_data_access_fuel_service.py
+++ b/bc_obps/service/tests/data_access_service/test_data_access_fuel_service.py
@@ -9,3 +9,10 @@ class TestDataAccessFacilityService:
     @staticmethod
     def test_get_fuels():
         assert FuelTypeDataAccessService.get_fuels().count() == FuelType.objects.all().count()
+
+    @staticmethod
+    def test_get_fuel():
+        returned_fuel = FuelTypeDataAccessService.get_fuel('Acetylene')
+        assert returned_fuel.name == 'Acetylene'
+        assert returned_fuel.unit == 'Sm^3'
+        assert returned_fuel.classification == 'Exempted Non-biomass'

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -7,6 +7,11 @@ import { Alert, Button } from "@mui/material";
 import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/ReportingTaskList";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import safeJsonParse from "@bciers/utils/safeJsonParse";
+import { FuelFields } from "./customFields/FuelFieldComponent";
+
+const CUSTOM_FIELDS = {
+  fuelType: (props) => <FuelFields {...props} />,
+};
 
 const tasklistData: TaskListElement[] = [
   {
@@ -171,6 +176,7 @@ export default function ActivityForm({
       <div className="w-full">
         <FormBase
           schema={jsonSchema}
+          fields={CUSTOM_FIELDS}
           formData={formState}
           uiSchema={uiSchema}
           validator={validator}

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -8,9 +8,10 @@ import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/R
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import safeJsonParse from "@bciers/utils/safeJsonParse";
 import { FuelFields } from "./customFields/FuelFieldComponent";
+import { FieldProps } from "@rjsf/utils";
 
 const CUSTOM_FIELDS = {
-  fuelType: (props) => <FuelFields {...props} />,
+  fuelType: (props: FieldProps) => <FuelFields {...props} />,
 };
 
 const tasklistData: TaskListElement[] = [

--- a/bciers/apps/reporting/src/app/components/activities/customFields/FuelFieldComponent.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/customFields/FuelFieldComponent.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { getDefaultRegistry } from "@rjsf/core";
+import { FieldProps } from "@rjsf/utils";
+const registry = getDefaultRegistry();
+
+const ObjectField = registry.fields.ObjectField;
+
+export const FuelFields: React.FunctionComponent<FieldProps> = (props) => {
+  const handleChange = () => {
+    props.onChange({
+      ...props.formData,
+      fuelClassification: "Woody Biomass",
+      fuelUnit: "kilolitres",
+    });
+  };
+
+  return <ObjectField {...props} onChange={handleChange} />;
+};
+
+export default FuelFields;

--- a/bciers/apps/reporting/src/app/components/activities/customFields/FuelFieldComponent.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/customFields/FuelFieldComponent.tsx
@@ -1,16 +1,26 @@
 "use client";
 import { getDefaultRegistry } from "@rjsf/core";
 import { FieldProps } from "@rjsf/utils";
+import { actionHandler } from "@bciers/actions";
+import { IChangeEvent } from "@rjsf/core";
 const registry = getDefaultRegistry();
 
 const ObjectField = registry.fields.ObjectField;
 
 export const FuelFields: React.FunctionComponent<FieldProps> = (props) => {
-  const handleChange = () => {
+  const handleChange = async (c: IChangeEvent) => {
+    const fuelData = await actionHandler(
+      `reporting/fuel?fuel_name=${c.fuelName}`,
+      "GET",
+      "",
+    );
+    console.log(c);
+    console.log(fuelData);
     props.onChange({
       ...props.formData,
-      fuelClassification: "Woody Biomass",
-      fuelUnit: "kilolitres",
+      fuelName: fuelData.name,
+      fuelClassification: fuelData.classification,
+      fuelUnit: fuelData.unit,
     });
   };
 

--- a/bciers/apps/reporting/src/app/components/activities/customFields/FuelFieldComponent.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/customFields/FuelFieldComponent.tsx
@@ -5,17 +5,19 @@ import { actionHandler } from "@bciers/actions";
 import { IChangeEvent } from "@rjsf/core";
 const registry = getDefaultRegistry();
 
+interface FuelDataChangeEvent extends IChangeEvent {
+  fuelName: string;
+}
+
 const ObjectField = registry.fields.ObjectField;
 
 export const FuelFields: React.FunctionComponent<FieldProps> = (props) => {
-  const handleChange = async (c: IChangeEvent) => {
+  const handleChange = async (c: FuelDataChangeEvent) => {
     const fuelData = await actionHandler(
       `reporting/fuel?fuel_name=${c.fuelName}`,
       "GET",
       "",
     );
-    console.log(c);
-    console.log(fuelData);
     props.onChange({
       ...props.formData,
       fuelName: fuelData.name,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/fuelCombustionMobileUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/fuelCombustionMobileUiSchema.ts
@@ -33,8 +33,7 @@ const uiSchema = {
         },
         items: {
           "ui:order": [
-            "fuelName",
-            "fuelClassification",
+            "fuelType",
             "fuelDescription",
             "q1FuelAmount",
             "q2FuelAmount",
@@ -43,11 +42,21 @@ const uiSchema = {
             "annualFuelAmount",
             "emissions",
           ],
-          fuelName: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          fuelClassification: {
-            "ui:FieldTemplate": InlineFieldTemplate,
+          fuelType: {
+            "ui:field": "fuelType",
+            "ui:FieldTemplate": FieldTemplate,
+            "ui:options": {
+              label: false,
+            },
+            fuelName: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+            fuelUnit: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+            fuelClassification: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
           },
           fuelDescription: {
             "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscNonCompressionNonProcessingUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscNonCompressionNonProcessingUiSchema.ts
@@ -66,21 +66,22 @@ const uiSchema = {
               title: "Fuel",
             },
             items: {
-              "ui:order": [
-                "fuelName",
-                "fuelUnit",
-                "fuelClassification",
-                "annualFuelAmount",
-                "emissions",
-              ],
-              fuelName: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
-              fuelUnit: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
-              fuelClassification: {
-                "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
+              fuelType: {
+                "ui:field": "fuelType",
+                "ui:FieldTemplate": FieldTemplate,
+                "ui:options": {
+                  label: false,
+                },
+                fuelName: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelUnit: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelClassification: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
               },
               annualFuelAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscOtherThanNonCompression.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscOtherThanNonCompression.ts
@@ -66,21 +66,22 @@ const uiSchema = {
               title: "Fuel",
             },
             items: {
-              "ui:order": [
-                "fuelName",
-                "fuelUnit",
-                "fuelClassification",
-                "annualFuelAmount",
-                "emissions",
-              ],
-              fuelName: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
-              fuelUnit: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
-              fuelClassification: {
-                "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
+              fuelType: {
+                "ui:field": "fuelType",
+                "ui:FieldTemplate": FieldTemplate,
+                "ui:options": {
+                  label: false,
+                },
+                fuelName: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelUnit: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelClassification: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
               },
               annualFuelAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscUiSchema.ts
@@ -59,21 +59,22 @@ const uiSchema = {
               title: "Fuel",
             },
             items: {
-              "ui:order": [
-                "fuelName",
-                "fuelUnit",
-                "fuelClassification",
-                "annualFuelAmount",
-                "emissions",
-              ],
-              fuelName: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
-              fuelUnit: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
-              fuelClassification: {
-                "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
+              fuelType: {
+                "ui:field": "fuelType",
+                "ui:FieldTemplate": FieldTemplate,
+                "ui:options": {
+                  label: false,
+                },
+                fuelName: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelUnit: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelClassification: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
               },
               annualFuelAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/refineryFuelGasUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/refineryFuelGasUiSchema.ts
@@ -24,21 +24,22 @@ const uiSchema = {
           padding: "p-2",
         },
         items: {
-          "ui:order": [
-            "fuelName",
-            "fuelUnits",
-            "fuelClassification",
-            "annualFuelAmount",
-            "emissions",
-          ],
-          fuelName: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          fuelUnits: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          fuelClassification: {
-            "ui:FieldTemplate": InlineFieldTemplate,
+          "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
+          fuelType: {
+            "ui:field": "fuelType",
+            "ui:FieldTemplate": FieldTemplate,
+            "ui:options": {
+              label: false,
+            },
+            fuelName: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+            fuelUnit: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+            fuelClassification: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
           },
           annualFuelAmount: {
             "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/libs/components/src/form/fields/index.ts
+++ b/bciers/libs/components/src/form/fields/index.ts
@@ -8,4 +8,3 @@ export { default as GroupedObjectFieldTemplateWrapper } from "./GroupedObjectFie
 export { default as InlineFieldTemplate } from "./InlineFieldTemplate";
 export { default as TitleFieldTemplate } from "./TitleFieldTemplate";
 export { default as TitleOnlyFieldTemplate } from "./TitleOnlyFieldTemplate";
-export { default as FuelObjectFieldTemplate } from "./FuelObjectFieldTemplate";

--- a/bciers/libs/components/src/form/fields/index.ts
+++ b/bciers/libs/components/src/form/fields/index.ts
@@ -8,3 +8,4 @@ export { default as GroupedObjectFieldTemplateWrapper } from "./GroupedObjectFie
 export { default as InlineFieldTemplate } from "./InlineFieldTemplate";
 export { default as TitleFieldTemplate } from "./TitleFieldTemplate";
 export { default as TitleOnlyFieldTemplate } from "./TitleOnlyFieldTemplate";
+export { default as FuelObjectFieldTemplate } from "./FuelObjectFieldTemplate";


### PR DESCRIPTION
On fuel selection, the classification & unit fields are filled automatically from data in the fuel_type database table.
- A fuelType object has been added to all schemas that contain fuels (object contains: fuelName, classification, units)
- A custom rjsf field for the fuelType object has been added to handle all these fields as one
- The form_builder has been updated to handle the change in the schema structure

To test this:
Go to any activity page that has fuels in the schema & add a fuel from the dropdown. After selection, the classification & unit fields should be automatically updated. They should also be read-only. 