### PR TITLE
2299 remove op rep

### DIFF
--- a/bc_obps/common/tests/endpoints/auth/test_endpoint_permissions.py
+++ b/bc_obps/common/tests/endpoints/auth/test_endpoint_permissions.py
@@ -141,6 +141,11 @@ class TestEndpointPermissions(TestCase):
                 "endpoint_name": "operation_registration_submission",
                 "kwargs": {"operation_id": mock_uuid},
             },
+            {
+                "method": "put",
+                "endpoint_name": "remove_operation_representative",
+                "kwargs": {"operation_id": mock_uuid},
+            },
         ],
         "all_roles": [
             {"method": "get", "endpoint_name": "get_reporting_year"},

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation_representative.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation_representative.py
@@ -45,7 +45,7 @@ def create_operation_representative(
 @handle_http_errors()
 def remove_operation_representative(
     request: HttpRequest, operation_id: UUID, payload: OperationRepresentativeRemove
-) -> Tuple[Literal[200], int]:
+) -> Tuple[Literal[200], OperationRepresentativeRemove]:
     return 200, OperationServiceV2.remove_operation_representative(
         get_current_user_guid(request), operation_id, payload
     )

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation_representative.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation_representative.py
@@ -45,7 +45,7 @@ def create_operation_representative(
 @handle_http_errors()
 def remove_operation_representative(
     request: HttpRequest, operation_id: UUID, payload: OperationRepresentativeRemove
-) -> Tuple[Literal[200], None]:
+) -> Tuple[Literal[200], int]:
     return 200, OperationServiceV2.remove_operation_representative(
         get_current_user_guid(request), operation_id, payload
     )

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation_representative.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation_representative.py
@@ -2,7 +2,11 @@ from typing import Literal, Tuple
 from uuid import UUID
 from django.http import HttpRequest
 from registration.models.contact import Contact
-from registration.schema.v2.operation import OperationRepresentativeIn, OperationRepresentativeOut
+from registration.schema.v2.operation import (
+    OperationRepresentativeIn,
+    OperationRepresentativeOut,
+    OperationRepresentativeRemove,
+)
 from service.operation_service_v2 import OperationServiceV2
 from registration.constants import V2
 from common.api.utils import get_current_user_guid
@@ -26,5 +30,22 @@ def create_operation_representative(
     request: HttpRequest, operation_id: UUID, payload: OperationRepresentativeIn
 ) -> Tuple[Literal[200], Contact]:
     return 200, OperationServiceV2.create_operation_representative(
+        get_current_user_guid(request), operation_id, payload
+    )
+
+
+@router.put(
+    "/v2/operations/{uuid:operation_id}/registration/operation-representative",
+    response={200: OperationRepresentativeOut, custom_codes_4xx: Message},
+    tags=V2,
+    description="""Removes operation representative from an operation.
+    The endpoint ensures that only authorized industry users can update operations belonging to their operator. Unauthorized access attempts raise an error.""",
+    auth=authorize("approved_industry_user"),
+)
+@handle_http_errors()
+def remove_operation_representative(
+    request: HttpRequest, operation_id: UUID, payload: OperationRepresentativeRemove
+) -> Tuple[Literal[200], None]:
+    return 200, OperationServiceV2.remove_operation_representative(
         get_current_user_guid(request), operation_id, payload
     )

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -41,6 +41,14 @@ class OperationRepresentativeIn(ModelSchema):
         fields = ['first_name', 'last_name', 'email', 'phone_number', 'position_title']
 
 
+class OperationRepresentativeRemove(ModelSchema):
+    id: int
+
+    class Meta:
+        model = Contact
+        fields = ['id']
+
+
 class OperationInformationIn(ModelSchema):
     registration_purpose: Optional[RegistrationPurpose.Purposes] = None
     regulated_products: Optional[list] = None

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation_representative.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation_representative.py
@@ -192,7 +192,7 @@ class TestOperationRepresentativePutEndpoint(CommonTestSetup):
             custom_reverse_lazy("remove_operation_representative", kwargs={'operation_id': operation.id}),
         )
         assert response.status_code == 200
