### PR TITLE
2210 run all e2e on merge to develop

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ name: main
 
 on:
   push:
-    branches: [develop, main]
+    branches: [develop, main, test-e2e-merge]
   pull_request:
     branches: [develop, main]
   workflow_dispatch:
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   PGUSER: postgres
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   check-nx-affected:
@@ -71,7 +72,7 @@ jobs:
       nx_project: administration
       nx_app_port: 4001
       image_url: "ghcr.io/bcgov/cas-admin-frontend"
-      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'administration')}}
+      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'administration') || github.ref_name == 'develop' || github.ref_name == 'main' || github.head_ref == 'develop' || github.head_ref == 'main'}}
     secrets: inherit
   test-coam-e2e:
     needs: [build-backend, build-dashboard-e2e, build-coam, check-nx-affected]
@@ -80,7 +81,7 @@ jobs:
       nx_project: coam
       nx_app_port: 7000
       image_url: "ghcr.io/bcgov/cas-coam-frontend"
-      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'coam')}}
+      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'coam') || github.ref_name == 'develop' || github.ref_name == 'main' || github.head_ref == 'develop' || github.head_ref == 'main'}}
     secrets: inherit
   test-reporting-e2e:
     needs:
@@ -90,7 +91,7 @@ jobs:
       nx_project: reporting
       nx_app_port: 5000
       image_url: "ghcr.io/bcgov/cas-rep-frontend"
-      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'reporting')}}
+      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'reporting') || github.ref_name == 'develop' || github.ref_name == 'main' || github.head_ref == 'develop' || github.head_ref == 'main'}}
     secrets: inherit
   test-registration1-e2e:
     needs: [build-backend, build-registration1, check-nx-affected]
@@ -109,7 +110,7 @@ jobs:
       nx_project: registration
       nx_app_port: 4000
       image_url: "ghcr.io/bcgov/cas-reg-frontend"
-      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'registration')}}
+      is_nx_affected: ${{contains(needs.check-nx-affected.outputs.NX_AFFECTED_E2E, 'registration') || github.ref_name == 'develop' || github.ref_name == 'main' || github.head_ref == 'develop' || github.head_ref == 'main'}}
     secrets: inherit
   e2e-finalize:
     needs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ name: main
 
 on:
   push:
-    branches: [develop, main, test-e2e-merge]
+    branches: [develop, main]
   pull_request:
     branches: [develop, main]
   workflow_dispatch:
@@ -15,7 +15,6 @@ concurrency:
 
 env:
   PGUSER: postgres
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   check-nx-affected:

--- a/.github/workflows/test-nx-project-e2e.yaml
+++ b/.github/workflows/test-nx-project-e2e.yaml
@@ -151,7 +151,7 @@ jobs:
 
   # Call Happo api and skip the project if it wasn't affected
   happo-skip-not-affected:
-    if: ${{ !inputs.is_nx_affected }}
+    if: ${{ !inputs.is_nx_affected && github.ref_name != 'develop' && github.ref_name != 'main' && github.head_ref != 'develop' && github.head_ref != 'main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
#2210 

Brianna pointed out that the `happo-skip` helper is failing on merge to main. I believe this is due to us passing in the last commit sha which works for pull requests, but doesn't seem to work here. Rather than debug this I think it's both easier and more safe to just run all e2e on merge so I moved up this issue.

Initially I used `github.event.pull_request.merged == 'true'` though I wanted to ensure this would run both on `develop` and `main` to ensure everything is good before deployment to dev/test.

