### PR TITLE
chore: programatically get poetry version from file to avoid drift

### DIFF
--- a/bc_obps/Dockerfile
+++ b/bc_obps/Dockerfile
@@ -34,7 +34,7 @@ RUN sed -i -nr '/python|poetry/p' ${HOME}/.tool-versions && \
     asdf reshim
 
 # Get poetry version from .tool-versions
-poetry_version=$(grep poetry .tool-versions | awk '{print $2}')
+ARG poetry_version=$(grep poetry .tool-versions | awk '{print $2}')
 # Add Poetry's bin directory to PATH
 ENV PATH="${HOME}/.asdf/installs/poetry/${poetry_version}/bin:${PATH}"
 

--- a/bc_obps/Dockerfile
+++ b/bc_obps/Dockerfile
@@ -33,8 +33,10 @@ RUN sed -i -nr '/python|poetry/p' ${HOME}/.tool-versions && \
     asdf install && \
     asdf reshim
 
+# Get poetry version from .tool-versions
+poetry_version=$(grep poetry .tool-versions | awk '{print $2}')
 # Add Poetry's bin directory to PATH
-ENV PATH="${HOME}/.asdf/installs/poetry/1.6.1/bin:${PATH}"
+ENV PATH="${HOME}/.asdf/installs/poetry/${poetry_version}/bin:${PATH}"
 
 # Configuring poetry to behave properly with asdf
 RUN poetry config virtualenvs.prefer-active-python true


### PR DESCRIPTION
The poetry version defined in the path of the Dockerfile drifted from what was defined in .tool-versions. This will get the version from .tool-versions to avoid this in the future.