-        assert response.json() == contact.id
+        assert response.json() == {'id': contact.id}
         assert operation.contacts.count() == 0
 
     def test_remove_operation_representative_endpoint_bad_data(self):

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation_representative.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation_representative.py
@@ -157,23 +157,6 @@ class TestOperationRepresentativePostEndpoint(CommonTestSetup):
 
 
 class TestOperationRepresentativePutEndpoint(CommonTestSetup):
-    def test_operation_representative_endpoint_unauthorized_roles_cannot_put(self):
-        operation = baker.make_recipe(
-            'utils.operation',
-        )
-        # cas users and unapproved industry users can't put
-        roles = ["cas_pending", "cas_analyst", "cas_admin", "industry_user"]
-        for role in roles:
-            response = TestUtils.mock_put_with_auth_role(
-                self,
-                role,
-                self.content_type,
-                {'id': 1},
-                custom_reverse_lazy("remove_operation_representative", kwargs={'operation_id': operation.id}),
-            )
-            assert response.status_code == 401
-            assert response.json().get('detail') == 'Unauthorized'
-
     def test_users_cannot_update_other_users_operations(self):
         # authorize current user
         baker.make_recipe('utils.approved_user_operator', user=self.user)
@@ -209,6 +192,7 @@ class TestOperationRepresentativePutEndpoint(CommonTestSetup):
             custom_reverse_lazy("remove_operation_representative", kwargs={'operation_id': operation.id}),
         )
         assert response.status_code == 200
+        assert response.json() == contact.id
         assert operation.contacts.count() == 0
 
     def test_remove_operation_representative_endpoint_bad_data(self):

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation_representative.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation_representative.py
@@ -3,7 +3,7 @@ from registration.utils import custom_reverse_lazy
 from model_bakery import baker
 
 
-class TestOperationRepresentativeEndpoint(CommonTestSetup):
+class TestOperationRepresentativePostEndpoint(CommonTestSetup):
     def test_users_cannot_update_other_users_operations(self):
         # authorize current user
         baker.make_recipe('utils.approved_user_operator', user=self.user)
@@ -150,6 +150,76 @@ class TestOperationRepresentativeEndpoint(CommonTestSetup):
             self.content_type,
             {'bad_data': 'I am bad data'},
             custom_reverse_lazy("create_operation_representative", kwargs={'operation_id': operation.id}),
+        )
+
+        # Assert
+        assert response.status_code == 422
+
+
+class TestOperationRepresentativePutEndpoint(CommonTestSetup):
+    def test_operation_representative_endpoint_unauthorized_roles_cannot_put(self):
+        operation = baker.make_recipe(
+            'utils.operation',
+        )
+        # cas users and unapproved industry users can't put
+        roles = ["cas_pending", "cas_analyst", "cas_admin", "industry_user"]
+        for role in roles:
+            response = TestUtils.mock_put_with_auth_role(
+                self,
+                role,
+                self.content_type,
+                {'id': 1},
+                custom_reverse_lazy("remove_operation_representative", kwargs={'operation_id': operation.id}),
+            )
+            assert response.status_code == 401
+            assert response.json().get('detail') == 'Unauthorized'
+
+    def test_users_cannot_update_other_users_operations(self):
+        # authorize current user
+        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        # create operation not belonging to current user
+        operation = baker.make_recipe(
+            'utils.operation',
+        )
+
+        response = TestUtils.mock_put_with_auth_role(
+            self,
+            "industry_user",
+            self.content_type,
+            {'id': 1},
+            custom_reverse_lazy("remove_operation_representative", kwargs={'operation_id': operation.id}),
+        )
+        assert response.status_code == 401
+        assert response.json().get('message') == 'Unauthorized.'
+
+    def test_remove_operation_representative_endpoint_success(self):
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        users_operator = approved_user_operator.operator
+        operation = baker.make_recipe('utils.operation', operator=users_operator)
+        contact = baker.make_recipe('utils.contact')
+        users_operator.contacts.add(contact)
+        data = {
+            'id': contact.id,
+        }
+        response = TestUtils.mock_put_with_auth_role(
+            self,
+            "industry_user",
+            self.content_type,
+            data,
+            custom_reverse_lazy("remove_operation_representative", kwargs={'operation_id': operation.id}),
+        )
+        assert response.status_code == 200
+        assert operation.contacts.count() == 0
+
+    def test_remove_operation_representative_endpoint_bad_data(self):
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        response = TestUtils.mock_post_with_auth_role(
+            self,
+            "industry_user",
+            self.content_type,
+            {'bad_data': 'I am bad data'},
+            custom_reverse_lazy("remove_operation_representative", kwargs={'operation_id': operation.id}),
         )
 
         # Assert

