### PR TITLE
form readonly poc

### DIFF
--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -8,7 +8,6 @@ import { actionHandler } from "@bciers/actions";
 import { ContactFormData } from "./types";
 import getUserData from "./getUserData";
 import { IChangeEvent } from "@rjsf/core";
-import { FormMode } from "@bciers/utils/enums";
 
 interface Props {
   schema: any;
@@ -56,7 +55,7 @@ export default function ContactForm({
       schema={schema}
       uiSchema={uiSchema}
       formData={formState}
-      mode={isCreatingState ? FormMode.CREATE : FormMode.READ_ONLY}
+      disabled={isCreatingState}
       allowEdit={allowEdit}
       inlineMessage={isCreatingState && <NewOperationMessage />}
       onSubmit={async (data: { formData?: any }) => {

--- a/bciers/apps/administration/app/components/facilities/FacilityForm.tsx
+++ b/bciers/apps/administration/app/components/facilities/FacilityForm.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import SingleStepTaskListForm from "@bciers/components/form/SingleStepTaskListForm";
 import { actionHandler } from "@bciers/actions";
-import { FormMode } from "@bciers/utils/enums";
 import serializeSearchParams from "@bciers/utils/serializeSearchParams";
 import { FacilityTypes } from "@bciers/utils/enums";
 
@@ -40,7 +39,7 @@ export default function FacilityForm({
       schema={schema}
       uiSchema={uiSchema}
       formData={formState}
-      mode={isCreatingState ? FormMode.CREATE : FormMode.READ_ONLY}
+      disabled={isCreatingState}
       onSubmit={async (data: { formData?: any }) => {
         const updatedFormData = { ...formState, ...data.formData };
         setFormState(updatedFormData);

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -12,7 +12,6 @@ import {
   OperationInformationPartialFormData,
 } from "./types";
 import { actionHandler } from "@bciers/actions";
-import { FormMode } from "@bciers/utils/enums";
 
 const OperationInformationForm = ({
   formData,
@@ -51,7 +50,8 @@ const OperationInformationForm = ({
   return (
     <SingleStepTaskListForm
       allowEdit={isIndustryUser}
-      mode={FormMode.READ_ONLY}
+      disabled
+      readOnly={!isIndustryUser}
       error={error}
       schema={schema}
       uiSchema={administrationOperationInformationUiSchema}

--- a/bciers/apps/administration/app/components/operators/OperatorForm.tsx
+++ b/bciers/apps/administration/app/components/operators/OperatorForm.tsx
@@ -5,7 +5,6 @@ import SingleStepTaskListForm from "@bciers/components/form/SingleStepTaskListFo
 import { RJSFSchema } from "@rjsf/utils";
 import { actionHandler } from "@bciers/actions";
 import { operatorUiSchema } from "../../data/jsonSchema/operator";
-import { FormMode } from "@bciers/utils/enums";
 import { useRouter } from "next/navigation";
 
 export interface OperatorFormData {
@@ -36,7 +35,7 @@ export default function OperatorForm({
       schema={schema}
       uiSchema={operatorUiSchema}
       formData={formState}
-      mode={isCreatingState ? FormMode.CREATE : FormMode.READ_ONLY}
+      disabled={isCreatingState}
       onSubmit={async (data: { formData?: any }) => {
         const updatedFormData = { ...formState, ...data.formData };
         setFormState(updatedFormData);

--- a/bciers/libs/components/src/form/FormBase.tsx
+++ b/bciers/libs/components/src/form/FormBase.tsx
@@ -32,6 +32,7 @@ export const customFormatsErrorMessages = {
   starting_date_year: `Starting Date must be between ${
     currentYear - 1
   } and ${currentYear}`,
+
   signature: "Signature should not include special characters or numbers",
 };
 
@@ -62,7 +63,7 @@ const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
     setErrorReset,
     theme,
   } = props;
-  const formTheme = disabled || readonly ? readOnlyTheme : defaultTheme;
+  const formTheme = readonly ? readOnlyTheme : defaultTheme;
   const Form = useMemo(() => withTheme(theme ?? formTheme), [theme, formTheme]);
   const [formState, setFormState] = useState(formData ?? {});
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -92,6 +93,8 @@ const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
     <Form
       {...props}
       ref={formRef}
+      disabled={disabled}
+      readonly={readonly}
       formData={isSubmitting ? formState : formData}
       onChange={handleChange}
       noHtml5Validate

--- a/bciers/libs/components/src/form/MultiStepBase.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.tsx
@@ -22,6 +22,7 @@ interface MultiStepBaseProps {
   formData?: any;
   onChange?: (e: IChangeEvent) => void;
   onSubmit: (e: IChangeEvent) => any;
+  readOnly?: boolean;
   schema: RJSFSchema;
   step: number;
   steps: string[];
@@ -48,6 +49,7 @@ const MultiStepBase = ({
   onChange,
   formData,
   onSubmit,
+  readOnly,
   schema,
   setErrorReset,
   step,
@@ -86,7 +88,7 @@ const MultiStepBase = ({
     }
   };
 
-  const isDisabled = (disabled && !isEditMode) || isSubmitting;
+  const isDisabled = (disabled && !isEditMode) || isSubmitting || readOnly;
 
   const handleEditClick = () => {
     setIsEditMode(true);
@@ -94,7 +96,7 @@ const MultiStepBase = ({
 
   return (
     <>
-      {allowEdit && (
+      {allowEdit && !readOnly && (
         <div className="w-full flex justify-end mb-10">
           <Button
             variant="contained"
@@ -113,7 +115,7 @@ const MultiStepBase = ({
         className="flex flex-col flex-grow"
         uiSchema={uiSchema}
         disabled={isDisabled}
-        readonly={isDisabled}
+        readonly={readOnly}
         onChange={onChange}
         onSubmit={submitHandler}
         formData={formData}

--- a/bciers/libs/components/src/form/SingleStepTaskListForm.test.tsx
+++ b/bciers/libs/components/src/form/SingleStepTaskListForm.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import SingleStepTaskListForm from "./SingleStepTaskListForm";
 import SectionFieldTemplate from "@bciers/components/form/fields/SectionFieldTemplate";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
-import { FormMode } from "@bciers/utils/enums";
 import { FrontendMessages } from "@bciers/utils/enums";
 const section1: RJSFSchema = {
   type: "object",
@@ -187,7 +186,6 @@ describe("the SingleStepTaskListForm component", () => {
         schema={schema}
         uiSchema={uiSchema}
         formData={mockFormData}
-        mode={FormMode.READ_ONLY}
         onCancel={() => {
           // eslint-disable-next-line no-console
           console.log("cancel");
@@ -219,7 +217,6 @@ describe("the SingleStepTaskListForm component", () => {
         schema={schema}
         uiSchema={uiSchema}
         formData={mockFormData}
-        mode={FormMode.READ_ONLY}
         onCancel={() => {
           // eslint-disable-next-line no-console
           console.log("cancel");

--- a/bciers/libs/components/src/form/widgets/FileWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/FileWidget.tsx
@@ -208,7 +208,9 @@ const FileWidget = ({
   );
 
   const disabledColour =
-    disabled || readonly ? "text-bc-bg-dark-grey" : "text-bc-link-blue";
+    disabled || readonly
+      ? "text-bc-component-grey opacity-60 cursor-default"
+      : "text-bc-link-blue";
 
   /*   File input styling options are limited so we are attaching a ref to it, hiding it and triggering it with a styled button. */
   return (
@@ -217,7 +219,7 @@ const FileWidget = ({
         <button
           type="button"
           onClick={handleClick}
-          className={`p-0 decoration-solid border-0 text-lg bg-transparent cursor-pointer underline ${disabledColour}`}
+          className={`p-0 decoration-solid border-0 text-lg bg-transparent  underline ${disabledColour}`}
         >
           {localValue ? "Reupload attachment" : "Upload attachment"}
         </button>

--- a/bciers/libs/components/src/form/widgets/MultiSelectWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/MultiSelectWidget.tsx
@@ -109,6 +109,7 @@ const MultiSelectWidget: React.FC<WidgetProps> = ({
           return (
             <Chip
               {...getTagProps}
+              disabled={disabled}
               key={option.id}
               label={option.label}
               {...getTagProps({

--- a/bciers/libs/components/src/theme/theme.ts
+++ b/bciers/libs/components/src/theme/theme.ts
@@ -4,6 +4,7 @@ import { createTheme } from "@mui/material/styles";
 import {
   BC_GOV_PRIMARY_BRAND_COLOR_BLUE,
   BC_GOV_BACKGROUND_COLOR_BLUE,
+  BC_GOV_BACKGROUND_COLOR_GREY,
   BC_GOV_COMPONENTS_GREY,
   BC_GOV_LINKS_COLOR,
   BC_GOV_YELLOW,
@@ -87,6 +88,9 @@ export const theme = createTheme({
               borderColor: BC_GOV_LINKS_COLOR,
             },
           },
+          "& .Mui-disabled": {
+            backgroundColor: BC_GOV_BACKGROUND_COLOR_GREY,
+          },
         },
       },
     },
@@ -100,6 +104,9 @@ export const theme = createTheme({
           },
           "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
             borderColor: BC_GOV_LINKS_COLOR,
+          },
+          "& .Mui-disabled": {
+            backgroundColor: BC_GOV_BACKGROUND_COLOR_GREY,
           },
         },
       },
@@ -130,6 +137,15 @@ export const theme = createTheme({
         colorInfo: {
           color: BC_GOV_LINKS_COLOR,
           borderColor: BC_GOV_LINKS_COLOR,
+        },
+        root: {
+          // disabled styles
+          "&.Mui-disabled": {
+            border: `1px solid ${BC_GOV_COMPONENTS_GREY}`,
+          },
+          ".MuiChip-deleteIcon": {
+            display: "none",
+          },
         },
       },
     },

--- a/bciers/libs/utils/enums.ts
+++ b/bciers/libs/utils/enums.ts
@@ -72,9 +72,3 @@ export enum Status {
   CHANGES_REQUESTED = "Changes Requested",
   NOT_STARTED = "Not Started",
 }
-
-export enum FormMode {
-  CREATE = "create",
-  EDIT = "edit",
-  READ_ONLY = "read-only",
-}


### PR DESCRIPTION
PR to differentiate between disabled and readonly form states. There has been discussion due to differing reporting/registration designs on how we should align our form theme. This will allow both disabled and readonly states as they both might be desired depending on the situation.  
  
Generally I imagine `readOnly` mostly being used for internal users since they won't be editing most forms ie: `readOnly={isExternalUser}`

Disabled would likely most be used for internal users as the disabled inputs communicates that they are disabled but can be edited. There might also be forms where we want to use disabled state but have a few fields that are never editable being `readOnly` - currently we have this on the `Operation Details` form in this PR when the form is disabled, the `Registration Purpose` field specifically uses the `ReadOnlyWidget`.

To be clear about which states I'm talking about this is `disabled`:
<img width="1145" alt="Screenshot 2024-10-04 at 9 55 35 AM" src="https://github.com/user-attachments/assets/888b745a-f220-4e1e-b9fb-bb64ef577095">

`readOnly`:
<img width="1145" alt="Screenshot 2024-10-04 at 9 56 29 AM" src="https://github.com/user-attachments/assets/7926adc9-c78e-4553-bca9-698359dc932a">



I have removed the `mode` from the SingleStepTask list. Some things to note about how this will work:
- If `readOnly` is true the form can't be edited no matter what
- If `disabled` is true and `allowEdit` is false, the form cannot be switched to edit mode
- If `disabled` is true and `allowEdit` is true (the default), the form will initially display in disabled mode, with the edit button enabled so the user can switch to edit mode and edit the form


This is just a POC so there may be some bugs and styling updates needed.
