### PR TITLE
2256 error handling

### DIFF
--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
@@ -1,11 +1,9 @@
 from typing import Literal, Tuple
 from uuid import UUID
 from django.http import HttpRequest
-from registration.schema.v1.operation import OperationUpdateStatusOut
 from registration.schema.v2.operation import (
     OperationInformationIn,
     OperationUpdateOut,
-    OperationRegistrationSubmissionIn,
 )
 from service.operation_service_v2 import OperationServiceV2
 from registration.constants import V2
@@ -34,25 +32,3 @@ def register_edit_operation_information(
     request: HttpRequest, operation_id: UUID, payload: OperationInformationIn
 ) -> Tuple[Literal[200], Operation]:
     return 200, OperationServiceV2.register_operation_information(get_current_user_guid(request), operation_id, payload)
-
-
-@router.patch(
-    "/v2/operations/{uuid:operation_id}/registration/submission",
-    response={200: OperationUpdateStatusOut, custom_codes_4xx: Message},
-    tags=V2,
-    description="""Updates the status of an operation to 'Registered' when the registration is submitted.
-    The endpoint ensures that only authorized industry users can update operations belonging to their operator.""",
-    auth=authorize('approved_industry_user'),
-)
-@handle_http_errors()
-def operation_registration_submission(
-    request: HttpRequest, operation_id: UUID, payload: OperationRegistrationSubmissionIn
-) -> Tuple[Literal[200], Operation]:
-    # Check if all checkboxes are checked
-    if not all(
-        [payload.acknowledgement_of_review, payload.acknowledgement_of_information, payload.acknowledgement_of_records]
-    ):
-        raise Exception("All checkboxes must be checked to submit the registration.")
-    return 200, OperationServiceV2.update_status(
-        get_current_user_guid(request), operation_id, Operation.Statuses.REGISTERED
-    )

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
@@ -31,4 +31,5 @@ from registration.schema.generic import Message
 def register_edit_operation_information(
     request: HttpRequest, operation_id: UUID, payload: OperationInformationIn
 ) -> Tuple[Literal[200], Operation]:
+    # raise Exception('d')
     return 200, OperationServiceV2.register_operation_information(get_current_user_guid(request), operation_id, payload)

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/submission.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/submission.py
@@ -27,6 +27,7 @@ def operation_registration_submission(
     request: HttpRequest, operation_id: UUID, payload: OperationRegistrationSubmissionIn
 ) -> Tuple[Literal[200], Operation]:
     # Check if all checkboxes are checked
+    # raise Exception('d')
     if not all(
         [payload.acknowledgement_of_review, payload.acknowledgement_of_information, payload.acknowledgement_of_records]
     ):

--- a/bciers/apps/registration/app/components/operations/registration/FacilityInformationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/FacilityInformationForm.tsx
@@ -65,7 +65,6 @@ const FacilityInformationForm = ({
   step,
   steps,
 }: FacilityInformationFormProps) => {
-  const [error, setError] = useState(undefined);
   const [formState, setFormState] = useState(formData ?? {});
   const [isSubmitting, setIsSubmitting] = useState(false);
   // Get the list of sections in the LFO schema - used to unnest the formData
@@ -126,15 +125,11 @@ const FacilityInformationForm = ({
             formSectionListLFo,
             operation,
           );
-
+      // errors are handled in MultiStepBase
       const response = await actionHandler(endpoint, method, "", {
         body: JSON.stringify(body),
       });
-      if (!response || response?.error) {
-        setError(response.error);
-        setIsSubmitting(false);
-        return { error: response.error };
-      }
+      return response;
     },
     [operation, isOperationSfo, formSectionListLFo, isCreating, facilityId],
   );
