### PR TITLE
"Transfers" tile in BCIERS dashboard for internal users

### DIFF
--- a/bc_obps/common/fixtures/dashboard/bciers/internal.json
+++ b/bc_obps/common/fixtures/dashboard/bciers/internal.json
@@ -32,18 +32,18 @@
             ]
           },
           {
-            "title": "Registration",
+            "title": "Transfers",
             "href": "/registration",
             "icon": "Layers",
-            "content": "View information of any event or to approve or decline operation registration.",
+            "content": "Transfer operations and facilities between Operators and view transfers.",
             "links": [
               {
-                "title": "Register an Operation",
-                "href": "/registration/operation"
+                "title": "Transfers",
+                "href": "/registration/transfers"
               },
               {
-                "title": "Report an Event",
-                "href": "/registration/event"
+                "title": "Transfer an operation or facility",
+                "href": "/registration/transfer"
               }
             ]
           },

--- a/bc_obps/common/fixtures/dashboard/registration/internal.json
+++ b/bc_obps/common/fixtures/dashboard/registration/internal.json
@@ -4,20 +4,14 @@
     "fields": {
       "name": "Internal Analyst Registration Dashboard",
       "data": {
-        "dashboard": "Transfers",
+        "dashboard": "registration",
         "access_roles": ["cas_analyst"],
         "tiles": [
           {
-            "title": "Register an Operation",
+            "title": "Transfers",
             "icon": "File",
             "content": "TBD here.",
-            "href": "/registration/operation"
-          },
-          {
-            "title": "Report an Event",
-            "icon": "File",
-            "content": "TBD here.",
-            "href": "/registration/event"
+            "href": "/registration/transfers"
           }
         ]
       }

--- a/bc_obps/common/fixtures/dashboard/registration/internal.json
+++ b/bc_obps/common/fixtures/dashboard/registration/internal.json
@@ -4,7 +4,7 @@
     "fields": {
       "name": "Internal Analyst Registration Dashboard",
       "data": {
-        "dashboard": "registration",
+        "dashboard": "Transfers",
         "access_roles": ["cas_analyst"],
         "tiles": [
           {

--- a/bc_obps/common/fixtures/dashboard/registration/internal_admin.json
+++ b/bc_obps/common/fixtures/dashboard/registration/internal_admin.json
@@ -8,16 +8,10 @@
         "access_roles": ["cas_admin"],
         "tiles": [
           {
-            "title": "Register an Operation",
+            "title": "Transfers",
             "icon": "File",
             "content": "TBD here.",
-            "href": "/registration/operation"
-          },
-          {
-            "title": "Report an Event",
-            "icon": "File",
-            "content": "TBD here.",
-            "href": "/registration/event"
+            "href": "/registration/transfers"
           }
         ]
       }


### PR DESCRIPTION
Ticket #2405 

feat: replaced Registration tile in BCIERS dashboard with Transfers (for internal users only)

Notes:
- renamed the "Registration" tile to "Transfers"
- replaced links in tile with links to view Transfers grid and to create a new transfer (these pages don't exist yet, so the links just take you to an error page)
- note that breadcrumb still includes "Registration" (consistent with wireframe)

### To test:
- sign in to BCIERS with your IDIR
- (you may have to update your user profile first)
- with a user role of either cas_analyst or cas_admin, go to the main BCIERS dashboard
- should see this:
![Screenshot 2024-10-29 at 2 05 45 PM](https://github.com/user-attachments/assets/78801177-9bae-44de-9456-b8611c196633)

