### PR TITLE
Registration status

### DIFF
--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
@@ -31,5 +31,4 @@ from registration.schema.generic import Message
 def register_edit_operation_information(
     request: HttpRequest, operation_id: UUID, payload: OperationInformationIn
 ) -> Tuple[Literal[200], Operation]:
-    # raise Exception('d')
     return 200, OperationServiceV2.register_operation_information(get_current_user_guid(request), operation_id, payload)

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/submission.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/submission.py
@@ -32,4 +32,4 @@ def operation_registration_submission(
     ):
         raise Exception("All checkboxes must be checked to submit the registration.")
 
-    return 200, OperationServiceV2.set_operation_status_to_registered(get_current_user_guid(request), operation_id)
+    return 200, OperationServiceV2.update_status(get_current_user_guid(request), operation_id)

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/submission.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/submission.py
@@ -32,6 +32,8 @@ def operation_registration_submission(
         [payload.acknowledgement_of_review, payload.acknowledgement_of_information, payload.acknowledgement_of_records]
     ):
         raise Exception("All checkboxes must be checked to submit the registration.")
+    # Check that all required registration data is given
+    OperationServiceV2.raise_exception_if_operation_is_missing_registration_data(operation_id)
     return 200, OperationServiceV2.update_status(
         get_current_user_guid(request), operation_id, Operation.Statuses.REGISTERED
     )

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/submission.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/submission.py
@@ -25,15 +25,11 @@ from registration.schema.generic import Message
 @handle_http_errors()
 def operation_registration_submission(
     request: HttpRequest, operation_id: UUID, payload: OperationRegistrationSubmissionIn
-) -> Tuple[Literal[200], Operation]:
+) -> Tuple[Literal[200], Operation | None]:
     # Check if all checkboxes are checked
-    # raise Exception('d')
     if not all(
         [payload.acknowledgement_of_review, payload.acknowledgement_of_information, payload.acknowledgement_of_records]
     ):
         raise Exception("All checkboxes must be checked to submit the registration.")
-    # Check that all required registration data is given
-    OperationServiceV2.raise_exception_if_operation_is_missing_registration_data(operation_id)
-    return 200, OperationServiceV2.update_status(
-        get_current_user_guid(request), operation_id, Operation.Statuses.REGISTERED
-    )
+
+    return 200, OperationServiceV2.set_operation_status_to_registered(get_current_user_guid(request), operation_id)

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/submission.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/submission.py
@@ -32,4 +32,6 @@ def operation_registration_submission(
     ):
         raise Exception("All checkboxes must be checked to submit the registration.")
 
-    return 200, OperationServiceV2.update_status(get_current_user_guid(request), operation_id)
+    return 200, OperationServiceV2.update_status(
+        get_current_user_guid(request), operation_id, Operation.Statuses.REGISTERED
+    )

--- a/bc_obps/registration/schema/v1/operation.py
+++ b/bc_obps/registration/schema/v1/operation.py
@@ -138,7 +138,7 @@ class OperationUpdateStatusIn(ModelSchema):
 class OperationUpdateStatusOut(ModelSchema):
     class Meta:
         model = Operation
-        fields = ["id"]
+        fields = ["id", "status"]
 
 
 class OperationPaginatedOut(Schema):

--- a/bc_obps/registration/tests/endpoints/v1/_operations/_operation_id/test_operation_update_status.py
+++ b/bc_obps/registration/tests/endpoints/v1/_operations/_operation_id/test_operation_update_status.py
@@ -42,7 +42,10 @@ class TestUpdateOperationStatusEndpoint(CommonTestSetup):
         assert put_response_1.status_code == 200
         put_response_1_dict = put_response_1.json()
         assert put_response_1_dict.get("id") == str(operation.id)  # string representation of UUID
-        assert put_response_1_dict.keys() == {"id"}  # Make sure the response has the expected keys based on the schema
+        assert put_response_1_dict.keys() == {
+            "id",
+            "status",
+        }  # Make sure the response has the expected keys based on the schema
         operation_after_put = Operation.objects.get(id=operation.id)
         assert operation_after_put.status == Operation.Statuses.APPROVED
         assert operation_after_put.verified_by == self.user
