### PR TITLE
353 methodology fields not flat with emission

### DIFF
--- a/bc_obps/reporting/json_schemas/2024/carbonates_use/carbonates_use.json
+++ b/bc_obps/reporting/json_schemas/2024/carbonates_use/carbonates_use.json
@@ -9,16 +9,6 @@
         "title": "Carbonate data",
         "type": "object",
         "properties": {
-          "methodology": {
-            "title": "Methodology",
-            "type": "string",
-            "enum": [
-              "Calcination Fraction",
-              "Mass of Output Carbonates",
-              "Alternative Parameter Methodology",
-              "Replacement Methodology"
-            ]
-          },
           "emissions": {
             "title": "Emissions",
             "type": "number"

--- a/bc_obps/service/form_builder_service.py
+++ b/bc_obps/service/form_builder_service.py
@@ -60,7 +60,7 @@ def handle_methodologies(
         reporting_fields = fetched_config_map[key]
 
         # Create methodology object
-        methodology_object: Dict[str, Dict] =  {"properties": {"methodology": {"enum": [methodology_name]}}}
+        methodology_object: Dict[str, Dict] = {"properties": {"methodology": {"enum": [methodology_name]}}}
 
         # Check for custom schema
         if config_element_for_methodology.custom_methodology_schema_id:
@@ -87,7 +87,9 @@ def handle_methodologies(
         methodology_one_of['methodology']['oneOf'].append(methodology_object)
 
     # Update gas_type_one_of with computed values
-    gas_type_one_of['gasType']['oneOf'][index]['properties']['methodology']['properties']['methodology']['enum'] = methodology_enum
+    gas_type_one_of['gasType']['oneOf'][index]['properties']['methodology']['properties']['methodology'][
+        'enum'
+    ] = methodology_enum
     gas_type_one_of['gasType']['oneOf'][index]['properties']['methodology']['dependencies'] = methodology_one_of
 
 
@@ -152,9 +154,9 @@ def handle_gas_types(
             {
                 "properties": {
                     "gasType": {"enum": [gas_type_chemical_formula]},
-                    "methodology": { "type": "object", "properties": { 
-                        "methodology": {"title": "Methodology", "type": "string", "enum": [] }
-                        }
+                    "methodology": {
+                        "type": "object",
+                        "properties": {"methodology": {"title": "Methodology", "type": "string", "enum": []}},
                     },
                 }
             }

--- a/bc_obps/service/form_builder_service.py
+++ b/bc_obps/service/form_builder_service.py
@@ -60,7 +60,7 @@ def handle_methodologies(
         reporting_fields = fetched_config_map[key]
 
         # Create methodology object
-        methodology_object: Dict[str, Dict] = {"properties": {"methodology": {"enum": [methodology_name]}}}
+        methodology_object: Dict[str, Dict] =  {"properties": {"methodology": {"enum": [methodology_name]}}}
 
         # Check for custom schema
         if config_element_for_methodology.custom_methodology_schema_id:
@@ -87,8 +87,8 @@ def handle_methodologies(
         methodology_one_of['methodology']['oneOf'].append(methodology_object)
 
     # Update gas_type_one_of with computed values
-    gas_type_one_of['gasType']['oneOf'][index]['properties']['methodology']['enum'] = methodology_enum
-    gas_type_one_of['gasType']['oneOf'][index]['dependencies'] = methodology_one_of
+    gas_type_one_of['gasType']['oneOf'][index]['properties']['methodology']['properties']['methodology']['enum'] = methodology_enum
+    gas_type_one_of['gasType']['oneOf'][index]['properties']['methodology']['dependencies'] = methodology_one_of
 
 
 def handle_gas_types(
@@ -152,7 +152,10 @@ def handle_gas_types(
             {
                 "properties": {
                     "gasType": {"enum": [gas_type_chemical_formula]},
-                    "methodology": {"title": "Methodology", "type": "string", "enum": []},
+                    "methodology": { "type": "object", "properties": { 
+                        "methodology": {"title": "Methodology", "type": "string", "enum": [] }
+                        }
+                    },
                 }
             }
         )

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/carbonatesUseUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/carbonatesUseUiSchema.ts
@@ -34,10 +34,10 @@ const uiSchema = {
         items: {
           "ui:order": [
             "gasType",
-            "methodology",
             "emissions",
             "equivalentEmissions",
             "carbonateType",
+            "methodology",
             "annualMassOfCarbonateTypeConsumedTonnes",
             "fractionCalcinationAchievedForEachParticularCarbonateTypeWeightFactor",
             "numberOfCarbonateTypes",
@@ -48,7 +48,38 @@ const uiSchema = {
             "description",
           ],
           methodology: {
-            "ui:FieldTemplate": InlineFieldTemplate,
+            "ui:FieldTemplate": FieldTemplate,
+            "ui:options": {
+              label: false,
+            },
+            methodology: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+            annualMassOfCarbonateTypeConsumedTonnes: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+            fractionCalcinationAchievedForEachParticularCarbonateTypeWeightFactor:
+              {
+                "ui:FieldTemplate": InlineFieldTemplate,
+              },
+            numberOfCarbonateTypes: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+            annualMassOfInputCarbonateTypeTonnes: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+            annualMassOfOutputCarbonateTypeTonnes: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+            numberOfInputCarbonateTypes: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+            numberOfOutputCarbonateTypes: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+            description: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
           },
           emissions: {
             "ui:FieldTemplate": InlineFieldTemplate,
@@ -60,31 +91,6 @@ const uiSchema = {
             "ui:FieldTemplate": InlineFieldTemplate,
           },
           equivalentEmissions: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          annualMassOfCarbonateTypeConsumedTonnes: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          fractionCalcinationAchievedForEachParticularCarbonateTypeWeightFactor:
-            {
-              "ui:FieldTemplate": InlineFieldTemplate,
-            },
-          numberOfCarbonateTypes: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          annualMassOfInputCarbonateTypeTonnes: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          annualMassOfOutputCarbonateTypeTonnes: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          numberOfInputCarbonateTypes: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          numberOfOutputCarbonateTypes: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          description: {
             "ui:FieldTemplate": InlineFieldTemplate,
           },
         },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/fuelCombustionMobileUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/fuelCombustionMobileUiSchema.ts
@@ -85,6 +85,17 @@ const uiSchema = {
               label: false,
               verticalBorder: true,
             },
+            items: {
+              methodology: {
+                "ui:FieldTemplate": FieldTemplate,
+                "ui:options": {
+                  label: false,
+                },
+                methodology: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+              },
+            },
           },
         },
       },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscNonCompressionNonProcessingUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscNonCompressionNonProcessingUiSchema.ts
@@ -95,6 +95,17 @@ const uiSchema = {
                   label: false,
                   verticalBorder: true,
                 },
+                items: {
+                  methodology: {
+                    "ui:FieldTemplate": FieldTemplate,
+                    "ui:options": {
+                      label: false,
+                    },
+                    methodology: {
+                      "ui:FieldTemplate": InlineFieldTemplate,
+                    },
+                  },
+                },
               },
             },
           },
@@ -134,17 +145,22 @@ const uiSchema = {
               title: "Fuel",
             },
             items: {
-              "ui:order": [
-                "fuelName",
-                "fuelUnit",
-                "annualFuelAmount",
-                "emissions",
-              ],
-              fuelName: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
+              "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
               fuelType: {
-                "ui:FieldTemplate": InlineFieldTemplate,
+                "ui:field": "fuelType",
+                "ui:FieldTemplate": FieldTemplate,
+                "ui:options": {
+                  label: false,
+                },
+                fuelName: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelUnit: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelClassification: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
               },
               annualFuelAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,
@@ -157,6 +173,17 @@ const uiSchema = {
                   title: "Emission",
                   label: false,
                   verticalBorder: true,
+                },
+                items: {
+                  methodology: {
+                    "ui:FieldTemplate": FieldTemplate,
+                    "ui:options": {
+                      label: false,
+                    },
+                    methodology: {
+                      "ui:FieldTemplate": InlineFieldTemplate,
+                    },
+                  },
                 },
               },
             },
@@ -197,17 +224,22 @@ const uiSchema = {
               title: "Fuel",
             },
             items: {
-              "ui:order": [
-                "fuelName",
-                "fuelUnit",
-                "annualFuelAmount",
-                "emissions",
-              ],
-              fuelName: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
+              "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
               fuelType: {
-                "ui:FieldTemplate": InlineFieldTemplate,
+                "ui:field": "fuelType",
+                "ui:FieldTemplate": FieldTemplate,
+                "ui:options": {
+                  label: false,
+                },
+                fuelName: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelUnit: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelClassification: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
               },
               annualFuelAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,
@@ -220,6 +252,17 @@ const uiSchema = {
                   title: "Emission",
                   label: false,
                   verticalBorder: true,
+                },
+                items: {
+                  methodology: {
+                    "ui:FieldTemplate": FieldTemplate,
+                    "ui:options": {
+                      label: false,
+                    },
+                    methodology: {
+                      "ui:FieldTemplate": InlineFieldTemplate,
+                    },
+                  },
                 },
               },
             },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscOtherThanNonCompression.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscOtherThanNonCompression.ts
@@ -95,6 +95,17 @@ const uiSchema = {
                   label: false,
                   verticalBorder: true,
                 },
+                items: {
+                  methodology: {
+                    "ui:FieldTemplate": FieldTemplate,
+                    "ui:options": {
+                      label: false,
+                    },
+                    methodology: {
+                      "ui:FieldTemplate": InlineFieldTemplate,
+                    },
+                  },
+                },
               },
             },
           },
@@ -162,6 +173,17 @@ const uiSchema = {
                   title: "Emission",
                   label: false,
                   verticalBorder: true,
+                },
+                items: {
+                  methodology: {
+                    "ui:FieldTemplate": FieldTemplate,
+                    "ui:options": {
+                      label: false,
+                    },
+                    methodology: {
+                      "ui:FieldTemplate": InlineFieldTemplate,
+                    },
+                  },
                 },
               },
             },
