### PR TITLE
chore: add missing tests for activities form configs

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -10,7 +10,7 @@ sonar.python.version=3.12
 # Path is relative to the sonar-project.properties file. Defaults to .
 sonar.sources=.
 
-sonar.exclusions=**/Makefile, **/migrations/**, **bc_obps/registration1/tests/**, **/bciers/apps/registration1/tests/**, **/bciers/apps/registration1/e2e/**, **/bciers/apps/registration/tests/**,
+sonar.exclusions=**/Makefile, **/migrations/**, **bc_obps/registration1/tests/**, **/bciers/apps/registration1/tests/**, **/bciers/apps/registration1/e2e/**, **/bciers/apps/registration/tests/**, **/bc_obps/reporting/tests/models/program_configuration_tests/**,
 
 # Ignore duplication scanning for registration part 2 (will be removed once part 2 is merged into part 1)
 # Adding COAM as well for its middleware and middleware testing

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_carbonates_use_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_carbonates_use_2024.py
@@ -1,0 +1,55 @@
+from django.test import TestCase
+from django.db.models import Count
+from registration.models.activity import Activity
+from reporting.models.configuration import Configuration
+from reporting.models.configuration_element import ConfigurationElement
+
+
+class TestCarbonateUse2024(TestCase):
+    def testDataExists(self):
+        activity = Activity.objects.get(name='Carbonate use')
+        config = Configuration.objects.get(slug='2024')
+
+        config_elements = ConfigurationElement.objects.filter(
+            valid_from__lte=config, valid_to__gte=config, activity=activity
+        )
+
+        # For each gas, the list of methodologies and their associated field's count
+        gas_config = {
+            'CO2': {
+                'Calcination Fraction': 3,
+                'Mass of Output Carbonates': 4,
+                'Alternative Parameter Methodology': 1,
+                'Replacement Methodology': 1,
+            },
+        }
+
+        config = {'Carbonates used but not consumed in other activities set out in column 2': gas_config}
+
+        self.assertQuerysetEqual(
+            config_elements.values_list('source_type__name', flat=True).distinct(),
+            config.keys(),
+            ordered=False,
+            msg=f'{activity} contains config for the proper source types',
+        )
+
+        for source_type_name, gas_config in config.items():
+            self.assertQuerysetEqual(
+                config_elements.filter(source_type__name=source_type_name)
+                .values_list('gas_type__chemical_formula', flat=True)
+                .distinct(),
+                gas_config.keys(),
+                ordered=False,
+                msg=f'{source_type_name} contains config for the proper gas types',
+            )
+            for gas_name, methods in gas_config.items():
+                self.assertQuerysetEqual(
+                    config_elements.filter(source_type__name=source_type_name, gas_type__chemical_formula=gas_name)
+                    .annotate(field_count=Count('reporting_fields'))
+                    .values_list('methodology__name', 'field_count'),
+                    list(methods.items()),
+                    ordered=False,
+                    msg=f'{source_type_name}:{gas_name} contains config for the proper methods and field counts',
+                )
+
+        assert len(config_elements) == 4

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_fuel_combustion_mobile_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_fuel_combustion_mobile_2024.py
@@ -1,0 +1,69 @@
+from django.test import TestCase
+from django.db.models import Count
+from registration.models.activity import Activity
+from reporting.models.configuration import Configuration
+from reporting.models.configuration_element import ConfigurationElement
+
+
+class TestFuelCombustionMobile2024(TestCase):
+    def testDataExists(self):
+        activity = Activity.objects.get(name='Fuel combustion by mobile equipment')
+        config = Configuration.objects.get(slug='2024')
+
+        config_elements = ConfigurationElement.objects.filter(
+            valid_from__lte=config, valid_to__gte=config, activity=activity
+        )
+
+        # For each gas, the list of methodologies and their associated field's count
+        gas_config = {
+            'CO2': {
+                'Default EF': 1,
+                'Site-specific EF': 1,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+            'CH4': {
+                'Default EF': 1,
+                'Site-specific EF': 1,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+            'N2O': {
+                'Default EF': 1,
+                'Site-specific EF': 1,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+        }
+
+        config = {
+            'Fuel combustion by mobile equipment that is part of the facility': gas_config,
+        }
+
+        self.assertQuerysetEqual(
+            config_elements.values_list('source_type__name', flat=True).distinct(),
+            config.keys(),
+            ordered=False,
+            msg=f'{activity} contains config for the proper source types',
+        )
+
+        for source_type_name, gas_config in config.items():
+            self.assertQuerysetEqual(
+                config_elements.filter(source_type__name=source_type_name)
+                .values_list('gas_type__chemical_formula', flat=True)
+                .distinct(),
+                gas_config.keys(),
+                ordered=False,
+                msg=f'{source_type_name} contains config for the proper gas types',
+            )
+            for gas_name, methods in gas_config.items():
+                self.assertQuerysetEqual(
+                    config_elements.filter(source_type__name=source_type_name, gas_type__chemical_formula=gas_name)
+                    .annotate(field_count=Count('reporting_fields'))
+                    .values_list('methodology__name', 'field_count'),
+                    list(methods.items()),
+                    ordered=False,
+                    msg=f'{source_type_name}:{gas_name} contains config for the proper methods and field counts',
+                )
+
+        assert len(config_elements) == 12

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_gsc_excluding_line_tracing_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_gsc_excluding_line_tracing_2024.py
@@ -1,0 +1,82 @@
+from django.test import TestCase
+from django.db.models import Count
+from registration.models.activity import Activity
+from reporting.models.configuration import Configuration
+from reporting.models.configuration_element import ConfigurationElement
+
+
+class TestGSCExcludingLineTracing2024(TestCase):
+    def testDataExists(self):
+        activity = Activity.objects.get(name='General stationary combustion excluding line tracing')
+        config = Configuration.objects.get(slug='2024')
+
+        config_elements = ConfigurationElement.objects.filter(
+            valid_from__lte=config, valid_to__gte=config, activity=activity
+        )
+
+        # For each gas, the list of methodologies and their associated field's count
+        gas_config = {
+            'CO2': {
+                'Default HHV/Default EF': 2,
+                'Default EF': 1,
+                'Measured HHV/Default EF': 2,
+                'Measured Steam/Default EF': 3,
+                'Measured CC': 1,
+                'Measured Steam/Measured EF': 2,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+            'CH4': {
+                'Default HHV/Default EF': 2,
+                'Default EF': 1,
+                'Measured HHV/Default EF': 2,
+                'Measured EF': 1,
+                'Measured Steam/Default EF': 3,
+                'Heat Input/Default EF': 2,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+            'N2O': {
+                'Default HHV/Default EF': 2,
+                'Default EF': 1,
+                'Measured HHV/Default EF': 2,
+                'Measured EF': 1,
+                'Measured Steam/Default EF': 3,
+                'Heat Input/Default EF': 2,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+        }
+
+        config = {
+            'General stationary combustion of fuel or waste with production of useful energy': gas_config,
+            'General stationary combustion of waste without production of useful energy': gas_config,
+        }
+
+        self.assertQuerysetEqual(
+            config_elements.values_list('source_type__name', flat=True).distinct(),
+            config.keys(),
+            ordered=False,
+            msg=f'{activity} contains config for the proper source types',
+        )
+
+        for source_type_name, gas_config in config.items():
+            self.assertQuerysetEqual(
+                config_elements.filter(source_type__name=source_type_name)
+                .values_list('gas_type__chemical_formula', flat=True)
+                .distinct(),
+                gas_config.keys(),
+                ordered=False,
+                msg=f'{source_type_name} contains config for the proper gas types',
+            )
+            for gas_name, methods in gas_config.items():
+                self.assertQuerysetEqual(
+                    config_elements.filter(source_type__name=source_type_name, gas_type__chemical_formula=gas_name)
+                    .annotate(field_count=Count('reporting_fields'))
+                    .values_list('methodology__name', 'field_count'),
+                    list(methods.items()),
+                    ordered=False,
+                    msg=f'{source_type_name}:{gas_name} contains config for the proper methods and field counts',
+                )
+
+        assert len(config_elements) == 48

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_gsc_other_than_non_compression_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_gsc_other_than_non_compression_2024.py
@@ -1,0 +1,85 @@
+from django.test import TestCase
+from django.db.models import Count
+from registration.models.activity import Activity
+from reporting.models.configuration import Configuration
+from reporting.models.configuration_element import ConfigurationElement
+
+
+class TestGSCExcludingLineTracing2024(TestCase):
+    def testDataExists(self):
+        activity = Activity.objects.get(
+            name='General stationary combustion, other than non-compression and non-processing combustion'
+        )
+        config = Configuration.objects.get(slug='2024')
+
+        config_elements = ConfigurationElement.objects.filter(
+            valid_from__lte=config, valid_to__gte=config, activity=activity
+        )
+
+        # For each gas, the list of methodologies and their associated field's count
+        gas_config = {
+            'CO2': {
+                'Default HHV/Default EF': 2,
+                'Default EF': 1,
+                'Measured HHV/Default EF': 2,
+                'Measured Steam/Default EF': 3,
+                'Measured CC': 1,
+                'Measured Steam/Measured EF': 2,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+            'CH4': {
+                'Default HHV/Default EF': 2,
+                'Default EF': 1,
+                'Measured HHV/Default EF': 2,
+                'Measured EF': 1,
+                'Measured Steam/Default EF': 3,
+                'Heat Input/Default EF': 2,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+            'N2O': {
+                'Default HHV/Default EF': 2,
+                'Default EF': 1,
+                'Measured HHV/Default EF': 2,
+                'Measured EF': 1,
+                'Measured Steam/Default EF': 3,
+                'Heat Input/Default EF': 2,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+        }
+
+        config = {
+            'General stationary combustion of fuel or waste at a linear facilities operation resulting in the production of useful energy': gas_config,
+            'General stationary combustion of fuel or waste at a linear facilities operation not resulting in the production of useful energy': gas_config,
+            'Field gas or process vent gas combustion at a linear facilities operation': gas_config,
+        }
+
+        self.assertQuerysetEqual(
+            config_elements.values_list('source_type__name', flat=True).distinct(),
+            config.keys(),
+            ordered=False,
+            msg=f'{activity} contains config for the proper source types',
+        )
+
+        for source_type_name, gas_config in config.items():
+            self.assertQuerysetEqual(
+                config_elements.filter(source_type__name=source_type_name)
+                .values_list('gas_type__chemical_formula', flat=True)
+                .distinct(),
+                gas_config.keys(),
+                ordered=False,
+                msg=f'{source_type_name} contains config for the proper gas types',
+            )
+            for gas_name, methods in gas_config.items():
+                self.assertQuerysetEqual(
+                    config_elements.filter(source_type__name=source_type_name, gas_type__chemical_formula=gas_name)
+                    .annotate(field_count=Count('reporting_fields'))
+                    .values_list('methodology__name', 'field_count'),
+                    list(methods.items()),
+                    ordered=False,
+                    msg=f'{source_type_name}:{gas_name} contains config for the proper methods and field counts',
+                )
+
+        assert len(config_elements) == 72

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_gsc_solely_for_line_tracing_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_gsc_solely_for_line_tracing_2024.py
@@ -1,0 +1,82 @@
+from django.test import TestCase
+from django.db.models import Count
+from registration.models.activity import Activity
+from reporting.models.configuration import Configuration
+from reporting.models.configuration_element import ConfigurationElement
+
+
+class TestGSCExcludingLineTracing2024(TestCase):
+    def testDataExists(self):
+        activity = Activity.objects.get(name='General stationary combustion solely for the purpose of line tracing')
+        config = Configuration.objects.get(slug='2024')
+
+        config_elements = ConfigurationElement.objects.filter(
+            valid_from__lte=config, valid_to__gte=config, activity=activity
+        )
+
+        # For each gas, the list of methodologies and their associated field's count
+        gas_config = {
+            'CO2': {
+                'Default HHV/Default EF': 2,
+                'Default EF': 1,
+                'Measured HHV/Default EF': 2,
+                'Measured Steam/Default EF': 3,
+                'Measured CC': 1,
+                'Measured Steam/Measured EF': 2,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+            'CH4': {
+                'Default HHV/Default EF': 2,
+                'Default EF': 1,
+                'Measured HHV/Default EF': 2,
+                'Measured EF': 1,
+                'Measured Steam/Default EF': 3,
+                'Heat Input/Default EF': 2,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+            'N2O': {
+                'Default HHV/Default EF': 2,
+                'Default EF': 1,
+                'Measured HHV/Default EF': 2,
+                'Measured EF': 1,
+                'Measured Steam/Default EF': 3,
+                'Heat Input/Default EF': 2,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+        }
+
+        config = {
+            'General stationary combustion of fuel or waste with production of useful energy': gas_config,
+            'General stationary combustion of waste without production of useful energy': gas_config,
+        }
+
+        self.assertQuerysetEqual(
+            config_elements.values_list('source_type__name', flat=True).distinct(),
+            config.keys(),
+            ordered=False,
+            msg=f'{activity} contains config for the proper source types',
+        )
+
+        for source_type_name, gas_config in config.items():
+            self.assertQuerysetEqual(
+                config_elements.filter(source_type__name=source_type_name)
+                .values_list('gas_type__chemical_formula', flat=True)
+                .distinct(),
+                gas_config.keys(),
+                ordered=False,
+                msg=f'{source_type_name} contains config for the proper gas types',
+            )
+            for gas_name, methods in gas_config.items():
+                self.assertQuerysetEqual(
+                    config_elements.filter(source_type__name=source_type_name, gas_type__chemical_formula=gas_name)
+                    .annotate(field_count=Count('reporting_fields'))
+                    .values_list('methodology__name', 'field_count'),
+                    list(methods.items()),
+                    ordered=False,
+                    msg=f'{source_type_name}:{gas_name} contains config for the proper methods and field counts',
+                )
+
+        assert len(config_elements) == 48

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_refinery_fuel_gas_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_refinery_fuel_gas_2024.py
@@ -1,0 +1,77 @@
+from django.test import TestCase
+from django.db.models import Count
+from registration.models.activity import Activity
+from reporting.models.configuration import Configuration
+from reporting.models.configuration_element import ConfigurationElement
+
+
+class TestGSCExcludingLineTracing2024(TestCase):
+    def testDataExists(self):
+        activity = Activity.objects.get(name='Refinery fuel gas combustion')
+        config = Configuration.objects.get(slug='2024')
+
+        config_elements = ConfigurationElement.objects.filter(
+            valid_from__lte=config, valid_to__gte=config, activity=activity
+        )
+
+        # For each gas, the list of methodologies and their associated field's count
+        gas_config = {
+            'CO2': {
+                'CEMS': 0,
+                'Measured CC and MW': 3,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+            'CH4': {
+                'Default HHV/Default EF': 2,
+                'Default EF': 1,
+                'Measured HHV/Default EF': 2,
+                'Measured EF': 1,
+                'Measured Steam/Default EF': 3,
+                'Heat Input/Default EF': 2,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+            'N2O': {
+                'Default HHV/Default EF': 2,
+                'Default EF': 1,
+                'Measured HHV/Default EF': 2,
+                'Measured EF': 1,
+                'Measured Steam/Default EF': 3,
+                'Heat Input/Default EF': 2,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            },
+        }
+
+        config = {
+            'Combustion of refinery fuel gas, still gas, flexigas or associated gas': gas_config,
+        }
+
+        self.assertQuerysetEqual(
+            config_elements.values_list('source_type__name', flat=True).distinct(),
+            config.keys(),
+            ordered=False,
+            msg=f'{activity} contains config for the proper source types',
+        )
+
+        for source_type_name, gas_config in config.items():
+            self.assertQuerysetEqual(
+                config_elements.filter(source_type__name=source_type_name)
+                .values_list('gas_type__chemical_formula', flat=True)
+                .distinct(),
+                gas_config.keys(),
+                ordered=False,
+                msg=f'{source_type_name} contains config for the proper gas types',
+            )
+            for gas_name, methods in gas_config.items():
+                self.assertQuerysetEqual(
+                    config_elements.filter(source_type__name=source_type_name, gas_type__chemical_formula=gas_name)
+                    .annotate(field_count=Count('reporting_fields'))
+                    .values_list('methodology__name', 'field_count'),
+                    list(methods.items()),
+                    ordered=False,
+                    msg=f'{source_type_name}:{gas_name} contains config for the proper methods and field counts',
+                )
+
+        assert len(config_elements) == 20


### PR DESCRIPTION
Addresses bcgov/cas-reporting#330 | [project link](https://github.com/orgs/bcgov/projects/123/views/1?pane=issue&itemId=78665449). Adds tests for activities that were previously missing. 

## Changes 🚧

- Python tests added for 
  - Carbonates Use
  - Mobile fuel combustion
  - GSC excluding line tracing
  - GSC other than non-compression
  - GSC solely for line tracing
  - Refinery fuel gas

## To test 🔬

- In the `/bc-obps` directory, start your DB (`make start_pg`) and Django (`make run`).
- Run `make pytest` and ensure tests pass. 