@@ -104,7 +107,10 @@ class TestUpdateOperationStatusEndpoint(CommonTestSetup):
         assert put_response.status_code == 200
         put_response_dict = put_response.json()
         assert put_response_dict.get("id") == str(operation.id)  # string representation of UUID
-        assert put_response_dict.keys() == {"id"}  # Make sure the response has the expected keys based on the schema
+        assert put_response_dict.keys() == {
+            "id",
+            "status",
+        }  # Make sure the response has the expected keys based on the schema
         operation_after_put = Operation.objects.get(id=operation.id)
         assert operation_after_put.status == Operation.Statuses.DECLINED
         assert operation_after_put.verified_by == self.user
@@ -139,7 +145,10 @@ class TestUpdateOperationStatusEndpoint(CommonTestSetup):
         assert put_response.status_code == 200
         put_response_dict = put_response.json()
         assert put_response_dict.get("id") == str(operation.id)  # string representation of UUID
-        assert put_response_dict.keys() == {"id"}  # Make sure the response has the expected keys based on the schema
+        assert put_response_dict.keys() == {
+            "id",
+            "status",
+        }  # Make sure the response has the expected keys based on the schema
         operation_after_put = Operation.objects.get(id=operation.id)
         assert operation_after_put.status == Operation.Statuses.CHANGES_REQUESTED
         assert operation_after_put.verified_by is None

--- a/bc_obps/registration/tests/utils/baker_recipes.py
+++ b/bc_obps/registration/tests/utils/baker_recipes.py
@@ -3,7 +3,6 @@ from registration.models.facility_designated_operation_timeline import FacilityD
 from registration.models.document import Document
 from registration.models.event.transfer_event import TransferEvent
 from registration.models.facility import Facility
-from registration.models.facility import Facility
 from registration.models.facility_designated_operation_timeline import FacilityDesignatedOperationTimeline
 from registration.models.multiple_operator import MultipleOperator
 from registration.models.app_role import AppRole
@@ -28,7 +27,7 @@ import uuid
 
 naics_code = Recipe(NaicsCode)
 address = Recipe(Address, street_address='Dreary Lane', municipality='Candyland', province='BC', postal_code='HOHOHO')
