### PR TITLE
2151 issue bcghgid service

### DIFF
--- a/bc_obps/common/tests/endpoints/auth/test_endpoint_permissions.py
+++ b/bc_obps/common/tests/endpoints/auth/test_endpoint_permissions.py
@@ -173,6 +173,8 @@ class TestEndpointPermissions(TestCase):
             {"method": "patch", "endpoint_name": "facility_bcghg_id", "kwargs": {"facility_id": mock_uuid}},
             {"method": "patch", "endpoint_name": "operation_boro_id", "kwargs": {"operation_id": mock_uuid}},
             {"method": "patch", "endpoint_name": "operation_bcghg_id", "kwargs": {"operation_id": mock_uuid}},
+            {"method": "patch", "endpoint_name": "facility_bcghg_id", "kwargs": {'facility_id': mock_uuid}},
+            {"method": "patch", "endpoint_name": "operation_bcghg_id", "kwargs": {'operation_id': mock_uuid}},
         ],
         "approved_authorized_roles": [
             {"method": "get", "endpoint_name": "list_operations"},

--- a/bc_obps/registration/api/v1/_facilities/_facility_id/bcghg_id.py
+++ b/bc_obps/registration/api/v1/_facilities/_facility_id/bcghg_id.py
@@ -1,6 +1,7 @@
 from typing import Literal, Tuple
 from uuid import UUID
 from django.http import HttpRequest
+from registration.models.bc_greenhouse_gas_id import BcGreenhouseGasId
 from service.facility_service import FacilityService
 from registration.schema.v2.operation import OperationBoroIdOut
 from registration.constants import V2
@@ -20,7 +21,7 @@ from registration.schema.generic import Message
     auth=authorize('authorized_irc_user'),
 )
 @handle_http_errors()
-def facility_bcghg_id(request: HttpRequest, facility_id: UUID) -> Tuple[Literal[200], None]:
+def facility_bcghg_id(request: HttpRequest, facility_id: UUID) -> Tuple[Literal[200], BcGreenhouseGasId]:
     return 200, FacilityService.generate_bcghg_id(
         get_current_user_guid(request),
         facility_id,

--- a/bc_obps/registration/api/v2/_operations/_operation_id/bcghg_id.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/bcghg_id.py
@@ -1,6 +1,7 @@
 from typing import Literal, Tuple
 from uuid import UUID
 from django.http import HttpRequest
+from registration.models.bc_greenhouse_gas_id import BcGreenhouseGasId
 from registration.schema.v2.operation import OperationBoroIdOut
 from service.operation_service_v2 import OperationServiceV2
 from registration.constants import V2
@@ -20,7 +21,7 @@ from registration.schema.generic import Message
     auth=authorize('authorized_irc_user'),
 )
 @handle_http_errors()
-def operation_bcghg_id(request: HttpRequest, operation_id: UUID) -> Tuple[Literal[200], None]:
+def operation_bcghg_id(request: HttpRequest, operation_id: UUID) -> Tuple[Literal[200], BcGreenhouseGasId]:
     return 200, OperationServiceV2.generate_bcghg_id(
         get_current_user_guid(request),
         operation_id,

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -1,4 +1,5 @@
 from uuid import UUID
+from registration.models.bc_greenhouse_gas_id import BcGreenhouseGasId
 from registration.models.bc_obps_regulated_operation import BcObpsRegulatedOperation
 from typing import List, Optional, Literal
 from registration.schema.v1.multiple_operator import MultipleOperatorOut
@@ -265,4 +266,10 @@ class OperationRepresentativeOut(ModelSchema):
 class OperationBoroIdOut(ModelSchema):
     class Meta:
         model = BcObpsRegulatedOperation
+        fields = ['id']
+
+
+class OperationBcghgIdOut(ModelSchema):
+    class Meta:
+        model = BcGreenhouseGasId
         fields = ['id']

--- a/bc_obps/registration/tests/endpoints/v1/_facilities/_facility_id/test_facility_bcghg_id.py
+++ b/bc_obps/registration/tests/endpoints/v1/_facilities/_facility_id/test_facility_bcghg_id.py
@@ -1,8 +1,10 @@
 from registration.tests.utils.helpers import CommonTestSetup
+from registration.tests.utils.helpers import TestUtils
+from registration.utils import custom_reverse_lazy
+from model_bakery import baker
 
 
 class TestFacilityBcghgIdEndpoint(CommonTestSetup):
-   
     def test_authorized_role_can_issue_id(self):
         timeline = baker.make_recipe('utils.facility_designated_operation_timeline', end_date=None)
         roles = ["cas_admin", "cas_analyst"]
@@ -18,4 +20,4 @@ class TestFacilityBcghgIdEndpoint(CommonTestSetup):
                 ),
             )
             assert response.status_code == 200
-            assert response.json()['id'] == '14862100001'  # '1' and '486210' come from the recipe's mock data
+            assert response.json() == {'id': '14862100001'}  # '1' and '486210' come from the recipe's mock data

--- a/bc_obps/registration/tests/endpoints/v1/_facilities/_facility_id/test_facility_bcghg_id.py
+++ b/bc_obps/registration/tests/endpoints/v1/_facilities/_facility_id/test_facility_bcghg_id.py
@@ -2,21 +2,20 @@ from registration.tests.utils.helpers import CommonTestSetup
 
 
 class TestFacilityBcghgIdEndpoint(CommonTestSetup):
