### PR TITLE
chore: update auth.config call to user-profile

### DIFF
--- a/bciers/apps/dashboard/auth/auth.config.ts
+++ b/bciers/apps/dashboard/auth/auth.config.ts
@@ -100,16 +100,18 @@ export default {
 
           token.identity_provider = account.providerAccountId.split("@")[1];
         }
-        // 🚀 API call: Get user name from user table
-        const response = await actionHandler(
-          `registration/user/user-profile/${token.user_guid}`,
-          "GET",
-        );
-        const { first_name: firstName, last_name: lastName } = response || {};
-        if (firstName && lastName) {
-          token.full_name = `${firstName} ${lastName}`;
-        } else {
-          token.full_name = `${token.given_name} ${token.family_name}`;
+        if (!token.full_name) {
+          // 🚀 API call: Get user name from user table
+          const response = await actionHandler(
+            `registration/user/user-profile/${token.user_guid}`,
+            "GET",
+          );
+          const { first_name: firstName, last_name: lastName } = response || {};
+          if (firstName && lastName) {
+            token.full_name = `${firstName} ${lastName}`;
+          } else {
+            token.full_name = `${token.given_name} ${token.family_name}`;
+          }
         }
         // If no token.app_role, augment the keycloak token with cas registration user app_role
         if (!token.app_role) {


### PR DESCRIPTION
### 🚀 Impact:
- Updated auth.config to limit API call to `user-profile` only if token is missing `full_name`


### 🔬 Local Testing:

1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd client && yarn dev-all

```

3. Verify the `bc_obps` terminal has correct number of calls to `user-profile` from the auth.config 
BEFORE
![image](https://github.com/user-attachments/assets/21b7bd9d-84d4-4651-a5a4-2d69c3b8c9da)
AFTER
![image](https://github.com/user-attachments/assets/c3913c8c-b917-4064-adeb-b33ac3fe46cb)