--- a/bc_obps/service/operation_service_v2.py
+++ b/bc_obps/service/operation_service_v2.py
@@ -185,11 +185,11 @@ class OperationServiceV2:
     @transaction.atomic()
     def remove_operation_representative(
         cls, user_guid: UUID, operation_id: UUID, payload: OperationRepresentativeRemove
-    ) -> int:
+    ) -> OperationRepresentativeRemove:
         operation: Operation = OperationService.get_if_authorized(user_guid, operation_id)
         operation.contacts.remove(payload.id)
         operation.set_create_or_update(user_guid)
-        return payload.id
+        return OperationRepresentativeRemove(id=payload.id)
 
     @classmethod
     @transaction.atomic()

--- a/bc_obps/service/operation_service_v2.py
+++ b/bc_obps/service/operation_service_v2.py
@@ -29,6 +29,7 @@ from service.data_access_service.registration_purpose_service import Registratio
 from registration.schema.v2.operation import (
     OperationFilterSchema,
     OperationInformationIn,
+    OperationRepresentativeRemove,
     OptedInOperationDetailIn,
     OperationNewEntrantApplicationIn,
     RegistrationPurposeIn,
@@ -179,6 +180,15 @@ class OperationServiceV2:
         operation.contacts.add(contact)
         operation.set_create_or_update(user_guid)
         return contact
+
+    @classmethod
+    @transaction.atomic()
+    def remove_operation_representative(
+        cls, user_guid: UUID, operation_id: UUID, payload: OperationRepresentativeRemove
+    ) -> None:
+        operation: Operation = OperationService.get_if_authorized(user_guid, operation_id)
+        operation.contacts.remove(payload.id)
+        operation.set_create_or_update(user_guid)
 
     @classmethod
     @transaction.atomic()

--- a/bc_obps/service/operation_service_v2.py
+++ b/bc_obps/service/operation_service_v2.py
@@ -185,10 +185,11 @@ class OperationServiceV2:
     @transaction.atomic()
     def remove_operation_representative(
         cls, user_guid: UUID, operation_id: UUID, payload: OperationRepresentativeRemove
-    ) -> None:
+    ) -> int:
         operation: Operation = OperationService.get_if_authorized(user_guid, operation_id)
         operation.contacts.remove(payload.id)
         operation.set_create_or_update(user_guid)
+        return payload.id
 
     @classmethod
     @transaction.atomic()

--- a/bciers/apps/registration/app/components/operations/registration/NewOperationRepresentativeForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/NewOperationRepresentativeForm.tsx
@@ -148,6 +148,7 @@ const NewOperationRepresentativeForm: FC<
         uiSchema={createOperationRepresentativeUiSchema(
           Boolean(existingContactId),
         )}
+        formContext={{ operationId: operation }}
         onChange={handleChange}
         onSubmit={submitHandler}
         formData={formState}

--- a/bciers/apps/registration/app/data/jsonSchema/operationRegistration/operationRepresentative.ts
+++ b/bciers/apps/registration/app/data/jsonSchema/operationRegistration/operationRepresentative.ts
@@ -181,7 +181,7 @@ export const operationRepresentativeUiSchema: UiSchema = {
     "ui:title": operationRepresentativePreface,
   },
   operation_representatives: {
-    "ui:widget": "ReadOnlyMultiSelectWidget",
+    "ui:widget": "OperationRepresentativeWidget",
     "ui:inline": true,
     "ui:classNames": "[&>div:last-child]:w-full",
   },

--- a/bciers/apps/registration/tests/components/operations/registration/NewOperationRepresentativeForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/NewOperationRepresentativeForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, vi } from "vitest";
 import { actionHandler, useSession } from "@bciers/testConfig/mocks";
 import userEvent from "@testing-library/user-event";
