### PR TITLE
1879 edit operation

### DIFF
--- a/bc_obps/common/management/commands/load_fixtures.py
+++ b/bc_obps/common/management/commands/load_fixtures.py
@@ -47,6 +47,7 @@ class Command(BaseCommand):
                 f'{fixture_base_dir}/transfer_event.json',
                 f'{fixture_base_dir}/parent_operator.json',
                 f'{fixture_base_dir}/partner_operator.json',
+                f'{fixture_base_dir}/registration_purpose.json',
             ]
 
         for fixture in fixtures:

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
@@ -6,10 +6,9 @@ from registration.schema.v2.operation import (
     OperationInformationIn,
     OperationUpdateOut,
     OperationRegistrationSubmissionIn,
-    OperationStatutoryDeclarationIn,
 )
 from service.operation_service_v2 import OperationServiceV2
-from registration.constants import OPERATION_TAGS, V2
+from registration.constants import V2
 from common.permissions import authorize
 from registration.api.utils.current_user_utils import get_current_user_guid
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -17,7 +16,6 @@ from registration.models import Operation
 from registration.decorators import handle_http_errors
 from registration.api.router import router
 from registration.schema.generic import Message
-from ninja.responses import codes_4xx
 
 
 ##### PUT #####
@@ -36,22 +34,6 @@ def register_edit_operation_information(
     request: HttpRequest, operation_id: UUID, payload: OperationInformationIn
 ) -> Tuple[Literal[200], Operation]:
     return 200, OperationServiceV2.register_operation_information(get_current_user_guid(request), operation_id, payload)
-
-
-@router.put(
-    "/v2/operations/{operation_id}/registration/statutory-declaration",
-    response={200: OperationUpdateOut, codes_4xx: Message},
-    tags=OPERATION_TAGS,
-    description="Creates or replaces a statutory declaration document for an Operation",
-    auth=authorize("approved_industry_user"),
-)
-@handle_http_errors()
-def create_or_replace_statutory_declarations(
-    request: HttpRequest, operation_id: UUID, payload: OperationStatutoryDeclarationIn
-) -> Tuple[Literal[200], Operation]:
-    return 200, OperationServiceV2.create_or_replace_statutory_declaration(
-        get_current_user_guid(request), operation_id, payload
-    )
 
 
 @router.patch(

--- a/bc_obps/registration/api/v2/_operations/operation_id.py
+++ b/bc_obps/registration/api/v2/_operations/operation_id.py
@@ -59,4 +59,4 @@ def get_operation_with_documents(request: HttpRequest, operation_id: UUID) -> Tu
 def update_operation_v2(
     request: HttpRequest, operation_id: UUID, payload: OperationInformationIn
 ) -> Tuple[Literal[200], Operation]:
-    return 200, OperationServiceV2.create_or_update_operation_v2(get_current_user_guid(request), payload, operation_id)
+    return 200, OperationServiceV2.update_operation(get_current_user_guid(request), payload, operation_id)

--- a/bc_obps/registration/api/v2/_operations/operation_id.py
+++ b/bc_obps/registration/api/v2/_operations/operation_id.py
@@ -1,10 +1,11 @@
 from typing import Literal, Tuple
 from uuid import UUID
-from registration.schema.v2.operation import OperationOutV2
+from registration.schema.v2.operation import OperationOutV2, OperationInformationIn
 from common.permissions import authorize
 from django.http import HttpRequest
 from registration.constants import OPERATION_TAGS
 from service.operation_service import OperationService
+from service.operation_service_v2 import OperationServiceV2
 from registration.api.utils.current_user_utils import get_current_user_guid
 from registration.decorators import handle_http_errors
 from registration.api.router import router
@@ -29,3 +30,21 @@ from ninja.responses import codes_4xx
 @handle_http_errors()
 def get_operation_v2(request: HttpRequest, operation_id: UUID) -> Tuple[Literal[200], Operation]:
     return 200, OperationService.get_if_authorized(get_current_user_guid(request), operation_id)
+
+
+##### PUT ######
+
+
+@router.put(
+    # TODO: solve the naming conflict and remove /update/ from the path
+    "/v2/operations/update/{operation_id}",
+    response={200: OperationOutV2, codes_4xx: Message},
+    tags=OPERATION_TAGS,
+    description="Updates the details of a specific operation by its ID.",
+    auth=authorize("approved_industry_user"),
+)
+@handle_http_errors()
+def update_operation_v2(
+    request: HttpRequest, operation_id: UUID, payload: OperationInformationIn
+) -> Tuple[Literal[200], Operation]:
+    return 200, OperationServiceV2.create_or_update_operation_v2(get_current_user_guid(request), payload, operation_id)

--- a/bc_obps/registration/api/v2/_operations/operation_id.py
+++ b/bc_obps/registration/api/v2/_operations/operation_id.py
@@ -49,7 +49,6 @@ def get_operation_with_documents(request: HttpRequest, operation_id: UUID) -> Tu
 
 
 @router.put(
-    # TODO: solve the naming conflict and remove /update/ from the path
     "/v2/operations/{uuid:operation_id}",
     response={200: OperationOutV2, codes_4xx: Message},
     tags=OPERATION_TAGS,

--- a/bc_obps/registration/api/v2/_operations/operation_id.py
+++ b/bc_obps/registration/api/v2/_operations/operation_id.py
@@ -1,6 +1,6 @@
 from typing import Literal, Tuple
 from uuid import UUID
-from registration.schema.v2.operation import OperationOutV2, OperationInformationIn
+from registration.schema.v2.operation import OperationOutV2, OperationInformationIn, OperationOutWithDocuments
 from common.permissions import authorize
 from django.http import HttpRequest
 from registration.constants import OPERATION_TAGS
@@ -32,12 +32,25 @@ def get_operation_v2(request: HttpRequest, operation_id: UUID) -> Tuple[Literal[
     return 200, OperationService.get_if_authorized(get_current_user_guid(request), operation_id)
 
 
+@router.get(
+    "/v2/operations/{uuid:operation_id}/with-documents",
+    response={200: OperationOutWithDocuments, codes_4xx: Message},
+    tags=OPERATION_TAGS,
+    description="""Retrieves the details of a specific operation by its ID along with it's documents""",
+    exclude_none=True,
+    auth=authorize("approved_authorized_roles"),
+)
+@handle_http_errors()
+def get_operation_with_documents(request: HttpRequest, operation_id: UUID) -> Tuple[Literal[200], Operation]:
+    return 200, OperationService.get_if_authorized(get_current_user_guid(request), operation_id)
+
+
 ##### PUT ######
 
 
 @router.put(
     # TODO: solve the naming conflict and remove /update/ from the path
-    "/v2/operations/update/{operation_id}",
+    "/v2/operations/{uuid:operation_id}",
     response={200: OperationOutV2, codes_4xx: Message},
     tags=OPERATION_TAGS,
     description="Updates the details of a specific operation by its ID.",

--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -243,6 +243,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "df62d793-8cfe-4272-a93e-ea9c9139ff82",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],
@@ -260,6 +261,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "c5b3643b-c143-42f3-8a2b-03ccc7319cd9",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],
@@ -278,6 +280,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "954c0382-ff61-4e87-a8a0-873586534b54",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],
@@ -296,6 +299,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "6d07d02a-1ad2-46ed-ad56-2f84313e98bf",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],
@@ -314,6 +318,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "59d95661-c752-489b-9fd1-0c3fa3454dda",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],
@@ -332,6 +337,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "1bd04128-d070-4d3a-940a-0874c4956181",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],
@@ -350,6 +356,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "17f13f4d-29b4-45f4-b025-b21f2e126771",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],
@@ -367,6 +374,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "ef9044dd-2a27-4d26-86fe-02e51e0755f7",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],
@@ -383,6 +391,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "aeeb781e-a97b-4ab2-9a6e-02e4522add1a",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],
@@ -399,6 +408,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "02a3ab84-26c6-4a79-bf89-72f877ceef8e",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],
@@ -431,6 +441,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "0ac72fa9-2636-4f54-b378-af6b1a070787",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],