@@ -143,12 +138,10 @@ const FacilityInformationForm = ({
     <MultiStepBase
       allowBackNavigation
       baseUrl={`/register-an-operation/${operation}`}
-      baseUrlParams="title=Placeholder+Title"
       cancelUrl="/"
       formData={formState}
       onChange={handleFormChange}
       onSubmit={handleSubmit}
-      error={error}
       schema={schema}
       step={step}
       steps={steps}

--- a/bciers/apps/registration/app/components/operations/registration/NewEntrantOperationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/NewEntrantOperationForm.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { actionHandler } from "@bciers/actions";
 import { IChangeEvent } from "@rjsf/core";
 import MultiStepBase from "@bciers/components/form/MultiStepBase";
@@ -22,30 +21,24 @@ const NewEntrantOperationForm = ({
   steps,
 }: NewEntrantOperationFormProps) => {
   const baseUrl = `/register-an-operation/${operation}`;
-  const [error, setError] = useState(undefined);
   const handleSubmit = async (e: IChangeEvent) => {
     const method = "PUT";
     const endpoint = `registration/v2/operations/${operation}/registration/statutory-declaration`;
     const body = {
       statutory_declaration: e.formData.statutory_declaration,
     };
+    // errors are handled in MultiStepBase
     const response = await actionHandler(endpoint, method, `${baseUrl}`, {
       body: JSON.stringify(body),
     });
-
-    if (!response || response?.error) {
-      setError(response.error);
-      return { error: response.error };
-    }
+    return response;
   };
 
   return (
     <MultiStepBase
       allowBackNavigation
       baseUrl={baseUrl}
-      baseUrlParams="title=Placeholder+Title"
       cancelUrl="/"
-      error={error}
       formData={formData}
       onSubmit={handleSubmit}
       schema={schema}

--- a/bciers/apps/registration/app/components/operations/registration/OperationInformationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/OperationInformationForm.tsx
@@ -99,9 +99,7 @@ const OperationInformationForm = ({
       onSubmit={handleSubmit}
       firstStepExtraHandling={(response) => {
         // Since our form's route includes the operation's id, which doesn't exist until after the first step, we need to pass in a custom function that uses the response to generate a redirect url
-        const nextStepUrl = `/register-an-operation/${response.id}/${
-          step + 1
-        }$`;
+        const nextStepUrl = `/register-an-operation/${response.id}/${step + 1}`;
         router.push(nextStepUrl);
       }}
       schema={schema}

--- a/bciers/apps/registration/app/components/operations/registration/OperationInformationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/OperationInformationForm.tsx
@@ -12,6 +12,7 @@ import {
   createUnnestedFormData,
 } from "@bciers/components/form/formDataUtils";
 import { registrationOperationInformationUiSchema } from "@/registration/app/data/jsonSchema/operationInformation/registrationOperationInformation";
+import { useRouter } from "next/navigation";
 
 interface OperationInformationFormProps {
   rawFormData: OperationInformationFormData;
@@ -26,6 +27,7 @@ const OperationInformationForm = ({
   step,
   steps,
 }: OperationInformationFormProps) => {
+  const router = useRouter();
   const [selectedOperation, setSelectedOperation] = useState("");
   const [error, setError] = useState(undefined);
   const nestedFormData = rawFormData
@@ -95,6 +97,13 @@ const OperationInformationForm = ({
       cancelUrl="/"
       formData={formState}
       onSubmit={handleSubmit}
+      firstStepExtraHandling={(response) => {
+        // Since our form's route includes the operation's id, which doesn't exist until after the first step, we need to pass in a custom function that uses the response to generate a redirect url
+        const nextStepUrl = `/register-an-operation/${response.id}/${
+          step + 1
+        }$`;
+        router.push(nextStepUrl);
+      }}
       schema={schema}
       step={step}
       steps={steps}

--- a/bciers/apps/registration/app/components/operations/registration/OperationRepresentativeForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/OperationRepresentativeForm.tsx
@@ -11,7 +11,6 @@ import { IChangeEvent } from "@rjsf/core";
 import { contactsSchema } from "@/administration/app/data/jsonSchema/contact";
 import { RJSFSchema } from "@rjsf/utils";
 import { createUnnestedFormData } from "@bciers/components/form/formDataUtils";
-import { useState } from "react";
 
 interface OperationRepresentativeFormProps
   extends OperationRegistrationFormProps {
@@ -40,7 +39,6 @@ const OperationRepresentativeForm = ({
   step,
   steps,
 }: OperationRepresentativeFormProps) => {
-  const [error, setError] = useState(undefined);
   const handleSubmit = async (e: IChangeEvent) => {
     // unnest the contact data
     const hasNewReps = e.formData?.new_operation_representatives.length > 0;
@@ -55,16 +53,14 @@ const OperationRepresentativeForm = ({
       );
     }
     const endpoint = `registration/v2/operations/${operation}/registration/operation-representative`;
+    // errors are handled in MultiStepBase
     const response = await actionHandler(endpoint, "PUT", "", {
       body: JSON.stringify({
         ...e.formData,
         ...(hasNewReps && { new_operation_representatives: unnestedNewReps }),
       }),
     });
-    if (!response || response?.error) {
-      setError(response.error);
-      return { error: response.error };
-    }
+    return response;
   };
   return (
     <MultiStepBase
@@ -76,7 +72,6 @@ const OperationRepresentativeForm = ({
       onSubmit={handleSubmit}
       schema={schema}
       step={step}
-      error={error}
       steps={steps}
       uiSchema={operationRepresentativeUiSchema}
       customValidate={customValidate}

--- a/bciers/apps/registration/app/components/operations/registration/OptedInOperationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/OptedInOperationForm.tsx
@@ -28,7 +28,6 @@ const OptedInOperationForm = ({
   const [formState, setFormState] = useState(formData);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
-  const [error, setError] = useState("");
 
   //To run the check on initial load when the form already has data
   useEffect(() => {
@@ -55,20 +54,15 @@ const OptedInOperationForm = ({
         }),
       },
     );
-    if (response?.error) {
-      setError(response.error);
-      setIsSubmitting(false);
-      setSubmitButtonDisabled(false);
-      return { error: response.error };
-    }
+
+    // errors are handled in MultiStepBase
+    return response;
   };
   return (
     <MultiStepBase
       allowBackNavigation
       baseUrl={`/register-an-operation/${operation}`}
-      baseUrlParams="title=Placeholder+Title"
       cancelUrl="/"
-      error={error}
       formData={formState}
       onChange={handleChange}
       onSubmit={handleSubmit}

--- a/bciers/apps/registration/app/components/operations/registration/OptedInOperationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/OptedInOperationForm.tsx
@@ -26,7 +26,6 @@ const OptedInOperationForm = ({
   formData,
 }: OptedInOperationFormProps) => {
   const [formState, setFormState] = useState(formData);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
 
   //To run the check on initial load when the form already has data
@@ -42,7 +41,6 @@ const OptedInOperationForm = ({
   };
 
   const handleSubmit = async (e: IChangeEvent) => {
-    setIsSubmitting(true);
     setSubmitButtonDisabled(true);
     const response = await actionHandler(
       `registration/v2/operations/${operation}/registration/opted-in-operation-detail`,
@@ -66,14 +64,7 @@ const OptedInOperationForm = ({
       formData={formState}
       onChange={handleChange}
       onSubmit={handleSubmit}
-      schema={
-        isSubmitting // A workaround to not show the read-only schema when submitting
-          ? {
-              title: "Submitting...",
-              type: "object",
-            }
-          : schema
-      }
+      schema={schema}
       step={step}
       steps={steps}
       uiSchema={optedInOperationUiSchema}

--- a/bciers/apps/registration/app/components/operations/registration/RegistrationSubmissionForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/RegistrationSubmissionForm.tsx
@@ -23,7 +23,6 @@ const RegistrationSubmissionForm = ({
   steps,
 }: OperationRegistrationFormProps) => {
   const [formState, setFormState] = useState({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
 
   const handleChange = (e: IChangeEvent) => {
@@ -32,7 +31,6 @@ const RegistrationSubmissionForm = ({
   };
 
   const handleSubmit = async (e: IChangeEvent) => {
-    setIsSubmitting(true);
     setSubmitButtonDisabled(true);
     const response = await actionHandler(
       `registration/v2/operations/${operation}/registration/submission`,
@@ -56,14 +54,7 @@ const RegistrationSubmissionForm = ({
         cancelUrl="/"
         formData={formState}
         onSubmit={handleSubmit}
-        schema={
-          isSubmitting
-            ? {
-                title: "Submitting...",
-                type: "object",
-              }
-            : schema
-        }
+        schema={schema}
         step={step}
         steps={steps}
         uiSchema={submissionUiSchema}

--- a/bciers/apps/registration/app/components/operations/registration/RegistrationSubmissionForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/RegistrationSubmissionForm.tsx
@@ -23,10 +23,8 @@ const RegistrationSubmissionForm = ({
   steps,
 }: OperationRegistrationFormProps) => {
   const [formState, setFormState] = useState({});
-  const [isSubmitted, setIsSubmitted] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
-  const [error, setError] = useState("");
 
   const handleChange = (e: IChangeEvent) => {
     setFormState(e.formData);
@@ -46,43 +44,33 @@ const RegistrationSubmissionForm = ({
         }),
       },
     );
-    if (response?.error) {
-      setError(response.error);
-      setSubmitButtonDisabled(false);
-      setIsSubmitting(false);
-      return { error: response.error };
-    }
-    setIsSubmitted(true);
+    // errors are handled in MultiStepBase
+    return response;
   };
 
   return (
     <>
-      {isSubmitted ? (
-        <Success step={step} steps={steps} />
-      ) : (
-        <MultiStepBase
-          allowBackNavigation
-          baseUrl={`/register-an-operation/${operation}`}
-          baseUrlParams="title=Placeholder+Title"
-          cancelUrl="/"
-          formData={formState}
-          onSubmit={handleSubmit}
-          error={error}
-          schema={
-            isSubmitting
-              ? {
-                  title: "Submitting...",
-                  type: "object",
-                }
-              : schema
-          }
-          step={step}
-          steps={steps}
-          uiSchema={submissionUiSchema}
-          onChange={handleChange}
-          submitButtonDisabled={submitButtonDisabled}
-        />
-      )}
+      <MultiStepBase
+        allowBackNavigation
+        baseUrl={`/register-an-operation/${operation}`}
+        cancelUrl="/"
+        formData={formState}
+        onSubmit={handleSubmit}
+        schema={
+          isSubmitting
+            ? {
+                title: "Submitting...",
+                type: "object",
+              }
+            : schema
+        }
+        step={step}
+        steps={steps}
+        uiSchema={submissionUiSchema}
+        onChange={handleChange}
+        submitButtonDisabled={submitButtonDisabled}
+        successComponent=<Success step={step} steps={steps} />
+      />
     </>
   );
 };

--- a/bciers/apps/registration/app/components/operations/registration/RegistrationSubmissionForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/RegistrationSubmissionForm.tsx
@@ -24,6 +24,7 @@ const RegistrationSubmissionForm = ({
 }: OperationRegistrationFormProps) => {
   const [formState, setFormState] = useState({});
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
+  const [isSubmitted, setIsSubmitted] = useState(false);
 
   const handleChange = (e: IChangeEvent) => {
     setFormState(e.formData);
@@ -41,27 +42,38 @@ const RegistrationSubmissionForm = ({
           ...e.formData,
         }),
       },
-    );
-    // errors are handled in MultiStepBase
+    ).then((resolve) => {
+      if (resolve?.error) {
+        setSubmitButtonDisabled(false);
+        return { error: resolve.error };
+      } else {
+        setIsSubmitted(true);
+        return resolve;
+      }
+    });
+
     return response;
   };
 
   return (
     <>
-      <MultiStepBase
-        allowBackNavigation
-        baseUrl={`/register-an-operation/${operation}`}
-        cancelUrl="/"
-        formData={formState}
-        onSubmit={handleSubmit}
-        schema={schema}
-        step={step}
-        steps={steps}
-        uiSchema={submissionUiSchema}
-        onChange={handleChange}
-        submitButtonDisabled={submitButtonDisabled}
-        successComponent=<Success step={step} steps={steps} />
-      />
+      {isSubmitted ? (
+        <Success step={step} steps={steps} />
+      ) : (
+        <MultiStepBase
+          allowBackNavigation
+          // baseUrl={`/register-an-operation/${operation}`}
+          cancelUrl="/"
+          formData={formState}
+          onSubmit={handleSubmit}
+          schema={schema}
+          step={step}
+          steps={steps}
+          uiSchema={submissionUiSchema}
+          onChange={handleChange}
+          submitButtonDisabled={submitButtonDisabled}
+        />
+      )}
     </>
   );
 };

--- a/bciers/apps/registration/tests/components/operations/registration/NewEntrantOperationForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/NewEntrantOperationForm.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, vi } from "vitest";
 import React from "react";
@@ -171,15 +177,8 @@ describe("the NewEntrantOperationForm component", () => {
 
     expect(screen.getByText("test.pdf")).toBeVisible();
 
-    await userEvent.click(
-      screen.getByRole("button", { name: /save and continue/i }),
-    );
-
     const submitButton = screen.getByRole("button", {
       name: "Save and Continue",
-    });
-    actionHandler.mockResolvedValueOnce({
-      error: null,
     });
 
     act(() => {
@@ -196,11 +195,10 @@ describe("the NewEntrantOperationForm component", () => {
         body: '{"statutory_declaration":"data:application/pdf;name=test.pdf;base64,dGVzdA=="}',
       },
     );
-
-    expect(mockPush).toHaveBeenCalledTimes(1);
-
-    expect(mockPush).toHaveBeenCalledWith(
-      "/register-an-operation/002d5a9e-32a6-4191-938c-2c02bfec592d/5?title=Placeholder+Title",
-    );
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        "/register-an-operation/002d5a9e-32a6-4191-938c-2c02bfec592d/5",
+      );
+    });
   });
 });

--- a/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
@@ -192,7 +192,9 @@ describe("the OperationInformationForm component", () => {
     },
     async () => {
       fetchFormEnums();
-      actionHandler.mockReturnValueOnce({ id: "uuid2", name: "Operation 2" });
+      actionHandler.mockResolvedValueOnce({
+        id: "b974a7fc-ff63-41aa-9d57-509ebe2553a4",
+      }); // mock the POST response from the submit handler
       render(
         <OperationInformationForm
           rawFormData={{}}
@@ -348,7 +350,9 @@ describe("the OperationInformationForm component", () => {
           },
         );
       });
-      expect(mockPush).toHaveBeenCalledWith("/register-an-operation/uuid2/2");
+      expect(mockPush).toHaveBeenCalledWith(
+        "/register-an-operation/b974a7fc-ff63-41aa-9d57-509ebe2553a4/2",
+      );
     },
   );
 

--- a/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
@@ -179,7 +179,7 @@ describe("the OperationInformationForm component", () => {
         );
 
         expect(mockPush).toHaveBeenCalledWith(
-          "/register-an-operation/b974a7fc-ff63-41aa-9d57-509ebe2553a4/2?title=Existing Operation edited",
+          "/register-an-operation/b974a7fc-ff63-41aa-9d57-509ebe2553a4/2",
         );
       });
     },
@@ -348,9 +348,7 @@ describe("the OperationInformationForm component", () => {
           },
         );
       });
-      expect(mockPush).toHaveBeenCalledWith(
-        "/register-an-operation/uuid2/2?title=Operation 2",
-      );
+      expect(mockPush).toHaveBeenCalledWith("/register-an-operation/uuid2/2");
     },
   );
 

--- a/bciers/apps/registration/tests/components/operations/registration/OperationRepresentativeForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/OperationRepresentativeForm.test.tsx
@@ -161,6 +161,7 @@ describe("the OperationRepresentativeForm component", () => {
 
     userEvent.click(screen.getByRole("button", { name: /save and continue/i }));
     await waitFor(() => {
+      expect(actionHandler).toHaveBeenCalledTimes(1);
       expect(actionHandler).toHaveBeenCalledWith(
         "registration/v2/operations/002d5a9e-32a6-4191-938c-2c02bfec592d/registration/operation-representative",
         "PUT",

--- a/bciers/libs/components/src/form/MultiStepBase.test.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.test.tsx
@@ -111,7 +111,7 @@ describe("The MultiStepBase component", () => {
     expect(headerSteps[2]).toHaveTextContent(/page3/i);
   });
 
-  it("navigation buttons work on first form page", async () => {
+  it("navigation buttons work on first form page when given first page handler", async () => {
     mockOnSubmit.mockReturnValue({ id: "uuid" });
     render(
       <MultiStepBase
@@ -120,6 +120,9 @@ describe("The MultiStepBase component", () => {
         schema={{
           ...testSchema,
           title: "page1",
+        }}
+        firstStepExtraHandling={(response) => {
+          console.log(response);
         }}
       />,
     );
@@ -140,8 +143,11 @@ describe("The MultiStepBase component", () => {
     expect(saveAndContinueButton).not.toBeDisabled();
     fireEvent.click(saveAndContinueButton);
     expect(mockOnSubmit).toHaveBeenCalled();
+    vi.spyOn(console, "log");
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith("/register-an-operation/uuid/2");
+      expect(console.log).toHaveBeenCalledWith({
+        id: "uuid",
+      });
     });
   });
 

--- a/bciers/libs/components/src/form/MultiStepBase.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.tsx
@@ -111,6 +111,8 @@ const MultiStepBase = ({
 
   return isSuccessfullySubmitted ? (
     successComponent
+  ) : isSubmitting ? (
+    <div>Submitting...</div>
   ) : (
     <>
       {allowEdit && (

--- a/bciers/libs/components/src/form/MultiStepBase.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.tsx
@@ -30,6 +30,7 @@ interface MultiStepBaseProps {
   submitButtonDisabled?: boolean;
   customValidate?: any;
   successComponent?: React.ReactNode;
+  firstStepExtraHandling?: (response: any) => any;
 }
 
 // Modified MultiStepFormBase meant to facilitate more modularized Multi-step forms
@@ -56,6 +57,7 @@ const MultiStepBase = ({
   submitButtonDisabled,
   customValidate,
   successComponent,
+  firstStepExtraHandling,
 }: MultiStepBaseProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccessfullySubmitted, setIsSuccessfullySubmitted] = useState(false);
@@ -77,16 +79,11 @@ const MultiStepBase = ({
         setError(response?.error);
         return;
       }
-      // First step
-      if (step === 1) {
-        // The URL below is customized for the registration workflow. It can be generalized later if needed.
-        const nextStepUrl = `/register-an-operation/${response.id}/${step + 1}${
-          baseUrlParams ? `?${baseUrlParams}` : ""
-        }`;
-        router.push(nextStepUrl);
+      // In some cases, for the first step, we need to do something beyond simply redirecting to the baseUrl after successful onSubmit.
+      if (step === 1 && firstStepExtraHandling) {
+        firstStepExtraHandling(response);
         return;
       }
-      // Middle steps
       if (isNotFinalStep && baseUrl) {
         const nextStepUrl = `${baseUrl}/${step + 1}${
           baseUrlParams ? `?${baseUrlParams}` : ""


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=80555060

This PR:
- adds broader error handling to MultiStepBase (previously it was only handling `response.error` errors)
- moved onSubmit error handling from individual form components to MultiStepBase (other error handling, e.g. fetching to populate a dropdown, is still handled in the form components and then the error is passed to MultiStepBase)
- ~move step 1 handling to the MultiStepBase so we don't have to do extra handling in the OperationInformationForm. Step 1 of _any_ workflow will always need to be handled specially because we won't ever have an id before create, but I didn't write a generic case--premature optimization evil and all that~ created new prop for handling step 1
- moves success confirmation to MultiStepBase so that we don't have to do extra error handling in the RegistrationSubmission. Also because a success confirmation is a pretty standard form feature that makes sense in a generic component
- moves isSubmitting logic to MultiStepBase
- removes baseUrl param from our forms because the wireframes don't show a title in the workflow. It's still in the MultiStep component
- Sonarcloud warnings are duplication in test files, I think they're ok to ignore

To test, raise an exception in each endpoint of the registration workflow, and you should see your exception appear on the front end when you hit the endpoint. You can also raise exceptions in `/v2/operations/{uuid:operation_id}` etc. to test that errors in the form components are passed to the multistepbase correctly


Updates after revisions:
- removed showing Submitting... when `isSubmitting` is true--it was only randomly applied, and a loading spinner will be applied in [another ticket ](https://github.com/bcgov/cas-registration/issues/2290)
- no special step 1 handling in MultiStepBase
- success confirmation back to the last step (not necessarily generic to always show a confirmation)
- new prop to optionally put the successful response in state to make it available for the parent component if needed (currently used in first and last steps)
- removed try/catch from MultiStepBase per dev agreement session (let sentry/error boundary handle it)