-document = Recipe(Document,file='test.pdf')
+document = Recipe(Document, file='test.pdf')
 
 
 operator = Recipe(

--- a/bc_obps/registration/tests/utils/baker_recipes.py
+++ b/bc_obps/registration/tests/utils/baker_recipes.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 from registration.models.facility_designated_operation_timeline import FacilityDesignatedOperationTimeline
+from registration.models.document import Document
 from registration.models.event.transfer_event import TransferEvent
 from registration.models.facility import Facility
+from registration.models.facility import Facility
+from registration.models.facility_designated_operation_timeline import FacilityDesignatedOperationTimeline
 from registration.models.multiple_operator import MultipleOperator
 from registration.models.app_role import AppRole
 from registration.models.opted_in_operation_detail import OptedInOperationDetail
@@ -25,6 +28,8 @@ import uuid
 
 naics_code = Recipe(NaicsCode)
 address = Recipe(Address, street_address='Dreary Lane', municipality='Candyland', province='BC', postal_code='HOHOHO')
+document = Recipe(Document,file='test.pdf')
+
 
 operator = Recipe(
     Operator,

--- a/bc_obps/registration/tests/utils/baker_recipes.py
+++ b/bc_obps/registration/tests/utils/baker_recipes.py
@@ -3,7 +3,6 @@ from registration.models.facility_designated_operation_timeline import FacilityD
 from registration.models.document import Document
 from registration.models.event.transfer_event import TransferEvent
 from registration.models.facility import Facility
-from registration.models.facility_designated_operation_timeline import FacilityDesignatedOperationTimeline
 from registration.models.multiple_operator import MultipleOperator
 from registration.models.app_role import AppRole
 from registration.models.opted_in_operation_detail import OptedInOperationDetail

--- a/bc_obps/registration/tests/utils/baker_recipes.py
+++ b/bc_obps/registration/tests/utils/baker_recipes.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
+
 from registration.models.facility_designated_operation_timeline import FacilityDesignatedOperationTimeline
 from registration.models.document import Document
 from registration.models.event.transfer_event import TransferEvent
@@ -144,5 +146,5 @@ facility_designated_operation_timeline = Recipe(
     operation=foreign_key(operation),
     facility=foreign_key(facility),
     status=FacilityDesignatedOperationTimeline.Statuses.TEMPORARILY_SHUTDOWN,
-    end_date=datetime.now(),
+    end_date=datetime.now(ZoneInfo("UTC")),
 )

--- a/bc_obps/service/operation_service_v2.py
+++ b/bc_obps/service/operation_service_v2.py
@@ -246,6 +246,7 @@ class OperationServiceV2:
             registration_purpose=payload.registration_purpose, regulated_products=payload.regulated_products
         )
         cls.set_registration_purpose(user_guid, operation.id, registration_payload)
+        cls.update_status(user_guid, operation.id, Operation.Statuses.DRAFT)
 
         return operation
 

--- a/bc_obps/service/tests/test_operation_service_v2.py
+++ b/bc_obps/service/tests/test_operation_service_v2.py
@@ -361,6 +361,7 @@ class TestOperationServiceV2:
         assert operation.updated_by is not None  # the operation is created first, and then we add the purpose
         # check purpose
         assert operation.registration_purposes.count() == 1
+        assert operation.status == Operation.Statuses.DRAFT
 
     @staticmethod
     def test_register_operation_information_existing_operation():
@@ -390,6 +391,7 @@ class TestOperationServiceV2:
         assert operation.updated_at is not None
         # check purpose
         assert operation.registration_purposes.count() == 1
+        assert operation.status == Operation.Statuses.DRAFT
 
 
 class TestOperationServiceV2CreateOrUpdateOperation:

--- a/bc_obps/service/tests/test_operation_service_v2.py
+++ b/bc_obps/service/tests/test_operation_service_v2.py
@@ -613,7 +613,9 @@ class TestOperationServiceV2UpdateOperation:
             operation.operator = approved_user_operator.operator
             operation.save()
 
-            OperationServiceV2.set_operation_status_to_registered(approved_user_operator.user.user_guid, operation.id)
+            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
+                approved_user_operator.user.user_guid, operation.id
+            )
 
             operation.refresh_from_db()
             assert operation.status == Operation.Statuses.REGISTERED
@@ -625,7 +627,9 @@ class TestOperationServiceV2UpdateOperation:
             operation.operator = approved_user_operator.operator
             operation.save()
 
-            OperationServiceV2.set_operation_status_to_registered(approved_user_operator.user.user_guid, operation.id)
+            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
+                approved_user_operator.user.user_guid, operation.id
+            )
 
             operation.refresh_from_db()
             assert operation.status == Operation.Statuses.REGISTERED
@@ -635,7 +639,7 @@ class TestOperationServiceV2UpdateOperation:
             operation = baker.make_recipe('utils.operation', status=Operation.Statuses.DRAFT)
 
             # we check if a user is authorized to update the status only after checking that all of the info is complete, so to test incomplete operations, we can use any user
-            OperationServiceV2.set_operation_status_to_registered(
+            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
                 baker.make_recipe('utils.industry_operator_user'), operation.id
             )
 
@@ -647,7 +651,7 @@ class TestOperationServiceV2UpdateOperation:
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
             operation.contacts.all().delete()
 
-            OperationServiceV2.set_operation_status_to_registered(
+            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
                 baker.make_recipe('utils.industry_operator_user'), operation.id
             )
 
@@ -662,7 +666,7 @@ class TestOperationServiceV2UpdateOperation:
             operation_rep.address = blank_address
             operation_rep.save()
 
-            OperationServiceV2.set_operation_status_to_registered(
+            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
                 baker.make_recipe('utils.industry_operator_user').user_guid, operation.id
             )
 
@@ -674,7 +678,7 @@ class TestOperationServiceV2UpdateOperation:
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
             FacilityDesignatedOperationTimeline.objects.filter(operation=operation).all().delete()
 
