### PR TITLE
Chore: facility review fixes

### DIFF
--- a/bc_obps/registration/tests/utils/baker_recipes.py
+++ b/bc_obps/registration/tests/utils/baker_recipes.py
@@ -1,4 +1,5 @@
 from registration.models.event.transfer_event import TransferEvent
+from registration.models.facility import Facility
 from registration.models.multiple_operator import MultipleOperator
 from registration.models.app_role import AppRole
 from registration.models.opted_in_operation_detail import OptedInOperationDetail
@@ -121,3 +122,4 @@ transfer_event = Recipe(
     other_operator=foreign_key(other_operator_for_transfer_event),
     other_operator_contact=foreign_key(contact_for_transfer_event),
 )
+facility = Recipe(Facility, address=foreign_key(address))

--- a/bc_obps/reporting/api/__init__.py
+++ b/bc_obps/reporting/api/__init__.py
@@ -4,3 +4,4 @@ from .reports import start_report
 from .build_form_schema import build_form_schema
 from .operations import get_dashboard_operations_list
 from .activity_data import get_initial_activity_data
+from .facility_report import get_facility_report_form_data

--- a/bc_obps/reporting/api/facility_report.py
+++ b/bc_obps/reporting/api/facility_report.py
@@ -1,0 +1,66 @@
+from typing import Literal, Tuple, Optional
+from uuid import UUID
+from django.http import HttpRequest
+from registration.decorators import handle_http_errors
+from reporting.constants import EMISSIONS_REPORT_TAGS
+from reporting.schema.generic import Message
+from service.facility_report_service import FacilityReportService
+from service.error_service.custom_codes_4xx import custom_codes_4xx
+from .router import router
+from reporting.schema.facility_report import FacilityReportOut, FacilityReportIn
+
+
+@router.get(
+    "/report-version/{version_id}/facility-report/{facility_id}",
+    response={200: FacilityReportOut, 404: Message, 400: Message, 500: Message},
+    tags=EMISSIONS_REPORT_TAGS,
+    description="""Takes `version_id` (primary key of the ReportVersion model) and `facility_id` to return a single matching `facility_report` object.
+    Includes the associated activity IDs if found; otherwise, returns an error message if not found or in case of other issues.""",
+)
+@handle_http_errors()
+def get_facility_report_form_data(
+    request: HttpRequest, version_id: int, facility_id: UUID
+) -> Tuple[Literal[200], Optional[FacilityReportOut]]:
+    facility_report = FacilityReportService.get_facility_report_by_version_and_id(version_id, facility_id)
+    activity_ids = FacilityReportService.get_activity_ids_for_facility(version_id, facility_id) or []
+    return 200, FacilityReportService.get_facility_report_form_data(facility_report, activity_ids)
+
+
+@router.post(
+    "/report-version/{version_id}/facility-report/{facility_id}",
+    response={201: FacilityReportOut, custom_codes_4xx: Message},
+    tags=EMISSIONS_REPORT_TAGS,
+    description="""Updates the report facility details by version_id and facility_id. The request body should include
+    fields to be updated, such as facility name, type, BC GHG ID, activities, and products. Returns the updated report
+    facility object or an error message if the update fails.""",
+)
+@handle_http_errors()
+def save_facility_report(
+    request: HttpRequest, version_id: int, facility_id: UUID, payload: FacilityReportIn
+) -> Tuple[Literal[201], FacilityReportOut]:
+    """
+    Save or update a report facility and its related activities.
+
+    Args:
+        request (HttpRequest): The HTTP request object.
+        version_id (int): The ID of the report version.
+        facility_id (int): The ID of the facility.
+        payload (FacilityReportIn): The input data for the report facility.
+
+    Returns:
+        Tuple: HTTP status code and the response data or an error message.
+    """
+    # Fetch the existing facility report or create a new one
+    facility_report = FacilityReportService.save_facility_report(version_id, facility_id, payload)
+
+    # Prepare the response data
+    response_data = FacilityReportOut(
+        id=facility_id,
+        report_version_id=facility_report.report_version.id,
+        facility_name=facility_report.facility_name,
+        facility_type=facility_report.facility_type,
+        facility_bcghgid=facility_report.facility_bcghgid,
+        activities=list(facility_report.activities.values_list('id', flat=True)),
+        products=list(facility_report.products.values_list('id', flat=True)) or [],
+    )
+    return 201, response_data

--- a/bc_obps/reporting/api/reports.py
+++ b/bc_obps/reporting/api/reports.py
@@ -1,5 +1,4 @@
-from typing import Literal, Tuple, Optional
-from uuid import UUID
+from typing import Literal, Tuple
 from django.http import HttpRequest
 from registration.decorators import handle_http_errors
 from reporting.constants import EMISSIONS_REPORT_TAGS
@@ -12,7 +11,6 @@ from reporting.schema.report_operation import ReportOperationOut, ReportOperatio
 from reporting.schema.reporting_year import ReportingYearOut
 from .router import router
 from ..models import ReportingYear
