### PR TITLE
Feat/345 load activity data from database

### DIFF
--- a/bc_obps/common/tests/endpoints/auth/test_endpoint_permissions.py
+++ b/bc_obps/common/tests/endpoints/auth/test_endpoint_permissions.py
@@ -75,6 +75,11 @@ class TestEndpointPermissions(TestCase):
                 "endpoint_name": "get_report_non_attributable_by_version_id",
                 "kwargs": {"version_id": mock_int, "facility_id": mock_uuid},
             },
+            {
+                "method": "get",
+                "endpoint_name": "load_report_activity_data",
+                "kwargs": {"report_version_id": mock_int, "facility_id": mock_uuid, "activity_id": mock_int},
+            },
             {"method": "post", "endpoint_name": "create_operation"},
             {"method": "post", "endpoint_name": "create_facilities"},
             {"method": "post", "endpoint_name": "create_contact"},
@@ -100,11 +105,7 @@ class TestEndpointPermissions(TestCase):
             {
                 "method": "post",
                 "endpoint_name": "save_report_activity_data",
-                "kwargs": {
-                    "report_version_id": mock_int,
-                    "facility_id": mock_uuid,
-                    "activity_id": mock_int,
-                },
+                "kwargs": {"report_version_id": mock_int, "facility_id": mock_uuid, "activity_id": mock_int},
             },
             {
                 "method": "post",

--- a/bc_obps/reporting/api/__init__.py
+++ b/bc_obps/reporting/api/__init__.py
@@ -9,9 +9,9 @@ from .facility_report import get_facility_report_by_version_id
 from .fuel import get_fuel_data
 from .report_person_responsible import get_report_person_responsible_by_version_id
 from .report_person_responsible import save_report_contact
-from .report_activity import save_report_activity_data
 from .report_additional_data import get_registration_purpose_by_version_id
 from .gas_type import get_gas_type
 from .emission_category import get_emission_category
 from .production_data import save_production_data
 from .report_non_attributable_emissions import save_report
+from .report_activity import save_report_activity_data, load_report_activity_data

--- a/bc_obps/reporting/api/report_activity.py
+++ b/bc_obps/reporting/api/report_activity.py
@@ -15,7 +15,7 @@ from .router import router
 
 @router.post(
     "report-version/{report_version_id}/facilities/{facility_id}/activity/{activity_id}/report-activity",
-    response={200: int, custom_codes_4xx: Message},
+    response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Saves the data for an activity report form, for a given report version, facility and activity; returns the id of the ReportActivity record on success.""",
     auth=authorize('approved_industry_user'),
@@ -27,14 +27,14 @@ def save_report_activity_data(
     facility_id: UUID,
     activity_id: int,
     payload: ReportActivityDataIn,
-) -> Tuple[Literal[200], int]:
+) -> Tuple[Literal[200], dict]:
 
     user_guid = get_current_user_guid(request)
 
     service = ReportActivitySaveService(report_version_id, facility_id, activity_id, user_guid)
-    report_activity = service.save(payload.activity_data)
+    service.save(payload.activity_data)
 
-    return 200, report_activity.id
+    return load_report_activity_data(request, report_version_id, facility_id, activity_id)
 
 
 @router.get(

--- a/bc_obps/reporting/api/report_activity.py
+++ b/bc_obps/reporting/api/report_activity.py
@@ -9,7 +9,7 @@ from reporting.models.report_activity import ReportActivity
 from reporting.schema.generic import Message
 from reporting.schema.report_activity_data import ReportActivityDataIn, ReportActivityDataOut
 from reporting.service.report_activity_save_service import ReportActivitySaveService
-from reporting.service.serializers import ReportActivitySerializer
+from reporting.service.report_activity_serializers import ReportActivitySerializer
 from service.error_service import custom_codes_4xx
 from .router import router
 

--- a/bc_obps/reporting/api/report_activity.py
+++ b/bc_obps/reporting/api/report_activity.py
@@ -5,9 +5,11 @@ from django.http import HttpRequest
 from common.api.utils import get_current_user_guid
 from registration.decorators import handle_http_errors
 from reporting.constants import EMISSIONS_REPORT_TAGS
+from reporting.models.report_activity import ReportActivity
 from reporting.schema.generic import Message
-from reporting.schema.report_activity_data import ReportActivityDataIn
+from reporting.schema.report_activity_data import ReportActivityDataIn, ReportActivityDataOut
 from reporting.service.report_activity_save_service import ReportActivitySaveService
+from reporting.service.serializers import ReportActivitySerializer
 from service.error_service import custom_codes_4xx
 from .router import router
 
@@ -34,3 +36,26 @@ def save_report_activity_data(
     report_activity = service.save(payload.activity_data)
 
     return 200, report_activity.id
+
+
+@router.get(
+    "report-version/{report_version_id}/facilities/{facility_id}/activity/{activity_id}/report-activity",
+    response={200: ReportActivityDataOut, custom_codes_4xx: Message},
+    tags=EMISSIONS_REPORT_TAGS,
+    description="""Loads the initial data for an activity report form, for a given report version, facility and activity.""",
+)
+# @handle_http_errors()
+def load_report_activity_data(
+    request: HttpRequest,
+    report_version_id: int,
+    facility_id: UUID,
+    activity_id: int,
+) -> Tuple[Literal[200], ReportActivityDataOut]:
+
+    r = ReportActivity.objects.get(
+        report_version_id=report_version_id, facility_report__facility_id=facility_id, activity_id=activity_id
+    )
+
+    s = ReportActivitySerializer.serialize(r)
+
+    return 200, {"form_data": s}

--- a/bc_obps/reporting/json_schemas/2024/carbonates_use/carbonates_use.json
+++ b/bc_obps/reporting/json_schemas/2024/carbonates_use/carbonates_use.json
@@ -20,7 +20,7 @@
           },
           "equivalentEmission": {
             "title": "Equivalent Emission",
-            "type": "number",
+            "type": "string",
             "readOnly": true
           },
           "carbonateType": {

--- a/bc_obps/reporting/json_schemas/2024/carbonates_use/carbonates_use.json
+++ b/bc_obps/reporting/json_schemas/2024/carbonates_use/carbonates_use.json
@@ -21,7 +21,8 @@
           "equivalentEmission": {
             "title": "Equivalent Emission",
             "type": "string",
-            "readOnly": true
+            "readOnly": true,
+            "default": "Value will be computed upon saving"
           },
           "carbonateType": {
             "title": "Carbonate Type",

--- a/bc_obps/reporting/json_schemas/2024/fuel_combustion_mobile/combustion_by_equipment.json
+++ b/bc_obps/reporting/json_schemas/2024/fuel_combustion_mobile/combustion_by_equipment.json
@@ -72,8 +72,9 @@
                 },
                 "equivalentEmission": {
                   "title": "Equivalent Emission",
-                  "type": "number",
-                  "readOnly": true
+                  "type": "string",
+                  "readOnly": true,
+                  "default": "Value will be computed upon saving"
                 }
               }
             }

--- a/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/with_useful_energy.json
@@ -72,8 +72,9 @@
                       },
                       "equivalentEmission": {
                         "title": "Equivalent Emission",
-                        "type": "number",
-                        "readOnly": true
+                        "type": "string",
+                        "readOnly": true,
+                        "default": "Value will be computed upon saving"
                       }
                     }
                   }

--- a/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/without_useful_energy.json
@@ -72,8 +72,9 @@
                       },
                       "equivalentEmission": {
                         "title": "Equivalent Emission",
-                        "type": "number",
-                        "readOnly": true
+                        "type": "string",
+                        "readOnly": true,
+                        "default": "Value will be computed upon saving"
                       }
                     }
                   }

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/field_gas_process_vent_gas_at_lfo.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/field_gas_process_vent_gas_at_lfo.json
@@ -72,8 +72,9 @@
                       },
                       "equivalentEmission": {
                         "title": "Equivalent Emission",
-                        "type": "number",
-                        "readOnly": true
+                        "type": "string",
+                        "readOnly": true,
+                        "default": "Value will be computed upon saving"
                       }
                     }
                   }

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/with_useful_energy.json
@@ -72,8 +72,9 @@
                       },
                       "equivalentEmission": {
                         "title": "Equivalent Emission",
-                        "type": "number",
-                        "readOnly": true
+                        "type": "string",
+                        "readOnly": true,
+                        "default": "Value will be computed upon saving"
                       }
                     }
                   }

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/without_useful_energy.json
@@ -72,8 +72,9 @@
                       },
                       "equivalentEmission": {
                         "title": "Equivalent Emission",
-                        "type": "number",
-                        "readOnly": true
+                        "type": "string",
+                        "readOnly": true,
+                        "default": "Value will be computed upon saving"
                       }
                     }
                   }

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
@@ -72,8 +72,9 @@
                       },
                       "equivalentEmission": {
                         "title": "Equivalent Emission",
-                        "type": "number",
-                        "readOnly": true
+                        "type": "string",
+                        "readOnly": true,
+                        "default": "Value will be computed upon saving"
                       }
                     }
                   }

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
@@ -72,8 +72,9 @@
                       },
                       "equivalentEmission": {
                         "title": "Equivalent Emission",
-                        "type": "number",
-                        "readOnly": true
+                        "type": "string",
+                        "readOnly": true,
+                        "default": "Value will be computed upon saving"
                       }
                     }
                   }

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
@@ -72,8 +72,9 @@
                       },
                       "equivalentEmission": {
                         "title": "Equivalent Emission",
-                        "type": "number",
-                        "readOnly": true
+                        "type": "string",
+                        "readOnly": true,
+                        "default": "Value will be computed upon saving"
                       }
                     }
                   }

--- a/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/with_useful_energy.json
@@ -72,8 +72,9 @@
                       },
                       "equivalentEmission": {
                         "title": "Equivalent Emission",
-                        "type": "number",
-                        "readOnly": true
+                        "type": "string",
+                        "readOnly": true,
+                        "default": "Value will be computed upon saving"
                       }
                     }
                   }

--- a/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/without_useful_energy.json
@@ -72,8 +72,9 @@
                       },
                       "equivalentEmission": {
                         "title": "Equivalent Emission",
-                        "type": "number",
-                        "readOnly": true
+                        "type": "string",
+                        "readOnly": true,
+                        "default": "Value will be computed upon saving"
                       }
                     }
                   }

--- a/bc_obps/reporting/json_schemas/2024/hydrogen_production/steam_reformation_or_gasification.json
+++ b/bc_obps/reporting/json_schemas/2024/hydrogen_production/steam_reformation_or_gasification.json
@@ -18,7 +18,9 @@
           },
           "equivalentEmission": {
             "title": "Equivalent Emission",
-            "type": "number"
+            "type": "string",
+            "readOnly": true,
+            "default": "Value will be computed upon saving"
           }
         }
       }

--- a/bc_obps/reporting/json_schemas/2024/open_pit_coal_mining/coal_exposed_during_mining.json
+++ b/bc_obps/reporting/json_schemas/2024/open_pit_coal_mining/coal_exposed_during_mining.json
@@ -19,8 +19,9 @@
           },
           "equivalentEmission": {
             "title": "Equivalent Emission",
-            "type": "number",
-            "readOnly": true
+            "type": "string",
+            "readOnly": true,
+            "default": "Value will be computed upon saving"
           }
         }
       }

--- a/bc_obps/reporting/json_schemas/2024/pulp_and_paper_production/pulp_and_paper_production.json
+++ b/bc_obps/reporting/json_schemas/2024/pulp_and_paper_production/pulp_and_paper_production.json
@@ -20,8 +20,9 @@
           },
           "equivalentEmission": {
             "title": "Equivalent Emission",
-            "type": "number",
-            "readOnly": true
+            "type": "string",
+            "readOnly": true,
+            "default": "Value will be computed upon saving"
           }
         }
       }

--- a/bc_obps/reporting/json_schemas/2024/refinery_fuel_gas/combustion_of_refinery_gas.json
+++ b/bc_obps/reporting/json_schemas/2024/refinery_fuel_gas/combustion_of_refinery_gas.json
@@ -51,8 +51,9 @@
                 },
                 "equivalentEmission": {
                   "title": "Equivalent Emission",
-                  "type": "number",
-                  "readOnly": true
+                  "type": "string",
+                  "readOnly": true,
+                  "default": "Value will be computed upon saving"
                 }
               }
             }

--- a/bc_obps/reporting/json_schemas/2024/storage_of_petroleum_products/storage_of_petroleum_products.json
+++ b/bc_obps/reporting/json_schemas/2024/storage_of_petroleum_products/storage_of_petroleum_products.json
@@ -19,8 +19,9 @@
           },
           "equivalentEmissions": {
             "title": "Equivalent Emissions",
-            "type": "number",
-            "readOnly": true
+            "type": "string",
+            "readOnly": true,
+            "default": "Value will be computed upon saving"
           }
         }
       }

--- a/bc_obps/reporting/schema/report_activity_data.py
+++ b/bc_obps/reporting/schema/report_activity_data.py
@@ -4,3 +4,7 @@ from ninja import Schema
 
 class ReportActivityDataIn(Schema):
     activity_data: Dict
+
+
+class ReportActivityDataOut(Schema):
+    form_data: Dict

--- a/bc_obps/reporting/schema/report_activity_data.py
+++ b/bc_obps/reporting/schema/report_activity_data.py
@@ -4,7 +4,3 @@ from ninja import Schema
 
 class ReportActivityDataIn(Schema):
     activity_data: Dict
-
-
-class ReportActivityDataOut(Schema):
-    form_data: Dict

--- a/bc_obps/reporting/service/report_activity_load_service.py
+++ b/bc_obps/reporting/service/report_activity_load_service.py
@@ -6,7 +6,11 @@ from reporting.service.report_activity_serializers import ReportActivitySerializ
 class ReportActivityLoadService:
     @classmethod
     def load(cls, report_version_id: int, facility_id: UUID, activity_id: int) -> dict:
-
+        """
+        Loads the report activity data from the database structure into a json dictionary.
+        If the ReportActivity record is not found, it means this is the first load of the
+        form and we can safely return an empty object.
+        """
         try:
             r = ReportActivity.objects.get(
                 report_version_id=report_version_id, facility_report__facility_id=facility_id, activity_id=activity_id

--- a/bc_obps/reporting/service/report_activity_load_service.py
+++ b/bc_obps/reporting/service/report_activity_load_service.py
@@ -7,8 +7,10 @@ class ReportActivityLoadService:
     @classmethod
     def load(cls, report_version_id: int, facility_id: UUID, activity_id: int) -> dict:
 
-        r = ReportActivity.objects.get(
-            report_version_id=report_version_id, facility_report__facility_id=facility_id, activity_id=activity_id
-        )
-
-        return ReportActivitySerializer.serialize(r)
+        try:
+            r = ReportActivity.objects.get(
+                report_version_id=report_version_id, facility_report__facility_id=facility_id, activity_id=activity_id
+            )
+            return ReportActivitySerializer.serialize(r)
+        except ReportActivity.DoesNotExist:
+            return {}

--- a/bc_obps/reporting/service/report_activity_load_service.py
+++ b/bc_obps/reporting/service/report_activity_load_service.py
@@ -1,0 +1,14 @@
+from uuid import UUID
+from reporting.models.report_activity import ReportActivity
+from reporting.service.report_activity_serializers import ReportActivitySerializer
+
+
+class ReportActivityLoadService:
+    @classmethod
+    def load(cls, report_version_id: int, facility_id: UUID, activity_id: int) -> dict:
+
+        r = ReportActivity.objects.get(
+            report_version_id=report_version_id, facility_report__facility_id=facility_id, activity_id=activity_id
+        )
+
+        return ReportActivitySerializer.serialize(r)

--- a/bc_obps/reporting/service/report_activity_load_service.py
+++ b/bc_obps/reporting/service/report_activity_load_service.py
@@ -12,7 +12,17 @@ class ReportActivityLoadService:
         form and we can safely return an empty object.
         """
         try:
-            r = ReportActivity.objects.get(
+            r = ReportActivity.objects.prefetch_related(
+                "facility_report",
+                "reportsourcetype_records",
+                "reportsourcetype_records__reportunit_records",
+                "reportsourcetype_records__reportfuel_records",
+                "reportsourcetype_records__reportemission_records",
+                "reportsourcetype_records__reportemission_records__report_methodology",
+                "reportsourcetype_records__reportunit_records__reportfuel_records",
+                "reportsourcetype_records__reportunit_records__reportfuel_records__reportemission_records",
+                "reportsourcetype_records__reportunit_records__reportfuel_records__reportemission_records__report_methodology",
+            ).get(
                 report_version_id=report_version_id, facility_report__facility_id=facility_id, activity_id=activity_id
             )
             return ReportActivitySerializer.serialize(r)

--- a/bc_obps/reporting/service/report_activity_serializer.py
+++ b/bc_obps/reporting/service/report_activity_serializer.py
@@ -1,0 +1,89 @@
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import Generic, TypeVar
+
+from reporting.models.report_activity import ReportActivity
+from reporting.models.report_emission import ReportEmission
+from reporting.models.report_fuel import ReportFuel
+from reporting.models.report_source_type import ReportSourceType
+from reporting.models.report_unit import ReportUnit
+
+TSerialized = TypeVar("TSerialized")
+
+
+class BaseSerializer(ABC, Generic[TSerialized]):
+    @classmethod
+    @abstractmethod
+    def serialize(cls, obj: TSerialized) -> dict:
+        pass
+
+
+class ReportEmissionIterableSerializer(BaseSerializer[Iterable[ReportEmission]]):
+    @classmethod
+    def serialize(cls, obj: Iterable[ReportEmission]) -> dict:
+        return [
+            {
+                "gasType": emission.gas_type.chemical_formula,
+                **emission.json_data,
+            }
+            for emission in obj
+        ]
+
+
+class ReportFuelIterableSerializer(BaseSerializer[Iterable[ReportFuel]]):
+    @classmethod
+    def serialize(cls, obj: Iterable[ReportFuel]) -> dict:
+        return [
+            {
+                **fuel.json_data,
+                "fuelType": {
+                    "fuelName": fuel.fuel_type.name,
+                    "fuelUnit": fuel.fuel_type.unit,
+                    "fuelClassification": fuel.fuel_type.classification,
+                },
+                "emissions": ReportEmissionIterableSerializer.serialize(fuel.reportemission_records.all()),
+            }
+            for fuel in obj
+        ]
+
+
+class ReportUnitIterableSerializer(BaseSerializer[Iterable[ReportUnit]]):
+    @classmethod
+    def serialize(cls, obj: Iterable[ReportUnit]) -> dict:
+        return [
+            {
+                **unit.json_data,
+                "fuels": ReportFuelIterableSerializer.serialize(unit.reportfuel_records.all()),
+            }
+            for unit in obj
+        ]
+
+
+class ReportSourceTypeIterableSerializer(BaseSerializer[Iterable[ReportSourceType]]):
+    @classmethod
+    def serialize(cls, obj: Iterable[ReportSourceType]) -> dict:
+        return {
+            report_source_type.source_type.json_key: cls.serialize_source_type(report_source_type)
+            for report_source_type in obj
+        }
+
+    @classmethod
+    def serialize_source_type(cls, obj: ReportSourceType) -> dict:
+        serialized = {**obj.json_data}
+        if obj.activity_source_type_base_schema.has_unit:
+            return {**serialized, "units": ReportUnitIterableSerializer.serialize(obj.reportunit_records.all())}
+        if obj.activity_source_type_base_schema.has_fuel:
+            return {**serialized, "fuels": ReportFuelIterableSerializer.serialize(obj.reportfuel_records.all())}
+        return {**serialized, "emissions": ReportEmissionIterableSerializer.serialize(obj.reportfuel_records.all())}
+
+
+class ReportActivitySerializer(BaseSerializer[ReportActivity]):
+    """
+    Serializes a ReportActivity object into a dict that can be loaded into the form that created it.
+    """
+
+    def serialize(obj: ReportActivity) -> dict:
+        return {
+            **obj.json_data,
+            "sourceTypes": ReportSourceTypeIterableSerializer.serialize(obj.reportsourcetype_records.all()),
+        }

--- a/bc_obps/reporting/service/report_activity_serializers.py
+++ b/bc_obps/reporting/service/report_activity_serializers.py
@@ -5,6 +5,7 @@ from typing import Generic, TypeVar
 from reporting.models.report_activity import ReportActivity
 from reporting.models.report_emission import ReportEmission
 from reporting.models.report_fuel import ReportFuel
+from reporting.models.report_methodology import ReportMethodology
 from reporting.models.report_source_type import ReportSourceType
 from reporting.models.report_unit import ReportUnit
 
@@ -15,7 +16,17 @@ class BaseSerializer(ABC, Generic[TSerialized]):
     @classmethod
     @abstractmethod
     def serialize(cls, obj: TSerialized) -> dict | list[dict]:
-        pass
+        raise NotImplementedError("BaseSerializer.serialize : This is an abstract method that should be overridden.")
+
+
+class ReportMethodologySerializer(BaseSerializer[ReportMethodology]):
+    @classmethod
+    def serialize(cls, obj: ReportMethodology) -> dict | list[dict]:
+        return {
+            "id": obj.id,
+            "methodology": obj.methodology.name,
+            **obj.json_data,
+        }
 
 
 class ReportEmissionIterableSerializer(BaseSerializer[Iterable[ReportEmission]]):
@@ -26,6 +37,7 @@ class ReportEmissionIterableSerializer(BaseSerializer[Iterable[ReportEmission]])
                 "id": report_emission.id,
                 "gasType": report_emission.gas_type.chemical_formula,
                 **report_emission.json_data,
+                "methodology": ReportMethodologySerializer.serialize(report_emission.report_methodology),
             }
             for report_emission in obj
         ]

--- a/bc_obps/reporting/service/report_activity_serializers.py
+++ b/bc_obps/reporting/service/report_activity_serializers.py
@@ -23,10 +23,11 @@ class ReportEmissionIterableSerializer(BaseSerializer[Iterable[ReportEmission]])
     def serialize(cls, obj: Iterable[ReportEmission]) -> dict:
         return [
             {
-                "gasType": emission.gas_type.chemical_formula,
-                **emission.json_data,
+                "id": report_emission.id,
+                "gasType": report_emission.gas_type.chemical_formula,
+                **report_emission.json_data,
             }
-            for emission in obj
+            for report_emission in obj
         ]
 
 
@@ -35,15 +36,16 @@ class ReportFuelIterableSerializer(BaseSerializer[Iterable[ReportFuel]]):
     def serialize(cls, obj: Iterable[ReportFuel]) -> dict:
         return [
             {
-                **fuel.json_data,
+                "id": report_fuel.id,
+                **report_fuel.json_data,
                 "fuelType": {
-                    "fuelName": fuel.fuel_type.name,
-                    "fuelUnit": fuel.fuel_type.unit,
-                    "fuelClassification": fuel.fuel_type.classification,
+                    "fuelName": report_fuel.fuel_type.name,
+                    "fuelUnit": report_fuel.fuel_type.unit,
+                    "fuelClassification": report_fuel.fuel_type.classification,
                 },
-                "emissions": ReportEmissionIterableSerializer.serialize(fuel.reportemission_records.all()),
+                "emissions": ReportEmissionIterableSerializer.serialize(report_fuel.reportemission_records.all()),
             }
-            for fuel in obj
+            for report_fuel in obj
         ]
 
 
@@ -52,6 +54,7 @@ class ReportUnitIterableSerializer(BaseSerializer[Iterable[ReportUnit]]):
     def serialize(cls, obj: Iterable[ReportUnit]) -> dict:
         return [
             {
+                "id": unit.id,
                 **unit.json_data,
                 "fuels": ReportFuelIterableSerializer.serialize(unit.reportfuel_records.all()),
             }
@@ -69,7 +72,10 @@ class ReportSourceTypeIterableSerializer(BaseSerializer[Iterable[ReportSourceTyp
 
     @classmethod
     def serialize_source_type(cls, obj: ReportSourceType) -> dict:
-        serialized = {**obj.json_data}
+        serialized = {
+            "id": obj.id,
+            **obj.json_data,
+        }
         if obj.activity_source_type_base_schema.has_unit:
             return {**serialized, "units": ReportUnitIterableSerializer.serialize(obj.reportunit_records.all())}
         if obj.activity_source_type_base_schema.has_fuel:
@@ -84,6 +90,7 @@ class ReportActivitySerializer(BaseSerializer[ReportActivity]):
 
     def serialize(obj: ReportActivity) -> dict:
         return {
+            "id": obj.id,
             **obj.json_data,
             "sourceTypes": ReportSourceTypeIterableSerializer.serialize(obj.reportsourcetype_records.all()),
         }

--- a/bc_obps/reporting/service/report_activity_serializers.py
+++ b/bc_obps/reporting/service/report_activity_serializers.py
@@ -14,13 +14,13 @@ TSerialized = TypeVar("TSerialized")
 class BaseSerializer(ABC, Generic[TSerialized]):
     @classmethod
     @abstractmethod
-    def serialize(cls, obj: TSerialized) -> dict:
+    def serialize(cls, obj: TSerialized) -> dict | list[dict]:
         pass
 
 
 class ReportEmissionIterableSerializer(BaseSerializer[Iterable[ReportEmission]]):
     @classmethod
-    def serialize(cls, obj: Iterable[ReportEmission]) -> dict:
+    def serialize(cls, obj: Iterable[ReportEmission]) -> list[dict]:
         return [
             {
                 "id": report_emission.id,
@@ -33,7 +33,7 @@ class ReportEmissionIterableSerializer(BaseSerializer[Iterable[ReportEmission]])
 
 class ReportFuelIterableSerializer(BaseSerializer[Iterable[ReportFuel]]):
     @classmethod
-    def serialize(cls, obj: Iterable[ReportFuel]) -> dict:
+    def serialize(cls, obj: Iterable[ReportFuel]) -> list[dict]:
         return [
             {
                 "id": report_fuel.id,
@@ -51,7 +51,7 @@ class ReportFuelIterableSerializer(BaseSerializer[Iterable[ReportFuel]]):
 
 class ReportUnitIterableSerializer(BaseSerializer[Iterable[ReportUnit]]):
     @classmethod
-    def serialize(cls, obj: Iterable[ReportUnit]) -> dict:
+    def serialize(cls, obj: Iterable[ReportUnit]) -> list[dict]:
         return [
             {
                 "id": unit.id,
@@ -80,7 +80,7 @@ class ReportSourceTypeIterableSerializer(BaseSerializer[Iterable[ReportSourceTyp
             return {**serialized, "units": ReportUnitIterableSerializer.serialize(obj.reportunit_records.all())}
         if obj.activity_source_type_base_schema.has_fuel:
             return {**serialized, "fuels": ReportFuelIterableSerializer.serialize(obj.reportfuel_records.all())}
-        return {**serialized, "emissions": ReportEmissionIterableSerializer.serialize(obj.reportfuel_records.all())}
+        return {**serialized, "emissions": ReportEmissionIterableSerializer.serialize(obj.reportemission_records.all())}
 
 
 class ReportActivitySerializer(BaseSerializer[ReportActivity]):
@@ -88,7 +88,8 @@ class ReportActivitySerializer(BaseSerializer[ReportActivity]):
     Serializes a ReportActivity object into a dict that can be loaded into the form that created it.
     """
 
-    def serialize(obj: ReportActivity) -> dict:
+    @classmethod
+    def serialize(cls, obj: ReportActivity) -> dict:
         return {
             "id": obj.id,
             **obj.json_data,

--- a/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
@@ -61,3 +61,7 @@ class TestReportActivityEndpoint(CommonTestSetup):
         assert response.status_code == 200
         mock_service.assert_called_once_with({"test_data": "1"})
         assert response.json() == 12345
+
+    @patch("reporting.service.report_activity_serializer.ReportActivitySerializer.serialize")
+    def test_get_returns_the_serialized_value_from_the_serializer(self, mock_serialize: MagicMock):
+        raise NotImplementedError

--- a/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
@@ -49,7 +49,7 @@ class TestReportActivityEndpoint(CommonTestSetup):
 
     # SERVICE OUTPUT
     @patch("reporting.service.report_activity_save_service.ReportActivitySaveService.save")
-    def test_returns_the_service_output(self, mock_service: MagicMock):
+    def test_post_returns_the_service_output(self, mock_service: MagicMock):
         """Test that the endpoint returns the service's output correctly"""
         # Arrange
         mock_service.return_value = SimpleNamespace(id=12345)

--- a/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
@@ -91,6 +91,9 @@ class TestReportActivityEndpoint(CommonTestSetup):
         # let's get cooking
         report_emission = make_recipe(
             "reporting.tests.utils.report_emission",
+            report_methodology__report_version=report_version,
+            report_methodology__methodology__name="Test Method",
+            report_methodology__json_data={"method_prop": True},
             report_version=report_version,
             gas_type__chemical_formula="CaS",
             json_data={"emission_prop": "emission!", "emission": 123},
@@ -147,6 +150,11 @@ class TestReportActivityEndpoint(CommonTestSetup):
                                             "emission": 123,
                                             "id": report_emission.id,
                                             "gasType": "CaS",
+                                            "methodology": {
+                                                "id": report_emission.report_methodology.id,
+                                                "methodology": "Test Method",
+                                                "method_prop": True,
+                                            },
                                         }
                                     ],
                                 }

--- a/bc_obps/reporting/tests/service/test_report_activity_load_service.py
+++ b/bc_obps/reporting/tests/service/test_report_activity_load_service.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+import uuid
 import pytest
 from unittest.mock import MagicMock
 from model_bakery.baker import make_recipe
@@ -25,3 +26,9 @@ class TestReportActivityLoadService:
 
         assert serialized == {"successful test": True}
         mock_serializer.assert_called_once_with(ReportActivity.objects.get(id=report_activity.id))
+
+    def test_returns_empty_dict_if_no_report_activity_record_exists_yet(self):
+
+        serialized = ReportActivityLoadService.load(1000, uuid.UUID(int=0), 1000)
+
+        assert serialized == {}

--- a/bc_obps/reporting/tests/service/test_report_activity_load_service.py
+++ b/bc_obps/reporting/tests/service/test_report_activity_load_service.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+import pytest
+from unittest.mock import MagicMock
+from model_bakery.baker import make_recipe
+from reporting.models.report_activity import ReportActivity
+from reporting.service.report_activity_load_service import ReportActivityLoadService
+
+
+@pytest.mark.django_db
+class TestReportActivityLoadService:
+    @patch("reporting.service.report_activity_serializers.ReportActivitySerializer.serialize")
+    def test_serializes_the_right_object(self, mock_serializer: MagicMock):
+        mock_serializer.return_value = {"successful test": True}
+
+        report_version = make_recipe("reporting.tests.utils.report_version")
+        report_activity = make_recipe(
+            "reporting.tests.utils.report_activity",
+            report_version=report_version,
+            facility_report__report_version=report_version,
+        )
+
+        serialized = ReportActivityLoadService.load(
+            report_version.id, report_activity.facility_report.facility_id, report_activity.activity_id
+        )
+
+        assert serialized == {"successful test": True}
+        mock_serializer.assert_called_once_with(ReportActivity.objects.get(id=report_activity.id))

--- a/bc_obps/reporting/tests/service/test_report_activity_serializers.py
+++ b/bc_obps/reporting/tests/service/test_report_activity_serializers.py
@@ -1,0 +1,216 @@
+from unittest.mock import patch, MagicMock
+from django.test import SimpleTestCase
+from reporting.models.report_emission import ReportEmission
+from model_bakery.baker import prepare
+from reporting.models.report_fuel import ReportFuel
+from reporting.models.report_source_type import ReportSourceType
+from reporting.models.report_unit import ReportUnit
+from reporting.service.report_activity_serializers import (
+    ReportEmissionIterableSerializer,
+    ReportFuelIterableSerializer,
+    ReportSourceTypeIterableSerializer,
+    ReportUnitIterableSerializer,
+)
+
+
+class TestReportActivityDataSerializers(SimpleTestCase):
+    def test_report_emissions_serializer(self):
+
+        report_emissions = [
+            prepare(
+                ReportEmission,
+                id=92871,
+                gas_type__chemical_formula="CaS",
+                json_data={"testprop1": "test", "emission": 1234},
+            ),
+            prepare(
+                ReportEmission,
+                id=987134,
+                gas_type__chemical_formula="GaS",
+                json_data={"testprop2": "test", "emission": 0},
+            ),
+        ]
+
+        serialized = ReportEmissionIterableSerializer.serialize(report_emissions)
+
+        print(serialized)
+
+        assert serialized == [
+            {
+                'emission': 1234,
+                'gasType': 'CaS',
+                'id': 92871,
+                'testprop1': 'test',
+            },
+            {
+                'emission': 0,
+                'gasType': 'GaS',
+                'id': 987134,
+                'testprop2': 'test',
+            },
+        ]
+
+    @patch("reporting.models.report_fuel.ReportFuel.reportemission_records")
+    @patch("reporting.service.report_activity_serializers.ReportEmissionIterableSerializer.serialize")
+    def test_report_fuel_serializer(self, mock_emissions_serializer: MagicMock, mock_reverse_manager: MagicMock):
+        mock_emissions_serializer.return_value = "mock serialized!!"
+        report_fuels = [
+            prepare(
+                ReportFuel,
+                id=2,
+                fuel_type__name='testFuelName',
+                fuel_type__unit='testFuelUnit',
+                fuel_type__classification='testFuelClass',
+                json_data={"aaa": "bbb", "ccc": 123},
+            ),
+            prepare(
+                ReportFuel,
+                id=9876,
+                fuel_type__name='fuel2',
+                fuel_type__unit='unit2',
+                fuel_type__classification='class2',
+                json_data={"x": "y", "z": 1},
+            ),
+        ]
+
+        serialized = ReportFuelIterableSerializer.serialize(report_fuels)
+
+        assert mock_emissions_serializer.call_count == 2
+        assert mock_reverse_manager.all.call_count == 2
+        assert serialized == [
+            {
+                'aaa': 'bbb',
+                'ccc': 123,
+                'emissions': 'mock serialized!!',
+                'fuelType': {
+                    'fuelClassification': 'testFuelClass',
+                    'fuelName': 'testFuelName',
+                    'fuelUnit': 'testFuelUnit',
+                },
+                'id': 2,
+            },
+            {
+                'emissions': 'mock serialized!!',
+                'fuelType': {
+                    'fuelClassification': 'class2',
+                    'fuelName': 'fuel2',
+                    'fuelUnit': 'unit2',
+                },
+                'id': 9876,
+                'x': 'y',
+                'z': 1,
+            },
+        ]
+
+    @patch("reporting.models.report_unit.ReportUnit.reportfuel_records")
+    @patch("reporting.service.report_activity_serializers.ReportFuelIterableSerializer.serialize")
+    def test_report_unit_serializer(self, mock_fuels_serializer: MagicMock, mock_reverse_manager: MagicMock):
+        mock_fuels_serializer.return_value = 'serialized!'
+
+        report_units = [
+            prepare(ReportUnit, id=8971, json_data={"mock_json_prop": True}),
+            prepare(ReportUnit, id=999999, json_data={"real_json_prop": False}),
+        ]
+
+        serialized = ReportUnitIterableSerializer.serialize(report_units)
+
+        assert mock_fuels_serializer.call_count == 2
+        assert mock_reverse_manager.all.call_count == 2
+        assert serialized == [
+            {
+                'fuels': 'serialized!',
+                'id': 8971,
+                'mock_json_prop': True,
+            },
+            {
+                'fuels': 'serialized!',
+                'id': 999999,
+                'real_json_prop': False,
+            },
+        ]
+
+    @patch("reporting.models.report_source_type.ReportSourceType.reportunit_records")
+    @patch("reporting.models.report_source_type.ReportSourceType.reportfuel_records")
+    @patch("reporting.models.report_source_type.ReportSourceType.reportemission_records")
+    @patch("reporting.service.report_activity_serializers.ReportUnitIterableSerializer.serialize")
+    @patch("reporting.service.report_activity_serializers.ReportFuelIterableSerializer.serialize")
+    @patch("reporting.service.report_activity_serializers.ReportEmissionIterableSerializer.serialize")
+    def test_report_source_type_serializer(
+        self,
+        mock_emissions_serializer: MagicMock,
+        mock_fuels_serializer: MagicMock,
+        mock_units_serializer: MagicMock,
+        mock_emission_reverse_manager: MagicMock,
+        mock_fuel_reverse_manager: MagicMock,
+        mock_unit_reverse_manager: MagicMock,
+    ):
+        mock_emissions_serializer.return_value = "emissions serialized!"
+        mock_fuels_serializer.return_value = "fuels serialized!"
+        mock_units_serializer.return_value = "units serialized!"
+
+        report_source_types = [
+            prepare(
+                ReportSourceType,
+                id=1,
+                json_data={"with_unit_1": 1},
+                source_type__json_key="stWithUnit",
+                activity_source_type_base_schema__has_unit=True,
+                activity_source_type_base_schema__has_fuel=True,
+            ),
+            prepare(
+                ReportSourceType,
+                id=2,
+                json_data={"with_unit_2": 1},
+                source_type__json_key="anotherStWithUnit",
+                activity_source_type_base_schema__has_unit=True,
+                activity_source_type_base_schema__has_fuel=True,
+            ),
+            prepare(
+                ReportSourceType,
+                id=3,
+                json_data={"with_fuel_only": 1},
+                source_type__json_key="stWithFuelOnly",
+                activity_source_type_base_schema__has_unit=False,
+                activity_source_type_base_schema__has_fuel=True,
+            ),
+            prepare(
+                ReportSourceType,
+                id=4,
+                json_data={"with_emission_only": 1},
+                source_type__json_key="stWithEmissionOnly",
+                activity_source_type_base_schema__has_unit=False,
+                activity_source_type_base_schema__has_fuel=False,
+            ),
+        ]
+
+        serialized = ReportSourceTypeIterableSerializer.serialize(report_source_types)
+
+        assert mock_units_serializer.call_count == 2
+        assert mock_fuels_serializer.call_count == 1
+        assert mock_emissions_serializer.call_count == 1
+
+        assert mock_unit_reverse_manager.all.call_count == 2
+        assert mock_fuel_reverse_manager.all.call_count == 1
+        assert mock_emission_reverse_manager.all.call_count == 1
+        assert serialized == {
+            'anotherStWithUnit': {
+                'id': 1,
+                'units': 'units serialized!',
+                'with_unit_2': 1,
+            },
+            'stWithEmissionOnly': {
+                'emissions': 'emissions serialized!',
+                'id': 1,
+                'with_emission_only': 1,
+            },
+            'stWithFuelOnly': {
+                'fuels': 'fuels serialized!',
+                'id': 1,
+                'with_fuel_only': 1,
+            },
+            'stWithUnit': {
+                'id': 1,
+                'units': 'units serialized!',
+                'with_unit_1': 1,
+            },
+        }

--- a/bc_obps/reporting/tests/service/test_report_activity_serializers.py
+++ b/bc_obps/reporting/tests/service/test_report_activity_serializers.py
@@ -106,7 +106,7 @@ class TestReportActivityDataSerializers(SimpleTestCase):
     @patch("reporting.service.report_activity_serializers.ReportFuelIterableSerializer.serialize")
     def test_report_unit_serializer(self, mock_fuels_serializer: MagicMock, mock_reverse_manager: MagicMock):
         mock_fuels_serializer.return_value = 'serialized!'
-
+        mock_fuels_serializer.ass
         report_units = [
             prepare(ReportUnit, id=8971, json_data={"mock_json_prop": True}),
             prepare(ReportUnit, id=999999, json_data={"real_json_prop": False}),
@@ -193,24 +193,24 @@ class TestReportActivityDataSerializers(SimpleTestCase):
         assert mock_fuel_reverse_manager.all.call_count == 1
         assert mock_emission_reverse_manager.all.call_count == 1
         assert serialized == {
-            'anotherStWithUnit': {
-                'id': 1,
-                'units': 'units serialized!',
-                'with_unit_2': 1,
-            },
-            'stWithEmissionOnly': {
-                'emissions': 'emissions serialized!',
-                'id': 1,
-                'with_emission_only': 1,
-            },
-            'stWithFuelOnly': {
-                'fuels': 'fuels serialized!',
-                'id': 1,
-                'with_fuel_only': 1,
-            },
             'stWithUnit': {
                 'id': 1,
                 'units': 'units serialized!',
                 'with_unit_1': 1,
+            },
+            'anotherStWithUnit': {
+                'id': 2,
+                'units': 'units serialized!',
+                'with_unit_2': 1,
+            },
+            'stWithFuelOnly': {
+                'fuels': 'fuels serialized!',
+                'id': 3,
+                'with_fuel_only': 1,
+            },
+            'stWithEmissionOnly': {
+                'emissions': 'emissions serialized!',
+                'id': 4,
+                'with_emission_only': 1,
             },
         }

--- a/bc_obps/reporting/tests/utils/baker_recipes.py
+++ b/bc_obps/reporting/tests/utils/baker_recipes.py
@@ -1,3 +1,5 @@
+from datetime import date, timedelta
+from typing import Any
 from registration.models.activity import Activity
 from reporting.models.activity_json_schema import ActivityJsonSchema
 from reporting.models.activity_source_type_json_schema import ActivitySourceTypeJsonSchema
@@ -8,17 +10,29 @@ from reporting.models.methodology import Methodology
 from reporting.models.report_activity import ReportActivity
 from reporting.models.report_operation import ReportOperation
 from reporting.models.report_product import ReportProduct
+from reporting.models.report_emission import ReportEmission
+from reporting.models.report_fuel import ReportFuel
+from reporting.models.report_source_type import ReportSourceType
+from reporting.models.report_unit import ReportUnit
 from reporting.models.reporting_year import ReportingYear
 from reporting.models.report import Report
 from reporting.models.report_version import ReportVersion
 from reporting.models.facility_report import FacilityReport
-from registration.tests.utils.baker_recipes import operation, operator, facility
-from model_bakery.recipe import Recipe, foreign_key
+from registration.tests.utils.baker_recipes import operation, operator, facility, regulated_product
+from model_bakery.recipe import Recipe, foreign_key, seq
 from reporting.models.source_type import SourceType
 from reporting.models.emission_category import EmissionCategory
 from reporting.models.emission_category_mapping import EmissionCategoryMapping
 
-from registration.tests.utils.baker_recipes import regulated_product
+
+def json_seq(json_key="generated_json", json_value="test json value", seq_value: Any = 1, **seq_args):
+    """
+    Extends model_bakery's `seq` function to generate sequential json values.
+    seq_value is passed as the first argument to seq() and will initialize that sequence.
+    """
+    generator = seq(seq_value, **seq_args)
+    while True:
+        yield {json_key: f'{json_value} {next(generator)}'}
 
 
 reporting_year = Recipe(ReportingYear)
@@ -35,7 +49,12 @@ report_version = Recipe(ReportVersion, report=foreign_key(report))
 facility_report = Recipe(FacilityReport, report_version=foreign_key(report_version), facility=foreign_key(facility))
 report_operation = Recipe(ReportOperation, report_version=foreign_key(report_version))
 
-configuration = Recipe(Configuration)
+configuration = Recipe(
+    Configuration,
+    # We make one config per week
+    valid_from=seq(date(4001, 1, 1), start=date(3001, 1, 1), increment_by=timedelta(days=8)),
+    valid_to=seq(date(4001, 1, 7), start=date(3001, 1, 7), increment_by=timedelta(days=8)),
+)
 
 activity = Recipe(Activity)
 source_type = Recipe(SourceType)
@@ -64,6 +83,37 @@ report_activity = Recipe(
     facility_report=foreign_key(facility_report),
     activity_base_schema=foreign_key(activity_json_schema),
     activity=foreign_key(activity),
+    report_version=foreign_key(report_version),
+    json_data=json_seq(json_value="generated report activity"),
+)
+report_source_type = Recipe(
+    ReportSourceType,
+    activity_source_type_base_schema=foreign_key(activity_source_type_json_schema),
+    source_type=foreign_key(source_type),
+    report_activity=foreign_key(report_activity),
+    json_data=json_seq(json_value="generated report source type"),
+    report_version=foreign_key(report_version),
+)
+report_unit = Recipe(
+    ReportUnit,
+    report_source_type=foreign_key(report_source_type),
+    json_data=json_seq(json_value="generated report unit"),
+    report_version=foreign_key(report_version),
+)
+report_fuel = Recipe(
+    ReportFuel,
+    fuel_type=foreign_key(fuel_type),
+    report_unit=foreign_key(report_unit),
+    report_source_type=foreign_key(report_source_type),
+    json_data=json_seq(json_value="generated report fuel"),
+    report_version=foreign_key(report_version),
+)
+report_emission = Recipe(
+    ReportEmission,
+    gas_type=foreign_key(gas_type),
+    report_source_type=foreign_key(report_source_type),
+    report_fuel=foreign_key(report_fuel),
+    json_data=json_seq(json_value="generated report emission"),
     report_version=foreign_key(report_version),
 )
 

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -1,5 +1,4 @@
 "use client";
-import FormBase from "@bciers/components/form/FormBase";
 import { customizeValidator } from "@rjsf/validator-ajv8";
 import { useEffect, useState } from "react";
 import { actionHandler } from "@bciers/actions";
@@ -11,6 +10,10 @@ import { FuelFields } from "./customFields/FuelFieldComponent";
 import { FieldProps } from "@rjsf/utils";
 import { getUiSchema } from "./uiSchemas/schemaMaps";
 import { UUID } from "crypto";
+import { withTheme } from "@rjsf/core";
+import formTheme from "@bciers/components/form/theme/defaultTheme";
+
+const Form = withTheme(formTheme);
 
 const CUSTOM_FIELDS = {
   fuelType: (props: FieldProps) => <FuelFields {...props} />,
@@ -70,6 +73,7 @@ export default function ActivityForm({
 
   useEffect(() => {
     let isFetching = true;
+
     const fetchSchemaData = async (
       selectedSourceTypes: string,
       selectedKeys: number[],
@@ -99,6 +103,7 @@ export default function ActivityForm({
       setPreviousActivityId(activityId);
       setUiSchema(getUiSchema(currentActivity.slug));
     };
+
     let selectedSourceTypes = "";
     const selectedKeys = [];
     for (const [key, value] of Object.entries(sourceTypeMap)) {
@@ -142,6 +147,7 @@ export default function ActivityForm({
         }),
       },
     );
+    setFormState(response);
 
     // 🛑 Set loading to false after the API call is completed
     setIsLoading(false);
@@ -168,7 +174,7 @@ export default function ActivityForm({
         "Loading Form..."
       ) : (
         <div className="w-full">
-          <FormBase
+          <Form
             schema={jsonSchema}
             fields={CUSTOM_FIELDS}
             formData={formState}
@@ -177,7 +183,6 @@ export default function ActivityForm({
             onChange={handleFormChange}
             onError={(e: any) => console.log("ERROR: ", e)}
             onSubmit={submitHandler}
-            omitExtraData={false}
           >
             {errorList.length > 0 &&
               errorList.map((e: any) => (
@@ -196,7 +201,7 @@ export default function ActivityForm({
                 {isSuccess ? "✅ Success" : "Submit"}
               </Button>
             </div>
-          </FormBase>
+          </Form>
         </div>
       )}
     </div>

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -25,6 +25,7 @@ interface Props {
     activityId: number;
     sourceTypeMap: { [key: number]: string };
   };
+  activityFormData: object;
   currentActivity: { id: number; name: string; slug: string };
   taskListData: TaskListElement[];
   defaultEmptySourceTypeState:
@@ -38,6 +39,7 @@ interface Props {
 // 🧩 Main component
 export default function ActivityForm({
   activityData,
+  activityFormData,
   currentActivity,
   taskListData,
   defaultEmptySourceTypeState,
@@ -50,7 +52,7 @@ export default function ActivityForm({
   const [isLoading, setIsLoading] = useState(false);
   // ✅ Success state for for the Submit button
   const [isSuccess, setIsSuccess] = useState(false);
-  const [formState, setFormState] = useState({} as any);
+  const [formState, setFormState] = useState(activityFormData as any);
   const [jsonSchema, setJsonSchema] = useState({});
   const [uiSchema, setUiSchema] = useState({});
   const [previousActivityId, setPreviousActivityId] = useState<number>();
@@ -105,7 +107,7 @@ export default function ActivityForm({
         selectedKeys.push(Number(key));
       }
     }
-    if (previousActivityId !== activityId) setFormState({});
+    if (previousActivityId !== activityId) setFormState(activityFormData);
     fetchSchemaData(selectedSourceTypes, selectedKeys);
     return () => {
       isFetching = false;
@@ -144,14 +146,14 @@ export default function ActivityForm({
     // 🛑 Set loading to false after the API call is completed
     setIsLoading(false);
 
+    // Apply new data to NextAuth JWT
+    console.log("SUBMITTED: ", JSON.stringify(data.formData, null, 2));
+    console.log("RESPONSE: ", response);
+
     if (response.error) {
       setErrorList([{ message: response.error }]);
       return;
     }
-
-    // Apply new data to NextAuth JWT
-    console.log("SUBMITTED: ", JSON.stringify(data.formData, null, 2));
-    console.log("RESPONSE: ", response);
   };
 
   const formIsLoading =
@@ -175,6 +177,7 @@ export default function ActivityForm({
             onChange={handleFormChange}
             onError={(e: any) => console.log("ERROR: ", e)}
             onSubmit={submitHandler}
+            omitExtraData={false}
           >
             {errorList.length > 0 &&
               errorList.map((e: any) => (

--- a/bciers/apps/reporting/src/app/components/activities/ActivityInit.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityInit.tsx
@@ -10,6 +10,7 @@ import {
   getFacilitiesInformationTaskList,
 } from "../taskList/2_facilitiesInformation";
 import { getOrderedActivities } from "../../utils/getOrderedActivities";
+import { getActivityFormData } from "../../utils/getActivityFormData";
 
 interface Props {
   versionId: number;
@@ -35,10 +36,17 @@ export default async function ActivityInit({
     "GET",
     "",
   );
+
   if (activityData.error) {
     throw new Error("We couldn't find the activity data for this facility.");
   }
   const activityDataObject = safeJsonParse(activityData);
+
+  const formData = await getActivityFormData(
+    versionId,
+    facilityId,
+    currentActivity.id,
+  );
 
   const defaultEmptySourceTypeState =
     defaultEmtpySourceTypeMap[currentActivity.slug];
@@ -59,6 +67,7 @@ export default async function ActivityInit({
     <Suspense fallback={<Loading />}>
       <ActivityForm
         activityData={activityDataObject}
+        activityFormData={formData}
         currentActivity={currentActivity}
         taskListData={taskListData}
         defaultEmptySourceTypeState={defaultEmptySourceTypeState}

--- a/bciers/apps/reporting/src/app/utils/getActivityFormData.ts
+++ b/bciers/apps/reporting/src/app/utils/getActivityFormData.ts
@@ -1,0 +1,17 @@
+import { actionHandler } from "@bciers/actions";
+
+export async function getActivityFormData(
+  versionId: number,
+  facilityId: string,
+  activityId: number,
+) {
+  const response = await actionHandler(
+    `reporting/report-version/${versionId}/facilities/${facilityId}/activity/${activityId}/report-activity`,
+    "GET",
+    "",
+  );
+  if (response.error) {
+    throw new Error("We couldn't find the activity list for this facility.");
+  }
+  return response;
+}


### PR DESCRIPTION

- report-activity GET endpoint serializes the `ReportActivity`, `ReportUnit`, `ReportFuel`, `ReportEmission` and `ReportMethodology` in a format that the activity form can display and understand
- report-activity POST endpoint makes use of the serialization endpoint to return saved data with ids and computed fields
- Updates the `ActivityForm` to update the form data with the saved IDs and computed data