@@ -133,6 +133,7 @@ describe("the NewOperationRepresentativeForm component", () => {
     );
     expect(screen.getByText(/operation representative\(s\):/i)).toBeVisible();
     expect(screen.getByText(/john doe/i)).toBeVisible();
+    expect(screen.getByTestId("DeleteOutlineIcon")).toBeVisible();
 
     //This button should not be visible before clicking the add new operation representative button
     expect(
@@ -320,4 +321,31 @@ describe("the NewOperationRepresentativeForm component", () => {
     },
     { timeout: 10000 },
   );
+  it("remove an operation representative", async () => {
+    render(
+      <NewOperationRepresentativeForm
+        formData={{
+          operation_representatives: [3],
+        }}
+        operation="002d5a9e-32a6-4191-938c-2c02bfec592d"
+        step={5}
+        existingOperationRepresentatives={existingOperationRepresentativesMock}
+        contacts={contactsMock}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("DeleteOutlineIcon"));
+    expect(actionHandler).toHaveBeenCalledWith(
+      "registration/v2/operations/002d5a9e-32a6-4191-938c-2c02bfec592d/registration/operation-representative",
+      "PUT",
+      "registration/administration/operations/002d5a9e-32a6-4191-938c-2c02bfec592d",
+      {
+        body: '{"id":3}',
+      },
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Operation Representative removed successfully/i),
+      ).toBeVisible();
+    });
+  });
 });

--- a/bciers/libs/components/src/form/theme/readOnlyTheme.ts
+++ b/bciers/libs/components/src/form/theme/readOnlyTheme.ts
@@ -11,7 +11,11 @@ import { InlineFieldTemplate } from "../fields";
 import TitleFieldTemplate from "@bciers/components/form/fields/TitleFieldTemplate";
 import ReadOnlyArrayFieldTemplate from "../fields/readonly/ReadOnlyArrayFieldTemplate";
 import ReadOnlyRadioWidget from "../widgets/readOnly/ReadOnlyRadioWidget";
-import { BcghgIdWidget, BoroIdWidget } from "../widgets";
+import {
+  BcghgIdWidget,
+  BoroIdWidget,
+  OperationRepresentativeWidget,
+} from "../widgets";
 
 const { templates: defaultTemplates } = getDefaultRegistry();
 
