### PR TITLE
chore: add create confirmation message

### DIFF
--- a/bciers/apps/administration/middlewares/withRulesAppliedAdmin.ts
+++ b/bciers/apps/administration/middlewares/withRulesAppliedAdmin.ts
@@ -93,7 +93,6 @@ const handleIndustryUserRoutes = async (request: NextRequest, token: any) => {
         );
       }
     } catch (error) {
-      console.error("❗ Error fetching user operator data:", error);
       // Proceed to next middleware in case of error
       return null;
     }

--- a/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../../app/data/jsonSchema/contact";
 import ContactForm from "apps/administration/app/components/contacts/ContactForm";
 import { createContactSchema } from "apps/administration/app/components/contacts/createContactSchema";
+import { FrontendMessages } from "@bciers/utils/enums";
 
 const mockReplace = vi.fn();
 useRouter.mockReturnValue({
@@ -257,6 +258,12 @@ describe("ContactForm component", () => {
         expect(mockReplace).toHaveBeenCalledWith(
           "/contacts/123?contacts_title=John Doe",
         );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(FrontendMessages.SUBMIT_CONFIRMATION),
+        ).toBeVisible();
       });
     },
   );

--- a/bciers/apps/administration/tests/components/facilities/FacilityForm.test.tsx
+++ b/bciers/apps/administration/tests/components/facilities/FacilityForm.test.tsx
@@ -16,12 +16,13 @@ import FacilityForm from "apps/administration/app/components/facilities/Facility
 import {
   facilitiesSfoSchema,
   facilitiesSfoUiSchema,
-} from "../../../app/data/jsonSchema/facilitiesSfo";
+} from "apps/administration/app/data/jsonSchema/facilitiesSfo";
 import { RJSFSchema } from "@rjsf/utils";
 import {
   facilitiesLfoSchema,
   facilitiesLfoUiSchema,
-} from "../../../app/data/jsonSchema/facilitiesLfo";
+} from "apps/administration/app/data/jsonSchema/facilitiesLfo";
+import { FrontendMessages } from "@bciers/utils/enums";
 
 const operationId = "8be4c7aa-6ab3-4aad-9206-0ef914fea063";
 const facilityId = "025328a0-f9e8-4e1a-888d-aa192cb053db";
@@ -335,6 +336,12 @@ const assertFormPost = async (
       body: JSON.stringify(responseData),
     },
   );
+
+  await waitFor(() => {
+    expect(
+      screen.getByText(FrontendMessages.SUBMIT_CONFIRMATION),
+    ).toBeVisible();
+  });
 };
 
 // ⛏️ Helper function to simulate form PUT submission and assert the result
@@ -347,7 +354,7 @@ const assertFormPut = async (): Promise<void> => {
   actionHandler.mockReturnValue({ error: null });
   await waitFor(() => {
     expect(
-      screen.getByText("Your edits were saved successfully"),
+      screen.getByText(FrontendMessages.SUBMIT_CONFIRMATION),
     ).toBeVisible();
   });
 };

--- a/bciers/apps/administration/tests/components/operators/OperatorForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operators/OperatorForm.test.tsx
@@ -9,6 +9,7 @@ import { createOperatorSchema } from "apps/administration/app/components/operato
 import expectButton from "../helpers/expectButton";
 import expectField from "../helpers/expectField";
 import expectHeader from "../helpers/expectHeader";
+import { FrontendMessages } from "@bciers/utils/enums";
 
 useSession.mockReturnValue({
   get: vi.fn(),
@@ -354,6 +355,12 @@ describe("OperatorForm component", () => {
         body: JSON.stringify(postMandatory),
       },
     );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(FrontendMessages.SUBMIT_CONFIRMATION),
+      ).toBeVisible();
+    });
   }, 60000);
   it("fills the partner and parent form fields, creates new operator, and redirects on success", async () => {
     render(
@@ -654,6 +661,12 @@ describe("OperatorForm component", () => {
           }),
         },
       );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(FrontendMessages.SUBMIT_CONFIRMATION),
+      ).toBeVisible();
     });
   }, 60000);
 });

--- a/bciers/libs/components/src/form/SingleStepTaskListForm.test.tsx
+++ b/bciers/libs/components/src/form/SingleStepTaskListForm.test.tsx
@@ -3,7 +3,7 @@ import SingleStepTaskListForm from "./SingleStepTaskListForm";
 import SectionFieldTemplate from "@bciers/components/form/fields/SectionFieldTemplate";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import { FormMode } from "@bciers/utils/enums";
