### PR TITLE
Task/update tile titles registration external user/2350

### DIFF
--- a/bc_obps/common/fixtures/dashboard/bciers/external.json
+++ b/bc_obps/common/fixtures/dashboard/bciers/external.json
@@ -144,10 +144,6 @@
                     "value": false
                   }
                 ]
-              },
-              {
-                "title": "Report an Event",
-                "href": "/registration/event"
               }
             ]
           },

--- a/bc_obps/common/fixtures/dashboard/registration/external.json
+++ b/bc_obps/common/fixtures/dashboard/registration/external.json
@@ -10,7 +10,7 @@
           {
             "title": "Register an Operation",
             "icon": "File",
-            "content": "Start a new registration here.",
+            "content": "Register your operations here.",
             "href": "/registration/register-an-operation",
             "conditions": [
               {
@@ -24,7 +24,7 @@
           {
             "title": "Register an Operation<sup style='color: red;'>*</sup><small> (action required)</small>",
             "icon": "File",
-            "content": "Start a new registration here.",
+            "content": "Register your operations here.",
             "href": "/registration/register-an-operation",
             "conditions": [
               {

--- a/bc_obps/common/fixtures/dashboard/registration/external.json
+++ b/bc_obps/common/fixtures/dashboard/registration/external.json
@@ -10,7 +10,7 @@
           {
             "title": "Register an Operation",
             "icon": "File",
-            "content": "TBD here.",
+            "content": "Start a new registration here.",
             "href": "/registration/register-an-operation",
             "conditions": [
               {
@@ -24,7 +24,7 @@
           {
             "title": "Register an Operation<sup style='color: red;'>*</sup><small> (action required)</small>",
             "icon": "File",
-            "content": "TBD here.",
+            "content": "Start a new registration here.",
             "href": "/registration/register-an-operation",
             "conditions": [
               {
@@ -36,10 +36,15 @@
             ]
           },
           {
-            "title": "Report an Event",
+            "title": "Report Transfers and Closures",
             "icon": "File",
-            "content": "TBD here.",
-            "href": "/registration/event"
+            "content": "Report a transfer, closure, temporary shut down, or re-start for your operation or facility(s).",
+            "href": "/registration/event",
+            "conditions": [
+              {
+                "value": false
+              }
+            ]
           }
         ]
       }


### PR DESCRIPTION
Reminder to devs when running this locally to test - you have to `make reset_db` for the updated tiles to take effect. Just adding this as a reminder because I consistently forget and then get confused why it isn't working.


**Registration dashboard:**
I updated the tile descriptions to match the updated wireframes, and set the Report an Event tile to always be hidden for the time being, since this page won't be available to external users as part of Reg2 MVP.
 
![Screenshot 2024-11-14 at 4 55 34 PM](https://github.com/user-attachments/assets/011b6c46-8eb9-459a-a9c7-87f67cf25251)

**Main dashboard:**
Hid the link to Report an Event from the "Registration" tile (for the same reason as above).

![Screenshot 2024-11-14 at 4 55 44 PM](https://github.com/user-attachments/assets/486e5cce-e3f7-467f-9135-ee7e10f476e6)
