### PR TITLE
2383 session token update

### DIFF
--- a/bciers/apps/administration/app/components/operators/OperatorForm.tsx
+++ b/bciers/apps/administration/app/components/operators/OperatorForm.tsx
@@ -7,6 +7,7 @@ import { actionHandler } from "@bciers/actions";
 import { operatorUiSchema } from "../../data/jsonSchema/operator";
 import { FormMode } from "@bciers/utils/enums";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 
 export interface OperatorFormData {
   [key: string]: any;
@@ -17,7 +18,6 @@ interface Props {
   formData: OperatorFormData;
   isCreating?: boolean;
 }
-
 export default function OperatorForm({
   formData,
   schema,
@@ -29,7 +29,7 @@ export default function OperatorForm({
   const [formState, setFormState] = useState(formData ?? {});
   const [isCreatingState, setIsCreatingState] = useState(isCreating);
   const router = useRouter();
-
+  const { update } = useSession();
   return (
     <SingleStepTaskListForm
       error={error}
@@ -59,9 +59,11 @@ export default function OperatorForm({
         } else {
           setError(undefined);
         }
-
         if (isCreatingState) {
           setIsCreatingState(false);
+          // With Auth strategy: "jwt" , update() method will trigger a jwt callback
+          // where app_role will be augmented to "industry_user_admin" in the jwt and session objects
+          await update({ trigger: "update" }); // Indicate this is an update call to update the session token
         }
       }}
       onCancel={() => (isCreatingState ? router.back() : router.push("/"))}

--- a/bciers/apps/administration/app/components/profile/ProfileForm.tsx
+++ b/bciers/apps/administration/app/components/profile/ProfileForm.tsx
@@ -62,7 +62,7 @@ export default function ProfileForm({ formData, isCreate }: Props) {
   // 🛠️ Function to update the session, without reloading the page
   const handleUpdate = async () => {
     // With NextAuth strategy: "jwt" , update() method will trigger a jwt callback where app_role will be augmented to the jwt and session objects
-    await update();
+    await update({ trigger: "update" });
     // ✅ Set success state to true
     setIsSuccess(true);
     // 🕐 Wait for 3 second and then reset success state

--- a/bciers/apps/administration/tests/components/helpers/mockUseSession.ts
+++ b/bciers/apps/administration/tests/components/helpers/mockUseSession.ts
@@ -1,0 +1,23 @@
+import { useSession } from "@bciers/testConfig/mocks";
+import { Session } from "@bciers/testConfig/types";
+import { vi } from "vitest";
+
+// ⛏️ Helper function to mock the useSession hook with default values
+export const mockUseSession = (
+  fullName: string = "bc-cas-dev secondary",
+  appRole: string = "industry_user",
+) => {
+  const update = vi.fn(); // Mock the update function
+
+  useSession.mockReturnValue({
+    data: {
+      user: {
+        full_name: fullName,
+        app_role: appRole,
+      },
+    },
+    update, // Include the mocked update function
+  } as Session);
+
+  return { update }; // Return the update function for assertions in tests
+};

--- a/bciers/apps/administration/tests/components/operators/OperatorForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operators/OperatorForm.test.tsx
@@ -9,6 +9,8 @@ import { createOperatorSchema } from "apps/administration/app/components/operato
 import expectButton from "../helpers/expectButton";
 import expectField from "../helpers/expectField";
 import expectHeader from "../helpers/expectHeader";
+import { mockUseSession } from "../helpers/mockUseSession";
+
 import { FrontendMessages } from "@bciers/utils/enums";
 
 useSession.mockReturnValue({
@@ -331,31 +333,43 @@ describe("OperatorForm component", () => {
     // Assert on the validation errors
     expect(screen.getAllByText(/Required field/i)).toHaveLength(8);
   });
-  it("fills the mandatory form fields, creates new operator, and redirects on success", async () => {
+  it("fills the mandatory form fields, creates a new operator, updates the session, and shows a success message", async () => {
+    // Mock the session and get access to the update function
+    const { update } = mockUseSession();
+
     render(
       <OperatorForm schema={testSchema} formData={{}} isCreating={true} />,
     );
 
-    await fillMandatoryFields();
+    await fillMandatoryFields(); // Mock function to fill the form
 
-    // Submit
+    // Mock the actionHandler response
+    const response = { success: true }; // Example response
     actionHandler.mockReturnValueOnce(response);
-    const submitButton = screen.getByRole("button", {
-      name: /submit/i,
-    });
+
+    // Submit the form
+    const submitButton = screen.getByRole("button", { name: /submit/i });
     act(() => {
       submitButton.click();
     });
+
+    // Ensure actionHandler is called with the correct arguments
     expect(actionHandler).toHaveBeenNthCalledWith(
       1,
       "registration/v2/user-operators",
       "POST",
       "administration/operators",
       {
-        body: JSON.stringify(postMandatory),
+        body: JSON.stringify(postMandatory), // Ensure postMandatory is defined
       },
     );
 
+    // Ensure the session is updated by calling the update function
+    await waitFor(() => {
+      expect(update).toHaveBeenCalledWith({ trigger: "update" });
+    });
+
+    // Check for the success message after submission
     await waitFor(() => {
       expect(
         screen.getByText(FrontendMessages.SUBMIT_CONFIRMATION),

--- a/bciers/apps/administration/tests/components/operators/OperatorForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operators/OperatorForm.test.tsx
@@ -344,8 +344,8 @@ describe("OperatorForm component", () => {
     await fillMandatoryFields(); // Mock function to fill the form
 
     // Mock the actionHandler response
-    const response = { success: true }; // Example response
-    actionHandler.mockReturnValueOnce(response);
+    const res = { success: true }; // Example response
+    actionHandler.mockReturnValueOnce(res);
 
     // Submit the form
     const submitButton = screen.getByRole("button", { name: /submit/i });

--- a/bciers/apps/administration/tests/components/operators/OperatorPage.test.tsx
+++ b/bciers/apps/administration/tests/components/operators/OperatorPage.test.tsx
@@ -4,6 +4,7 @@ import {
   useSearchParams,
   useSession,
 } from "@bciers/testConfig/mocks";
+import { mockUseSession } from "../helpers/mockUseSession";
 import { getBusinessStructures, getCurrentOperator } from "./mocks";
 import OperatorPage from "apps/administration/app/components/operators/OperatorPage";
 
@@ -49,6 +50,8 @@ describe("Operator component", () => {
     }).rejects.toThrow("Failed to retrieve business structure information");
   });
   it("renders the operator form with form data", async () => {
+    // Mock the session data
+    mockUseSession();
     getCurrentOperator.mockReturnValueOnce({
       street_address: "123 Main St",
       municipality: "City",
@@ -106,6 +109,8 @@ describe("Operator component", () => {
     expect(screen.getByText(/BC Corporation/i)).toBeVisible();
   });
   it("renders the operator form for adding a new operator", async () => {
+    // Mock the session data
+    mockUseSession();
     // Mock getBusinessStructures for create mode
     getBusinessStructures.mockReturnValueOnce([
       { name: "General Partnership" },

--- a/bciers/apps/administration/tests/components/userOperators/SelectOperatorPage.test.tsx
+++ b/bciers/apps/administration/tests/components/userOperators/SelectOperatorPage.test.tsx
@@ -2,29 +2,12 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, vi } from "vitest";
 import SelectOperatorPage from "../../../app/bceidbusiness/industry_user/select-operator/(request-access)/page";
 
-import { useSession } from "@bciers/testConfig/mocks";
-import { Session } from "@bciers/testConfig/types";
-
-// ⛏️  Helper function to mock the useSession hook with default values
-const mockUseSession = (
-  fullName: string = "bc-cas-dev secondary",
-  appRole: string = "industry_user",
-) => {
-  useSession.mockReturnValue({
-    data: {
-      user: {
-        full_name: fullName,
-        app_role: appRole,
-      },
-    },
-  } as Session);
-};
+import { mockUseSession } from "../helpers/mockUseSession";
 
 describe("Select Operator Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-
   it("renders the page correctly", async () => {
     // Mock the session data
     mockUseSession();

--- a/bciers/apps/dashboard/auth/auth.config.ts
+++ b/bciers/apps/dashboard/auth/auth.config.ts
@@ -78,7 +78,7 @@ export default {
     error: "/auth/error", // Error code passed in query string as ?error=
   },
   callbacks: {
-    async jwt({ token, account, profile }) {
+    async jwt({ token, account, profile, trigger }) {
       try {
         // 🧩 custom properties are configured through module augmentation
         if (profile) {
@@ -113,8 +113,9 @@ export default {
             token.full_name = `${token.given_name} ${token.family_name}`;
           }
         }
-        // If no token.app_role, augment the keycloak token with cas registration user app_role
-        if (!token.app_role) {
+        // Check if app_role is missing or if the update trigger was called
+        if (!token.app_role || trigger === "update") {
+          // Augment the keycloak token with the user app_role
           // 🚀 API call: Get user app_role by user_guid from user table
           const responseRole = await actionHandler(
             `registration/user/user-app-role/${token.user_guid}`,

--- a/bciers/apps/registration1/app/components/users/UserForm.tsx
+++ b/bciers/apps/registration1/app/components/users/UserForm.tsx
@@ -35,7 +35,7 @@ export default function UserForm({ formData, isCreate }: Props) {
   // 🛠️ Function to update the session, without reloading the page
   const handleUpdate = async () => {
     // With NextAuth strategy: "jwt" , update() method will trigger a jwt callback where app_role will be augmented to the jwt and session objects
-    await update();
+    await update({ trigger: "update" });
     // ✅ Set success state to true
     setIsSuccess(true);
     // 🕐 Wait for 3 second and then reset success state


### PR DESCRIPTION
Addresses [2383](https://github.com/bcgov/cas-registration/issues/2383)


### 🚀 Impact:
- modified `bciers/apps/dashboard/auth/auth.config.ts` to conditionally update token if triggered by "update"
- modified `bciers/apps/administration/app/components/operators/OperatorForm.tsx` to call session token update on create
- modified legacy calls to update() to be  await update({ trigger: "update" });
- modified vitests for `bciers/apps/administration/tests/components/operators/OperatorForm.test.tsx`

### 🔬 Local Testing:

1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd bciers && yarn dev-all
```

### Test Add an Operator:
1. Navigate to `http://localhost:3000`
2. Click button "Log in with Business BCeID"
3. Sign in to Keycloak using `bc-cas-dev-secondary`
4. Click link `Administration\Select an Operator` 
**Expected results:** 
- Select an Operator page is displayed
- Page has link `Add Operator`
![image](https://github.com/user-attachments/assets/d831a157-e93c-49d3-ad91-2b4128f003d5)
5. Click link `Add Operator`
**Expected results:** 
- Add an operator page displays
- Page has button `Submit`
- Page has button `Cancel`
![image](https://github.com/user-attachments/assets/0582fc7b-898e-45b2-a736-dc4c4118cfcf)
6. Complete required fields
7. Click button `Submit`
**Expected results:** 
- Form submits and creates a new approved operator with an approved admin user operator
8. Click breadcrumb `Administration`
**Expected results:** 
- Redirection to http://localhost:3000/administration page 
- Dashboard has tile ` Users And Access Requests`
![image](https://github.com/user-attachments/assets/af75e0f5-b9ac-4cb9-823a-c8d8984c8878)
9. Click link tile ` Users And Access Requests`
**Expected results:** 
- Redirection to http://localhost:3000/administration/users-and-access-requests
![image](https://github.com/user-attachments/assets/7e8ce543-504d-40aa-afa9-694464ec7b2a)
10. Click breadcrumb `Dashboard`
**Expected results:** 
- Redirection to http://localhost:3000/dashboard page 
- Dashboard has tile `Administration\Users And Access Requests`
![image](https://github.com/user-attachments/assets/a825b8b2-a2d3-43e5-8f38-a97f4cd5ab0d)
13. Click link `Administration\Users And Access Requests`
- Redirection to http://localhost:3000/administration/users-and-access-requests
![image](https://github.com/user-attachments/assets/7e8ce543-504d-40aa-afa9-694464ec7b2a)