-
+import { FrontendMessages } from "@bciers/utils/enums";
 const section1: RJSFSchema = {
   type: "object",
   title: "Section 1",
@@ -146,7 +146,41 @@ describe("the SingleStepTaskListForm component", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
   });
+  it("should show the confirmation snackbar when new form is submitted (when creating)", async () => {
+    const schemaNonRequired: RJSFSchema = {
+      type: "object",
+      properties: {
+        section1,
+        section2,
+        section3,
+      },
+    };
+    render(
+      <SingleStepTaskListForm
+        schema={schemaNonRequired}
+        uiSchema={uiSchema}
+        formData={{}}
+        onCancel={() => {
+          // eslint-disable-next-line no-console
+          console.log("cancel");
+        }}
+        onSubmit={async (e) => {
+          // eslint-disable-next-line no-console
+          console.log("submit", e);
+        }}
+      />,
+    );
+    const submitButton = screen.getByRole("button", { name: "Submit" });
+    fireEvent.click(submitButton);
+    await waitFor(() => {
+      expect(
+        screen.getByText(FrontendMessages.SUBMIT_CONFIRMATION),
+      ).toBeVisible();
+    });
 
+    // check that the component correctly unnested the formData
+    expect(consoleSpy.mock.calls[0][1].formData).toEqual({});
+  });
   it("should transform and render the formData (when editing)", () => {
     render(
       <SingleStepTaskListForm
@@ -179,56 +213,7 @@ describe("the SingleStepTaskListForm component", () => {
     expect(screen.getByText("Testing inline message")).toBeVisible();
   });
 
-  // it("should render the task list checkmarks as sections are filled", async () => {
-  //   render(
-  //     <SingleStepTaskListForm
-  //       schema={schema}
-  //       uiSchema={uiSchema}
-  //       formData={{}}
-  //       onCancel={() => console.log("cancel")}
-  //       onSubmit={async (e) => console.log("submit", e)}
-  //     />,
-  //   );
-  //   expect(screen.getByTestId("section1-tasklist-check")).not.toContainHTML(
-  //     "svg",
-  //   );
-  //   await userEvent.type(screen.getByLabelText(/First name+/i), "test");
-  //   await userEvent.type(screen.getByLabelText(/Last name+/i), "test");
-
-  //   expect(screen.getByTestId("section1-tasklist-check")).toContainHTML("svg");
-  //   expect(screen.getByTestId("section2-tasklist-check")).not.toContainHTML(
-  //     "svg",
-  //   );
-  //   expect(screen.getByTestId("section3-tasklist-check")).not.toContainHTML(
-  //     "svg",
-  //   );
-  // });
-
-  // it("should render the correct task list checks when formData is provided", () => {
-  //   render(
-  //     <SingleStepTaskListForm
-  //       schema={schema}
-  //       uiSchema={uiSchema}
-  //       formData={{
-  //         first_name: "Test",
-  //         last_name: "User",
-  //         phone: "+1234567890",
-  //         email: "test@testing.ca",
-  //       }}
-  //       onCancel={() => console.log("cancel")}
-  //       onSubmit={async (e) => console.log("submit", e)}
-  //       disabled={false}
-  //     />,
-  //   );
-
-  //   expect(screen.getByTestId("section1-tasklist-check")).toContainHTML("svg");
-  //   expect(screen.getByTestId("section2-tasklist-check")).toContainHTML("svg");
-  //   expect(screen.queryByTestId("section3-tasklist-check")).not.toContainHTML(
-  //     "svg",
-  //   );
-  // });
-
-  it("should call the onSubmit function, transform the form data, and show the edit snackbar when the form is submitted", async () => {
+  it("should call the onSubmit function, transform the form data, and shows the confirmation snackbar when the form is submitted", async () => {
     render(
       <SingleStepTaskListForm
         schema={schema}
@@ -251,7 +236,7 @@ describe("the SingleStepTaskListForm component", () => {
     fireEvent.click(submitButton);
     await waitFor(() => {
       expect(
-        screen.getByText("Your edits were saved successfully"),
+        screen.getByText(FrontendMessages.SUBMIT_CONFIRMATION),
       ).toBeVisible();
     });
 
@@ -350,87 +335,6 @@ describe("the SingleStepTaskListForm component", () => {
     expect(inputBorderElement).toHaveStyle(defaultStyle);
   });
 
-  // it("should validate each section as the user types and display check in task list", async () => {
-  //   render(
-  //     <SingleStepTaskListForm
-  //       schema={schema}
-  //       uiSchema={uiSchema}
-  //       formData={{}}
-  //       onCancel={() => console.log("cancel")}
-  //       onSubmit={async (e) => console.log("submit", e)}
-  //     />,
-  //   );
-
-  //   expect(screen.queryByTestId("section1-tasklist-check")).not.toContainHTML(
-  //     "svg",
-  //   );
-  //   expect(screen.queryByTestId("section2-tasklist-check")).not.toContainHTML(
-  //     "svg",
-  //   );
-  //   expect(screen.queryByTestId("section3-tasklist-check")).not.toContainHTML(
-  //     "svg",
-  //   );
-
-  //   // Fill in section 1 fields and verify the task list check appears
-  //   const firstNameField = screen.getByLabelText("First name*");
-  //   const lastNameField = screen.getByLabelText("Last name*");
-
-  //   fireEvent.change(firstNameField, { target: { value: "Test" } });
-  //   fireEvent.change(lastNameField, { target: { value: "User" } });
-
-  //   expect(screen.getByTestId("section1-tasklist-check")).toContainHTML("svg");
-
-  //   // Fill in section 2 fields and verify the task list check appears
-  //   const phoneField = screen.getByLabelText("Phone*");
-  //   const emailField = screen.getByLabelText("Email*");
-
-  //   fireEvent.change(phoneField, { target: { value: "12345678901" } });
-  //   fireEvent.change(emailField, { target: { value: "test@testing.ca" } });
-
-  //   expect(screen.getByTestId("section2-tasklist-check")).toContainHTML("svg");
-
-  //   // Fill in section 3 fields and verify the task list check appears
-  //   const addressField = screen.getByLabelText("Address*");
-  //   const cityField = screen.getByLabelText("City*");
-
-  //   fireEvent.change(addressField, { target: { value: "123 Test St" } });
-  //   fireEvent.change(cityField, { target: { value: "Victoria" } });
-
-  //   expect(screen.getByTestId("section3-tasklist-check")).toContainHTML("svg");
-  // });
-
-  // it("should not render a task list check if the format validation fails", () => {
-  //   render(
-  //     <SingleStepTaskListForm
-  //       schema={schema}
-  //       uiSchema={uiSchema}
-  //       formData={{}}
-  //       onCancel={() => console.log("cancel")}
-  //       onSubmit={async (e) => console.log("submit", e)}
-  //     />,
-  //   );
-
-  //   const phoneField = screen.getByLabelText("Phone*");
-  //   const emailField = screen.getByLabelText("Email*");
-
-  //   // Invalid phone number
-  //   fireEvent.change(phoneField, { target: { value: "1234567" } });
-  //   // Invalid email
-  //   fireEvent.change(emailField, { target: { value: "test@tes" } });
-
-  //   expect(
-  //     screen.queryByTestId("section2-tasklist-check"),
-  //   ).toBeEmptyDOMElement();
-
-  //   // Valid phone number
-  //   fireEvent.change(phoneField, { target: { value: "12345678901" } });
-  //   // Valid email
-  //   fireEvent.change(emailField, { target: { value: "test@testing.ca" } });
-
-  //   expect(
-  //     screen.getByTestId("section2-tasklist-check"),
-  //   ).not.toBeEmptyDOMElement();
-  // });
   it("should render an api error if an error is passed", () => {
     render(
       <SingleStepTaskListForm
@@ -453,6 +357,7 @@ describe("the SingleStepTaskListForm component", () => {
       screen.getByText("Name: Facility with this Name already exists"),
     ).toBeVisible();
   });
+
   it("should not render Edit/Submit button when allowEdit is false", () => {
     render(
       <SingleStepTaskListForm
@@ -474,3 +379,134 @@ describe("the SingleStepTaskListForm component", () => {
     expect(screen.queryByRole("button", { name: "Submit" })).toBeNull();
   });
 });
+
+// it("should render the task list checkmarks as sections are filled", async () => {
+//   render(
+//     <SingleStepTaskListForm
+//       schema={schema}
+//       uiSchema={uiSchema}
+//       formData={{}}
+//       onCancel={() => console.log("cancel")}
+//       onSubmit={async (e) => console.log("submit", e)}
+//     />,
+//   );
+//   expect(screen.getByTestId("section1-tasklist-check")).not.toContainHTML(
+//     "svg",
+//   );
+//   await userEvent.type(screen.getByLabelText(/First name+/i), "test");
+//   await userEvent.type(screen.getByLabelText(/Last name+/i), "test");
+
+//   expect(screen.getByTestId("section1-tasklist-check")).toContainHTML("svg");
+//   expect(screen.getByTestId("section2-tasklist-check")).not.toContainHTML(
+//     "svg",
+//   );
+//   expect(screen.getByTestId("section3-tasklist-check")).not.toContainHTML(
+//     "svg",
+//   );
+// });
+
+// it("should render the correct task list checks when formData is provided", () => {
+//   render(
+//     <SingleStepTaskListForm
+//       schema={schema}
+//       uiSchema={uiSchema}
+//       formData={{
+//         first_name: "Test",
+//         last_name: "User",
+//         phone: "+1234567890",
+//         email: "test@testing.ca",
+//       }}
+//       onCancel={() => console.log("cancel")}
+//       onSubmit={async (e) => console.log("submit", e)}
+//       disabled={false}
+//     />,
+//   );
+
+//   expect(screen.getByTestId("section1-tasklist-check")).toContainHTML("svg");
+//   expect(screen.getByTestId("section2-tasklist-check")).toContainHTML("svg");
+//   expect(screen.queryByTestId("section3-tasklist-check")).not.toContainHTML(
+//     "svg",
+//   );
+// });
+
+// it("should validate each section as the user types and display check in task list", async () => {
+//   render(
+//     <SingleStepTaskListForm
+//       schema={schema}
+//       uiSchema={uiSchema}
+//       formData={{}}
+//       onCancel={() => console.log("cancel")}
+//       onSubmit={async (e) => console.log("submit", e)}
+//     />,
+//   );
+
+//   expect(screen.queryByTestId("section1-tasklist-check")).not.toContainHTML(
+//     "svg",
+//   );
+//   expect(screen.queryByTestId("section2-tasklist-check")).not.toContainHTML(
+//     "svg",
+//   );
+//   expect(screen.queryByTestId("section3-tasklist-check")).not.toContainHTML(
+//     "svg",
+//   );
+
+//   // Fill in section 1 fields and verify the task list check appears
+//   const firstNameField = screen.getByLabelText("First name*");
+//   const lastNameField = screen.getByLabelText("Last name*");
+
+//   fireEvent.change(firstNameField, { target: { value: "Test" } });
+//   fireEvent.change(lastNameField, { target: { value: "User" } });
+
+//   expect(screen.getByTestId("section1-tasklist-check")).toContainHTML("svg");
+
+//   // Fill in section 2 fields and verify the task list check appears
+//   const phoneField = screen.getByLabelText("Phone*");
+//   const emailField = screen.getByLabelText("Email*");
+
+//   fireEvent.change(phoneField, { target: { value: "12345678901" } });
+//   fireEvent.change(emailField, { target: { value: "test@testing.ca" } });
+
+//   expect(screen.getByTestId("section2-tasklist-check")).toContainHTML("svg");
+
+//   // Fill in section 3 fields and verify the task list check appears
+//   const addressField = screen.getByLabelText("Address*");
+//   const cityField = screen.getByLabelText("City*");
+
+//   fireEvent.change(addressField, { target: { value: "123 Test St" } });
+//   fireEvent.change(cityField, { target: { value: "Victoria" } });
+
+//   expect(screen.getByTestId("section3-tasklist-check")).toContainHTML("svg");
+// });
+
+// it("should not render a task list check if the format validation fails", () => {
+//   render(
+//     <SingleStepTaskListForm
+//       schema={schema}
+//       uiSchema={uiSchema}
+//       formData={{}}
+//       onCancel={() => console.log("cancel")}
+//       onSubmit={async (e) => console.log("submit", e)}
+//     />,
+//   );
+
+//   const phoneField = screen.getByLabelText("Phone*");
+//   const emailField = screen.getByLabelText("Email*");
+
+//   // Invalid phone number
+//   fireEvent.change(phoneField, { target: { value: "1234567" } });
+//   // Invalid email
+//   fireEvent.change(emailField, { target: { value: "test@tes" } });
+
+//   expect(
+//     screen.queryByTestId("section2-tasklist-check"),
+//   ).toBeEmptyDOMElement();
+
+//   // Valid phone number
+//   fireEvent.change(phoneField, { target: { value: "12345678901" } });
+//   // Valid email
+//   fireEvent.change(emailField, { target: { value: "test@testing.ca" } });
+
+//   expect(
+//     screen.getByTestId("section2-tasklist-check"),
+//   ).not.toBeEmptyDOMElement();
+// });

--- a/bciers/libs/components/src/form/SingleStepTaskListForm.tsx
+++ b/bciers/libs/components/src/form/SingleStepTaskListForm.tsx
@@ -9,6 +9,7 @@ import TaskList from "@bciers/components/form/components/TaskList";
 import { createNestedFormData, createUnnestedFormData } from "./formDataUtils";
 import { FormMode } from "@bciers/utils/enums";
 import SnackBar from "@bciers/components/form/components/SnackBar";
+import { FrontendMessages } from "@bciers/utils/enums";
 
 interface SingleStepTaskListFormProps {
   disabled?: boolean;
@@ -69,8 +70,7 @@ const SingleStepTaskListForm = ({
       setIsDisabled(false);
     } else {
       setIsDisabled(true);
-      // we only show the snackbar confirmation when editing
-      if (hasFormData) setIsSnackbarOpen(true);
+      setIsSnackbarOpen(true);
     }
   };
 
@@ -86,7 +86,7 @@ const SingleStepTaskListForm = ({
     <div className="w-full flex flex-row mt-8">
       <SnackBar
         isSnackbarOpen={isSnackbarOpen}
-        message="Your edits were saved successfully"
+        message={FrontendMessages.SUBMIT_CONFIRMATION}
         setIsSnackbarOpen={setIsSnackbarOpen}
       />
       <TaskList

--- a/bciers/libs/utils/enums.ts
+++ b/bciers/libs/utils/enums.ts
@@ -15,6 +15,10 @@ export enum FrontEndRoles {
   INDUSTRY_USER_ADMIN = "industry_user_admin",
 }
 
+export enum FrontendMessages {
+  SUBMIT_CONFIRMATION = "All changes have been successfully saved",
+}
+
 export enum OperationStatus {
   NOT_STARTED = "Not Started",
   DRAFT = "Draft",


### PR DESCRIPTION
Addresses [1983](https://github.com/bcgov/cas-registration/issues/1983)

### 🚀 Impact:
- Updated `Snackbar` to display confirmation message for create action
- Added vitests


### 🔬 Local Testing:

1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
3.  From terminal command, start the app development server:
 ```
cd client && yarn dev-all

```


### Add an Operator:
1. Navigate to `http://localhost:3000`
2. Click button "Log in with Business BCeID"
3. Sign in to Keycloak using `bc-cas-dev-secondary`
4. Click link `Administration\Select an Operator` 
5. Click link `Add Operator`
6. Compete the form
7. Click button `Submit`
**Expected results:** 
- Form displays snackbar with confirmation message
![image](https://github.com/user-attachments/assets/6517e1d9-dab6-44cb-8d99-5ea2cac08cec)



### Add a Contact:
1. Navigate to `http://localhost:3000`
2. Click button "Log in with Business BCeID"
3. Sign in to Keycloak using `bc-cas-dev`
4. Click link `Administration\Contacts` 
5. Click link `Add Contact`
6. Compete the form
7. Click button `Submit`
**Expected results:** 
- Form displays snackbar with confirmation message
![image](https://github.com/user-attachments/assets/6517e1d9-dab6-44cb-8d99-5ea2cac08cec)


### Add a Facility:
1. Navigate to `http://localhost:3000`
2. Click button "Log in with Business BCeID"
3. Sign in to Keycloak using `bc-cas-dev`
4. Click link `Administration\Operations` 
5. Click link row action `View Facilities`
6. Click button `Add Facility`
7. Compete the form
9. Click button `Submit`
**Expected results:** 
- Form displays snackbar with confirmation message
![image](https://github.com/user-attachments/assets/6517e1d9-dab6-44cb-8d99-5ea2cac08cec)

