### PR TITLE
Chore: minor schema fixes

### DIFF
--- a/bc_obps/reporting/json_schemas/2024/hydrogen_production/feedstock_material_balance_custom.json
+++ b/bc_obps/reporting/json_schemas/2024/hydrogen_production/feedstock_material_balance_custom.json
@@ -1,19 +1,19 @@
 {
   "type": "object",
   "properties": {
-    "feedStocks": {
+    "feedstocks": {
       "type": "array",
-      "title": "Feed Stocks",
+      "title": "Feedstocks",
       "items": {
         "type": "object",
         "properties": {
-          "feedStock": {
+          "feedstock": {
             "type": "string",
             "title": "Feedstock"
           },
           "annualFeedStockAmount": {
             "type": "string",
-            "title": "Annual Feed Stock Amount"
+            "title": "Annual Feedstock Amount"
           },
           "annualHydrogenProduction": {
             "type": "number",

--- a/bc_obps/reporting/json_schemas/2024/hydrogen_production/feedstock_material_balance_custom.json
+++ b/bc_obps/reporting/json_schemas/2024/hydrogen_production/feedstock_material_balance_custom.json
@@ -11,7 +11,7 @@
             "type": "string",
             "title": "Feedstock"
           },
-          "annualFeedStockAmount": {
+          "annualFeedstockAmount": {
             "type": "string",
             "title": "Annual Feedstock Amount"
           },

--- a/bc_obps/reporting/migrations/0018_pulp_and_paper_production.py
+++ b/bc_obps/reporting/migrations/0018_pulp_and_paper_production.py
@@ -261,18 +261,6 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
             field_name='Annual high heat value of spent liquor solids (GJ/kg)', field_units__isnull=True
         ),
     )
-    ConfigurationElement.objects.get(
-        activity_id=Activity.objects.get(name='Pulp and paper production').id,
-        source_type_id=SourceType.objects.get(name='Pulping and chemical recovery').id,
-        gas_type_id=GasType.objects.get(chemical_formula='CO2').id,
-        methodology_id=Methodology.objects.get(name='Solids-HHV').id,
-        valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
-        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(
-        ReportingField.objects.get(
-            field_name='Annual carbon content of spent liquor solids (% by weight)', field_units__isnull=True
-        ),
-    )
     # CO2 - Solids-CC
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(name='Pulp and paper production').id,

--- a/bc_obps/reporting/migrations/0018_pulp_and_paper_production.py
+++ b/bc_obps/reporting/migrations/0018_pulp_and_paper_production.py
@@ -237,26 +237,6 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Carbonate Name', field_units__isnull=True),
-    )
-    ConfigurationElement.objects.get(
-        activity_id=Activity.objects.get(name='Pulp and paper production').id,
-        source_type_id=SourceType.objects.get(name='Pulping and chemical recovery').id,
-        gas_type_id=GasType.objects.get(chemical_formula='CO2').id,
-        methodology_id=Methodology.objects.get(name='Solids-HHV').id,
-        valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
-        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Purity Of Carbonate (Weight Fraction)', field_units__isnull=True),
-    )
-    ConfigurationElement.objects.get(
-        activity_id=Activity.objects.get(name='Pulp and paper production').id,
-        source_type_id=SourceType.objects.get(name='Pulping and chemical recovery').id,
-        gas_type_id=GasType.objects.get(chemical_formula='CO2').id,
-        methodology_id=Methodology.objects.get(name='Solids-HHV').id,
-        valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
-        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(
         ReportingField.objects.get(field_name='Mass of spent liquor combusted (tonnes/year)', field_units__isnull=True),
     )
     ConfigurationElement.objects.get(
@@ -313,18 +293,6 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
         ReportingField.objects.get(field_name='Solids percentage by weight (%)', field_units__isnull=True),
-    )
-    ConfigurationElement.objects.get(
-        activity_id=Activity.objects.get(name='Pulp and paper production').id,
-        source_type_id=SourceType.objects.get(name='Pulping and chemical recovery').id,
-        gas_type_id=GasType.objects.get(chemical_formula='CO2').id,
-        methodology_id=Methodology.objects.get(name='Solids-CC').id,
-        valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
-        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(
-        ReportingField.objects.get(
-            field_name='Annual high heat value of spent liquor solids (GJ/kg)', field_units__isnull=True
-        ),
     )
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(name='Pulp and paper production').id,

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_gsc_other_than_non_compression_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_gsc_other_than_non_compression_2024.py
@@ -5,7 +5,7 @@ from reporting.models.configuration import Configuration
 from reporting.models.configuration_element import ConfigurationElement
 
 
-class TestGSCExcludingLineTracing2024(TestCase):
+class TestGSCOtherThanNonCompression2024(TestCase):
     def testDataExists(self):
         activity = Activity.objects.get(
             name='General stationary combustion, other than non-compression and non-processing combustion'

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_gsc_solely_for_line_tracing_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_gsc_solely_for_line_tracing_2024.py
@@ -5,7 +5,7 @@ from reporting.models.configuration import Configuration
 from reporting.models.configuration_element import ConfigurationElement
 
 
-class TestGSCExcludingLineTracing2024(TestCase):
+class TestGSCSolelyLineTracing2024(TestCase):
     def testDataExists(self):
         activity = Activity.objects.get(name='General stationary combustion solely for the purpose of line tracing')
         config = Configuration.objects.get(slug='2024')

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_hydrogen_production_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_hydrogen_production_2024.py
@@ -91,14 +91,14 @@ class HydrogenProduction2024Test(TestCase):
 
         # Define the expected schema for the "Feedstock Material Balance" methodology
         expected_schema = {
-            "feedStocks": {
+            "feedstocks": {
                 "type": "array",
-                "title": "Feed Stocks",
+                "title": "FeedStocks",
                 "items": {
                     "type": "object",
                     "properties": {
-                        "feedStock": {"type": "string", "title": "Feedstock"},
-                        "annualFeedStockAmount": {"type": "string", "title": "Annual Feed Stock Amount"},
+                        "feedstock": {"type": "string", "title": "Feedstock"},
+                        "annualFeedStockAmount": {"type": "string", "title": "Annual Feedstock Amount"},
                         "annualHydrogenProduction": {"type": "number", "title": "Annual Hydrogen Production"},
                         "unitForAnnualFeedstockAmount": {
                             "type": "string",

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_hydrogen_production_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_hydrogen_production_2024.py
@@ -93,12 +93,12 @@ class HydrogenProduction2024Test(TestCase):
         expected_schema = {
             "feedstocks": {
                 "type": "array",
-                "title": "FeedStocks",
+                "title": "Feedstocks",
                 "items": {
                     "type": "object",
                     "properties": {
                         "feedstock": {"type": "string", "title": "Feedstock"},
-                        "annualFeedStockAmount": {"type": "string", "title": "Annual Feedstock Amount"},
+                        "annualFeedstockAmount": {"type": "string", "title": "Annual Feedstock Amount"},
                         "annualHydrogenProduction": {"type": "number", "title": "Annual Hydrogen Production"},
                         "unitForAnnualFeedstockAmount": {
                             "type": "string",

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_pulp_and_paper_production_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_pulp_and_paper_production_2024.py
@@ -17,8 +17,8 @@ class PulpAndPaperProduction2024TestCase(TestCase):
         # For each gas, the list of methodologies and their associated field's count
         gas_config = {
             'CO2': {
-                'Solids-HHV': 6,
-                'Solids-CC': 4,
+                'Solids-HHV': 3,
+                'Solids-CC': 3,
                 'Make-up Chemical Use Methodology': 2,
                 'Alternative Parameter Methodology': 1,
                 'Replacement Methodology': 1,

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_refinery_fuel_gas_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_refinery_fuel_gas_2024.py
@@ -5,7 +5,7 @@ from reporting.models.configuration import Configuration
 from reporting.models.configuration_element import ConfigurationElement
 
 
-class TestGSCExcludingLineTracing2024(TestCase):
+class TestRefineryFuelGas2024(TestCase):
     def testDataExists(self):
         activity = Activity.objects.get(name='Refinery fuel gas combustion')
         config = Configuration.objects.get(slug='2024')

--- a/bciers/apps/reporting/next-env.d.ts
+++ b/bciers/apps/reporting/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscOtherThanNonCompression.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscOtherThanNonCompression.ts
@@ -134,17 +134,22 @@ const uiSchema = {
               title: "Fuel",
             },
             items: {
-              "ui:order": [
-                "fuelName",
-                "fuelUnit",
-                "annualFuelAmount",
-                "emissions",
-              ],
-              fuelName: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
+              "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
               fuelType: {
-                "ui:FieldTemplate": InlineFieldTemplate,
+                "ui:field": "fuelType",
+                "ui:FieldTemplate": FieldTemplate,
+                "ui:options": {
+                  label: false,
+                },
+                fuelName: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelUnit: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelClassification: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
               },
               annualFuelAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,
@@ -198,17 +203,22 @@ const uiSchema = {
               title: "Fuel",
             },
             items: {
-              "ui:order": [
-                "fuelName",
-                "fuelUnit",
-                "annualFuelAmount",
-                "emissions",
-              ],
-              fuelName: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
+              "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
               fuelType: {
-                "ui:FieldTemplate": InlineFieldTemplate,
+                "ui:field": "fuelType",
+                "ui:FieldTemplate": FieldTemplate,
+                "ui:options": {
+                  label: false,
+                },
+                fuelName: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelUnit: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelClassification: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
               },
               annualFuelAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
@@ -69,7 +69,7 @@ const uiSchema = {
             "ui:ArrayFieldTemplate": NestedArrayFieldTemplate,
             "ui:FieldTemplate": FieldTemplate,
             "ui:options": {
-              arrayAddLabel: "Add FeedStock",
+              arrayAddLabel: "Add Feedstock",
               title: "Feedstock",
               label: false,
               verticalBorder: true,
@@ -77,7 +77,7 @@ const uiSchema = {
             items: {
               "ui:order": [
                 "feedstock",
-                "annualFeedStockAmount",
+                "annualFeedstockAmount",
                 "unitForAnnualFeedstockAmount",
                 "annualHydrogenProduction",
               ],
@@ -85,7 +85,7 @@ const uiSchema = {
               feedstock: {
                 "ui:FieldTemplate": InlineFieldTemplate,
               },
-              annualFeedStockAmount: {
+              annualFeedstockAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,
               },
               unitForAnnualFeedstockAmount: {

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
@@ -35,7 +35,7 @@ const uiSchema = {
             "emission",
             "equivalentEmissions",
             "methodology",
-            "feedStocks",
+            "feedstocks",
             "description",
           ],
           gasType: {
@@ -64,8 +64,8 @@ const uiSchema = {
               ],
             },
           },
-          feedStocks: {
-            "ui:title": "Feed Stocks",
+          feedstocks: {
+            "ui:title": "Feedstocks",
             "ui:ArrayFieldTemplate": NestedArrayFieldTemplate,
             "ui:FieldTemplate": FieldTemplate,
             "ui:options": {
@@ -76,13 +76,13 @@ const uiSchema = {
             },
             items: {
               "ui:order": [
-                "feedStock",
+                "feedstock",
                 "annualFeedStockAmount",
                 "unitForAnnualFeedstockAmount",
                 "annualHydrogenProduction",
               ],
 
-              feedStock: {
+              feedstock: {
                 "ui:FieldTemplate": InlineFieldTemplate,
               },
               annualFeedStockAmount: {


### PR DESCRIPTION
- Fix ui schemas I missed when adding the fuelType object to the schemas (GSC other than non-compression)
- Remove extraneous fields from pulp & paper methodologies for CO2
- Harmonize "Feedstocks" to be one word & capitalized consistently
- Fix copy-paste errors in test names