### PR TITLE
fix: activity form state should not persist when switching activities

### DIFF
--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -138,46 +138,48 @@ export default function ActivityForm({
     console.log("SUBMITTED: ", JSON.stringify(data.formData));
   };
 
-  if (
+  const formIsLoading =
     (Object.keys(jsonSchema).length === 0 &&
       jsonSchema.constructor === Object) ||
-    previousActivityId !== activityId
-  )
-    return <>Loading...</>;
-  // Render the Activity form and tasklist
+    previousActivityId !== activityId;
+
   return (
     <div className="w-full flex flex-row">
       <ReportingTaskList elements={taskListData} />
-      <div className="w-full">
-        <FormBase
-          schema={jsonSchema}
-          fields={CUSTOM_FIELDS}
-          formData={formState}
-          uiSchema={uiSchema}
-          validator={validator}
-          onChange={handleFormChange}
-          onError={(e: any) => console.log("ERROR: ", e)}
-          onSubmit={submitHandler}
-        >
-          {errorList.length > 0 &&
-            errorList.map((e: any) => (
-              <Alert key={e.message} severity="error">
-                {e?.stack ?? e.message}
-              </Alert>
-            ))}
-          <div className="flex justify-end gap-3">
-            {/* Disable the button when loading or when success state is true */}
-            <Button
-              variant="contained"
-              type="submit"
-              aria-disabled={isLoading}
-              disabled={isLoading}
-            >
-              {isSuccess ? "✅ Success" : "Submit"}
-            </Button>
-          </div>
-        </FormBase>
-      </div>
+      {formIsLoading ? (
+        "Loading Form..."
+      ) : (
+        <div className="w-full">
+          <FormBase
+            schema={jsonSchema}
+            fields={CUSTOM_FIELDS}
+            formData={formState}
+            uiSchema={uiSchema}
+            validator={validator}
+            onChange={handleFormChange}
+            onError={(e: any) => console.log("ERROR: ", e)}
+            onSubmit={submitHandler}
+          >
+            {errorList.length > 0 &&
+              errorList.map((e: any) => (
+                <Alert key={e.message} severity="error">
+                  {e?.stack ?? e.message}
+                </Alert>
+              ))}
+            <div className="flex justify-end gap-3">
+              {/* Disable the button when loading or when success state is true */}
+              <Button
+                variant="contained"
+                type="submit"
+                aria-disabled={isLoading}
+                disabled={isLoading}
+              >
+                {isSuccess ? "✅ Success" : "Submit"}
+              </Button>
+            </div>
+          </FormBase>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
The formState was being persisted when navigating to different activity pages.
The dependency array for the useEffect() was throwing warnings across different activity because it was changing its shape depending on how many source types each activity has.

This PR should fix those issues. Though I think that useEffect() is probably doing too much & we should look into potentially splitting it up into different components. I think the way it is set up currently may have an effect on the [Load data ticket](https://github.com/bcgov/cas-reporting/issues/345)