### PR TITLE
fix/facilty lfo save and continue

### DIFF
--- a/bciers/apps/registration/app/components/operations/registration/FacilityInformationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/FacilityInformationForm.tsx
@@ -125,11 +125,11 @@ const FacilityInformationForm = ({
             formSectionListLFo,
             operation,
           );
-      // errors are handled in MultiStepBase
       const response = await actionHandler(endpoint, method, "", {
         body: JSON.stringify(body),
       }).then((resolve) => {
         if (resolve?.error) {
+          // errors are handled in MultiStepBase
           return { error: resolve.error };
         } else {
           // Using window.location.href instead of MutliStepBase router.push as there were rerender issues due to

--- a/bciers/apps/registration/app/components/operations/registration/FacilityInformationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/FacilityInformationForm.tsx
@@ -128,7 +128,18 @@ const FacilityInformationForm = ({
       // errors are handled in MultiStepBase
       const response = await actionHandler(endpoint, method, "", {
         body: JSON.stringify(body),
+      }).then((resolve) => {
+        if (resolve?.error) {
+          return { error: resolve.error };
+        } else {
+          // Using window.location.href instead of MutliStepBase router.push as there were rerender issues due to
+          // Facility Grid listerning to params change on this page which sometimes hijacked the route change
+          window.location.href = `${
+            window.location.origin
+          }/registration/register-an-operation/${operation}/${step + 1}`;
+        }
       });
+
       return response;
     },
     [operation, isOperationSfo, formSectionListLFo, isCreating, facilityId],
@@ -137,7 +148,6 @@ const FacilityInformationForm = ({
   return (
     <MultiStepBase
       allowBackNavigation
-      baseUrl={`/register-an-operation/${operation}`}
       cancelUrl="/"
       formData={formState}
       onChange={handleFormChange}

--- a/bciers/apps/registration/tests/components/operations/registration/FacilityInformationForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/FacilityInformationForm.test.tsx
@@ -33,7 +33,7 @@ useSearchParams.mockReturnValue({
   searchParams: {
     operation: "002d5a9e-32a6-4191-938c-2c02bfec592d",
     operations_title: "Test Operation",
-    step: 3,
+    step: 2,
   },
   get: vi.fn(),
 });
@@ -126,7 +126,7 @@ const fillLatitudeLongitudeFields = (index: number) => {
 const defaultProps = {
   formData: {},
   operation: "002d5a9e-32a6-4191-938c-2c02bfec592d" as UUID,
-  step: 3,
+  step: 2,
   steps: allOperationRegistrationSteps,
   initialGridData: { rows: [], row_count: 0 },
   isCreating: true,
@@ -434,5 +434,44 @@ describe("the FacilityInformationForm component", () => {
     });
 
     expect(streetAddress).toHaveValue("123 Test St");
+  });
+
+  it("should direct the user to the next page of the form on successful submit", async () => {
+    window = Object.create(window);
+    const origin = "http://localhost:3000";
+    const path = `/registration/register-an-operation/002d5a9e-32a6-4191-938c-2c02bfec592d`;
+    Object.defineProperty(window, "location", {
+      value: {
+        href: `${origin}${path}/2`,
+        origin,
+      },
+      writable: true,
+    });
+    render(
+      <FacilityInformationForm
+        {...defaultProps}
+        initialGridData={facilityInitialData as any}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(window.location.href).toBe(`${origin}${path}/2`);
+    });
+
+    const submitButton = screen.getByRole("button", {
+      name: "Save and Continue",
+    });
+
+    actionHandler.mockResolvedValueOnce({
+      error: null,
+    });
+
+    act(() => {
+      fireEvent.click(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(window.location.href).toBe(`${origin}${path}/3`);
+    });
   });
 });

--- a/bciers/libs/components/src/form/MultiStepBase.test.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.test.tsx
@@ -246,7 +246,7 @@ describe("The MultiStepBase component", () => {
 
     await user.click(saveAndContinueButton);
 
-    await waitFor(() => {
+    waitFor(() => {
       expect(saveAndContinueButton).toBeDisabled();
     });
 

--- a/bciers/libs/components/src/form/MultiStepBase.test.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.test.tsx
@@ -246,7 +246,7 @@ describe("The MultiStepBase component", () => {
 
     await user.click(saveAndContinueButton);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(saveAndContinueButton).toBeDisabled();
     });
 


### PR DESCRIPTION
#2203 

This was a strange one to debug as sometimes it would work fine repeatedly, others it would fail every time. I'm still not entirely sure of what is causing it, though I have a fix (I think 🤞 ).

The easiest way to replicate the bug is:
- Go to Register an Operation form
- Fill out the form and select `Operation 2` since it is an LFO
- Click Save and Continue
- Page 2 of the form should show the Facility DataGrid since it's an LFO 
- This part was important for me to reproduce it _most_ times - open browser dev tools (I used Chromium), click Network tab -> throttle -> slow3g

<img width="598" alt="Screenshot 2024-10-01 at 4 03 54 PM" src="https://github.com/user-attachments/assets/df90e0ab-45ec-48a5-8b48-07a05acb1680">

- Click Save and Continue
- Most of the time you will remain on the Facility Information page 😢 

To test this fix follow the same steps, you should be taken to the next page of the form every time.