### PR TITLE
test: vitests for MultiStepBase error handling

### DIFF
--- a/bciers/libs/components/src/form/MultiStepBase.test.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.test.tsx
@@ -314,4 +314,38 @@ describe("The MultiStepBase component", () => {
       expect(screen.getByText("whoopsie")).toBeVisible();
     });
   });
+
+  it("calls the onChange prop when the form changes", () => {
+    useParams.mockReturnValue({
+      formSection: "1",
+      operation: "create",
+    } as QueryParams);
+
+    const changeHandler = vi.fn();
+    render(
+      <MultiStepBase
+        {...defaultProps}
+        disabled={false}
+        onChange={changeHandler}
+      />,
+    );
+    const input = screen.getByLabelText(/field1*/i);
+    fireEvent.change(input, { target: { value: "new value" } });
+
+    expect(changeHandler).toHaveBeenCalled();
+  });
+
+  it("renders children", () => {
+    useParams.mockReturnValue({
+      formSection: "1",
+      operation: "create",
+    } as QueryParams);
+
+    render(
+      <MultiStepBase {...defaultProps}>
+        <div data-testid="test-child">Test child</div>
+      </MultiStepBase>,
+    );
+    expect(screen.getByTestId("test-child")).toBeVisible();
+  });
 });

--- a/bciers/libs/components/src/form/MultiStepBase.test.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.test.tsx
@@ -318,7 +318,7 @@ describe("The MultiStepBase component", () => {
   it(
     "calls the onChange prop when the form changes",
     {
-      timeout: 10000,
+      timeout: 60000,
     },
     () => {
       useParams.mockReturnValue({
@@ -344,7 +344,7 @@ describe("The MultiStepBase component", () => {
   it(
     "renders children",
     {
-      timeout: 10000,
+      timeout: 60000,
     },
     () => {
       useParams.mockReturnValue({
@@ -363,7 +363,7 @@ describe("The MultiStepBase component", () => {
   it(
     "clear old errors",
     {
-      timeout: 10000,
+      timeout: 60000,
     },
     () => {
       render(

--- a/bciers/libs/components/src/form/MultiStepBase.test.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.test.tsx
@@ -315,37 +315,78 @@ describe("The MultiStepBase component", () => {
     });
   });
 
-  it("calls the onChange prop when the form changes", () => {
-    useParams.mockReturnValue({
-      formSection: "1",
-      operation: "create",
-    } as QueryParams);
+  it(
+    "calls the onChange prop when the form changes",
+    {
+      timeout: 10000,
+    },
+    () => {
+      useParams.mockReturnValue({
+        formSection: "1",
+        operation: "create",
+      } as QueryParams);
 
-    const changeHandler = vi.fn();
-    render(
-      <MultiStepBase
-        {...defaultProps}
-        disabled={false}
-        onChange={changeHandler}
-      />,
-    );
-    const input = screen.getByLabelText(/field1*/i);
-    fireEvent.change(input, { target: { value: "new value" } });
+      const changeHandler = vi.fn();
+      render(
+        <MultiStepBase
+          {...defaultProps}
+          disabled={false}
+          onChange={changeHandler}
+        />,
+      );
+      const input = screen.getByLabelText(/field1*/i);
+      fireEvent.change(input, { target: { value: "new value" } });
 
-    expect(changeHandler).toHaveBeenCalled();
-  });
+      expect(changeHandler).toHaveBeenCalled();
+    },
+  );
 
-  it("renders children", () => {
-    useParams.mockReturnValue({
-      formSection: "1",
-      operation: "create",
-    } as QueryParams);
+  it(
+    "renders children",
+    {
+      timeout: 10000,
+    },
+    () => {
+      useParams.mockReturnValue({
+        formSection: "1",
+        operation: "create",
+      } as QueryParams);
 
-    render(
-      <MultiStepBase {...defaultProps}>
-        <div data-testid="test-child">Test child</div>
-      </MultiStepBase>,
-    );
-    expect(screen.getByTestId("test-child")).toBeVisible();
-  });
+      render(
+        <MultiStepBase {...defaultProps}>
+          <div data-testid="test-child">Test child</div>
+        </MultiStepBase>,
+      );
+      expect(screen.getByTestId("test-child")).toBeVisible();
+    },
+  );
+  it(
+    "clear old errors",
+    {
+      timeout: 10000,
+    },
+    () => {
+      render(
+        <MultiStepBase
+          {...defaultProps}
+          disabled={false}
+          step={2}
+          schema={{
+            ...testSchema,
+            title: "page2",
+          }}
+          error={"old"}
+        />,
+      );
+      const saveAndContinueButton = screen.getByRole("button", {
+        name: /Save and Continue/i,
+      });
+
+      fireEvent.click(saveAndContinueButton);
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalled();
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      });
+    },
+  );
 });


### PR DESCRIPTION
More vitests for card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=80555060

I had a test to check that old errors are cleared (code below), but I couldn't get it working in CI, I always got the following:
![image](https://github.com/user-attachments/assets/f19f3ecd-9fb3-46dc-9ed9-9805cc5cdfb5)

I don't think it's a particularly important test because if the errors don't clear, it's just a visual problem. It doesn't affect form submission. My timebox has run out so I've just cut this test.

```
it("clear old errors", () => {
    render(
      <MultiStepBase
        {...defaultProps}
        disabled={false}
        step={2}
        schema={{
          ...testSchema,
          title: "page2",
        }}
        error={"old"}
      />,
    );
   const saveAndContinueButton = screen.getByRole("button", {
      name: /Save and Continue/i,
    });

    fireEvent.click(saveAndContinueButton);
    await waitFor(() => {
      expect(mockOnSubmit).toHaveBeenCalled();
      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
    });
  });
```