--- a/bc_obps/registration/fixtures/mock/registration_purpose.json
+++ b/bc_obps/registration/fixtures/mock/registration_purpose.json
@@ -1,0 +1,66 @@
+[
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 1,
+    "fields": {
+      "registration_purpose": "OBPS Regulated Operation",
+      "operation_id": "e1300fd7-2dee-47d1-b655-2ad3fd10f052"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 2,
+    "fields": {
+      "registration_purpose": "Reporting Operation",
+      "operation_id": "e1300fd7-2dee-47d1-b655-2ad3fd10f052"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 3,
+    "fields": {
+      "registration_purpose": "OBPS Regulated Operation",
+      "operation_id": "002d5a9e-32a6-4191-938c-2c02bfec592d"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 4,
+    "fields": {
+      "registration_purpose": "Reporting Operation",
+      "operation_id": "002d5a9e-32a6-4191-938c-2c02bfec592d"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 5,
+    "fields": {
+      "registration_purpose": "New Entrant Operation",
+      "operation_id": "002d5a9e-32a6-4191-938c-2c02bfec592d"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 6,
+    "fields": {
+      "registration_purpose": "OBPS Regulated Operation",
+      "operation_id": "3b5b95ea-2a1a-450d-8e2e-2e15feed96c9"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 7,
+    "fields": {
+      "registration_purpose": "Reporting Operation",
+      "operation_id": "3b5b95ea-2a1a-450d-8e2e-2e15feed96c9"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 8,
+    "fields": {
+      "registration_purpose": "Opted-in Operation",
+      "operation_id": "3b5b95ea-2a1a-450d-8e2e-2e15feed96c9"
+    }
+  }
+]

--- a/bc_obps/registration/fixtures/mock/registration_purpose.json
+++ b/bc_obps/registration/fixtures/mock/registration_purpose.json
@@ -4,7 +4,7 @@
     "pk": 1,
     "fields": {
       "registration_purpose": "OBPS Regulated Operation",
-      "operation_id": "e1300fd7-2dee-47d1-b655-2ad3fd10f052"
+      "operation_id": "c0743c09-82fa-4186-91aa-4b5412e3415c"
     }
   },
   {
@@ -12,7 +12,7 @@
     "pk": 2,
     "fields": {
       "registration_purpose": "Reporting Operation",
-      "operation_id": "e1300fd7-2dee-47d1-b655-2ad3fd10f052"
+      "operation_id": "c0743c09-82fa-4186-91aa-4b5412e3415c"
     }
   },
   {
@@ -20,7 +20,7 @@
     "pk": 3,
     "fields": {
       "registration_purpose": "OBPS Regulated Operation",
-      "operation_id": "002d5a9e-32a6-4191-938c-2c02bfec592d"
+      "operation_id": "1bd04128-d070-4d3a-940a-0874c4956181"
     }
   },
   {
@@ -28,7 +28,7 @@
     "pk": 4,
     "fields": {
       "registration_purpose": "Reporting Operation",
-      "operation_id": "002d5a9e-32a6-4191-938c-2c02bfec592d"
+      "operation_id": "1bd04128-d070-4d3a-940a-0874c4956181"
     }
   },
   {
@@ -36,7 +36,7 @@
     "pk": 5,
     "fields": {
       "registration_purpose": "New Entrant Operation",
-      "operation_id": "002d5a9e-32a6-4191-938c-2c02bfec592d"
+      "operation_id": "1bd04128-d070-4d3a-940a-0874c4956181"
     }
   },
   {
@@ -61,6 +61,94 @@
     "fields": {
       "registration_purpose": "Opted-in Operation",
       "operation_id": "3b5b95ea-2a1a-450d-8e2e-2e15feed96c9"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 9,
+    "fields": {
+      "registration_purpose": "OBPS Regulated Operation",
+      "operation_id": "17f13f4d-29b4-45f4-b025-b21f2e126771"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 10,
+    "fields": {
+      "registration_purpose": "Reporting Operation",
+      "operation_id": "1bd04128-d070-4d3a-940a-0874c4956181"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 11,
+    "fields": {
+      "registration_purpose": "OBPS Regulated Operation",
+      "operation_id": "aeeb781e-a97b-4ab2-9a6e-02e4522add1a"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 12,
+    "fields": {
+      "registration_purpose": "Reporting Operation",
+      "operation_id": "02a3ab84-26c6-4a79-bf89-72f877ceef8e"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 13,
+    "fields": {
+      "registration_purpose": "OBPS Regulated Operation",
+      "operation_id": "0ac72fa9-2636-4f54-b378-af6b1a070787"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 14,
+    "fields": {
+      "registration_purpose": "Reporting Operation",
+      "operation_id": "df62d793-8cfe-4272-a93e-ea9c9139ff82"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 15,
+    "fields": {
+      "registration_purpose": "OBPS Regulated Operation",
+      "operation_id": "c5b3643b-c143-42f3-8a2b-03ccc7319cd9"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 16,
+    "fields": {
+      "registration_purpose": "OBPS Regulated Operation",
+      "operation_id": "954c0382-ff61-4e87-a8a0-873586534b54"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 14,
+    "fields": {
+      "registration_purpose": "Reporting Operation",
+      "operation_id": "ef9044dd-2a27-4d26-86fe-02e51e0755f7"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 15,
+    "fields": {
+      "registration_purpose": "Reporting Operation",
+      "operation_id": "59d95661-c752-489b-9fd1-0c3fa3454dda"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 14,
+    "fields": {
+      "registration_purpose": "Reporting Operation",
+      "operation_id": "6d07d02a-1ad2-46ed-ad56-2f84313e98bf"
     }
   }
 ]

--- a/bc_obps/registration/fixtures/mock/registration_purpose.json
+++ b/bc_obps/registration/fixtures/mock/registration_purpose.json
@@ -11,7 +11,7 @@
     "model": "registration.registrationpurpose",
     "pk": 2,
     "fields": {
-      "registration_purpose": "Reporting Operation",
+      "registration_purpose": "Potential Reporting Operation",
       "operation_id": "c0743c09-82fa-4186-91aa-4b5412e3415c"
     }
   },
@@ -59,7 +59,7 @@
     "model": "registration.registrationpurpose",
     "pk": 8,
     "fields": {
-      "registration_purpose": "Opted-in Operation",
+      "registration_purpose": "Electricity Import Operation",
       "operation_id": "3b5b95ea-2a1a-450d-8e2e-2e15feed96c9"
     }
   },
@@ -149,6 +149,22 @@
     "fields": {
       "registration_purpose": "Reporting Operation",
       "operation_id": "6d07d02a-1ad2-46ed-ad56-2f84313e98bf"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 15,
+    "fields": {
+      "registration_purpose": "Potential Reporting Operation",
+      "operation_id": "df62d793-8cfe-4272-a93e-ea9c9139ff82"
+    }
+  },
+  {
+    "model": "registration.registrationpurpose",
+    "pk": 16,
+    "fields": {
+      "registration_purpose": "Electricity Import Operation",
+      "operation_id": "c5b3643b-c143-42f3-8a2b-03ccc7319cd9"
     }
   }
 ]

--- a/bc_obps/registration/models/operation.py
+++ b/bc_obps/registration/models/operation.py
@@ -191,6 +191,27 @@ class Operation(TimeStampedModel):
             .first()
         )  # filter returns a queryset, so we use .first() to get the single record (there will only ever be one statutory declaration per operation)
 
+    def get_boundary_map(self) -> Optional[Document]:
+        """
+        Returns the boundary map document associated with the operation.
+        """
+
+        return self.documents.filter(type=DocumentType.objects.get(name="boundary_map")).only('file').first()
+
+    def get_process_flow_diagram(self) -> Optional[Document]:
+        """
+        Returns the process flow diagram document associated with the operation.
+        """
+
+        return self.documents.filter(type=DocumentType.objects.get(name="process_flow_diagram")).only('file').first()
+
+    def get_equipment_list(self) -> Optional[Document]:
+        """
+        Returns the equipment list document associated with the operation.
+        """
+
+        return self.documents.filter(type=DocumentType.objects.get(name="equipment_list")).only('file').first()
+
     def user_has_access(self, user_guid: UUID) -> bool:
         """
         Returns whether a user has access to the operation.

--- a/bc_obps/registration/schema/v1/multiple_operator.py
+++ b/bc_obps/registration/schema/v1/multiple_operator.py
@@ -25,7 +25,7 @@ class MultipleOperatorOut(ModelSchema):
 
     @staticmethod
     def resolve_mo_is_extraprovincial_company(mo: MultipleOperator) -> bool:
-        return mo.bc_corporate_registry_number is not None
+        return mo.bc_corporate_registry_number is None
 
     class Meta:
         model = MultipleOperator

--- a/bc_obps/registration/schema/v1/multiple_operator.py
+++ b/bc_obps/registration/schema/v1/multiple_operator.py
@@ -1,7 +1,5 @@
 from typing import Optional
 from ninja import Field, ModelSchema
-from common.constants import AUDIT_FIELDS
-from registration.constants import BC_CORPORATE_REGISTRY_REGEX
 from registration.models import MultipleOperator
 
 
@@ -10,41 +8,25 @@ class MultipleOperatorOut(ModelSchema):
     Schema for the MultipleOperator model
     """
 
+    mo_is_extraprovincial_company: bool
     mo_legal_name: str = Field(..., alias="legal_name")
     mo_trade_name: str = Field(..., alias="trade_name")
     mo_cra_business_number: int = Field(..., alias="cra_business_number")
-    mo_bc_corporate_registry_number: str = Field(
-        ..., alias="bc_corporate_registry_number", regex=BC_CORPORATE_REGISTRY_REGEX
-    )  # type: ignore[call-arg]
+    mo_bc_corporate_registry_number: Optional[str] = Field(None, alias="bc_corporate_registry_number")
     mo_business_structure: str = Field(..., alias="business_structure")
-    mo_website: Optional[str] = Field("", alias="website")
-    mo_percentage_ownership: Optional[float] = Field(None, alias="percentage_ownership")
-    mo_physical_street_address: str = Field(..., alias="physical_address.street_address")
-    mo_physical_municipality: str = Field(..., alias="physical_address.municipality")
-    mo_physical_province: str = Field(..., alias="physical_address.province")
-    mo_physical_postal_code: str = Field(..., alias="physical_address.postal_code")
-    mo_mailing_address_same_as_physical: Optional[bool] = Field(False, alias="mailing_address_same_as_physical")
-    mo_mailing_street_address: Optional[str] = Field(None, alias="mailing_address.street_address")
-    mo_mailing_municipality: Optional[str] = Field(None, alias="mailing_address.municipality")
-    mo_mailing_province: Optional[str] = Field(None, alias="mailing_address.province")
-    mo_mailing_postal_code: Optional[str] = Field(None, alias="mailing_address.postal_code")
+    mo_attorney_street_address: Optional[str] = Field(None, alias="attorney_address.street_address")
+    mo_municipality: Optional[str] = Field(None, alias="attorney_address.municipality")
+    mo_province: Optional[str] = Field(None, alias="attorney_address.province")
+    mo_postal_code: Optional[str] = Field(None, alias="attorney_address.postal_code")
 
     @staticmethod
     def resolve_business_structure(mo: MultipleOperator) -> str:
         return mo.business_structure.name  # type: ignore # we know that business_structure is not None
 
+    @staticmethod
+    def resolve_mo_is_extraprovincial_company(mo: MultipleOperator) -> bool:
+        return mo.bc_corporate_registry_number is not None
+
     class Meta:
         model = MultipleOperator
-        exclude = [
-            *AUDIT_FIELDS,
-            # exclude the following fields since they are handled by the aliases above
-            "legal_name",
-            "trade_name",
-            "cra_business_number",
-            "bc_corporate_registry_number",
-            "business_structure",
-            "physical_address",
-            "mailing_address",
-            "percentage_ownership",
-            "website",
-        ]
+        fields = ["id"]

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -31,8 +31,8 @@ class OperationRepresentativeIn(Schema):
     new_operation_representatives: Optional[List[ContactIn]] = []
 
 
-class OperationInformationIn(Schema):
-    registration_purpose: Optional[str] = None
+class OperationInformationIn(ModelSchema):
+    registration_purpose: Optional[RegistrationPurpose.Purposes] = None
     regulated_products: Optional[list] = None
     activities: list[int]
     boundary_map: str
@@ -221,5 +221,4 @@ class OperationStatutoryDeclarationOut(ModelSchema):
 
     class Meta:
         model = Operation
-        fields = ['id', 'name']
         fields = ['id', 'name']

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -31,7 +31,7 @@ class OperationRepresentativeIn(Schema):
     new_operation_representatives: Optional[List[ContactIn]] = []
 
 
-class OperationInformationIn(ModelSchema):
+class OperationInformationIn(Schema):
     registration_purpose: Optional[str] = None
     regulated_products: Optional[list] = None
     activities: list[int]
@@ -70,6 +70,9 @@ class OperationOutV2(ModelSchema):
     bc_obps_regulated_operation: Optional[str] = Field(None, alias="bc_obps_regulated_operation.id")
     operator: Optional[OperatorForOperationOut] = None
     multiple_operators_array: Optional[List[MultipleOperatorIn]] = None
+    boundary_map: Optional[str] = None
+    process_flow_diagram: Optional[str] = None
+    equipment_list: Optional[str] = None
     registration_purposes: Optional[list] = []
 
     @staticmethod

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -2,9 +2,10 @@ from uuid import UUID
 from typing import List, Optional
 from registration.schema.v1.operator import OperatorForOperationOut
 from registration.schema.v1.contact import ContactIn
+from registration.schema.v1.multiple_operator import MultipleOperatorOut
 from registration.schema.v2.multiple_operator import MultipleOperatorIn
 from ninja import Field, FilterSchema, ModelSchema, Schema
-from registration.models import Operation
+from registration.models import MultipleOperator, Operation
 from registration.models.opted_in_operation_detail import OptedInOperationDetail
 from registration.models.registration_purpose import RegistrationPurpose
 from pydantic import field_validator
@@ -69,15 +70,24 @@ class OperationOutV2(ModelSchema):
     tertiary_naics_code_id: Optional[int] = Field(None, alias="tertiary_naics_code.id")
     bc_obps_regulated_operation: Optional[str] = Field(None, alias="bc_obps_regulated_operation.id")
     operator: Optional[OperatorForOperationOut] = None
-    multiple_operators_array: Optional[List[MultipleOperatorIn]] = None
     boundary_map: Optional[str] = None
     process_flow_diagram: Optional[str] = None
     equipment_list: Optional[str] = None
     registration_purposes: Optional[list] = []
+    multiple_operators_array: Optional[List[MultipleOperatorOut]] = []
+    operation_has_multiple_operators: Optional[bool] = False
 
     @staticmethod
     def resolve_registration_purposes(obj: Operation) -> List[str]:
         return list(obj.registration_purposes.all().values_list('registration_purpose', flat=True))
+
+    @staticmethod
+    def resolve_multiple_operators_array(obj: Operation) -> List[MultipleOperator]:
+        return list(obj.multiple_operators.all())
+
+    @staticmethod
+    def resolve_operation_has_multiple_operators(obj: Operation) -> bool:
+        return obj.multiple_operators.exists()
 
     @staticmethod
     def resolve_operator(obj: Operation, context: DictStrAny) -> Optional[Operator]:

--- a/bc_obps/registration/tests/endpoints/v2/_operations/test_operation_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/test_operation_id.py
@@ -4,9 +4,11 @@ from localflavor.ca.models import CAPostalCodeField
 from registration.models import (
     UserOperator,
 )
+from registration.tests.constants import MOCK_DATA_URL
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.tests.utils.bakers import operation_baker, operator_baker, user_operator_baker
 from registration.utils import custom_reverse_lazy
+import json
 
 baker.generators.add(CAPostalCodeField, TestUtils.mock_postal_code)
 
@@ -16,6 +18,20 @@ fake_timestamp_from_past_str_format = '%Y-%m-%d %H:%M:%S.%f%z'
 
 class TestOperationIdEndpoint(CommonTestSetup):
     endpoint = CommonTestSetup.base_endpoint + "operations"
+
+    test_payload = {
+        "registration_purpose": "Reporting Operation",
+        "regulated_products": [1],
+        "name": "op name",
+        "type": "SFO",
+        "naics_code_id": 1,
+        "secondary_naics_code_id": 2,
+        "tertiary_naics_code_id": 3,
+        "activities": [1],
+        "boundary_map": MOCK_DATA_URL,
+        "process_flow_diagram": MOCK_DATA_URL,
+        "equipment_list": MOCK_DATA_URL,
+    }
 
     def test_operations_endpoint_unauthorized_users_cannot_get(self):
         operation_instance_1 = operation_baker()
@@ -47,6 +63,73 @@ class TestOperationIdEndpoint(CommonTestSetup):
         )
         assert response.status_code == 401
 
+    def test_operations_with_documents_endpoint_unauthorized_users_cannot_get(self):
+        operation_instance_1 = operation_baker()
+        # /operations/{operation_id}/with-documents
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "cas_pending",
+            custom_reverse_lazy("get_operation_with_documents", kwargs={"operation_id": operation_instance_1.id}),
+        )
+        assert response.status_code == 401
+
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "industry_user",
+            custom_reverse_lazy("get_operation_with_documents", kwargs={"operation_id": operation_instance_1.id}),
+        )
+        assert response.status_code == 401
+
+        # unapproved industry users can't get
+        user_operator_instance = user_operator_baker()
+        user_operator_instance.status = UserOperator.Statuses.PENDING
+        user_operator_instance.user_id = self.user.user_guid
+        user_operator_instance.save()
+
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "industry_user",
+            custom_reverse_lazy("get_operation_with_documents", kwargs={"operation_id": operation_instance_1.id}),
+        )
+        assert response.status_code == 401
+
+    def test_operations_endpoint_unauthorized_users_cannot_put(self):
+        operation_instance_1 = operation_baker()
+
+        # /operations/{operation_id}
+        response = TestUtils.mock_put_with_auth_role(
+            self,
+            "cas_pending",
+            self.content_type,
+            json.dumps(self.test_payload),
+            custom_reverse_lazy("update_operation_v2", kwargs={"operation_id": operation_instance_1.id}),
+        )
+        assert response.status_code == 401
+
+        response = TestUtils.mock_put_with_auth_role(
+            self,
+            "industry_user",
+            self.content_type,
+            json.dumps(self.test_payload),
+            custom_reverse_lazy("update_operation_v2", kwargs={"operation_id": operation_instance_1.id}),
+        )
+        assert response.status_code == 401
+
+        # unapproved industry users can't put
+        user_operator_instance = user_operator_baker()
+        user_operator_instance.status = UserOperator.Statuses.PENDING
+        user_operator_instance.user_id = self.user.user_guid
+        user_operator_instance.save()
+
+        response = TestUtils.mock_put_with_auth_role(
+            self,
+            "industry_user",
+            self.content_type,
+            json.dumps(self.test_payload),
+            custom_reverse_lazy("update_operation_v2", kwargs={"operation_id": operation_instance_1.id}),
+        )
+        assert response.status_code == 401
+
     def test_industry_users_can_only_get_their_own_operations(self):
         random_operator = operator_baker()
         the_users_operator = operator_baker()
@@ -71,6 +154,34 @@ class TestOperationIdEndpoint(CommonTestSetup):
         )
         assert response_2.status_code == 401
 
+    def test_industry_users_can_only_get_their_own_operations_with_documents(self):
+        random_operator = operator_baker()
+        the_users_operator = operator_baker()
+        user_operator = baker.make(
+            UserOperator,
+            user_id=self.user.user_guid,
+            status=UserOperator.Statuses.APPROVED,
+            operator=the_users_operator,
+        )
+
+        random_operation = operation_baker(random_operator.id)
+        users_operation = operation_baker(user_operator.operator.id)
+
+        response_1 = TestUtils.mock_get_with_auth_role(
+            self,
+            "industry_user",
+            custom_reverse_lazy("get_operation_with_documents", kwargs={"operation_id": users_operation.id}),
+        )
+
+        assert response_1.status_code == 200
+
+        response_2 = TestUtils.mock_get_with_auth_role(
+            self,
+            "industry_user",
+            custom_reverse_lazy("get_operation_with_documents", kwargs={"operation_id": random_operation.id}),
+        )
+        assert response_2.status_code == 401
+
     def test_operations_endpoint_get_success(self):
         approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
         operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
@@ -82,3 +193,29 @@ class TestOperationIdEndpoint(CommonTestSetup):
         response_data = response.json()
         assert response_data.get("id") == str(operation.id)
         assert response_data.get("registration_purposes") == ['Potential Reporting Operation']
+
+    def test_operations_with_documents_endpoint_get_success(self):
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "cas_admin",
+            custom_reverse_lazy("get_operation_with_documents", kwargs={"operation_id": operation.id}),
+        )
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data.get("id") == str(operation.id)
+
+    def test_operations_endpoint_put_success(self):
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        response = TestUtils.mock_put_with_auth_role(
+            self,
+            "industry_user",
+            self.content_type,
+            json.dumps(self.test_payload),
+            custom_reverse_lazy("update_operation_v2", kwargs={"operation_id": operation.id}),
+        )
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data.get("id") == str(operation.id)

--- a/bc_obps/service/operation_service_v2.py
+++ b/bc_obps/service/operation_service_v2.py
@@ -302,6 +302,8 @@ class OperationServiceV2:
         )
 
         if payload.regulated_products:
+            # We should add a conditional to check registration_purpose type here
+            # At the time of implementation there are some changes to registration_purpose coming from the business area
             operation.regulated_products.set(payload.regulated_products)
             operation.set_create_or_update(user_guid)
         return operation

--- a/bc_obps/service/operation_service_v2.py
+++ b/bc_obps/service/operation_service_v2.py
@@ -284,3 +284,24 @@ class OperationServiceV2:
         for old_multiple in old_multiple_operators:
             if old_multiple not in new_multiple_operators:
                 old_multiple.set_archive(user_guid)
+
+    @classmethod
+    @transaction.atomic()
+    def update_operation(
+        cls,
+        user_guid: UUID,
+        payload: OperationInformationIn,
+        operation_id: UUID,
+    ) -> Operation:
+        OperationService.get_if_authorized(user_guid, operation_id)
+
+        operation: Operation = cls.create_or_update_operation_v2(
+            user_guid,
+            payload,
+            operation_id,
+        )
+
+        if payload.regulated_products:
+            operation.regulated_products.set(payload.regulated_products)
+            operation.set_create_or_update(user_guid)
+        return operation

--- a/bc_obps/service/tests/test_operation_service_v2.py
+++ b/bc_obps/service/tests/test_operation_service_v2.py
@@ -534,14 +534,14 @@ class TestOperationServiceV2UpdateOperation:
             'utils.operation', operator=approved_user_operator.operator, created_by=approved_user_operator.user
         )
         payload = OperationInformationIn(
-            registration_purpose='Reporting Operation',
+            registration_purpose='Potential Reporting Operation',
             regulated_products=[1],
-            name="string",
+            name="Test Update Operation Name",
             type="SFO",
             naics_code_id=1,
-            secondary_naics_code_id=2,
-            tertiary_naics_code_id=3,
-            activities=[1],
+            secondary_naics_code_id=1,
+            tertiary_naics_code_id=2,
+            activities=[2],
             process_flow_diagram=MOCK_DATA_URL,
             boundary_map=MOCK_DATA_URL,
             equipment_list=MOCK_DATA_URL,
@@ -564,13 +564,13 @@ class TestOperationServiceV2UpdateOperation:
             'utils.operation', operator=approved_user_operator.operator, created_by=approved_user_operator.user
         )
         payload = OperationInformationIn(
-            registration_purpose='Reporting Operation',
-            name="string",
+            registration_purpose='OBPS Regulated Operation',
+            name="Test Update Operation Name",
             type="SFO",
-            naics_code_id=1,
-            secondary_naics_code_id=2,
-            tertiary_naics_code_id=3,
-            activities=[1],
+            naics_code_id=2,
+            secondary_naics_code_id=3,
+            tertiary_naics_code_id=4,
+            activities=[3],
             process_flow_diagram=MOCK_DATA_URL,
             boundary_map=MOCK_DATA_URL,
             equipment_list=MOCK_DATA_URL,

--- a/bc_obps/service/tests/test_operation_service_v2.py
+++ b/bc_obps/service/tests/test_operation_service_v2.py
@@ -525,3 +525,64 @@ class TestOperationServiceV2CreateOrUpdateOperation:
         assert operation.multiple_operators.count() == 0
         assert operation.updated_by == approved_user_operator.user
         assert operation.updated_at is not None
+
+
+class TestOperationServiceV2UpdateOperation:
+    def test_update_operation(self):
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        existing_operation = baker.make_recipe(
+            'utils.operation', operator=approved_user_operator.operator, created_by=approved_user_operator.user
+        )
+        payload = OperationInformationIn(
+            registration_purpose='Reporting Operation',
+            regulated_products=[1],
+            name="string",
+            type="SFO",
+            naics_code_id=1,
+            secondary_naics_code_id=2,
+            tertiary_naics_code_id=3,
+            activities=[1],
+            process_flow_diagram=MOCK_DATA_URL,
+            boundary_map=MOCK_DATA_URL,
+            equipment_list=MOCK_DATA_URL,
+        )
+        operation = OperationServiceV2.update_operation(
+            approved_user_operator.user.user_guid, payload, existing_operation.id
+        )
+        operation.refresh_from_db()
+        assert Operation.objects.count() == 1
+        assert operation.activities.count() == 1
+        assert operation.documents.count() == 3
+        assert operation.created_by == approved_user_operator.user
+        assert operation.created_at is not None
+        assert operation.updated_at is not None
+        assert operation.regulated_products.count() == 1
+
+    def test_update_operation_with_no_regulated_products(self):
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        existing_operation = baker.make_recipe(
+            'utils.operation', operator=approved_user_operator.operator, created_by=approved_user_operator.user
+        )
+        payload = OperationInformationIn(
+            registration_purpose='Reporting Operation',
+            name="string",
+            type="SFO",
+            naics_code_id=1,
+            secondary_naics_code_id=2,
+            tertiary_naics_code_id=3,
+            activities=[1],
+            process_flow_diagram=MOCK_DATA_URL,
+            boundary_map=MOCK_DATA_URL,
+            equipment_list=MOCK_DATA_URL,
+        )
+        operation = OperationServiceV2.update_operation(
+            approved_user_operator.user.user_guid, payload, existing_operation.id
+        )
+        operation.refresh_from_db()
+        assert Operation.objects.count() == 1
+        assert operation.activities.count() == 1
+        assert operation.documents.count() == 3
+        assert operation.created_by == approved_user_operator.user
+        assert operation.created_at is not None
+        assert operation.updated_at is not None
+        assert operation.regulated_products.count() == 0

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -29,15 +29,11 @@ const OperationInformationForm = ({
     formData?: OperationInformationFormData;
   }) => {
     const response = await actionHandler(
-      `registration/v2/operations/update/${operationId}`,
+      `registration/v2/operations/${operationId}`,
       "PUT",
       "",
       {
-        body: JSON.stringify({
-          ...data.formData,
-          // TODO: Remove this once the backend is updated to not require this field for updates
-          registration_purpose: formData.registration_purpose?.[0],
-        }),
+        body: JSON.stringify(data.formData),
       },
     );
 

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { UUID } from "crypto";
 import SingleStepTaskListForm from "@bciers/components/form/SingleStepTaskListForm";
 import { RJSFSchema } from "@rjsf/utils";
 import { administrationOperationInformationUiSchema } from "../../data/jsonSchema/operationInformation/administrationOperationInformation";
@@ -13,9 +14,11 @@ import { actionHandler } from "@bciers/actions";
 
 const OperationInformationForm = ({
   formData,
+  operationId,
   schema,
 }: {
   formData: OperationInformationPartialFormData;
+  operationId: UUID;
   schema: RJSFSchema;
 }) => {
   const [error, setError] = useState(undefined);
@@ -25,13 +28,16 @@ const OperationInformationForm = ({
   const handleSubmit = async (data: {
     formData?: OperationInformationFormData;
   }) => {
-    // This is not currently working, just a placeholder for Edit Operation Information PR
     const response = await actionHandler(
-      "registration/v2/operations",
+      `registration/v2/operations/update/${operationId}`,
       "PUT",
       "",
       {
-        body: JSON.stringify(data.formData),
+        body: JSON.stringify({
+          ...data.formData,
+          // TODO: Remove this once the backend is updated to not require this field for updates
+          registration_purpose: formData.registration_purpose?.[0],
+        }),
       },
     );
 
@@ -43,7 +49,6 @@ const OperationInformationForm = ({
 
   return (
     <SingleStepTaskListForm
-      disabled
       error={error}
       schema={schema}
       uiSchema={administrationOperationInformationUiSchema}

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { UUID } from "crypto";
 import SingleStepTaskListForm from "@bciers/components/form/SingleStepTaskListForm";
 import { RJSFSchema } from "@rjsf/utils";
@@ -11,6 +12,7 @@ import {
   OperationInformationPartialFormData,
 } from "./types";
 import { actionHandler } from "@bciers/actions";
+import { FormMode } from "@bciers/utils/enums";
 
 const OperationInformationForm = ({
   formData,
@@ -24,6 +26,9 @@ const OperationInformationForm = ({
   const [error, setError] = useState(undefined);
 
   const router = useRouter();
+  const { data: session } = useSession();
+
+  const isIndustryUser = session?.user?.app_role?.includes("industry");
 
   const handleSubmit = async (data: {
     formData?: OperationInformationFormData;
@@ -45,6 +50,8 @@ const OperationInformationForm = ({
 
   return (
     <SingleStepTaskListForm
+      allowEdit={isIndustryUser}
+      mode={FormMode.READ_ONLY}
       error={error}
       schema={schema}
       uiSchema={administrationOperationInformationUiSchema}

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -42,7 +42,7 @@ const OperationInformationForm = ({
       },
     );
 
-    if (response.error) {
+    if (response?.error) {
       setError(response.error);
       return { error: response.error };
     }

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -1,5 +1,5 @@
 import OperationInformationForm from "./OperationInformationForm";
-import { getOperationV2 } from "@bciers/actions/api";
+import { getOperationWithDocuments } from "@bciers/actions/api";
 import { createAdministrationOperationInformationSchema } from "../../data/jsonSchema/operationInformation/administrationOperationInformation";
 import { UUID } from "crypto";
 import { validate as isValidUUID } from "uuid";
@@ -16,7 +16,7 @@ const OperationInformationPage = async ({
   let operation;
 
   if (operationId && isValidUUID(operationId)) {
-    operation = await getOperationV2(operationId);
+    operation = await getOperationWithDocuments(operationId);
   }
 
   const registrationPurposes = operation?.registration_purposes;

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -1,6 +1,7 @@
 import OperationInformationForm from "./OperationInformationForm";
-import { getOperation } from "@bciers/actions/api";
+import { getOperationV2 } from "@bciers/actions/api";
 import { createAdministrationOperationInformationSchema } from "../../data/jsonSchema/operationInformation/administrationOperationInformation";
+import { UUID } from "crypto";
 import { validate as isValidUUID } from "uuid";
 
 export const ExternalUserLayout = () => {
@@ -10,18 +11,28 @@ export const ExternalUserLayout = () => {
 const OperationInformationPage = async ({
   operationId,
 }: {
-  operationId: string;
+  operationId: UUID;
 }) => {
   let operation;
 
   if (operationId && isValidUUID(operationId)) {
-    operation = await getOperation(operationId);
+    operation = await getOperationV2(operationId);
   }
+
+  const registrationPurposes = operation?.registration_purposes;
+
+  const formSchema = await createAdministrationOperationInformationSchema(
+    operation?.registration_purposes,
+  );
 
   return (
     <OperationInformationForm
-      formData={operation}
-      schema={await createAdministrationOperationInformationSchema()}
+      formData={{
+        ...operation,
+        registration_purpose: registrationPurposes,
+      }}
+      operationId={operationId}
+      schema={formSchema}
     />
   );
 };

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -17,6 +17,8 @@ const OperationInformationPage = async ({
 
   if (operationId && isValidUUID(operationId)) {
     operation = await getOperationWithDocuments(operationId);
+  } else {
+    throw new Error(`Invalid operation id: ${operationId}`);
   }
 
   const registrationPurposes = operation?.registration_purposes;

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationOperationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationOperationInformation.ts
@@ -9,22 +9,35 @@ import {
   multipleOperatorsInformationUiSchema,
 } from "./multipleOperatorsInformation";
 import {
-  createRegistrationInformationSchema,
+  createAdministrationRegistrationInformationSchema,
   registrationInformationUiSchema,
-} from "./registrationInformation";
+} from "./administrationRegistrationInformation";
 
-export const createAdministrationOperationInformationSchema =
-  async (): Promise<RJSFSchema> => {
-    const administrationOperationInformationSchema: RJSFSchema = {
-      type: "object",
-      properties: {
-        section1: await createOperationInformationSchema(),
-        section2: await createMultipleOperatorsInformationSchema(),
-        section3: await createRegistrationInformationSchema(),
-      },
-    };
-    return administrationOperationInformationSchema;
+export const createAdministrationOperationInformationSchema = async (
+  registrationPurposesValue: string[],
+): Promise<RJSFSchema> => {
+  const administrationOperationInformationSchema: RJSFSchema = {
+    type: "object",
+    properties: {
+      section1: await createOperationInformationSchema(),
+      section2: await createMultipleOperatorsInformationSchema(),
+      section3: await createAdministrationRegistrationInformationSchema(
+        registrationPurposesValue,
+      ),
+    },
   };
+  if (
+    !administrationOperationInformationSchema.properties ||
+    typeof administrationOperationInformationSchema.properties.section3 !==
+      "object"
+  ) {
+    throw new Error(
+      "Invalid schema: section3 is not an object or properties is undefined",
+    );
+  }
+
+  return administrationOperationInformationSchema;
+};
 
 export const administrationOperationInformationUiSchema: UiSchema = {
   "ui:FieldTemplate": SectionFieldTemplate,
@@ -33,5 +46,10 @@ export const administrationOperationInformationUiSchema: UiSchema = {
   },
   section1: operationInformationUISchema,
   section2: multipleOperatorsInformationUiSchema,
-  section3: registrationInformationUiSchema,
+  section3: {
+    ...registrationInformationUiSchema,
+    registration_purpose: {
+      "ui:widget": "ReadOnlyWidget",
+    },
+  },
 };

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationOperationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationOperationInformation.ts
@@ -48,7 +48,8 @@ export const administrationOperationInformationUiSchema: UiSchema = {
   section2: multipleOperatorsInformationUiSchema,
   section3: {
     ...registrationInformationUiSchema,
-    registration_purpose: {
+    "ui:order": ["registration_purposes", "regulated_products"],
+    registration_purposes: {
       "ui:widget": "ReadOnlyWidget",
     },
   },

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
@@ -1,0 +1,57 @@
+import SectionFieldTemplate from "@bciers/components/form/fields/SectionFieldTemplate";
+import { RJSFSchema, UiSchema } from "@rjsf/utils";
+import { getRegulatedProducts } from "@bciers/actions/api";
+import { RegistrationPurposes } from "apps/registration/app/components/operations/registration/enums";
+
+export const createAdministrationRegistrationInformationSchema = async (
+  registrationPurposesValue: string[],
+): Promise<RJSFSchema> => {
+  // fetch db values that are dropdown options
+  const regulatedProducts: { id: number; name: string }[] =
+    await getRegulatedProducts();
+
+  const isRegulatedProducts =
+    !registrationPurposesValue.includes(
+      RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION,
+    ) &&
+    !registrationPurposesValue.includes(
+      RegistrationPurposes.POTENTIAL_REPORTING_OPERATION,
+    );
+
+  const regulatedProductsSchema = {
+    regulated_products: {
+      title: "Regulated Product Name(s)",
+      type: "array",
+      minItems: 1,
+      items: {
+        enum: regulatedProducts.map((product) => product.id),
+        enumNames: regulatedProducts.map((product) => product.name),
+      },
+    },
+  };
+
+  // create the schema with the fetched values
+  const registrationInformationSchema: RJSFSchema = {
+    title: "Registration Information",
+    type: "object",
+    required: ["registration_purpose"],
+    properties: {
+      registration_purpose: {
+        type: "array",
+        title: "The purpose of this registration is to register as a:",
+        items: {},
+      },
+      ...(isRegulatedProducts && regulatedProductsSchema),
+    },
+  };
+  return registrationInformationSchema;
+};
+
+export const registrationInformationUiSchema: UiSchema = {
+  "ui:order": ["registration_purpose", "regulated_products"],
+  "ui:FieldTemplate": SectionFieldTemplate,
+  regulated_products: {
+    "ui:widget": "MultiSelectWidget",
+    "ui:placeholder": "Select Regulated Product",
+  },
+};

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
@@ -3,6 +3,12 @@ import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import { getRegulatedProducts } from "@bciers/actions/api";
 import { RegistrationPurposes } from "apps/registration/app/components/operations/registration/enums";
 
+declare module "json-schema" {
+  export interface JSONSchema7 {
+    enumNames?: Array<string>;
+  }
+}
+
 export const createAdministrationRegistrationInformationSchema = async (
   registrationPurposesValue: string[],
 ): Promise<RJSFSchema> => {
@@ -18,18 +24,6 @@ export const createAdministrationRegistrationInformationSchema = async (
       RegistrationPurposes.POTENTIAL_REPORTING_OPERATION,
     );
 
-  const regulatedProductsSchema = {
-    regulated_products: {
-      title: "Regulated Product Name(s)",
-      type: "array",
-      minItems: 1,
-      items: {
-        enum: regulatedProducts.map((product) => product.id),
-        enumNames: regulatedProducts.map((product) => product.name),
-      },
-    },
-  };
-
   // create the schema with the fetched values
   const registrationInformationSchema: RJSFSchema = {
     title: "Registration Information",
@@ -41,7 +35,17 @@ export const createAdministrationRegistrationInformationSchema = async (
         title: "The purpose of this registration is to register as a:",
         items: {},
       },
-      ...(isRegulatedProducts && regulatedProductsSchema),
+      ...(isRegulatedProducts && {
+        regulated_products: {
+          title: "Regulated Product Name(s)",
+          type: "array",
+          minItems: 1,
+          items: {
+            enum: regulatedProducts.map((product) => product.id),
+            enumNames: regulatedProducts.map((product) => product.name),
+          },
+        },
+      }),
     },
   };
   return registrationInformationSchema;

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
@@ -11,10 +11,10 @@ export const createAdministrationRegistrationInformationSchema = async (
     await getRegulatedProducts();
 
   const isRegulatedProducts =
-    !registrationPurposesValue.includes(
+    !registrationPurposesValue?.includes(
       RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION,
     ) &&
-    !registrationPurposesValue.includes(
+    !registrationPurposesValue?.includes(
       RegistrationPurposes.POTENTIAL_REPORTING_OPERATION,
     );
 

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
@@ -22,7 +22,7 @@ export const createAdministrationRegistrationInformationSchema = async (
   const registrationInformationSchema: RJSFSchema = {
     title: "Registration Information",
     type: "object",
-    required: ["regulated_products"],
+    required: isRegulatedProducts ? ["regulated_products"] : [],
     properties: {
       registration_purposes: {
         type: "array",

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
@@ -22,7 +22,7 @@ export const createAdministrationRegistrationInformationSchema = async (
   const registrationInformationSchema: RJSFSchema = {
     title: "Registration Information",
     type: "object",
-    required: ["registration_purpose"],
+    required: ["regulated_products"],
     properties: {
       registration_purposes: {
         type: "array",

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
@@ -3,12 +3,6 @@ import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import { getRegulatedProducts } from "@bciers/actions/api";
 import { RegistrationPurposes } from "apps/registration/app/components/operations/registration/enums";
 
-declare module "json-schema" {
-  export interface JSONSchema7 {
-    enumNames?: Array<string>;
-  }
-}
-
 export const createAdministrationRegistrationInformationSchema = async (
   registrationPurposesValue: string[],
 ): Promise<RJSFSchema> => {
@@ -42,6 +36,8 @@ export const createAdministrationRegistrationInformationSchema = async (
           minItems: 1,
           items: {
             enum: regulatedProducts.map((product) => product.id),
+            // Ts-ignore until we refactor enumNames https://github.com/bcgov/cas-registration/issues/2176
+            // @ts-ignore
             enumNames: regulatedProducts.map((product) => product.name),
           },
         },

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
@@ -36,7 +36,7 @@ export const createAdministrationRegistrationInformationSchema = async (
     type: "object",
     required: ["registration_purpose"],
     properties: {
-      registration_purpose: {
+      registration_purposes: {
         type: "array",
         title: "The purpose of this registration is to register as a:",
         items: {},

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/multipleOperatorsInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/multipleOperatorsInformation.ts
@@ -74,7 +74,7 @@ export const createMultipleOperatorsInformationSchema =
                         ),
                       },
                       mo_cra_business_number: {
-                        type: "string",
+                        type: "number",
                         title: "CRA Business Number",
                       },
 

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/operationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/operationInformation.ts
@@ -127,11 +127,20 @@ export const operationInformationUISchema: UiSchema = {
   },
   process_flow_diagram: {
     "ui:widget": "FileWidget",
+    "ui:options": {
+      filePreview: true,
+    },
   },
   boundary_map: {
     "ui:widget": "FileWidget",
+    "ui:options": {
+      filePreview: true,
+    },
   },
   equipment_list: {
     "ui:widget": "FileWidget",
+    "ui:options": {
+      filePreview: true,
+    },
   },
 };

--- a/bciers/apps/administration/next-env.d.ts
+++ b/bciers/apps/administration/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
@@ -1,6 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import { RJSFSchema } from "@rjsf/utils";
 import OperationInformationForm from "apps/administration/app/components/operations/OperationInformationForm";
+import { useSession } from "@bciers/testConfig/mocks";
+
+useSession.mockReturnValue({
+  data: {
+    user: {
+      app_role: "industry_user_admin",
+    },
+  },
+});
 
 // Just using a simple schema for testing purposes
 // OperationInformationPage test will test the proper schema with extra enums provided by the backend
@@ -35,9 +44,17 @@ const formData = {
   type: "Single Facility Operation",
 };
 
+const operationId = "8be4c7aa-6ab3-4aad-9206-0ef914fea063";
+
 describe("the OperationInformationForm component", () => {
   it("renders the OperationInformationForm component", async () => {
-    render(<OperationInformationForm formData={{}} schema={testSchema} />);
+    render(
+      <OperationInformationForm
+        formData={{}}
+        schema={testSchema}
+        operationId={operationId}
+      />,
+    );
 
     expect(screen.getByText(/Operation Name/i)).toBeVisible();
     expect(screen.getByText(/Operation Type/i)).toBeVisible();
@@ -48,7 +65,11 @@ describe("the OperationInformationForm component", () => {
 
   it("should render the form with the correct values when formData is provided", async () => {
     render(
-      <OperationInformationForm formData={formData} schema={testSchema} />,
+      <OperationInformationForm
+        formData={formData}
+        schema={testSchema}
+        operationId={operationId}
+      />,
     );
 
     expect(screen.getByText(/Operation Name/i)).toBeVisible();

--- a/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { RJSFSchema } from "@rjsf/utils";
 import OperationInformationForm from "apps/administration/app/components/operations/OperationInformationForm";
-import { useSession } from "@bciers/testConfig/mocks";
+import { actionHandler, useSession } from "@bciers/testConfig/mocks";
 
 useSession.mockReturnValue({
   data: {
@@ -76,23 +76,68 @@ describe("the OperationInformationForm component", () => {
     expect(screen.getByText(/Operation Type/i)).toBeVisible();
   });
 
-  // it("should have unchecked task list sections when no formData is provided", async () => {
-  //   render(<OperationInformationForm formData={{}} schema={testSchema} />);
+  it("should enable editing when the Edit button is clicked", async () => {
+    render(
+      <OperationInformationForm
+        formData={formData}
+        schema={testSchema}
+        operationId={operationId}
+      />,
+    );
 
-  //  expect(screen.getByTestId("section1-tasklist-check")).not.toContainHTML(
-  //    "svg",
-  //  );
-  //  expect(screen.getByTestId("section2-tasklist-check")).not.toContainHTML(
-  //    "svg",
-  //  );
-  //});
+    expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
 
-  // it("should have checked task list sections when formData is provided", async () => {
-  //   render(
-  //     <OperationInformationForm formData={formData} schema={testSchema} />,
-  //   );
+    await act(async () => {
+      // Click the Edit button
+      screen.getByRole("button", { name: "Edit" }).click();
+    });
 
-  //   expect(screen.getByTestId("section1-tasklist-check")).toContainHTML("svg");
-  //   expect(screen.getByTestId("section2-tasklist-check")).toContainHTML("svg");
-  // });
+    // Expect the Edit button to be disabled
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+  });
+
+  it("should edit and submit the form", async () => {
+    render(
+      <OperationInformationForm
+        formData={formData}
+        schema={testSchema}
+        operationId={operationId}
+      />,
+    );
+
+    await act(async () => {
+      // Click the Edit button
+      screen.getByRole("button", { name: "Edit" }).click();
+    });
+
+    // Fill out the form
+    const nameInput = screen.getByLabelText(/Operation Name/i);
+
+    expect(nameInput).toHaveValue("Operation 3");
+
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Operation 4" } });
+    });
+
+    // Click the Submit button
+    await act(async () => {
+      screen.getByRole("button", { name: "Submit" }).click();
+    });
+
+    expect(actionHandler).toHaveBeenCalledTimes(1);
+    expect(actionHandler).toHaveBeenCalledWith(
+      `registration/v2/operations/${operationId}`,
+      "PUT",
+      "",
+      {
+        body: JSON.stringify({
+          name: "Operation 4",
+          type: "Single Facility Operation",
+        }),
+      },
+    );
+
+    // Expect the form to be submitted
+    expect(screen.getByText(/Operation 4/i)).toBeVisible();
+  });
 });

--- a/bciers/apps/administration/tests/components/operations/OperationInformationPage.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationPage.test.tsx
@@ -1,11 +1,25 @@
 import { render, screen } from "@testing-library/react";
 import OperationInformationPage from "apps/administration/app/components/operations/OperationInformationPage";
-import { getOperation } from "./mocks";
-import { actionHandler } from "@bciers/testConfig/mocks";
+import {
+  getOperationWithDocuments,
+  getNaicsCodes,
+  getReportingActivities,
+  getBusinessStructures,
+  getRegulatedProducts,
+} from "./mocks";
+import { actionHandler, useSession } from "@bciers/testConfig/mocks";
+
+useSession.mockReturnValue({
+  data: {
+    user: {
+      app_role: "industry_user_admin",
+    },
+  },
+});
 
 const fetchFormEnums = () => {
   // Naics codes
-  actionHandler.mockResolvedValueOnce([
+  getNaicsCodes.mockResolvedValue([
     {
       id: 1,
       naics_code: "211110",
@@ -18,7 +32,7 @@ const fetchFormEnums = () => {
     },
   ]);
   // Reporting activities
-  actionHandler.mockResolvedValueOnce([
+  getReportingActivities.mockResolvedValue([
     {
       name: "General stationary combustion excluding line tracing",
       applicable_to: "all",
@@ -27,19 +41,19 @@ const fetchFormEnums = () => {
   ]);
 
   // Business structures
-  actionHandler.mockResolvedValueOnce([
+  getBusinessStructures.mockResolvedValue([
     { name: "General Partnership" },
     { name: "BC Corporation" },
   ]);
 
   // Regulated products
-  actionHandler.mockResolvedValueOnce([
+  getRegulatedProducts.mockResolvedValue([
     { id: 1, name: "BC-specific refinery complexity throughput" },
     { id: 2, name: "Cement equivalent" },
   ]);
 
   // Registration purposes
-  actionHandler.mockResolvedValueOnce(["Potential Reporting Operation"]);
+  actionHandler.mockResolvedValue(["Potential Reporting Operation"]);
 };
 
 const formData = {
@@ -48,6 +62,7 @@ const formData = {
   naics_code_id: 1,
   secondary_naics_code_id: 2,
   operation_has_multiple_operators: true,
+  registration_purposes: ["Non-Regulated"],
   multiple_operators_array: [
     {
       mo_is_extraprovincial_company: false,
@@ -74,7 +89,8 @@ describe("the OperationInformationPage component", () => {
   });
   it("renders the OperationInformationPage component", async () => {
     fetchFormEnums();
-    render(await OperationInformationPage({ operationId: "1" }));
+    getOperationWithDocuments.mockResolvedValueOnce(formData);
+    render(await OperationInformationPage({ operationId }));
 
     expect(
       screen.getByRole("heading", { name: "Operation Information" }),
@@ -106,7 +122,7 @@ describe("the OperationInformationPage component", () => {
 
   it("should render the form with the correct values when formData is provided", async () => {
     fetchFormEnums();
-    getOperation.mockResolvedValueOnce(formData);
+    getOperationWithDocuments.mockResolvedValueOnce(formData);
 
     render(await OperationInformationPage({ operationId }));
 

--- a/bciers/apps/administration/tests/components/operations/mocks.ts
+++ b/bciers/apps/administration/tests/components/operations/mocks.ts
@@ -1,7 +1,45 @@
 const getOperation = vi.fn();
+const getOperationWithDocuments = vi.fn();
+const getNaicsCodes = vi.fn();
+const getReportingActivities = vi.fn();
+const getBusinessStructures = vi.fn();
+const getRegulatedProducts = vi.fn();
+const getRegistrationPurposes = vi.fn();
 
 vi.mock("libs/actions/src/api/getOperation", () => ({
   default: getOperation,
 }));
 
-export { getOperation };
+vi.mock("libs/actions/src/api/getOperationWithDocuments", () => ({
+  default: getOperationWithDocuments,
+}));
+
+vi.mock("libs/actions/src/api/getNaicsCodes", () => ({
+  default: getNaicsCodes,
+}));
+
+vi.mock("libs/actions/src/api/getReportingActivities", () => ({
+  default: getReportingActivities,
+}));
+
+vi.mock("libs/actions/src/api/getBusinessStructures", () => ({
+  default: getBusinessStructures,
+}));
+
+vi.mock("libs/actions/src/api/getRegulatedProducts", () => ({
+  default: getRegulatedProducts,
+}));
+
+vi.mock("libs/actions/src/api/getRegistrationPurposes", () => ({
+  default: getRegistrationPurposes,
+}));
+
+export {
+  getOperation,
+  getOperationWithDocuments,
+  getNaicsCodes,
+  getReportingActivities,
+  getBusinessStructures,
+  getRegulatedProducts,
+  getRegistrationPurposes,
+};

--- a/bciers/apps/coam/next-env.d.ts
+++ b/bciers/apps/coam/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/bciers/apps/registration/next-env.d.ts
+++ b/bciers/apps/registration/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
@@ -336,7 +336,7 @@ describe("the OperationInformationForm component", () => {
                   mo_legal_name: "edit",
                   mo_trade_name: "edit",
                   mo_business_structure: "BC Corporation",
-                  mo_cra_business_number: "999999999",
+                  mo_cra_business_number: 999999999,
                   mo_attorney_street_address: "edit",
                   mo_municipality: "edit",
                   mo_province: "AB",

--- a/bciers/apps/registration1/app/components/form/MultiStepFormBase.test.tsx
+++ b/bciers/apps/registration1/app/components/form/MultiStepFormBase.test.tsx
@@ -105,7 +105,7 @@ describe("The MultiStepFormBase component", () => {
     render(<MultiStepFormBase {...defaultProps} />);
     expect(screen.getByText(/test field1/i)).toHaveAttribute(
       "class",
-      "read-only-widget",
+      "read-only-widget whitespace-pre-line",
     );
     const editButton = screen.getByRole("button", { name: /Edit/i });
     fireEvent.click(editButton);

--- a/bciers/apps/reporting/next-env.d.ts
+++ b/bciers/apps/reporting/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/bciers/libs/actions/src/api/getOperationWithDocuments.ts
+++ b/bciers/libs/actions/src/api/getOperationWithDocuments.ts
@@ -1,0 +1,15 @@
+import { actionHandler } from "@bciers/actions";
+
+async function getOperationWithDocuments(id: string) {
+  try {
+    return await actionHandler(
+      `registration/v2/operations/${id}/with-documents`,
+      "GET",
+      "",
+    );
+  } catch (error) {
+    throw error;
+  }
+}
+
+export default getOperationWithDocuments;

--- a/bciers/libs/actions/src/api/index.ts
+++ b/bciers/libs/actions/src/api/index.ts
@@ -4,6 +4,7 @@ export { default as getNaicsCodes } from "./getNaicsCodes";
 export { default as getOperation } from "./getOperation";
 export { default as getOperationV2 } from "./getOperationV2";
 export { default as getOperationStatutoryDeclaration } from "./getOperationStatutoryDeclaration";
+export { default as getOperationWithDocuments } from "./getOperationWithDocuments";
 export { default as getRegulatedProducts } from "./getRegulatedProducts";
 export { default as getReportingActivities } from "./getReportingActivities";
 export { default as getRegistrationPurposes } from "./getRegistrationPurposes";

--- a/bciers/libs/components/src/form/FormBase.test.tsx
+++ b/bciers/libs/components/src/form/FormBase.test.tsx
@@ -57,7 +57,7 @@ describe("The FormBase component", () => {
     // can't getByLabel because there's no <input> element in the readonly theme
     expect(screen.getByText(/test field/i)).toHaveAttribute(
       "class",
-      "read-only-widget",
+      "read-only-widget whitespace-pre-line",
     );
   });
 

--- a/bciers/libs/components/src/form/MultiStepBase.test.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.test.tsx
@@ -89,7 +89,7 @@ describe("The MultiStepBase component", () => {
     render(<MultiStepBase {...defaultProps} />);
     expect(screen.getByText(/test field1/i)).toHaveAttribute(
       "class",
-      "read-only-widget",
+      "read-only-widget whitespace-pre-line",
     );
     const editButton = screen.getByRole("button", { name: /Edit/i });
     fireEvent.click(editButton);

--- a/bciers/libs/components/src/form/widgets/readOnly/ReadOnlyFileWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/readOnly/ReadOnlyFileWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { WidgetProps } from "@rjsf/utils/lib/types";
+import { useEffect, useState } from "react";
 import {
   extractFileInfo,
   FilesInfo,
@@ -12,15 +13,22 @@ const ReadOnlyFileWidget: React.FC<WidgetProps> = ({
   registry,
   value,
 }) => {
+  const [fileInfo, setFileInfo] = useState<any[]>([]);
+  const fileValue = Array.isArray(value) ? value : [value];
+
+  useEffect(() => {
+    // Fix for window not being defined on page load
+    if (fileValue.length) {
+      setFileInfo(fileValue);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div id={id} className="read-only-widget">
       {value ? (
         <FilesInfo
-          filesInfo={
-            Array.isArray(value)
-              ? extractFileInfo(value)
-              : extractFileInfo([value])
-          }
+          filesInfo={extractFileInfo(fileInfo)}
           preview={options.filePreview}
           registry={registry}
         />

--- a/bciers/libs/components/src/form/widgets/readOnly/ReadOnlyWidget.test.tsx
+++ b/bciers/libs/components/src/form/widgets/readOnly/ReadOnlyWidget.test.tsx
@@ -43,4 +43,34 @@ describe("RJSF ReadOnlyWidget", () => {
     const readOnlyWidget = container.querySelector("#root_stringTestField");
     expect(readOnlyWidget).toBeEmptyDOMElement();
   });
+
+  it("should render an array value", () => {
+    const { container } = render(
+      <FormBase
+        disabled
+        formData={{
+          arrayTestField: ["test1", "test2"],
+        }}
+        schema={{
+          properties: {
+            arrayTestField: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+          },
+        }}
+        uiSchema={{
+          arrayTestField: {
+            "ui:widget": "ReadOnlyWidget",
+          },
+        }}
+      />,
+    );
+
+    const readOnlyWidget = container.querySelector("#root_arrayTestField");
+    expect(readOnlyWidget).toBeVisible();
+    expect(readOnlyWidget).toHaveTextContent("test1, test2");
+  });
 });

--- a/bciers/libs/components/src/form/widgets/readOnly/ReadOnlyWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/readOnly/ReadOnlyWidget.tsx
@@ -1,9 +1,11 @@
 import { WidgetProps } from "@rjsf/utils/lib/types";
 
 const ReadOnlyWidget: React.FC<WidgetProps> = ({ id, value }) => {
+  const formatValue = Array.isArray(value) ? value.join(",\n") : value;
+
   return (
-    <div id={id} className="read-only-widget">
-      {value}
+    <div id={id} className="read-only-widget whitespace-pre-line">
+      {formatValue}
     </div>
   );
 };


### PR DESCRIPTION
#1879 
To test this make sure to reset the database since it includes updated fixtures:

- `cd bc_obps && make reset_db && make run`
- Navigate to the `Operations` dashboard in the `Administration` module
- Select any Operation that has `View Operation` in the action column and click `View Operation` (made [an issue](https://github.com/bcgov/cas-registration/issues/2270) to fix the `Start Registration` and `Continue Registration` URLs)
- Click `Edit` button at the bottom of the form
- Make any necessary changes (file upload fields will definitely be required)
- Click `Submit`
- The form should save. You can refresh the page and the updates will remain.

Other things to test:
- Click `View Details` for Operation 14 which has a purpose of `Electricity Import Operation`
- The `Regulated product names` field does not appear under `Registration Purpose`
- Return to Operations DataGrid, click `View Details` for Operation 14 which has a purpose of `Potential Reporting Operation`
- The `Regulated product names` field does not appear under `Registration Purpose`
- The Multiple Operators section works