@@ -231,6 +253,17 @@ const uiSchema = {
                   title: "Emission",
                   label: false,
                   verticalBorder: true,
+                },
+                items: {
+                  methodology: {
+                    "ui:FieldTemplate": FieldTemplate,
+                    "ui:options": {
+                      label: false,
+                    },
+                    methodology: {
+                      "ui:FieldTemplate": InlineFieldTemplate,
+                    },
+                  },
                 },
               },
             },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscUiSchema.ts
@@ -88,6 +88,17 @@ const uiSchema = {
                   label: false,
                   verticalBorder: true,
                 },
+                items: {
+                  methodology: {
+                    "ui:FieldTemplate": FieldTemplate,
+                    "ui:options": {
+                      label: false,
+                    },
+                    methodology: {
+                      "ui:FieldTemplate": InlineFieldTemplate,
+                    },
+                  },
+                },
               },
             },
           },
@@ -127,21 +138,22 @@ const uiSchema = {
               title: "Fuel",
             },
             items: {
-              "ui:order": [
-                "fuelName",
-                "fuelUnit",
-                "fuelClassification",
-                "annualFuelAmount",
-                "emissions",
-              ],
-              fuelName: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
-              fuelUnit: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
-              fuelClassification: {
-                "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
+              fuelType: {
+                "ui:field": "fuelType",
+                "ui:FieldTemplate": FieldTemplate,
+                "ui:options": {
+                  label: false,
+                },
+                fuelName: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelUnit: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                fuelClassification: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
               },
               annualFuelAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,
@@ -154,6 +166,17 @@ const uiSchema = {
                   title: "Emission",
                   label: false,
                   verticalBorder: true,
+                },
+                items: {
+                  methodology: {
+                    "ui:FieldTemplate": FieldTemplate,
+                    "ui:options": {
+                      label: false,
+                    },
+                    methodology: {
+                      "ui:FieldTemplate": InlineFieldTemplate,
+                    },
+                  },
                 },
               },
             },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