-            OperationServiceV2.set_operation_status_to_registered(
+            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
                 baker.make_recipe('utils.industry_operator_user'), operation.id
             )
 
@@ -686,7 +690,7 @@ class TestOperationServiceV2UpdateOperation:
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
             operation.activities.all().delete()
 
-            OperationServiceV2.set_operation_status_to_registered(
+            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
                 baker.make_recipe('utils.industry_operator_user'), operation.id
             )
 
@@ -699,7 +703,7 @@ class TestOperationServiceV2UpdateOperation:
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
             operation.documents.all().delete()
 
-            OperationServiceV2.set_operation_status_to_registered(
+            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
                 baker.make_recipe('utils.industry_operator_user'), operation.id
             )
 
@@ -714,7 +718,7 @@ class TestOperationServiceV2UpdateOperation:
                 type=DocumentType.objects.get(name='signed_statutory_declaration')
             ).all().delete()
 
-            OperationServiceV2.set_operation_status_to_registered(
+            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
                 baker.make_recipe('utils.industry_operator_user').user_guid, operation.id
             )
 
@@ -728,7 +732,7 @@ class TestOperationServiceV2UpdateOperation:
             operation.opted_in_operation = None
             operation.save()
 
-            OperationServiceV2.set_operation_status_to_registered(
+            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
                 baker.make_recipe('utils.industry_operator_user'), operation.id
             )
 
@@ -742,7 +746,7 @@ class TestOperationServiceV2UpdateOperation:
             operation.opted_in_operation = baker.make(OptedInOperationDetail)
             operation.save()
 
-            OperationServiceV2.set_operation_status_to_registered(
+            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
                 baker.make_recipe('utils.industry_operator_user'), operation.id
             )
 

--- a/bc_obps/service/tests/test_operation_service_v2.py
+++ b/bc_obps/service/tests/test_operation_service_v2.py
@@ -185,7 +185,22 @@ class TestOperationServiceV2:
         assert result[0] == users_unregistered_operation
 
     @staticmethod
-    def test_update_status():
+    def test_update_status_success():
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        users_operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
+        users_operation.operator=approved_user_operator.operator
+        users_operation.save()
+        
+        updated_operation = OperationServiceV2.update_status(
+            approved_user_operator.user.user_guid, users_operation.id, Operation.Statuses.REGISTERED
+        )
+        updated_operation.refresh_from_db()
+        assert updated_operation.status == Operation.Statuses.REGISTERED
+        assert updated_operation.updated_by == approved_user_operator.user
+        assert updated_operation.updated_at is not None
+
+    @staticmethod
+    def test_update_status_fail():
         approved_user_operator = baker.make_recipe('utils.approved_user_operator')
         users_operation = baker.make_recipe(
             'utils.operation', operator=approved_user_operator.operator, created_by=approved_user_operator.user
@@ -605,150 +620,138 @@ class TestOperationServiceV2UpdateOperation:
         assert operation.updated_at is not None
         assert operation.regulated_products.count() == 0
 
-    class TestCanRegister:
+    class TestRaiseExceptionIfOperationDataIncomplete:
         @staticmethod
-        def test_status_updated_if_data_complete_opt_in():
-            approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        def test_do_not_raise_exception_if_data_complete_opt_in():
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
-            operation.operator = approved_user_operator.operator
-            operation.save()
 
+            # test will pass if no exception raised
             OperationServiceV2.raise_exception_if_operation_missing_registration_information(
-                approved_user_operator.user.user_guid, operation.id
+                operation.id
             )
 
-            operation.refresh_from_db()
-            assert operation.status == Operation.Statuses.REGISTERED
 
         @staticmethod
-        def test_status_updated_if_data_complete_new_entrant():
-            approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        def test_do_not_raise_exception_if_data_complete_new_entrant():
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.NEW_ENTRANT_OPERATION)
-            operation.operator = approved_user_operator.operator
-            operation.save()
 
             OperationServiceV2.raise_exception_if_operation_missing_registration_information(
-                approved_user_operator.user.user_guid, operation.id
+                 operation.id
             )
 
-            operation.refresh_from_db()
-            assert operation.status == Operation.Statuses.REGISTERED
 
         @staticmethod