@@ -34,6 +38,7 @@ const readOnlyTheme = {
     URLWidget: ReadOnlyWidget,
     BoroIdWidget: BoroIdWidget,
     BcghgIdWidget: BcghgIdWidget,
+    OperationRepresentativeWidget: OperationRepresentativeWidget,
   },
   templates: {
     ...defaultTemplates,

--- a/bciers/libs/components/src/form/widgets/OperationRepresentativeWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/OperationRepresentativeWidget.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import { BC_GOV_SEMANTICS_RED } from "@bciers/styles";
 import SnackBar from "../components/SnackBar";
+import { IconButton } from "@mui/material";
 
 async function removeOperationRepresentative(
   operation_id: string,
@@ -49,21 +50,23 @@ const OperationRepresentativeWidget: React.FC<WidgetProps> = ({
   const displayOptions = selectedOptions.map((option) => (
     <>
       {option.label}
-      <DeleteOutlineIcon
-        key={option.id}
-        style={{ color: BC_GOV_SEMANTICS_RED }}
-        onClick={async () => {
-          const response = await removeOperationRepresentative(
-            formContext?.operationId,
-            option.id,
-          );
-          if (response?.error) {
-            setError(response.error);
-            return;
-          }
-          setIsSnackbarOpen(true);
-        }}
-      />
+      <IconButton aria-label="delete">
+        <DeleteOutlineIcon
+          key={option.id}
+          style={{ color: BC_GOV_SEMANTICS_RED }}
+          onClick={async () => {
+            const response = await removeOperationRepresentative(
+              formContext?.operationId,
+              option.id,
+            );
+            if (response?.error) {
+              setError(response.error);
+              return;
+            }
+            setIsSnackbarOpen(true);
+          }}
+        />
+      </IconButton>
     </>
   ));
 

--- a/bciers/libs/components/src/form/widgets/OperationRepresentativeWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/OperationRepresentativeWidget.tsx
@@ -1,0 +1,86 @@
+import { WidgetProps } from "@rjsf/utils/lib/types";
+import {
+  FieldSchema,
+  mapOptions,
+} from "@bciers/components/form/widgets/MultiSelectWidget";
+import { actionHandler } from "@bciers/actions";
+import { useState } from "react";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import { BC_GOV_SEMANTICS_RED } from "@bciers/styles";
+import SnackBar from "../components/SnackBar";
+
+async function removeOperationRepresentative(
+  operation_id: string,
+  // Id will always be a number for operation representatives. We have to additionally type string to make FieldSchema happy.
+  representative_id: number | string,
+) {
+  const response = await actionHandler(
+    `registration/v2/operations/${operation_id}/registration/operation-representative`,
+    "PUT",
+    `registration/administration/operations/${operation_id}`,
+    {
+      body: JSON.stringify({ id: representative_id }),
+    },
+  );
+  return response;
+}
+
+const OperationRepresentativeWidget: React.FC<WidgetProps> = ({
+  id,
+  value,
+  schema,
+  formContext,
+}) => {
+  const [isSnackbarOpen, setIsSnackbarOpen] = useState(false);
+  const [error, setError] = useState(undefined);
+
+  if (error) {
+    return (
+      <div id={id} className="read-only-widget whitespace-pre-line">
+        Error: {error}
+      </div>
+    );
+  }
+
+  const fieldSchema = schema.items as FieldSchema;
+  const options = mapOptions(fieldSchema);
+  const selectedOptions = options.filter((option) => value.includes(option.id));
+
+  const displayOptions = selectedOptions.map((option) => (
+    <>
+      {option.label}
+      <DeleteOutlineIcon
+        key={option.id}
+        style={{ color: BC_GOV_SEMANTICS_RED }}
+        onClick={async () => {
+          const response = await removeOperationRepresentative(
+            formContext?.operationId,
+            option.id,
+          );
+          if (response?.error) {
+            setError(response.error);
+            return;
+          }
+          setIsSnackbarOpen(true);
+        }}
+      />
+    </>
+  ));
+
+  return (
+    <div
+      id={id}
+      // Use whitespace-pre-line to display items with \n line breaks
+      className="read-only-widget whitespace-pre-line"
+    >
+      {displayOptions}
+      <SnackBar
+        isSnackbarOpen={isSnackbarOpen}
+        message="Operation Representative removed successfully"
+        setIsSnackbarOpen={setIsSnackbarOpen}
+      />
+    </div>
+  );
+};
+
+export default OperationRepresentativeWidget;

--- a/bciers/libs/components/src/form/widgets/index.ts
+++ b/bciers/libs/components/src/form/widgets/index.ts
@@ -17,3 +17,4 @@ export { default as URLWidget } from "./URLWidget";
 export { default as BoroIdWidget } from "./BoroIdWidget";
 export { default as CheckboxGroupWidget } from "./CheckboxGroupWidget";
 export { default as BcghgIdWidget } from "./BcghgIdWidget";
+export { default as OperationRepresentativeWidget } from "./OperationRepresentativeWidget";

--- a/bciers/libs/components/src/form/widgets/readOnly/OperationRepresentativeWidget.test.tsx
+++ b/bciers/libs/components/src/form/widgets/readOnly/OperationRepresentativeWidget.test.tsx
@@ -1,0 +1,129 @@
+import { userEvent } from "@testing-library/user-event";
+import { render, screen, waitFor } from "@testing-library/react";
+import { RJSFSchema } from "@rjsf/utils";
+import FormBase from "@bciers/components/form/FormBase";
+import { actionHandler } from "@bciers/testConfig/mocks";
+
+const operationRepresentativeWidgetLabel = "Operation Representative(s)";
+const operationRepresentativeValue = [1, 2];
+
+const operationRepresentativeWidgetSchema = {
+  type: "object",
+  properties: {
+    operationRepresentativeTestField: {
+      type: "array",
+      title: operationRepresentativeWidgetLabel,
+      minItems: 1,
+      items: {
+        type: "string",
+        enum: [1, 2],
+        enumNames: ["Neville Flashdance", "Oz Twindlewinks"],
+      },
+    },
+  },
+} as RJSFSchema;
+
+const operationRepresentativeWidgetUiSchema = {
+  operationRepresentativeTestField: {
+    "ui:widget": "OperationRepresentativeWidget",
+  },
+};
+
+const defaultFormContext = {
+  operationId: "6d07d02a-1ad2-46ed-ad56-2f84313e98bf",
+};
+
+describe("RJSF OperationRepresentativeWidget", () => {
+  it("should render the field with no data", async () => {
+    const { container } = render(
+      <FormBase
+        schema={operationRepresentativeWidgetSchema}
+        uiSchema={operationRepresentativeWidgetUiSchema}
+        formContext={defaultFormContext}
+      />,
+    );
+    const operationRepresentativeTestField = container.querySelector(
+      "#root_operationRepresentativeTestField",
+    );
+    expect(operationRepresentativeTestField).toBeVisible();
+  });
+
+  it("should show the operation reprentatives when formData provided", () => {
+    const { container } = render(
+      <FormBase
+        schema={operationRepresentativeWidgetSchema}
+        uiSchema={operationRepresentativeWidgetUiSchema}
+        formData={{
+          operationRepresentativeTestField: operationRepresentativeValue,
+        }}
+        formContext={defaultFormContext}
+      />,
+    );
+    const operationRepresentativeTestField = container.querySelector(
+      "#root_operationRepresentativeTestField",
+    );
+    expect(operationRepresentativeTestField).toBeVisible();
+    expect(operationRepresentativeTestField).toHaveTextContent(
+      "Neville FlashdanceOz Twindlewinks",
+    );
+    expect(screen.getAllByTestId("DeleteOutlineIcon")).toHaveLength(2);
+  });
+
+  it("should hit the API to remove a contact", async () => {
+    render(
+      <FormBase
+        schema={operationRepresentativeWidgetSchema}
+        uiSchema={operationRepresentativeWidgetUiSchema}
+        formContext={defaultFormContext}
+        formData={{
+          operationRepresentativeTestField: operationRepresentativeValue,
+        }}
+      />,
+    );
+    const trashNevilleButton = screen.getAllByTestId("DeleteOutlineIcon")[0];
+    await userEvent.click(trashNevilleButton);
+    expect(actionHandler).toHaveBeenCalledWith(
+      "registration/v2/operations/6d07d02a-1ad2-46ed-ad56-2f84313e98bf/registration/operation-representative",
+      "PUT",
+      "registration/administration/operations/6d07d02a-1ad2-46ed-ad56-2f84313e98bf",
+      {
+        body: '{"id":1}',
+      },
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Operation Representative removed successfully/i),
+      ).toBeVisible();
+    });
+  });
+
+  it("should show an error if deletion fails", async () => {
+    actionHandler.mockReturnValueOnce({ error: " i bork :(" });
+    render(
+      <FormBase
+        schema={operationRepresentativeWidgetSchema}
+        uiSchema={operationRepresentativeWidgetUiSchema}
+        formContext={defaultFormContext}
+        formData={{
+          operationRepresentativeTestField: operationRepresentativeValue,
+        }}
+      />,
+    );
+    const trashNevilleButton = screen.getAllByTestId("DeleteOutlineIcon")[0];
+    await userEvent.click(trashNevilleButton);
+    expect(actionHandler).toHaveBeenCalledWith(
+      "registration/v2/operations/6d07d02a-1ad2-46ed-ad56-2f84313e98bf/registration/operation-representative",
+      "PUT",
+      "registration/administration/operations/6d07d02a-1ad2-46ed-ad56-2f84313e98bf",
+      {
+        body: '{"id":1}',
+      },
+    );
+    expect(screen.getByText(/i bork :\(/i)).toBeVisible();
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Operation Representative removed successfully/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=81400225&issue=bcgov%7Ccas-registration%7C2299

This PR:
- new widget for operation reps
- vitests^
- new endpoint to remove a rep
- pytests^

I wasn't sure what to return from the endpoint since we don't need anything. I tried to return nothing (suggestions for something better?), but I'm getting {id: None}/{id: null} for some reason.