@@ -53,9 +53,10 @@ const uiSchema = {
             "ui:FieldTemplate": InlineFieldTemplate,
           },
           methodology: {
-            "ui:FieldTemplate": InlineFieldTemplate,
+            "ui:FieldTemplate": FieldTemplate,
             "ui:widget": "select",
             "ui:options": {
+              label: false,
               enumOptions: [
                 "CEMS",
                 "Feedstock Material Balance",
@@ -63,36 +64,39 @@ const uiSchema = {
                 "Replacement Methodology",
               ],
             },
-          },
-          feedstocks: {
-            "ui:title": "Feedstocks",
-            "ui:ArrayFieldTemplate": NestedArrayFieldTemplate,
-            "ui:FieldTemplate": FieldTemplate,
-            "ui:options": {
-              arrayAddLabel: "Add Feedstock",
-              title: "Feedstock",
-              label: false,
-              verticalBorder: true,
+            methodology: {
+              "ui:FieldTemplate": InlineFieldTemplate,
             },
-            items: {
-              "ui:order": [
-                "feedstock",
-                "annualFeedstockAmount",
-                "unitForAnnualFeedstockAmount",
-                "annualHydrogenProduction",
-              ],
 
-              feedstock: {
-                "ui:FieldTemplate": InlineFieldTemplate,
+            feedstocks: {
+              "ui:ArrayFieldTemplate": NestedArrayFieldTemplate,
+              "ui:FieldTemplate": FieldTemplate,
+              "ui:options": {
+                arrayAddLabel: "Add Feedstock",
+                title: "Feedstocks",
+                label: false,
+                verticalBorder: true,
               },
-              annualFeedstockAmount: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
-              unitForAnnualFeedstockAmount: {
-                "ui:FieldTemplate": InlineFieldTemplate,
-              },
-              annualHydrogenProduction: {
-                "ui:FieldTemplate": InlineFieldTemplate,
+              items: {
+                "ui:order": [
+                  "feedstock",
+                  "annualFeedstockAmount",
+                  "unitForAnnualFeedstockAmount",
+                  "annualHydrogenProduction",
+                ],
+
+                feedstock: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                annualFeedstockAmount: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                unitForAnnualFeedstockAmount: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+                annualHydrogenProduction: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
               },
             },
           },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/pulpAndPaperUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/pulpAndPaperUiSchema.ts
@@ -41,6 +41,15 @@ const uiSchema = {
           equivalentEmission: {
             "ui:FieldTemplate": InlineFieldTemplate,
           },
+          methodology: {
+            "ui:FieldTemplate": FieldTemplate,
+            "ui:options": {
+              label: false,
+            },
+            methodology: {
+              "ui:FieldTemplate": InlineFieldTemplate,
+            },
+          },
         },
       },
     },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/refineryFuelGasUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/refineryFuelGasUiSchema.ts
@@ -53,6 +53,17 @@ const uiSchema = {
               label: false,
               verticalBorder: true,
             },
+            items: {
+              methodology: {
+                "ui:FieldTemplate": FieldTemplate,
+                "ui:options": {
+                  label: false,
+                },
+                methodology: {
+                  "ui:FieldTemplate": InlineFieldTemplate,
+                },
+              },
+            },
           },
         },
       },


### PR DESCRIPTION
Card = reporting [#353](https://github.com/bcgov/cas-reporting/issues/353)

 - Updated form_builder_service to have methodology field/data nested inside its own object
 - Updated carbonates_use.json : removed methodology fields from the schema as it is getting added by the form builder
 - Updated activity uiSchemas to account for the new schema structure. Also addressed errors that were showing from some fuelTypes fields not matching between schema and uiSchema.

### Testing
To test locally: Go to -> http://localhost:3000/reporting/reports/6/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/review and make sure that the relevant existing activities are selected:
 - ALL activities dealing with ```General stationary combustion```
 - ```Fuel combustion by mobile equipment```
 - ```Carbonate use```
 - ```Hydrogen production```
 - ```Pulp and paper production```
 - ```Refinery fuel gas combustion```

Click ```Save & Continue```

For each of the activities, see that:
 - the form renders as expected. 
 - dependant fields appear as expected
 - there are no errors related to uischema
 - if you put some mock data in and submit, all methodology-related fields will be nested inside a methodology object.