-from ..schema.facility_report import FacilityReportOut, FacilityReportIn
 
 
 @router.post(
@@ -67,59 +65,3 @@ def save_report(
 @handle_http_errors()
 def get_reporting_year(request: HttpRequest) -> Tuple[Literal[200], ReportingYear]:
     return 200, ReportingYearService.get_current_reporting_year()
-
-
-@router.get(
-    "/report-version/{version_id}/facility-report/{facility_id}",
-    response={200: FacilityReportOut, 404: Message, 400: Message, 500: Message},
-    tags=EMISSIONS_REPORT_TAGS,
-    description="""Takes `version_id` (primary key of the ReportVersion model) and `facility_id` to return a single matching `facility_report` object.
-    Includes the associated activity IDs if found; otherwise, returns an error message if not found or in case of other issues.""",
-)
-@handle_http_errors()
-def get_facility_report_form_data(
-    request: HttpRequest, version_id: int, facility_id: UUID
-) -> Tuple[Literal[200], Optional[FacilityReportOut]]:
-    facility_report = ReportService.get_facility_report_by_version_and_id(version_id, facility_id)
-    activity_ids = ReportService.get_activity_ids_for_facility(version_id, facility_id) or []
-    return 200, ReportService.get_facility_report_form_data(facility_report, activity_ids)
-
-
-@router.post(
-    "/report-version/{version_id}/facility-report/{facility_id}",
-    response={201: FacilityReportOut, custom_codes_4xx: Message},
-    tags=EMISSIONS_REPORT_TAGS,
-    description="""Updates the report facility details by version_id and facility_id. The request body should include
-    fields to be updated, such as facility name, type, BC GHG ID, activities, and products. Returns the updated report
-    facility object or an error message if the update fails.""",
-)
-@handle_http_errors()
-def save_facility_report(
-    request: HttpRequest, version_id: int, facility_id: UUID, payload: FacilityReportIn
-) -> Tuple[Literal[201], FacilityReportOut]:
-    """
-    Save or update a report facility and its related activities.
-
-    Args:
-        request (HttpRequest): The HTTP request object.
-        version_id (int): The ID of the report version.
-        facility_id (int): The ID of the facility.
-        payload (FacilityReportIn): The input data for the report facility.
-
-    Returns:
-        Tuple: HTTP status code and the response data or an error message.
-    """
-    # Fetch the existing facility report or create a new one
-    facility_report = ReportService.save_facility_report(version_id, facility_id, payload)
-
-    # Prepare the response data
-    response_data = FacilityReportOut(
-        id=facility_id,
-        report_version_id=facility_report.report_version.id,
-        facility_name=facility_report.facility_name,
-        facility_type=facility_report.facility_type,
-        facility_bcghgid=facility_report.facility_bcghgid,
-        activities=list(facility_report.activities.values_list('id', flat=True)),
-        products=list(facility_report.products.values_list('id', flat=True)) or [],
-    )
-    return 201, response_data

--- a/bc_obps/reporting/tests/api/test_facility_report_api.py
+++ b/bc_obps/reporting/tests/api/test_facility_report_api.py
@@ -1,0 +1,47 @@
+import json
+import pytest
+from django.test import Client
+from reporting.models import FacilityReport
+from reporting.tests.utils.bakers import facility_report_baker
+
+client = Client()
+
+
+@pytest.mark.django_db
+class TestFacilityReportEndpoints:
+    # GET
+    def test_error_if_no_facility_report_exists(self):
+        response = client.get('/api/reporting/report-version/9999/facility-report/00000000-0000-0000-0000-000000000000')
+        assert response.status_code == 404
+        assert response.json()["message"] == "Not Found"
+
+    def test_error_if_no_invalid_facility_id(self):
+        response = client.get('/api/reporting/report-version/9999/facility-report/1')
+        assert response.status_code == 422
+        assert "Input should be a valid UUID" in response.json()["detail"][0]["msg"]
+
+    def test_returns_correct_data(self):
+        facility_report = facility_report_baker()
+        response = client.get(
+            f'/api/reporting/report-version/{facility_report.report_version_id}/facility-report/{facility_report.facility_id}'
+        )
+        assert response.status_code == 200
+        assert response.json()['facility_name'] == facility_report.facility_name
+
+    # POST
+    def test_saves_facility_data(self):
+        facility_report = facility_report_baker()
+        request_data = {
+            "facility_name": "CHANGED",
+            "facility_type": "Single Facility Operation",
+            "facility_bcghgid": "abc12345",
+            "activities": ["1", "2", "3"],
+            "products": [],
+        }
+        client.post(
+            f'/api/reporting/report-version/{facility_report.report_version_id}/facility-report/{facility_report.facility_id}',
+            data=json.dumps(request_data),
+            content_type="application/json",
+        )
+        assert FacilityReport.objects.get(pk=facility_report.id).facility_name == "CHANGED"
+        assert FacilityReport.objects.get(pk=facility_report.id).activities.count() == 3

--- a/bc_obps/reporting/tests/models/test_report_activity.py
+++ b/bc_obps/reporting/tests/models/test_report_activity.py
@@ -4,7 +4,7 @@ from reporting.models.activity_json_schema import ActivityJsonSchema
 from reporting.models.report_activity import ReportActivity
 from reporting.tests.utils.bakers import report_version_baker
 from reporting.tests.utils.constants import REPORT_DATA_MODELS_COMMON_FIELDS
-from reporting.tests.utils.report_data_bakers import facility_report_baker
+from model_bakery import baker
 
 
 class ReportActivityModelTest(BaseTestCase):
@@ -17,7 +17,7 @@ class ReportActivityModelTest(BaseTestCase):
             json_data="{'test': 1}",
             activity_base_schema=ActivityJsonSchema.objects.first(),
             activity=ActivityJsonSchema.objects.first().activity,
-            facility_report=facility_report_baker(report_version=report_version),
+            facility_report=baker.make_recipe('reporting.tests.utils.facility_report'),
         )
         cls.field_data = [
             *TIMESTAMP_COMMON_FIELDS,

--- a/bc_obps/reporting/tests/utils/baker_recipes.py
+++ b/bc_obps/reporting/tests/utils/baker_recipes.py
@@ -1,0 +1,20 @@
+from reporting.models.reporting_year import ReportingYear
+from reporting.models.report import Report
+from reporting.models.report_version import ReportVersion
+from reporting.models.facility_report import FacilityReport
+from registration.tests.utils.baker_recipes import operation, operator, facility
+from model_bakery.recipe import Recipe, foreign_key
+
+
+reporting_year = Recipe(ReportingYear)
+
+report = Recipe(
+    Report,
+    operator=foreign_key(operator),
+    operation=foreign_key(operation),
+    reporting_year=foreign_key(reporting_year),
+)
+
+report_version = Recipe(ReportVersion, report=foreign_key(report))
+
+facility_report = Recipe(FacilityReport, report_version=foreign_key(report_version), facility=foreign_key(facility))

--- a/bc_obps/reporting/tests/utils/bakers.py
+++ b/bc_obps/reporting/tests/utils/bakers.py
@@ -1,4 +1,4 @@
-from registration.tests.utils.bakers import operation_baker, operator_baker, facility_baker
+from registration.tests.utils.bakers import operation_baker, operator_baker
 from reporting.models import configuration_element
 from reporting.models.gas_type import GasType
 from registration.models import Activity
@@ -11,7 +11,6 @@ from reporting.models.report import Report
 from reporting.models.configuration_element import ConfigurationElement
 from reporting.models.configuration import Configuration
 from reporting.models.methodology import Methodology
-from reporting.models.facility_report import FacilityReport
 
 
 def report_baker(**props) -> Report:
@@ -32,18 +31,6 @@ def report_version_baker(**props) -> ReportVersion:
         baker.make(ReportOperation, report_version=version)
 
     return version
-
-
-def facility_report_baker(**props) -> FacilityReport:
-    if "report_version" not in props and "report_version_id" not in props:
-        props["report_version"] = report_version_baker()
-
-    if "facility" not in props and "facility_id" not in props:
-        props["facility"] = facility_baker()
-
-    fr = baker.make(FacilityReport, **props)
-
-    return fr
 
 
 def activity_baker(custom_properties=None) -> Activity:

--- a/bc_obps/reporting/tests/utils/bakers.py
+++ b/bc_obps/reporting/tests/utils/bakers.py
@@ -1,4 +1,4 @@
-from registration.tests.utils.bakers import operation_baker, operator_baker
+from registration.tests.utils.bakers import operation_baker, operator_baker, facility_baker
 from reporting.models import configuration_element
 from reporting.models.gas_type import GasType
 from registration.models import Activity
@@ -11,6 +11,7 @@ from reporting.models.report import Report
 from reporting.models.configuration_element import ConfigurationElement
 from reporting.models.configuration import Configuration
 from reporting.models.methodology import Methodology
+from reporting.models.facility_report import FacilityReport
 
 
 def report_baker(**props) -> Report:
@@ -31,6 +32,18 @@ def report_version_baker(**props) -> ReportVersion:
         baker.make(ReportOperation, report_version=version)
 
     return version
+
+
+def facility_report_baker(**props) -> FacilityReport:
+    if "report_version" not in props and "report_version_id" not in props:
+        props["report_version"] = report_version_baker()
+
+    if "facility" not in props and "facility_id" not in props:
+        props["facility"] = facility_baker()
+
+    fr = baker.make(FacilityReport, **props)
+
+    return fr
 
 
 def activity_baker(custom_properties=None) -> Activity:

--- a/bc_obps/service/facility_report_service.py
+++ b/bc_obps/service/facility_report_service.py
@@ -1,0 +1,65 @@
+from uuid import UUID
+from django.db import transaction
+from typing import List, Optional
+
+from registration.models import Activity
+from reporting.models.facility_report import FacilityReport
+from reporting.schema.facility_report import FacilityReportIn, FacilityReportOut
+
+
+class FacilityReportService:
+    @classmethod
+    def get_facility_report_by_version_and_id(
+        cls, report_version_id: int, facility_id: UUID
+    ) -> Optional[FacilityReport]:
+        return FacilityReport.objects.get(report_version_id=report_version_id, facility_id=facility_id)
+
+    @classmethod
+    def get_activity_ids_for_facility(cls, version_id: int, facility_id: UUID) -> List[int]:
+        facility_report = FacilityReport.objects.get(report_version_id=version_id, facility_id=facility_id)
+        return list(facility_report.activities.values_list('id', flat=True))
+
+    @classmethod
+    def get_facility_report_form_data(
+        cls, facility_report: FacilityReport | None, activity_ids: List[int]
+    ) -> Optional[FacilityReportOut]:
+        if facility_report:
+            return FacilityReportOut(
+                id=facility_report.id,
+                report_version_id=facility_report.report_version.id,
+                facility_name=facility_report.facility_name,
+                facility_type=facility_report.facility_type,
+                facility_bcghgid=facility_report.facility_bcghgid,
+                activities=activity_ids,
+                products=[],
+            )
+        else:
+            return None
+
+    @classmethod
+    @transaction.atomic()
+    def save_facility_report(cls, report_version_id: int, facility_id: UUID, data: FacilityReportIn) -> FacilityReport:
+        """
+        Update a facility report and its related activities.
+
+        Args:
+            report_version_id (int): The ID of the report version.
+            facility_id (int): The ID of the facility.
+            data (FacilityReportIn): The input data for the facility report.
+
+        Returns:
+            FacilityReport: The updated or created FacilityReport instance.
+        """
+        # Update FacilityReport instance
+        facility_report = FacilityReport.objects.get(report_version_id=report_version_id, facility_id=facility_id)
+        facility_report.facility_name = data.facility_name.strip()
+        facility_report.facility_type = data.facility_type.strip()
+
+        # Update ManyToMany fields (activities)
+        if data.activities:
+            facility_report.activities.set(Activity.objects.filter(id__in=data.activities))
+
+        # Save the updated FacilityReport instance
+        facility_report.save()
+
+        return facility_report

--- a/bc_obps/service/report_service.py
+++ b/bc_obps/service/report_service.py
@@ -1,14 +1,11 @@
 from uuid import UUID
 from django.db import transaction
-from typing import List, Optional
-
 from registration.models import Activity, RegulatedProduct
 from registration.models.operation import Operation
 from reporting.models.report import Report
 from reporting.models.facility_report import FacilityReport
 from reporting.models.report_operation import ReportOperation
 from reporting.models.report_version import ReportVersion
-from reporting.schema.facility_report import FacilityReportIn, FacilityReportOut
 from reporting.schema.report_operation import ReportOperationIn
 from service.data_access_service.facility_service import FacilityDataAccessService
 from service.data_access_service.report_service import ReportDataAccessService
@@ -107,59 +104,3 @@ class ReportService:
         report_operation.save()
 
         return report_operation
-
-    @classmethod
-    def get_facility_report_by_version_and_id(
-        cls, report_version_id: int, facility_id: UUID
-    ) -> Optional[FacilityReport]:
-        return FacilityReport.objects.get(report_version_id=report_version_id, facility_id=facility_id)
-
-    @classmethod
-    def get_activity_ids_for_facility(cls, version_id: int, facility_id: UUID) -> List[int]:
-        facility_report = FacilityReport.objects.get(report_version_id=version_id, facility_id=facility_id)
-        return list(facility_report.activities.values_list('id', flat=True))
-
-    @classmethod
-    def get_facility_report_form_data(
-        cls, facility_report: FacilityReport | None, activity_ids: List[int]
-    ) -> Optional[FacilityReportOut]:
-        if facility_report:
-            return FacilityReportOut(
-                id=facility_report.id,
-                report_version_id=facility_report.report_version.id,
-                facility_name=facility_report.facility_name,
-                facility_type=facility_report.facility_type,
-                facility_bcghgid=facility_report.facility_bcghgid,
-                activities=activity_ids,
-                products=[],
-            )
-        else:
-            return None
-
-    @classmethod
-    @transaction.atomic()
-    def save_facility_report(cls, report_version_id: int, facility_id: UUID, data: FacilityReportIn) -> FacilityReport:
-        """
-        Update a facility report and its related activities.
-
-        Args:
-            report_version_id (int): The ID of the report version.
-            facility_id (int): The ID of the facility.
-            data (FacilityReportIn): The input data for the facility report.
-
-        Returns:
-            FacilityReport: The updated or created FacilityReport instance.
-        """
-        # Update FacilityReport instance
-        facility_report = FacilityReport.objects.get(report_version_id=report_version_id, facility_id=facility_id)
-        facility_report.facility_name = data.facility_name.strip()
-        facility_report.facility_type = data.facility_type.strip()
-
-        # Update ManyToMany fields (activities)
-        if data.activities:
-            facility_report.activities.set(Activity.objects.filter(id__in=data.activities))
-
-        # Save the updated FacilityReport instance
-        facility_report.save()
-
-        return facility_report

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -71,7 +71,8 @@ class TestFacilityReportService(TestCase):
 
     @staticmethod
     def test_saves_facility_report_form_data():
-        facility_report = facility_report_baker()
+        facility_report = facility_report_baker(facility_bcghgid='abc')
+        print(facility_report.facility_bcghgid)
         data = FacilityReportIn(
             facility_name="CHANGED",
             facility_type=facility_report.facility_type,
@@ -82,6 +83,6 @@ class TestFacilityReportService(TestCase):
         returned_data = FacilityReportService.save_facility_report(
             report_version_id=facility_report.report_version_id, facility_id=facility_report.facility_id, data=data
         )
-        assert facility_report.facility_name == "CHANGEDs"
-        assert facility_report.facility_type == returned_data.facility_type
-        assert facility_report.facility_bcghgid == returned_data.facility_bcghgid
+        assert returned_data.facility_name == "CHANGED"
+        assert returned_data.facility_type == facility_report.facility_type
+        assert returned_data.facility_bcghgid == facility_report.facility_bcghgid

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -1,0 +1,83 @@
+from django.test import TestCase
+from django.core.exceptions import ObjectDoesNotExist
+from reporting.tests.utils.bakers import facility_report_baker, activity_baker
+from service.facility_report_service import FacilityReportService
+
+
+class TestFacilityReportService(TestCase):
+    def test_get_facility_throws_if_facility_report_does_not_exist(self):
+        with self.assertRaises(ObjectDoesNotExist) as exception_context:
+            FacilityReportService.get_facility_report_by_version_and_id(
+                report_version_id=999, facility_id="00000000-00000000-00000000-00000000"
+            )
+
+        self.assertEqual(str(exception_context.exception), "FacilityReport matching query does not exist.")
+
+    @staticmethod
+    def returns_facility_report():
+        facility_report = facility_report_baker()
+        assert facility_report == FacilityReportService.get_facility_report_by_version_and_id(
+            report_version_id=facility_report.report_version_id, facility_id=facility_report.faclity_id
+        )
+
+    def test_get_activities_throws_if_facility_report_does_not_exist(self):
+        with self.assertRaises(ObjectDoesNotExist) as exception_context:
+            FacilityReportService.get_activity_ids_for_facility(
+                version_id=999, facility_id="00000000-00000000-00000000-00000000"
+            )
+
+        self.assertEqual(str(exception_context.exception), "FacilityReport matching query does not exist.")
+
+    @staticmethod
+    def returns_activity_id_list():
+        facility_report = facility_report_baker()
+        a1 = activity_baker()
+        a2 = activity_baker()
+        assert (
+            len(
+                FacilityReportService.get_activity_ids_for_facility(
+                    version_id=facility_report.report_version_id, facility_id=facility_report.faclity_id
+                )
+            )
+            == 0
+        )
+        facility_report.activities.add(a1)
+        facility_report.activities.add(a2)
+        assert (
+            len(
+                FacilityReportService.get_activity_ids_for_facility(
+                    version_id=facility_report.report_version_id, facility_id=facility_report.faclity_id
+                )
+            )
+            == 2
+        )
+
+    @staticmethod
+    def form_data_returns_none_if_facility_report_does_not_exist(self):
+        assert (
+            FacilityReportService.get_facility_report_form_data(
+                report_version_id=999, facility_id="00000000-00000000-00000000-00000000"
+            )
+            is None
+        )
+
+    @staticmethod
+    def form_data_returns_facility_report_form_data():
+        facility_report = facility_report_baker()
+        returned_data = FacilityReportService.get_facility_report_by_version_and_id(
+            report_version_id=facility_report.report_version_id, facility_id=facility_report.faclity_id
+        )
+        assert facility_report.facility_name == returned_data.facility_name
+        assert facility_report.facility_type == returned_data.facility_type
+        assert facility_report.facility_bcghgid == returned_data.facility_bcghgid
+
+    @staticmethod
+    def saves_facility_report_form_data():
+        facility_report = facility_report_baker()
+        data = {"facility_name": "CHANGED"}
+        returned_data = FacilityReportService.save_facility_report(
+            report_version_id=facility_report.report_version_id, facility_id=facility_report.faclity_id, data=data
+        )
+        assert facility_report.facility_name == "CHANGEDs"
+        assert facility_report.facility_type == returned_data.facility_type
+        assert facility_report.facility_bcghgid == returned_data.facility_bcghgid

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -4,6 +4,7 @@ from reporting.tests.utils.bakers import activity_baker
 from service.facility_report_service import FacilityReportService
 from reporting.schema.facility_report import FacilityReportIn
 from model_bakery import baker
+from registration.tests.utils.bakers import user_baker
 
 
 class TestFacilityReportService(TestCase):
@@ -65,8 +66,12 @@ class TestFacilityReportService(TestCase):
             activities=[],
             products=[],
         )
+        user = user_baker()
         returned_data = FacilityReportService.save_facility_report(
-            report_version_id=facility_report.report_version_id, facility_id=facility_report.facility_id, data=data
+            report_version_id=facility_report.report_version_id,
+            facility_id=facility_report.facility_id,
+            data=data,
+            user_guid=user.user_guid,
         )
         assert returned_data.facility_name == "CHANGED"
         assert returned_data.facility_type == facility_report.facility_type

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -1,8 +1,9 @@
 from django.test import TestCase
 from django.core.exceptions import ObjectDoesNotExist
-from reporting.tests.utils.bakers import facility_report_baker, activity_baker
+from reporting.tests.utils.bakers import activity_baker
 from service.facility_report_service import FacilityReportService
 from reporting.schema.facility_report import FacilityReportIn
+from model_bakery import baker
 
 
 class TestFacilityReportService(TestCase):
@@ -16,7 +17,7 @@ class TestFacilityReportService(TestCase):
 
     @staticmethod
     def test_returns_facility_report():
-        facility_report = facility_report_baker()
+        facility_report = baker.make_recipe('reporting.tests.utils.facility_report')
         assert facility_report == FacilityReportService.get_facility_report_by_version_and_id(
             report_version_id=facility_report.report_version_id, facility_id=facility_report.facility_id
         )
@@ -31,7 +32,7 @@ class TestFacilityReportService(TestCase):
 
     @staticmethod
     def test_returns_activity_id_list():
-        facility_report = facility_report_baker()
+        facility_report = baker.make_recipe('reporting.tests.utils.facility_report')
         a1 = activity_baker()
         a2 = activity_baker()
         assert (
@@ -54,24 +55,8 @@ class TestFacilityReportService(TestCase):
         )
 
     @staticmethod
-    def test_form_data_returns_none_if_facility_report_does_not_exist():
-        assert FacilityReportService.get_facility_report_form_data(None, []) is None
-
-    @staticmethod
-    def test_form_data_returns_facility_report_form_data():
-        facility_report = facility_report_baker()
-        returned_data = FacilityReportService.get_facility_report_form_data(
-            facility_report=facility_report, activity_ids=[1, 2]
-        )
-        assert facility_report.facility_name == returned_data.facility_name
-        assert facility_report.facility_type == returned_data.facility_type
-        assert facility_report.facility_bcghgid == returned_data.facility_bcghgid
-
-        print(returned_data)
-
-    @staticmethod
     def test_saves_facility_report_form_data():
-        facility_report = facility_report_baker(facility_bcghgid='abc')
+        facility_report = baker.make_recipe('reporting.tests.utils.facility_report', facility_bcghgid='abc')
         print(facility_report.facility_bcghgid)
         data = FacilityReportIn(
             facility_name="CHANGED",

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from django.core.exceptions import ObjectDoesNotExist
 from reporting.tests.utils.bakers import facility_report_baker, activity_baker
 from service.facility_report_service import FacilityReportService
+from reporting.schema.facility_report import FacilityReportIn
 
 
 class TestFacilityReportService(TestCase):
@@ -14,10 +15,10 @@ class TestFacilityReportService(TestCase):
         self.assertEqual(str(exception_context.exception), "FacilityReport matching query does not exist.")
 
     @staticmethod
-    def returns_facility_report():
+    def test_returns_facility_report():
         facility_report = facility_report_baker()
         assert facility_report == FacilityReportService.get_facility_report_by_version_and_id(
-            report_version_id=facility_report.report_version_id, facility_id=facility_report.faclity_id
+            report_version_id=facility_report.report_version_id, facility_id=facility_report.facility_id
         )
 
     def test_get_activities_throws_if_facility_report_does_not_exist(self):
@@ -29,14 +30,14 @@ class TestFacilityReportService(TestCase):
         self.assertEqual(str(exception_context.exception), "FacilityReport matching query does not exist.")
 
     @staticmethod
-    def returns_activity_id_list():
+    def test_returns_activity_id_list():
         facility_report = facility_report_baker()
         a1 = activity_baker()
         a2 = activity_baker()
         assert (
             len(
                 FacilityReportService.get_activity_ids_for_facility(
-                    version_id=facility_report.report_version_id, facility_id=facility_report.faclity_id
+                    version_id=facility_report.report_version_id, facility_id=facility_report.facility_id
                 )
             )
             == 0
@@ -46,37 +47,40 @@ class TestFacilityReportService(TestCase):
         assert (
             len(
                 FacilityReportService.get_activity_ids_for_facility(
-                    version_id=facility_report.report_version_id, facility_id=facility_report.faclity_id
+                    version_id=facility_report.report_version_id, facility_id=facility_report.facility_id
                 )
             )
             == 2
         )
 
     @staticmethod
-    def form_data_returns_none_if_facility_report_does_not_exist(self):
-        assert (
-            FacilityReportService.get_facility_report_form_data(
-                report_version_id=999, facility_id="00000000-00000000-00000000-00000000"
-            )
-            is None
-        )
+    def test_form_data_returns_none_if_facility_report_does_not_exist():
+        assert FacilityReportService.get_facility_report_form_data(None, []) is None
 
     @staticmethod
-    def form_data_returns_facility_report_form_data():
+    def test_form_data_returns_facility_report_form_data():
         facility_report = facility_report_baker()
-        returned_data = FacilityReportService.get_facility_report_by_version_and_id(
-            report_version_id=facility_report.report_version_id, facility_id=facility_report.faclity_id
+        returned_data = FacilityReportService.get_facility_report_form_data(
+            facility_report=facility_report, activity_ids=[1, 2]
         )
         assert facility_report.facility_name == returned_data.facility_name
         assert facility_report.facility_type == returned_data.facility_type
         assert facility_report.facility_bcghgid == returned_data.facility_bcghgid
 
+        print(returned_data)
+
     @staticmethod
-    def saves_facility_report_form_data():
+    def test_saves_facility_report_form_data():
         facility_report = facility_report_baker()
-        data = {"facility_name": "CHANGED"}
+        data = FacilityReportIn(
+            facility_name="CHANGED",
+            facility_type=facility_report.facility_type,
+            facility_bcghgid=facility_report.facility_bcghgid,
+            activities=[],
+            products=[],
+        )
         returned_data = FacilityReportService.save_facility_report(
-            report_version_id=facility_report.report_version_id, facility_id=facility_report.faclity_id, data=data
+            report_version_id=facility_report.report_version_id, facility_id=facility_report.facility_id, data=data
         )
         assert facility_report.facility_name == "CHANGEDs"
         assert facility_report.facility_type == returned_data.facility_type

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user/reports/[version_id]/facilities/[facility_id]/review/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user/reports/[version_id]/facilities/[facility_id]/review/page.tsx
@@ -1,11 +1,12 @@
 import FacilityReviewFormData from "@reporting/src/app/components/facility/FacilityReviewFormData";
 import { Suspense } from "react";
 import Loading from "@bciers/components/loading/SkeletonForm";
+import { UUID } from "crypto";
 
 export default async function Page({
   params,
 }: {
-  params: { version_id: number; facility_id: number };
+  params: { version_id: number; facility_id: UUID };
 }) {
   return (
     <Suspense fallback={<Loading />}>

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/reports/[version_id]/facilities/[facility_id]/review/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/reports/[version_id]/facilities/[facility_id]/review/page.tsx
@@ -1,11 +1,12 @@
 import FacilityReviewFormData from "@reporting/src/app/components/facility/FacilityReviewFormData";
 import { Suspense } from "react";
 import Loading from "@bciers/components/loading/SkeletonForm";
+import { UUID } from "crypto";
 
 export default async function Page({
   params,
 }: {
-  params: { version_id: number; facility_id: number };
+  params: { version_id: number; facility_id: UUID };
 }) {
   return (
     <Suspense fallback={<Loading />}>

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReview.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReview.tsx
@@ -20,10 +20,11 @@ import {
 import { RJSFSchema } from "@rjsf/utils";
 import { actionHandler } from "@bciers/actions";
 import { IChangeEvent } from "@rjsf/core";
+import { UUID } from "crypto";
 
 interface Props {
   version_id: number;
-  facility_id: number;
+  facility_id: UUID;
 }
 
 interface Activity {
@@ -31,7 +32,7 @@ interface Activity {
   id: number;
 }
 
-const getFacilityReport = async (version_id: number, facility_id: number) => {
+const getFacilityReport = async (version_id: number, facility_id: UUID) => {
   return actionHandler(
     `reporting/report-version/${version_id}/facility-report/${facility_id}`,
     "GET",
@@ -222,6 +223,7 @@ const FacilityReview: React.FC<Props> = ({ version_id, facility_id }) => {
                 type="submit"
                 aria-disabled={isLoading}
                 disabled={isLoading}
+                onClick={handleSave}
               >
                 {buttonContent}
               </Button>

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReview.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReview.tsx
@@ -131,10 +131,6 @@ const FacilityReview: React.FC<Props> = ({ version_id, facility_id }) => {
     try {
       await actionHandler(endpoint, method, pathToRevalidate, {
         body: JSON.stringify(formDataObject),
-        headers: {
-          "Content-Type": "application/json",
-          accept: "application/json",
-        },
       });
 
       setIsSuccess(true);

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewFormData.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewFormData.tsx
@@ -1,8 +1,9 @@
 import FacilityReview from "./FacilityReview";
+import { UUID } from "crypto";
 
 type FacilityReviewFormDataProps = Readonly<{
   version_id: number;
-  facility_id: number;
+  facility_id: UUID;
 }>;
 
 export default function FacilityReviewFormData({

--- a/bciers/apps/reporting/tests/components/FacilityReview.test.tsx
+++ b/bciers/apps/reporting/tests/components/FacilityReview.test.tsx
@@ -104,10 +104,6 @@ describe("FacilityReview", () => {
             ...mockFacilityData,
             activities: ["7", "10"], // Ensure this matches your implementation
           }),
-          headers: expect.objectContaining({
-            "Content-Type": "application/json",
-            accept: "application/json",
-          }),
         }),
       );
     });

--- a/bciers/apps/reporting/tests/components/FacilityReview.test.tsx
+++ b/bciers/apps/reporting/tests/components/FacilityReview.test.tsx
@@ -10,7 +10,7 @@ vi.mock("@bciers/actions", () => ({
 }));
 
 const mockFacilityData = {
-  id: 1,
+  id: "00000000-0000-0000-0000-000000000000",
   bcghg_id: "BCGHGID12345",
   name: "Facility1",
   facility_type: "SFO",
@@ -38,7 +38,12 @@ describe("FacilityReview", () => {
       .mockResolvedValueOnce(mockFacilityData) // Mock facility data
       .mockResolvedValueOnce(mockActivitiesData); // Mock activities data
 
-    render(<FacilityReview version_id={1} facility_id={1} />);
+    render(
+      <FacilityReview
+        version_id={1}
+        facility_id={"00000000-0000-0000-0000-000000000000"}
+      />,
+    );
 
     await waitFor(() => {
       expect(actionHandler).toHaveBeenCalledTimes(2); // Ensure initial fetches occurred
@@ -56,7 +61,12 @@ describe("FacilityReview", () => {
       () => new Promise(() => {}), // Mock loading indefinitely
     );
 
-    render(<FacilityReview version_id={1} facility_id={1} />);
+    render(
+      <FacilityReview
+        version_id={1}
+        facility_id={"00000000-0000-0000-0000-000000000000"}
+      />,
+    );
 
     fireEvent.click(screen.getByText("Save"));
     await waitFor(() => {
@@ -71,7 +81,12 @@ describe("FacilityReview", () => {
       .mockResolvedValueOnce(mockActivitiesData) // Mock activities data
       .mockResolvedValueOnce({}); // Mock successful save
 
-    render(<FacilityReview version_id={1} facility_id={1} />);
+    render(
+      <FacilityReview
+        version_id={1}
+        facility_id={"00000000-0000-0000-0000-000000000000"}
+      />,
+    );
 
     await waitFor(() => {
       expect(actionHandler).toHaveBeenCalledTimes(2); // Ensure initial fetches occurred
@@ -104,7 +119,12 @@ describe("FacilityReview", () => {
       .mockResolvedValueOnce(mockActivitiesData) // Mock activities data
       .mockRejectedValueOnce(new Error("Failed to save")); // Mock save error
 
-    render(<FacilityReview version_id={1} facility_id={1} />);
+    render(
+      <FacilityReview
+        version_id={1}
+        facility_id={"00000000-0000-0000-0000-000000000000"}
+      />,
+    );
 
     await waitFor(() => {
       expect(actionHandler).toHaveBeenCalledTimes(2); // Ensure initial fetches occurred
@@ -128,7 +148,12 @@ describe("FacilityReview", () => {
       .mockResolvedValueOnce(mockFacilityDataNoActivities) // Mock facility data with no activities
       .mockResolvedValueOnce([]); // Mock no activities data
 
-    render(<FacilityReview version_id={1} facility_id={1} />);
+    render(
+      <FacilityReview
+        version_id={1}
+        facility_id={"00000000-0000-0000-0000-000000000000"}
+      />,
+    );
 
     await waitFor(() => {
       expect(actionHandler).toHaveBeenCalledTimes(2); // Ensure initial fetches occurred
@@ -144,7 +169,12 @@ describe("FacilityReview", () => {
       .mockRejectedValueOnce(new Error("Failed to fetch facility data")) // Simulate error fetching facility data
       .mockRejectedValueOnce(new Error("Failed to fetch activities data")); // Simulate error fetching activities data
 
-    render(<FacilityReview version_id={1} facility_id={1} />);
+    render(
+      <FacilityReview
+        version_id={1}
+        facility_id={"00000000-0000-0000-0000-000000000000"}
+      />,
+    );
 
     // Check if error messages are displayed
     await waitFor(() => {

--- a/bciers/apps/reporting/tests/components/FacilityReview.test.tsx
+++ b/bciers/apps/reporting/tests/components/FacilityReview.test.tsx
@@ -96,9 +96,9 @@ describe("FacilityReview", () => {
 
     await waitFor(() => {
       expect(actionHandler).toHaveBeenCalledWith(
-        `reporting/report-version/1/facility-report/1`,
+        `reporting/report-version/1/facility-report/00000000-0000-0000-0000-000000000000`,
         "POST",
-        `reporting/report-version/1/facility-report/1`,
+        `reporting/report-version/1/facility-report/00000000-0000-0000-0000-000000000000`,
         expect.objectContaining({
           body: JSON.stringify({
             ...mockFacilityData,


### PR DESCRIPTION
There were some errors in how facility_id was being applied. 
It was being treated as a numeric where it is a UUID value, which had some cascading effects. 
This PR should fix that up. 
Also cleaned up the API a little bit by splitting out `facility-report` API/service stuff into its own directory & added some tests.

Easiest way to test this:
- Go to dashboard & create a report for Operation 3
- go to /reporting/reports/3/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/review (the facility ID associated with operation 3)
- There should be data in the form fields
- change some data & save
- reload the page
- see the data has changed