-        def test_does_not_update_status_if_no_purpose():
+        def test_raises_exception_if_no_purpose():
             operation = baker.make_recipe('utils.operation', status=Operation.Statuses.DRAFT)
 
-            # we check if a user is authorized to update the status only after checking that all of the info is complete, so to test incomplete operations, we can use any user
-            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
-                baker.make_recipe('utils.industry_operator_user'), operation.id
-            )
+            with pytest.raises(Exception):
+                OperationServiceV2.raise_exception_if_operation_missing_registration_information(
+                    operation.id
+                )
 
-            operation.refresh_from_db()
-            assert operation.status == Operation.Statuses.DRAFT
+            
 
         @staticmethod
-        def test_does_not_update_status_if_no_operation_rep():
+        def test_raises_exception_if_no_operation_rep():
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
             operation.contacts.all().delete()
 
-            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
-                baker.make_recipe('utils.industry_operator_user'), operation.id
-            )
+            with pytest.raises(Exception):
+                OperationServiceV2.raise_exception_if_operation_missing_registration_information(
+                    operation.id
+                )
 
-            operation.refresh_from_db()
-            assert operation.status == Operation.Statuses.DRAFT
+            
 
         @staticmethod
-        def test_does_not_update_status_if_incomplete_operation_rep():
+        def test_raises_exception_if_incomplete_operation_rep():
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
             blank_address = baker.make(Address)
             operation_rep = operation.contacts.all().filter(business_role__role_name='Operation Representative')[0]
             operation_rep.address = blank_address
             operation_rep.save()
 
-            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
-                baker.make_recipe('utils.industry_operator_user').user_guid, operation.id
-            )
+            with pytest.raises(Exception):
+                OperationServiceV2.raise_exception_if_operation_missing_registration_information(
+                    operation.id
+                )
 
-            operation.refresh_from_db()
-            assert operation.status == Operation.Statuses.DRAFT
+            
 
         @staticmethod
-        def test_does_not_update_status_if_no_facilities():
+        def test_raises_exception_if_no_facilities():
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
             FacilityDesignatedOperationTimeline.objects.filter(operation=operation).all().delete()
 
-            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
-                baker.make_recipe('utils.industry_operator_user'), operation.id
-            )
+            with pytest.raises(Exception):
+                OperationServiceV2.raise_exception_if_operation_missing_registration_information(
+                    operation.id
+                )
 
-            operation.refresh_from_db()
-            assert operation.status == Operation.Statuses.DRAFT
+            
 
         @staticmethod
-        def test_does_not_update_status_if_no_activities():
+        def test_raises_exception_if_no_activities():
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
             operation.activities.all().delete()
 
-            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
-                baker.make_recipe('utils.industry_operator_user'), operation.id
-            )
+            with pytest.raises(Exception):
+                OperationServiceV2.raise_exception_if_operation_missing_registration_information(
+                    operation.id
+                )
 
-            operation.refresh_from_db()
-            assert operation.status == Operation.Statuses.DRAFT
+            
 
         @staticmethod
-        def test_does_not_update_status_if_no_attachments():
+        def test_raises_exception_if_no_attachments():
 
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
             operation.documents.all().delete()
 
-            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
-                baker.make_recipe('utils.industry_operator_user'), operation.id
-            )
+            with pytest.raises(Exception):
+                OperationServiceV2.raise_exception_if_operation_missing_registration_information(
+                    operation.id
+                )
 
-            operation.refresh_from_db()
-            assert operation.status == Operation.Statuses.DRAFT
+            
 
         @staticmethod
-        def test_does_not_update_status_if_no_new_entrant_info():
+        def test_raises_exception_if_no_new_entrant_info():
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.NEW_ENTRANT_OPERATION)
             # remove statutory declaration
             operation.documents.filter(
                 type=DocumentType.objects.get(name='signed_statutory_declaration')
             ).all().delete()
 
-            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
-                baker.make_recipe('utils.industry_operator_user').user_guid, operation.id
-            )
-
-            operation.refresh_from_db()
-            assert operation.status == Operation.Statuses.DRAFT
+            with pytest.raises(Exception):
+                OperationServiceV2.raise_exception_if_operation_missing_registration_information(
+                    operation.id
+                )
+            
 
         @staticmethod
