### PR TITLE
1700 internal operator page

### DIFF
--- a/bciers/apps/administration/app/bceidbusiness/industry_user/select-operator/(request-access)/confirm/[id]/page.tsx
+++ b/bciers/apps/administration/app/bceidbusiness/industry_user/select-operator/(request-access)/confirm/[id]/page.tsx
@@ -1,9 +1,10 @@
 import SelectOperatorConfirmPage from "@/administration/app/components/userOperators/SelectOperatorConfirmPage";
 import { Suspense } from "react";
 import Loading from "@bciers/components/loading/SkeletonForm";
+import { UUID } from "crypto";
 export default function Page({
   params: { id },
-}: Readonly<{ params: { id: string } }>) {
+}: Readonly<{ params: { id: UUID } }>) {
   return (
     <Suspense fallback={<Loading />}>
       <SelectOperatorConfirmPage id={id} />

--- a/bciers/apps/administration/app/bceidbusiness/industry_user/select-operator/(request-access)/received/[step]/[id]/page.tsx
+++ b/bciers/apps/administration/app/bceidbusiness/industry_user/select-operator/(request-access)/received/[step]/[id]/page.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from "react";
 import Loading from "@bciers/components/loading/SkeletonForm";
 import SelectOperatorReceivedPage from "@/administration/app/components/userOperators/SelectOperatorReceivedPage";
+import { UUID } from "crypto";
 
 export default function Page({
   params: { step, id },
-}: Readonly<{ params: { step: string; id: string } }>) {
+}: Readonly<{ params: { step: string; id: UUID } }>) {
   return (
     <Suspense fallback={<Loading />}>
       <SelectOperatorReceivedPage step={step} id={id} />

--- a/bciers/apps/administration/app/components/operators/OperatorForm.tsx
+++ b/bciers/apps/administration/app/components/operators/OperatorForm.tsx
@@ -17,11 +17,13 @@ interface Props {
   schema: RJSFSchema;
   formData: OperatorFormData;
   isCreating?: boolean;
+  isInternalUser: boolean;
 }
 export default function OperatorForm({
   formData,
   schema,
   isCreating,
+  isInternalUser,
 }: Readonly<Props>) {
   // @ ts-ignore
   const [error, setError] = useState(undefined);
@@ -37,6 +39,7 @@ export default function OperatorForm({
       uiSchema={operatorUiSchema}
       formData={formState}
       mode={isCreatingState ? FormMode.CREATE : FormMode.READ_ONLY}
+      allowEdit={!isInternalUser}
       onSubmit={async (data: { formData?: any }) => {
         const updatedFormData = { ...formState, ...data.formData };
         setFormState(updatedFormData);

--- a/bciers/apps/administration/app/components/operators/getOperator.ts
+++ b/bciers/apps/administration/app/components/operators/getOperator.ts
@@ -1,7 +1,8 @@
 import { actionHandler } from "@bciers/actions";
+import { UUID } from "crypto";
 
 // 🛠️ Function to get an operator by operator id
-export default async function getOperator(id: string) {
+export default async function getOperator(id: UUID) {
   try {
     return await actionHandler(
       `registration/operators/${id}`,

--- a/bciers/apps/administration/app/components/userOperators/SelectOperatorConfirmPage.tsx
+++ b/bciers/apps/administration/app/components/userOperators/SelectOperatorConfirmPage.tsx
@@ -7,10 +7,11 @@ import SelectOperatorConfirmForm from "./SelectOperatorConfirmForm";
 import getOperator from "../operators/getOperator";
 import getOperatorHasAdmin from "../operators/getOperatorHasAdmin";
 import getOperatorAccessDeclined from "../operators/getOperatorAccessDeclined";
+import { UUID } from "crypto";
 // 🧩 Main component
 export default async function SelectOperatorConfirmPage({
   id,
-}: Readonly<{ id?: string }>) {
+}: Readonly<{ id?: UUID }>) {
   if (id) {
     const operator: Operator | { error: string } = await getOperator(id);
     const hasAdmin: boolean | { error: string } = await getOperatorHasAdmin(id);

--- a/bciers/apps/administration/app/components/userOperators/SelectOperatorReceivedPage.tsx
+++ b/bciers/apps/administration/app/components/userOperators/SelectOperatorReceivedPage.tsx
@@ -4,11 +4,12 @@ import { notFound } from "next/navigation";
 import { Operator } from "../userOperators/types";
 import getOperator from "../operators/getOperator";
 import getOperatorHasAdmin from "../operators/getOperatorHasAdmin";
+import { UUID } from "crypto";
 // 🧩 Main component
 export default async function SelectOperatorReceivedPage({
   step,
   id,
-}: Readonly<{ step: string; id?: string }>) {
+}: Readonly<{ step: string; id?: UUID }>) {
   if (id) {
     const operator: Operator | { error: string } = await getOperator(id);
     const hasAdmin: boolean | { error: string } = await getOperatorHasAdmin(id);

--- a/bciers/apps/administration/app/idir/cas_admin/operators/[operatorId]/page.tsx
+++ b/bciers/apps/administration/app/idir/cas_admin/operators/[operatorId]/page.tsx
@@ -1,0 +1,10 @@
+// 🚩 flagging that for shared routes between roles, `OperatorPage` code is a component for code maintainability
+
+import OperatorPage from "@/administration/app/components/operators/OperatorPage";
+import { UUID } from "crypto";
+
+export default async function Page({
+  params: { operatorId },
+}: Readonly<{ params: { operatorId: UUID } }>) {
+  return <OperatorPage operatorId={operatorId} />;
+}

--- a/bciers/apps/administration/app/idir/cas_admin/operators/user-operator/[id]/[formSection]/page.tsx
+++ b/bciers/apps/administration/app/idir/cas_admin/operators/user-operator/[id]/[formSection]/page.tsx
@@ -1,5 +1,0 @@
-// 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-
-export default async function Page() {
-  return <div>TBD</div>;
-}

--- a/bciers/apps/administration/app/idir/cas_analyst/operators/user-operator/[id]/[formSection]/page.tsx
+++ b/bciers/apps/administration/app/idir/cas_analyst/operators/user-operator/[id]/[formSection]/page.tsx
@@ -1,5 +1,0 @@
-// 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-
-export default async function Page() {
-  return <div>TBD</div>;
-}

--- a/bciers/apps/administration/tests/components/operators/OperatorForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operators/OperatorForm.test.tsx
@@ -305,7 +305,12 @@ describe("OperatorForm component", () => {
   });
   it("renders the empty operator form when creating a new operator", async () => {
     render(
-      <OperatorForm schema={testSchema} formData={{}} isCreating={true} />,
+      <OperatorForm
+        schema={testSchema}
+        formData={{}}
+        isCreating={true}
+        isInternalUser={false}
+      />,
     );
     // form fields and headings
     expectHeader(formHeaders);
@@ -321,7 +326,12 @@ describe("OperatorForm component", () => {
   });
   it("does not allow new operator form submission if there are validation errors", async () => {
     render(
-      <OperatorForm schema={testSchema} formData={{}} isCreating={true} />,
+      <OperatorForm
+        schema={testSchema}
+        formData={{}}
+        isCreating={true}
+        isInternalUser={false}
+      />,
     );
     const submitButton = screen.getByRole("button", { name: /submit/i });
 
@@ -338,7 +348,12 @@ describe("OperatorForm component", () => {
     const { update } = mockUseSession();
 
     render(
-      <OperatorForm schema={testSchema} formData={{}} isCreating={true} />,
+      <OperatorForm
+        schema={testSchema}
+        formData={{}}
+        isCreating={true}
+        isInternalUser={false}
+      />,
     );
 
     await fillMandatoryFields(); // Mock function to fill the form
@@ -403,129 +418,15 @@ describe("OperatorForm component", () => {
       },
     );
   }, 60000);
-  it("loads existing readonly Operator form data", async () => {
-    const { container } = render(
-      <OperatorForm schema={testSchema} formData={operatorFormData} />,
-    );
-    // section 1
-    expect(
-      container.querySelector("#root_section1_legal_name"),
-    ).toHaveTextContent("Existing Operator 2 Legal Name");
-
-    expect(
-      container.querySelector("#root_section1_trade_name"),
-    ).toHaveTextContent("Existing Operator 2 Trade Name");
-
-    expect(
-      container.querySelector("#root_section1_business_structure"),
-    ).toHaveTextContent("General Partnership");
-
-    expect(
-      container.querySelector("#root_section1_cra_business_number"),
-    ).toHaveTextContent("987654321");
-
-    expect(
-      container.querySelector("#root_section1_bc_corporate_registry_number"),
-    ).toHaveTextContent("def1234567");
-
-    expect(
-      container.querySelector(
-        "#root_section1_partner_operators_array_0_partner_legal_name",
-      ),
-    ).toHaveTextContent("Partner Operator Legal Name");
-
-    // section 2
-    expect(
-      container.querySelector("#root_section2_street_address"),
-    ).toHaveTextContent("123 Main St");
-
-    expect(
-      container.querySelector("#root_section2_municipality"),
-    ).toHaveTextContent("City");
-
-    expect(
-      container.querySelector("#root_section2_province"),
-    ).toHaveTextContent("Ontario");
-
-    expect(
-      container.querySelector("#root_section2_postal_code"),
-    ).toHaveTextContent("A1B 2C3");
-
-    // section 3
-    expect(
-      container.querySelector("#root_section3_operator_has_parent_operators"),
-    ).toHaveTextContent("Yes");
-
-    expect(
-      container.querySelector(
-        "#root_section3_parent_operators_array_0_po_legal_name",
-      ),
-    ).toHaveTextContent("Parent Operator Legal Name");
-
-    expect(
-      container.querySelector(
-        "#root_section3_parent_operators_array_0_po_cra_business_number",
-      ),
-    ).toHaveTextContent("123456780");
-
-    expect(
-      container.querySelector(
-        "#root_section3_parent_operators_array_0_po_street_address",
-      ),
-    ).toHaveTextContent("789 Oak St");
-
-    expect(
-      container.querySelector(
-        "#root_section3_parent_operators_array_0_po_municipality",
-      ),
-    ).toHaveTextContent("Village");
-
-    expect(
-      container.querySelector(
-        "#root_section3_parent_operators_array_0_po_province",
-      ),
-    ).toHaveTextContent("British Columbia");
-
-    expect(
-      container.querySelector(
-        "#root_section3_parent_operators_array_0_po_postal_code",
-      ),
-    ).toHaveTextContent("M2N 3P4");
-
-    expect(
-      container.querySelector(
-        "#root_section3_parent_operators_array_0_operator_registered_in_canada",
-      ),
-    ).toHaveTextContent("Yes");
-
-    expect(
-      container.querySelector(
-        "#root_section3_parent_operators_array_1_po_legal_name",
-      ),
-    ).toHaveTextContent("Foreign company");
-
-    expect(
-      container.querySelector(
-        "#root_section3_parent_operators_array_1_operator_registered_in_canada",
-      ),
-    ).toHaveTextContent("No");
-
-    expect(
-      container.querySelector(
-        "#root_section3_parent_operators_array_1_foreign_address",
-      ),
-    ).toHaveTextContent("f address");
-
-    expect(
-      container.querySelector(
-        "#root_section3_parent_operators_array_1_foreign_tax_id_number",
-      ),
-    ).toHaveTextContent("f id number");
-  });
-
   it("edits an Operator", async () => {
     actionHandler.mockReturnValue({ error: null });
-    render(<OperatorForm schema={testSchema} formData={operatorFormData} />);
+    render(
+      <OperatorForm
+        schema={testSchema}
+        formData={operatorFormData}
+        isInternalUser={false}
+      />,
+    );
     const editButton = screen.getByRole("button", { name: /edit/i });
     act(() => {
       editButton.click();
@@ -683,4 +584,130 @@ describe("OperatorForm component", () => {
       ).toBeVisible();
     });
   }, 60000);
+  it("loads existing readonly Operator form data for an internal user", async () => {
+    const { container } = render(
+      <OperatorForm
+        schema={testSchema}
+        formData={operatorFormData}
+        isInternalUser={true}
+      />,
+    );
+    // section 1
+    expect(
+      container.querySelector("#root_section1_legal_name"),
+    ).toHaveTextContent("Existing Operator 2 Legal Name");
+
+    expect(
+      container.querySelector("#root_section1_trade_name"),
+    ).toHaveTextContent("Existing Operator 2 Trade Name");
+
+    expect(
+      container.querySelector("#root_section1_business_structure"),
+    ).toHaveTextContent("General Partnership");
+
+    expect(
+      container.querySelector("#root_section1_cra_business_number"),
+    ).toHaveTextContent("987654321");
+
+    expect(
+      container.querySelector("#root_section1_bc_corporate_registry_number"),
+    ).toHaveTextContent("def1234567");
+
+    expect(
+      container.querySelector(
+        "#root_section1_partner_operators_array_0_partner_legal_name",
+      ),
+    ).toHaveTextContent("Partner Operator Legal Name");
+
+    // section 2
+    expect(
+      container.querySelector("#root_section2_street_address"),
+    ).toHaveTextContent("123 Main St");
+
+    expect(
+      container.querySelector("#root_section2_municipality"),
+    ).toHaveTextContent("City");
+
+    expect(
+      container.querySelector("#root_section2_province"),
+    ).toHaveTextContent("Ontario");
+
+    expect(
+      container.querySelector("#root_section2_postal_code"),
+    ).toHaveTextContent("A1B 2C3");
+
+    // section 3
+    expect(
+      container.querySelector("#root_section3_operator_has_parent_operators"),
+    ).toHaveTextContent("Yes");
+
+    expect(
+      container.querySelector(
+        "#root_section3_parent_operators_array_0_po_legal_name",
+      ),
+    ).toHaveTextContent("Parent Operator Legal Name");
+
+    expect(
+      container.querySelector(
+        "#root_section3_parent_operators_array_0_po_cra_business_number",
+      ),
+    ).toHaveTextContent("123456780");
+
+    expect(
+      container.querySelector(
+        "#root_section3_parent_operators_array_0_po_street_address",
+      ),
+    ).toHaveTextContent("789 Oak St");
+
+    expect(
+      container.querySelector(
+        "#root_section3_parent_operators_array_0_po_municipality",
+      ),
+    ).toHaveTextContent("Village");
+
+    expect(
+      container.querySelector(
+        "#root_section3_parent_operators_array_0_po_province",
+      ),
+    ).toHaveTextContent("British Columbia");
+
+    expect(
+      container.querySelector(
+        "#root_section3_parent_operators_array_0_po_postal_code",
+      ),
+    ).toHaveTextContent("M2N 3P4");
+
+    expect(
+      container.querySelector(
+        "#root_section3_parent_operators_array_0_operator_registered_in_canada",
+      ),
+    ).toHaveTextContent("Yes");
+
+    expect(
+      container.querySelector(
+        "#root_section3_parent_operators_array_1_po_legal_name",
+      ),
+    ).toHaveTextContent("Foreign company");
+
+    expect(
+      container.querySelector(
+        "#root_section3_parent_operators_array_1_operator_registered_in_canada",
+      ),
+    ).toHaveTextContent("No");
+
+    expect(
+      container.querySelector(
+        "#root_section3_parent_operators_array_1_foreign_address",
+      ),
+    ).toHaveTextContent("f address");
+
+    expect(
+      container.querySelector(
+        "#root_section3_parent_operators_array_1_foreign_tax_id_number",
+      ),
+    ).toHaveTextContent("f id number");
+    expect(
+      screen.queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/bciers/apps/administration/tests/components/operators/OperatorPage.test.tsx
+++ b/bciers/apps/administration/tests/components/operators/OperatorPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import {
+  auth,
   useRouter,
   useSearchParams,
   useSession,
@@ -31,6 +32,9 @@ describe("Operator component", () => {
     vi.resetAllMocks();
   });
   it("renders the appropriate error component when getCurrentOperator fails", async () => {
+    auth.mockReturnValueOnce({
+      user: { app_role: "industry_user_admin" },
+    });
     getCurrentOperator.mockReturnValueOnce({
       error: "no operator found",
     });


### PR DESCRIPTION
Partially addresses: https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=80445876&issue=bcgov%7Ccas-registration%7C1700

This PR:
- deletes placeholder files
- creates the internal view of the operator form (readonly, no edit button)
- types operatorId as a uuid instead of a string
- setting up the routing is blocked by #1699, so will leave #1700 open but blocked. Once 1699 is complete, will do another PR to hook everything together


Happo looks like flake to me