### PR TITLE
activity page- Open Pit Coal Mining

### DIFF
--- a/bc_obps/reporting/json_schemas/2024/carbonates_use/carbonates_use.json
+++ b/bc_obps/reporting/json_schemas/2024/carbonates_use/carbonates_use.json
@@ -9,8 +9,8 @@
         "title": "Carbonate data",
         "type": "object",
         "properties": {
-          "emissions": {
-            "title": "Emissions",
+          "emission": {
+            "title": "Emission",
             "type": "number"
           },
           "gasType": {
@@ -18,9 +18,10 @@
             "type": "string",
             "enum": []
           },
-          "equivalentEmissions": {
-            "title": "Equivalent Emissions",
-            "type": "number"
+          "equivalentEmission": {
+            "title": "Equivalent Emission",
+            "type": "number",
+            "readOnly": true
           },
           "carbonateType": {
             "title": "Carbonate Type",

--- a/bc_obps/reporting/json_schemas/2024/open_pit_coal_mining/activity.json
+++ b/bc_obps/reporting/json_schemas/2024/open_pit_coal_mining/activity.json
@@ -1,0 +1,5 @@
+{
+  "title": "Open pit coal mining",
+  "type": "object",
+  "properties": {}
+}

--- a/bc_obps/reporting/json_schemas/2024/open_pit_coal_mining/coal_exposed_during_mining.json
+++ b/bc_obps/reporting/json_schemas/2024/open_pit_coal_mining/coal_exposed_during_mining.json
@@ -1,24 +1,26 @@
 {
   "type": "object",
-  "title": "Steam reformation of hydrocarbons, partial oxidation of hydrocarbons or other transformation of hydrocarbon feedstock",
+  "title": "Coal when broken or exposed to the atmosphere during mining",
   "properties": {
     "emissions": {
       "type": "array",
+      "title": "Emissions",
       "items": {
         "type": "object",
         "properties": {
-          "emission": {
-            "title": "Emission",
-            "type": "number"
-          },
           "gasType": {
             "title": "Gas Type",
             "type": "string",
             "enum": []
           },
+          "emission": {
+            "title": "Emission",
+            "type": "number"
+          },
           "equivalentEmission": {
             "title": "Equivalent Emission",
-            "type": "number"
+            "type": "number",
+            "readOnly": true
           }
         }
       }

--- a/bc_obps/reporting/json_schemas/2024/open_pit_coal_mining/emission_factor_methodology_custom.json
+++ b/bc_obps/reporting/json_schemas/2024/open_pit_coal_mining/emission_factor_methodology_custom.json
@@ -1,0 +1,30 @@
+{
+  "type": "object",
+  "properties": {
+    "coalType": {
+      "title": "Coal type",
+      "type": "string",
+      "enum": ["Bituminous coal"]
+    },
+
+    "quantityOfCoal": {
+      "type": "number",
+      "title": "Quantity of coal"
+    },
+    "quantityOfCoalUnit": {
+      "type": "string",
+      "title": "Quantity of coal unit",
+      "default": "kt/year",
+      "readOnly": true
+    },
+
+    "emissionFactorUsed": {
+      "title": "Emission factor used",
+      "type": "string",
+      "enum": [
+        "Specified by the director",
+        "Fugitive Emission factor for coal mining from National Inventory Report"
+      ]
+    }
+  }
+}

--- a/bc_obps/reporting/migrations/0008_prod_data.py
+++ b/bc_obps/reporting/migrations/0008_prod_data.py
@@ -571,6 +571,7 @@ def init_methodology_data(apps, schema_monitor):
             Methodology(name='CEMS'),
             Methodology(name='Measured CC and MW'),
             Methodology(name='Feedstock Material Balance'),
+            Methodology(name='Emissions Factor Methodology'),
         ]
     )
 
@@ -602,6 +603,7 @@ def reverse_init_methodology_data(apps, schema_monitor):
             'CEMS',
             'Measured CC and MW',
             'Feedstock Material Balance',
+            'Emissions Factor Methodology',
         ]
     ).delete()
 
@@ -716,7 +718,6 @@ def reverse_init_reporting_field_data(apps, schema_monitor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('reporting', '0007_reinit'),
     ]

--- a/bc_obps/reporting/migrations/0022_open_pit_coal_mining.py
+++ b/bc_obps/reporting/migrations/0022_open_pit_coal_mining.py
@@ -1,0 +1,264 @@
+from django.db import migrations
+import json
+
+from reporting.models import CustomMethodologySchema
+
+
+#### CONFIG DATA ####
+
+
+def init_configuration_element_data(apps, schema_monitor):
+    '''
+    Add initial data to erc.configuration_element
+    '''
+
+    ConfigurationElement = apps.get_model('reporting', 'ConfigurationElement')
+    Activity = apps.get_model('registration', 'Activity')
+    SourceType = apps.get_model('reporting', 'SourceType')
+    GasType = apps.get_model('reporting', 'GasType')
+    Methodology = apps.get_model('reporting', 'Methodology')
+    Configuration = apps.get_model('reporting', 'Configuration')
+    # Coal when broken or exposed to the atmosphere during mining
+    ConfigurationElement.objects.bulk_create(
+        [
+            ConfigurationElement(
+                activity_id=Activity.objects.get(name='Open pit coal mining').id,
+                source_type_id=SourceType.objects.get(
+                    name='Coal when broken or exposed to the atmosphere during mining'
+                ).id,
+                gas_type_id=GasType.objects.get(chemical_formula='CH4').id,
+                methodology_id=Methodology.objects.get(name='Emissions Factor Methodology').id,
+                valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
+                valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+                custom_methodology_schema_id=CustomMethodologySchema.objects.get(
+                    activity_id=Activity.objects.get(name='Open pit coal mining').id,
+                    source_type_id=SourceType.objects.get(
+                        name='Coal when broken or exposed to the atmosphere during mining'
+                    ).id,
+                    gas_type_id=GasType.objects.get(chemical_formula='CH4').id,
+                    methodology_id=Methodology.objects.get(name='Emissions Factor Methodology').id,
+                    valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
+                    valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+                ).id,
+            ),
+            ConfigurationElement(
+                activity_id=Activity.objects.get(name='Open pit coal mining').id,
+                source_type_id=SourceType.objects.get(
+                    name='Coal when broken or exposed to the atmosphere during mining'
+                ).id,
+                gas_type_id=GasType.objects.get(chemical_formula='CH4').id,
+                methodology_id=Methodology.objects.get(name='Alternative Parameter Measurement').id,
+                valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
+                valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+            ),
+            ConfigurationElement(
+                activity_id=Activity.objects.get(name='Open pit coal mining').id,
+                source_type_id=SourceType.objects.get(
+                    name='Coal when broken or exposed to the atmosphere during mining'
+                ).id,
+                gas_type_id=GasType.objects.get(chemical_formula='CH4').id,
+                methodology_id=Methodology.objects.get(name='Replacement Methodology').id,
+                valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
+                valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+            ),
+        ]
+    )
+
+
+def reverse_init_configuration_element_data(apps, schema_monitor):
+    '''
+    Remove initial data from erc.configuration_element
+    '''
+    Configuration = apps.get_model('reporting', 'Configuration')
+    Activity = apps.getmodel('registration', 'Activity')
+    ConfigurationElement = apps.get_model('reporting', 'ConfigurationElement')
+    ConfigurationElement.objects.filter(
+        activity_id=Activity.objects.get(name='Open pit coal mining').id,
+        valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
+        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+    ).delete()
+
+
+def init_configuration_element_reporting_fields_data(apps, schema_monitor):
+    '''
+    Add initial data to erc.activity_source_type_base_schema
+    '''
+    ConfigurationElement = apps.get_model('reporting', 'ConfigurationElement')
+    Activity = apps.get_model('registration', 'Activity')
+    SourceType = apps.get_model('reporting', 'SourceType')
+    GasType = apps.get_model('reporting', 'GasType')
+    Methodology = apps.get_model('reporting', 'Methodology')
+    Configuration = apps.get_model('reporting', 'Configuration')
+    ReportingField = apps.get_model('reporting', 'ReportingField')
+    # CH4 - Alternative Parameter Measurement - Description
+    ConfigurationElement.objects.get(
+        activity_id=Activity.objects.get(name='Open pit coal mining').id,
+        source_type_id=SourceType.objects.get(name='Coal when broken or exposed to the atmosphere during mining').id,
+        gas_type_id=GasType.objects.get(chemical_formula='CH4').id,
+        methodology_id=Methodology.objects.get(name='Alternative Parameter Measurement').id,
+        valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
+        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+    ).reporting_fields.add(ReportingField.objects.get(field_name='Description', field_units__isnull=True))
+    # CH4 - Replacement Methodology - Description
+    ConfigurationElement.objects.get(
+        activity_id=Activity.objects.get(name='Open pit coal mining').id,
+        source_type_id=SourceType.objects.get(name='Coal when broken or exposed to the atmosphere during mining').id,
+        gas_type_id=GasType.objects.get(chemical_formula='CH4').id,
+        methodology_id=Methodology.objects.get(name='Replacement Methodology').id,
+        valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
+        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+    ).reporting_fields.add(ReportingField.objects.get(field_name='Description', field_units__isnull=True))
+
+
+def reverse_init_configuration_element_reporting_fields_data(apps, schema_monitor):
+    '''
+    Remove data from erc.configuration_element_reporting_fields
+    '''
+    ConfigurationElement = apps.get_model('reporting', 'ConfigurationElement')
+    Activity = apps.get_model('registration', 'Activity')
+
+    ConfigurationElement.reporting_fields.through.objects.filter(
+        configurationelement_id__in=ConfigurationElement.objects.filter(
+            activity_id=Activity.objects.get(name='Open pit coal mining').id
+        ).values_list('id', flat=True)
+    ).delete()
+
+
+def init_custom_schema_data(apps, schema_editor):
+    '''
+    Add initial data to erc.custom_methodology_schema
+    '''
+    import os
+    import json
+
+    cwd = os.getcwd()
+    with open(
+        f'{cwd}/reporting/json_schemas/2024/open_pit_coal_mining/emission_factor_methodology_custom.json'
+    ) as open_pit_coal_mining:
+        schema = json.load(open_pit_coal_mining)
+
+    # Get the model classes
+    CustomMethodologySchema = apps.get_model('reporting', 'CustomMethodologySchema')
+    Activity = apps.get_model('registration', 'Activity')
+    SourceType = apps.get_model('reporting', 'SourceType')
+    GasType = apps.get_model('reporting', 'GasType')
+    Methodology = apps.get_model('reporting', 'Methodology')
+    Configuration = apps.get_model('reporting', 'Configuration')
+
+    # Fetch or create necessary related objects
+    activity = Activity.objects.get(name='Open pit coal mining')
+    source_type = SourceType.objects.get(name='Coal when broken or exposed to the atmosphere during mining')
+    methodology = Methodology.objects.get(name='Emissions Factor Methodology')
+    gas_type = GasType.objects.get(chemical_formula='CH4')
+    valid_from = Configuration.objects.get(valid_from='2024-01-01')
+    valid_to = Configuration.objects.get(valid_to='2099-12-31')
+
+    # Create a new record in CustomMethodologySchema
+    CustomMethodologySchema.objects.create(
+        activity=activity,
+        source_type=source_type,
+        json_schema=schema,
+        methodology=methodology,
+        gas_type=gas_type,
+        valid_from=valid_from,
+        valid_to=valid_to,
+    )
+
+
+def reverse_init_custom_schema_data(apps, schema_monitor):
+    '''
+    Remove initial data from erc.base_schema
+    '''
+    CutsomSchema = apps.get_model('reporting', 'CustomMethodologySchema')
+    Activity = apps.get_model('registration', 'Activity')
+    CutsomSchema.objects.filter(activity_id=Activity.objects.get(name='Open pit coal mining').id).delete()
+
+
+#### SCHEMA DATA ####
+def init_activity_schema_data(apps, schema_monitor):
+    '''
+    Add initial schema data to erc.activity_schema
+    '''
+    ## Import JSON data
+    import os
+
+    cwd = os.getcwd()
+    with open(f'{cwd}/reporting/json_schemas/2024/open_pit_coal_mining/activity.json') as mfuel:
+        schema = json.load(mfuel)
+
+    ActivitySchema = apps.get_model('reporting', 'ActivityJsonSchema')
+    Activity = apps.get_model('registration', 'Activity')
+    Configuration = apps.get_model('reporting', 'Configuration')
+    ActivitySchema.objects.create(
+        activity_id=Activity.objects.get(name='Open pit coal mining').id,
+        json_schema=schema,
+        valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
+        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+    )
+
+
+def reverse_init_activity_schema_data(apps, schema_monitor):
+    '''
+    Remove initial data from erc.base_schema
+    '''
+    ActivitySchema = apps.get_model('reporting', 'ActivityJsonSchema')
+    Activity = apps.get_model('registration', 'Activity')
+    ActivitySchema.objects.filter(activity_id=Activity.objects.get(name='Open pit coal mining').id).delete()
+
+
+# SOURCE TYPE
+def init_activity_source_type_schema_data(apps, schema_monitor):
+    '''
+    Add initial schema data to erc.activity_source_type_schema
+    '''
+    ## Import JSON data
+    import os
+
+    cwd = os.getcwd()
+    with open(f'{cwd}/reporting/json_schemas/2024/open_pit_coal_mining/coal_exposed_during_mining.json') as mfuel_st:
+        schema = json.load(mfuel_st)
+
+    ActivitySourceTypeSchema = apps.get_model('reporting', 'ActivitySourceTypeJsonSchema')
+    Activity = apps.get_model('registration', 'Activity')
+    SourceType = apps.get_model('reporting', 'SourceType')
+    Configuration = apps.get_model('reporting', 'Configuration')
+    ActivitySourceTypeSchema.objects.bulk_create(
+        [
+            ActivitySourceTypeSchema(
+                activity_id=Activity.objects.get(name='Open pit coal mining').id,
+                source_type_id=SourceType.objects.get(
+                    name='Coal when broken or exposed to the atmosphere during mining'
+                ).id,
+                has_unit=False,
+                has_fuel=False,
+                json_schema=schema,
+                valid_from_id=Configuration.objects.get(valid_from='2024-01-01').id,
+                valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+            ),
+        ]
+    )
+
+
+def reverse_init_activity_source_type_schema_data(apps, schema_monitor):
+    '''
+    Remove initial data from erc.base_schema
+    '''
+    ActivitySourceTypeJsonSchema = apps.get_model('reporting', 'ActivitySourceTypeJsonSchema')
+    Activity = apps.get_model('registration', 'Activity')
+    ActivitySourceTypeJsonSchema.objects.filter(
+        activity_id=Activity.objects.get(name='Open pit coal mining').id
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [('reporting', '0021_report_additional_data')]
+
+    operations = [
+        migrations.RunPython(init_custom_schema_data, reverse_init_custom_schema_data),
+        migrations.RunPython(init_configuration_element_data, reverse_init_configuration_element_data),
+        migrations.RunPython(
+            init_configuration_element_reporting_fields_data, reverse_init_configuration_element_reporting_fields_data
+        ),
+        migrations.RunPython(init_activity_schema_data, reverse_init_activity_schema_data),
+        migrations.RunPython(init_activity_source_type_schema_data, reverse_init_activity_source_type_schema_data),
+    ]

--- a/bc_obps/reporting/migrations/0024_open_pit_coal_mining.py
+++ b/bc_obps/reporting/migrations/0024_open_pit_coal_mining.py
@@ -251,7 +251,7 @@ def reverse_init_activity_source_type_schema_data(apps, schema_monitor):
 
 
 class Migration(migrations.Migration):
-    dependencies = [('reporting', '0021_report_additional_data')]
+    dependencies = [('reporting', '0023_emission_category_mapping_with_data')]
 
     operations = [
         migrations.RunPython(init_custom_schema_data, reverse_init_custom_schema_data),

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_open_pit_coal_mining.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_open_pit_coal_mining.py
@@ -1,0 +1,123 @@
+from django.test import TestCase
+from django.db.models import Count
+from registration.models.activity import Activity
+from reporting.models import CustomMethodologySchema
+from reporting.models.configuration import Configuration
+from reporting.models.configuration_element import ConfigurationElement
+
+
+class OpenPitCoalMining2024Test(TestCase):
+    def testDataExists(self):
+        # Fetch the activity and configuration objects
+        activity = Activity.objects.get(name='Open pit coal mining')
+        config = Configuration.objects.get(slug='2024')
+
+        # Filter ConfigurationElement objects
+        config_elements = ConfigurationElement.objects.filter(
+            valid_from__lte=config, valid_to__gte=config, activity=activity
+        )
+
+        # Define the expected configuration for each gas type
+        gas_config = {
+            'CH4': {
+                'Emissions Factor Methodology': 0,
+                'Alternative Parameter Measurement': 1,
+                'Replacement Methodology': 1,
+            }
+        }
+
+        config = {'Coal when broken or exposed to the atmosphere during mining': gas_config}
+
+        # Check if the source types match the expected values
+        expected_source_types = config.keys()
+        actual_source_types = config_elements.values_list('source_type__name', flat=True).distinct()
+
+        self.assertQuerySetEqual(
+            actual_source_types,
+            expected_source_types,
+            ordered=False,
+            msg=f'{activity} contains config for the proper source types',
+        )
+
+        # For each source type, check if the gas types and methodology counts match the expected values
+        for source_type_name, gas_config in config.items():
+            actual_gas_types = (
+                config_elements.filter(source_type__name=source_type_name)
+                .values_list('gas_type__chemical_formula', flat=True)
+                .distinct()
+            )
+
+            self.assertQuerySetEqual(
+                actual_gas_types,
+                gas_config.keys(),
+                ordered=False,
+                msg=f'{source_type_name} contains config for the proper gas types',
+            )
+
+            for gas_name, methods in gas_config.items():
+                actual_methodologies = (
+                    config_elements.filter(source_type__name=source_type_name, gas_type__chemical_formula=gas_name)
+                    .annotate(field_count=Count('reporting_fields'))
+                    .values_list('methodology__name', 'field_count')
+                )
+
+                expected_methodologies = list(methods.items())
+
+                # Print actual vs. expected for debugging purposes
+                print(f"Checking {source_type_name}:{gas_name}")
+                print(f"Expected: {expected_methodologies}")
+                print(f"Actual: {list(actual_methodologies)}")
+
+                self.assertQuerySetEqual(
+                    actual_methodologies,
+                    expected_methodologies,
+                    ordered=False,
+                    msg=f'{source_type_name}:{gas_name} contains config for the proper methods and field counts',
+                )
+
+        # Ensure there are exactly 4 configuration elements
+        self.assertEqual(len(config_elements), 3)
+
+    def testCustomMethodologySchema(self):
+        # Fetch the activity and configuration objects
+        activity = Activity.objects.get(name='Open pit coal mining')
+        config = Configuration.objects.get(slug='2024')
+
+        # Fetch the custom methodology schemas
+        custom_schemas = CustomMethodologySchema.objects.filter(activity=activity, valid_from=config, valid_to=config)
+
+        # Define the expected schema for the "Feedstock Material Balance" methodology
+        expected_schema = {
+            "coalType": {"title": "Coal type", "type": "string", "enum": ["Bituminous coal"]},
+            "quantityOfCoal": {"type": "number", "title": "Quantity of coal"},
+            "quantityOfCoalUnit": {
+                "type": "string",
+                "title": "Quantity of coal unit",
+                "default": "kt/year",
+                "readOnly": True,
+            },
+            "emissionFactorUsed": {
+                "title": "Emission factor used",
+                "type": "string",
+                "enum": [
+                    "Specified by the director",
+                    "Fugitive Emission factor for coal mining from National Inventory Report",
+                ],
+            },
+        }
+
+        # Check if the expected schema is present for "Feedstock Material Balance"
+        feedstock_schema_exists = custom_schemas.filter(methodology__name='Emissions Factor Methodology').exists()
+
+        self.assertTrue(feedstock_schema_exists, msg='Emissions Factor Methodology schema is missing')
+
+        for custom_schema in custom_schemas:
+            if custom_schema.methodology.name == 'Emissions Factor Methodology':
+                actual_schema = custom_schema.json_schema['properties']
+
+                # Assert equality
+                self.assertEqual(
+                    actual_schema,
+                    expected_schema,
+                    msg='Custom schema for Emissions Factor Methodology does not match the expected schema',
+                )

--- a/bc_obps/reporting/tests/models/test_methodology.py
+++ b/bc_obps/reporting/tests/models/test_methodology.py
@@ -30,6 +30,7 @@ class TestInitialData(TestCase):
                 'Mass of Output Carbonates',
                 'Alternative Parameter Methodology',
                 'Feedstock Material Balance',
+                'Emissions Factor Methodology',
                 'Solids-HHV',
                 'Solids-CC',
                 'Make-up Chemical Use Methodology',

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/carbonatesUseUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/carbonatesUseUiSchema.ts
@@ -34,8 +34,8 @@ const uiSchema = {
         items: {
           "ui:order": [
             "gasType",
-            "emissions",
-            "equivalentEmissions",
+            "emission",
+            "equivalentEmission",
             "carbonateType",
             "methodology",
             "annualMassOfCarbonateTypeConsumedTonnes",

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
@@ -33,7 +33,7 @@ const uiSchema = {
           "ui:order": [
             "gasType",
             "emission",
-            "equivalentEmissions",
+            "equivalentEmission",
             "methodology",
             "feedstocks",
             "description",

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/openPitCoalMining.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/openPitCoalMining.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
+import ReadOnlyWidget from "@bciers/components/form/widgets/readOnly/ReadOnlyWidget";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -31,32 +32,22 @@ const uiSchema = {
           padding: "p-2",
         },
         items: {
-          "ui:order": [
-            "gasType",
-            "emission",
-            "equivalentEmission",
-            "carbonateType",
-            "methodology",
-            "coalType",
-            "emissionFactorUsed",
-            "quantityOfCoal",
-            "quantityOfCoalUnit",
-            "description",
-          ],
           methodology: {
             "ui:FieldTemplate": FieldTemplate,
             "ui:options": {
               label: false,
             },
-          },
-          emissions: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          gasType: {
-            "ui:FieldTemplate": InlineFieldTemplate,
-          },
-          equivalentEmissions: {
-            "ui:FieldTemplate": InlineFieldTemplate,
+            "ui:order": [
+              "methodology",
+              "coalType",
+              "quantityOfCoal",
+              "quantityOfCoalUnit",
+              "description",
+              "emissionFactorUsed",
+            ],
+            quantityOfCoalUnit: {
+              "ui:widget": ReadOnlyWidget,
+            },
           },
         },
       },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/openPitCoalMining.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/openPitCoalMining.ts
@@ -1,0 +1,67 @@
+import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
+import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArrayFieldTemplate";
+import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
+import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
+import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
+
+const uiSchema = {
+  "ui:FieldTemplate": FieldTemplate,
+  "ui:classNames": "form-heading-label",
+  coalExposedDuringMining: {
+    "ui:FieldTemplate": FieldTemplate,
+    "ui:widget": CheckboxWidgetLeft,
+    "ui:options": {
+      label: false,
+    },
+  },
+  sourceTypes: {
+    "ui:FieldTemplate": FieldTemplate,
+    "ui:options": {
+      label: false,
+    },
+    coalExposedDuringMining: {
+      "ui:FieldTemplate": SourceTypeBoxTemplate,
+      emissions: {
+        "ui:ArrayFieldTemplate": NestedArrayFieldTemplate,
+        "ui:FieldTemplate": FieldTemplate,
+        "ui:options": {
+          arrayAddLabel: "Add Emission",
+          label: false,
+          title: "Emission",
+          padding: "p-2",
+        },
+        items: {
+          "ui:order": [
+            "gasType",
+            "emission",
+            "equivalentEmission",
+            "carbonateType",
+            "methodology",
+            "coalType",
+            "emissionFactorUsed",
+            "quantityOfCoal",
+            "quantityOfCoalUnit",
+            "description",
+          ],
+          methodology: {
+            "ui:FieldTemplate": FieldTemplate,
+            "ui:options": {
+              label: false,
+            },
+          },
+          emissions: {
+            "ui:FieldTemplate": InlineFieldTemplate,
+          },
+          gasType: {
+            "ui:FieldTemplate": InlineFieldTemplate,
+          },
+          equivalentEmissions: {
+            "ui:FieldTemplate": InlineFieldTemplate,
+          },
+        },
+      },
+    },
+  },
+};
+
+export default uiSchema;

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/openPitCoalMining.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/openPitCoalMining.ts
@@ -2,7 +2,6 @@ import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
 import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArrayFieldTemplate";
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
-import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
 import ReadOnlyWidget from "@bciers/components/form/widgets/readOnly/ReadOnlyWidget";
 
 const uiSchema = {

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/schemaMaps.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/schemaMaps.tsx
@@ -6,6 +6,7 @@ import gscUiSchema from "./gscUiSchema";
 import hydrogenProduction from "./hydrogenProduction";
 import pulpAndPaperUiSchema from "./pulpAndPaperUiSchema";
 import refineryFuelGasUiSchema from "./refineryFuelGasUiSchema";
+import openPitCoalMining from "@reporting/src/app/components/activities/uiSchemas/openPitCoalMining";
 
 type UiSchemaMap = {
   [key: string]: any;
@@ -30,6 +31,7 @@ export const uiSchemaMap: UiSchemaMap = {
   pulp_and_paper: pulpAndPaperUiSchema,
   refinery_fuel_gas: refineryFuelGasUiSchema,
   carbonate_use: carbonatesUseUiSchema,
+  open_pit_coal_mining: openPitCoalMining,
 };
 
 export const getUiSchema = (slug: string) => {

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/schemaMaps.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/schemaMaps.tsx
@@ -53,4 +53,5 @@ export const defaultEmtpySourceTypeMap: DefaultEmptySourceTypeMap = {
   pulp_and_paper: onlyEmissions,
   refinery_fuel_gas: withFuels,
   carbonate_use: onlyEmissions,
+  open_pit_coal_mining: onlyEmissions,
 };


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/339
Changes:-

- Adds backend config/migration for Open Pit coal mining activity.
- Adds frontend page and components for Open Pit coal mining activity.
- Added components for activity-specific pages and dynamic field rendering.
- Fixed typo(Emission and Equivalent Emission in Hydrogen Production and Carbonates use)

To test:-
- make reset_db to apply latest migrations.
- spin up the front, backend and postgres.
- Login, then navigate to http://localhost:3000/reporting/reports , select operation 3 -> press save and continue to go to review Facilities page-> select Open pit coal mining(from the list of activities) and press save & continue. 
- The Gas type dropdown options should change options available in the methodology field.
- The Methodology dropdown options spawn additional fields, depending on the option selected.