-        def test_does_not_update_status_if_no_opt_in_info():
+        def test_raises_exception_if_no_opt_in_info():
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
             # remove opted in information
             operation.opted_in_operation = None
             operation.save()
 
-            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
-                baker.make_recipe('utils.industry_operator_user'), operation.id
-            )
+            with pytest.raises(Exception):
+                OperationServiceV2.raise_exception_if_operation_missing_registration_information(
+                    operation.id
+                )
 
-            operation.refresh_from_db()
-            assert operation.status == Operation.Statuses.DRAFT
+            
 
         @staticmethod
-        def test_does_not_update_status_if_incomplete_opt_in_info():
+        def test_raises_exception_if_incomplete_opt_in_info():
             operation = set_up_valid_mock_operation(RegistrationPurpose.Purposes.OPTED_IN_OPERATION)
             # make the opt-in record blank
             operation.opted_in_operation = baker.make(OptedInOperationDetail)
             operation.save()
 
-            OperationServiceV2.raise_exception_if_operation_missing_registration_information(
-                baker.make_recipe('utils.industry_operator_user'), operation.id
-            )
-
-            operation.refresh_from_db()
-            assert operation.status == Operation.Statuses.DRAFT
+            with pytest.raises(Exception):
+                OperationServiceV2.raise_exception_if_operation_missing_registration_information(
+                    operation.id
+                )
+            

--- a/bciers/apps/registration/app/components/operations/registration/RegistrationSubmissionForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/RegistrationSubmissionForm.tsx
@@ -10,6 +10,7 @@ import {
 } from "apps/registration/app/components/operations/registration/types";
 import { IChangeEvent } from "@rjsf/core";
 import Success from "apps/registration/app/components/operations/registration/Success";
+import { OperationStatus } from "@bciers/utils/enums";
 
 // Check if all checkboxes are checked
 const allChecked = (formData: RegistrationSubmissionFormData) => {
@@ -47,7 +48,9 @@ const RegistrationSubmissionForm = ({
         setSubmitButtonDisabled(false);
         return { error: resolve.error };
       } else {
-        setIsSubmitted(true);
+        if (resolve.status === OperationStatus.REGISTERED) {
+          setIsSubmitted(true);
+        }
         return resolve;
       }
     });
@@ -62,7 +65,6 @@ const RegistrationSubmissionForm = ({
       ) : (
         <MultiStepBase
           allowBackNavigation
-          // baseUrl={`/register-an-operation/${operation}`}
           cancelUrl="/"
           formData={formState}
           onSubmit={handleSubmit}

--- a/bciers/apps/registration/app/components/operations/registration/RegistrationSubmissionForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/RegistrationSubmissionForm.tsx
@@ -10,7 +10,6 @@ import {
 } from "apps/registration/app/components/operations/registration/types";
 import { IChangeEvent } from "@rjsf/core";
 import Success from "apps/registration/app/components/operations/registration/Success";
-import { OperationStatus } from "@bciers/utils/enums";
 
 // Check if all checkboxes are checked
 const allChecked = (formData: RegistrationSubmissionFormData) => {
@@ -48,9 +47,7 @@ const RegistrationSubmissionForm = ({
         setSubmitButtonDisabled(false);
         return { error: resolve.error };
       } else {
-        if (resolve.status === OperationStatus.REGISTERED) {
-          setIsSubmitted(true);
-        }
+        setIsSubmitted(true);
         return resolve;
       }
     });


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=72007934

This PR:
- creates a service to only update the operation status if all the criteria are met
- lots of pytests
- bakers and helper functions for pytests
- design doesn't want an error shown on the FE (see the card's comments), so all I've done there is not show the confirmation message
- ^vitest for this

To test this PR, you can delete a bunch of the mock operation's data so it no longer meets the criteria. Or, create a new operation and edit the URL to go to the last page without filling out all the steps.

@Sepehr-Sobhani , I put in all the revisions and started updating the API tests but didn't finish. I also haven't done a manual check. -> Sep: ✅ 