-    ...
-    # def test_authorized_role_can_patch(self):
-    #     roles = ["cas_admin", "cas_analyst"]
-    #     for role in roles:
-    #         response = TestUtils.mock_patch_with_auth_role(
-    #             self,
-    #             role,
-    #             self.content_type,
-    #             {},
-    #             custom_reverse_lazy(
-    #                 "facility_bcghg_id",
-    #                 kwargs={
-    #                     'facility_id': baker.make_recipe('utils.facility')
-    #                 },
-    #             ),
-    #         )
-    #         assert response.status_code == 200
-    #         assert response.json()['id'] is ???
+   
+    def test_authorized_role_can_issue_id(self):
+        timeline = baker.make_recipe('utils.facility_designated_operation_timeline', end_date=None)
+        roles = ["cas_admin", "cas_analyst"]
+        for role in roles:
+            response = TestUtils.mock_patch_with_auth_role(
+                self,
+                role,
+                self.content_type,
+                {},
+                custom_reverse_lazy(
+                    "facility_bcghg_id",
+                    kwargs={'facility_id': timeline.facility.id},
+                ),
+            )
+            assert response.status_code == 200
+            assert response.json()['id'] == '14862100001'  # '1' and '486210' come from the recipe's mock data

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/test_bcghg_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/test_bcghg_id.py
@@ -1,8 +1,10 @@
 from registration.tests.utils.helpers import CommonTestSetup
+from registration.tests.utils.helpers import TestUtils
+from registration.utils import custom_reverse_lazy
+from model_bakery import baker
 
 
 class TestOperationBcghgIdEndpoint(CommonTestSetup):
- 
     def test_authorized_role_can_issue_id(self):
         operation = baker.make_recipe('utils.operation')
         roles = ["cas_admin", "cas_analyst"]
@@ -18,4 +20,4 @@ class TestOperationBcghgIdEndpoint(CommonTestSetup):
                 ),
             )
             assert response.status_code == 200
-            assert response.json()['id'] == '14862100001'  # '1' and '486210' come from the recipe's mock data
+            assert response.json() == {'id': '14862100001'}  # '1' and '486210' come from the recipe's mock data

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/test_bcghg_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/test_bcghg_id.py
@@ -2,22 +2,20 @@ from registration.tests.utils.helpers import CommonTestSetup
 
 
 class TestOperationBcghgIdEndpoint(CommonTestSetup):
-    ...
-
-    # def test_authorized_role_can_patch(self):
-    #     roles = ["cas_admin", "cas_analyst"]
-    #     for role in roles:
-    #         response = TestUtils.mock_patch_with_auth_role(
-    #             self,
-    #             role,
-    #             self.content_type,
-    #             {},
-    #             custom_reverse_lazy(
-    #                 "operation_bcghg_id",
-    #                 kwargs={
-    #                     'operation_id': baker.make_recipe('utils.operation')
-    #                 },
-    #             ),
-    #         )
-    #         assert response.status_code == 200
-    #         assert response.json()['id'] is ???
+ 
+    def test_authorized_role_can_issue_id(self):
+        operation = baker.make_recipe('utils.operation')
+        roles = ["cas_admin", "cas_analyst"]
+        for role in roles:
+            response = TestUtils.mock_patch_with_auth_role(
+                self,
+                role,
+                self.content_type,
+                {},
+                custom_reverse_lazy(
+                    "operation_bcghg_id",
+                    kwargs={'operation_id': operation.id},
+                ),
+            )
+            assert response.status_code == 200
+            assert response.json()['id'] == '14862100001'  # '1' and '486210' come from the recipe's mock data

--- a/bc_obps/registration/tests/utils/baker_recipes.py
+++ b/bc_obps/registration/tests/utils/baker_recipes.py
@@ -84,6 +84,7 @@ operation = Recipe(
     naics_code=foreign_key(naics_code),
     operator=foreign_key(operator_for_operation),
     created_by=foreign_key(industry_operator_user),
+    type='Single Facility Operation',
 )
 
 

--- a/bc_obps/service/tests/test_facility_service.py
+++ b/bc_obps/service/tests/test_facility_service.py
@@ -527,3 +527,19 @@ class TestUpdateFacility:
 
         # Assert Updated State
         TestUtils.assert_facility_db_state(facility, expect_well_authorization_numbers=0)
+
+
+class TestGenerateBcghgId:
+    @staticmethod
+    def test_generates_bcghg_id():
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        timeline = baker.make_recipe('utils.facility_designated_operation_timeline')
+        timeline.operation.operator = approved_user_operator.operator
+        timeline.operation.save()
+        timeline.end_date = None
+        timeline.save()
+
+        FacilityService.generate_bcghg_id(approved_user_operator.user.user_guid, timeline.facility.id)
+        timeline.facility.refresh_from_db()
+        assert timeline.facility.bcghg_id is not None
+        assert timeline.facility.bcghg_id.issued_by == approved_user_operator.user

--- a/bc_obps/service/tests/test_operation_service_v2.py
+++ b/bc_obps/service/tests/test_operation_service_v2.py
@@ -884,3 +884,15 @@ class TestGenerateBoroId:
             OperationServiceV2.generate_boro_id(approved_user_operator.user.user_guid, operation.id)
         operation.refresh_from_db()
         assert operation.bc_obps_regulated_operation is not None
+
+
+class TestGenerateBcghgId:
+    @staticmethod
+    def test_generates_bcghg_id():
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+
+        OperationServiceV2.generate_bcghg_id(approved_user_operator.user.user_guid, operation.id)
+        operation.refresh_from_db()
+        assert operation.bcghg_id is not None
+        assert operation.bcghg_id.issued_by == approved_user_operator.user


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=80445811&issue=bcgov%7Ccas-registration%7C2152

This PR:
- creates services to issue a BCGHG ID
- tests the services and endpoints
- updates mock data so Operation 3 doesn't have a BCGHG ID

Notes:
- We don't have an internal facility page yet, so we're only able to test the "Issue BCGHG ID" button for operations. I've made a note in the internal facility page ticket to test the button at that point.


