### PR TITLE
test: test error handling

### DIFF
--- a/bciers/libs/components/src/form/MultiStepBase.test.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.test.tsx
@@ -314,4 +314,38 @@ describe("The MultiStepBase component", () => {
       expect(screen.getByText("whoopsie")).toBeVisible();
     });
   });
+
+  it("calls the onChange prop when the form changes", () => {
+    useParams.mockReturnValue({
+      formSection: "1",
+      operation: "create",
+    } as QueryParams);
+
+    const changeHandler = vi.fn();
+    render(
+      <MultiStepBase
+        {...defaultProps}
+        disabled={false}
+        onChange={changeHandler}
+      />,
+    );
+    const input = screen.getByLabelText(/field1*/i);
+    fireEvent.change(input, { target: { value: "new value" } });
+
+    expect(changeHandler).toHaveBeenCalled();
+  });
+
+  it("renders children", () => {
+    useParams.mockReturnValue({
+      formSection: "1",
+      operation: "create",
+    } as QueryParams);
+
+    render(
+      <MultiStepBase {...defaultProps}>
+        <div data-testid="test-child">Test child</div>
+      </MultiStepBase>,
+    );
+    expect(screen.getByTestId("test-child")).toBeVisible();
+  });
 });

--- a/bciers/libs/components/src/form/MultiStepBase.test.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.test.tsx
@@ -257,6 +257,40 @@ describe("The MultiStepBase component", () => {
     expect(saveAndContinueButton).not.toBeDisabled();
   });
 
+  it("calls the onChange prop when the form changes", () => {
+    useParams.mockReturnValue({
+      formSection: "1",
+      operation: "create",
+    } as QueryParams);
+
+    const changeHandler = vi.fn();
+    render(
+      <MultiStepBase
+        {...defaultProps}
+        disabled={false}
+        onChange={changeHandler}
+      />,
+    );
+    const input = screen.getByLabelText(/field1*/i);
+    fireEvent.change(input, { target: { value: "new value" } });
+
+    expect(changeHandler).toHaveBeenCalled();
+  });
+
+  it("renders children", () => {
+    useParams.mockReturnValue({
+      formSection: "1",
+      operation: "create",
+    } as QueryParams);
+
+    render(
+      <MultiStepBase {...defaultProps}>
+        <div data-testid="test-child">Test child</div>
+      </MultiStepBase>,
+    );
+    expect(screen.getByTestId("test-child")).toBeVisible();
+  });
+
   it("shows an error if there was a problem with form validation", () => {
     useParams.mockReturnValue({
       formSection: "1",
@@ -313,39 +347,5 @@ describe("The MultiStepBase component", () => {
       expect(screen.getByRole("alert")).toBeVisible();
       expect(screen.getByText("whoopsie")).toBeVisible();
     });
-  });
-
-  it("calls the onChange prop when the form changes", () => {
-    useParams.mockReturnValue({
-      formSection: "1",
-      operation: "create",
-    } as QueryParams);
-
-    const changeHandler = vi.fn();
-    render(
-      <MultiStepBase
-        {...defaultProps}
-        disabled={false}
-        onChange={changeHandler}
-      />,
-    );
-    const input = screen.getByLabelText(/field1*/i);
-    fireEvent.change(input, { target: { value: "new value" } });
-
-    expect(changeHandler).toHaveBeenCalled();
-  });
-
-  it("renders children", () => {
-    useParams.mockReturnValue({
-      formSection: "1",
-      operation: "create",
-    } as QueryParams);
-
-    render(
-      <MultiStepBase {...defaultProps}>
-        <div data-testid="test-child">Test child</div>
-      </MultiStepBase>,
-    );
-    expect(screen.getByTestId("test-child")).toBeVisible();
   });
 });


### PR DESCRIPTION
More vitests for card: https://github.com/orgs/bcgov/projects/122/views/2?pane=issue&itemId=80555060

I had a test to check that old errors are cleared (code below), but I was having a lot of problems with it (details below) and my timebox ran out, so I've just cut it. I don't think it's a particularly important test because if the errors don't clear, it's only a visual problem. It doesn't affect form submission. 

Problems:
- if you run push up the up the other tests, CI is fine. Add the old errors test, fail. Remove the old errors test, STILL fail.
- one time got an actual error log. But every other time just got:
![image](https://github.com/user-attachments/assets/f19f3ecd-9fb3-46dc-9ed9-9805cc5cdfb5)
- code for the haunted test:
```
it("clear old errors", () => {
    render(
      <MultiStepBase
        {...defaultProps}
        disabled={false}
        step={2}
        schema={{
          ...testSchema,
          title: "page2",
        }}
        error={"old"}
      />,
    );
   const saveAndContinueButton = screen.getByRole("button", {
      name: /Save and Continue/i,
    });

    fireEvent.click(saveAndContinueButton);
    await waitFor(() => {
      expect(mockOnSubmit).toHaveBeenCalled();
      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
    });
  });
```
