### PR TITLE
chore: conditionally add superuser envs

### DIFF
--- a/helm/cas-bciers/templates/_helpers.tpl
+++ b/helm/cas-bciers/templates/_helpers.tpl
@@ -141,16 +141,6 @@ Define environment variables for the application.
   value: '*'
 - name: BACKEND_HOST
   value: {{ .Values.backend.route.host }}
-- name: DJANGO_SUPERUSER_USERNAME
-  valueFrom:
-    secretKeyRef:
-      key: username
-      name: django-superuser
-- name: DJANGO_SUPERUSER_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      key: password
-      name: django-superuser
 - name: GS_BUCKET_NAME
   valueFrom:
     secretKeyRef:

--- a/helm/cas-bciers/templates/backend/deployment.yaml
+++ b/helm/cas-bciers/templates/backend/deployment.yaml
@@ -34,6 +34,16 @@ spec:
             - "create_superuser"
           env:
             {{- include "cas-bciers.backendEnvVars" . | nindent 12 }}
+            - name: DJANGO_SUPERUSER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: django-superuser
+            - name: DJANGO_SUPERUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: django-superuser
           volumeMounts:
             - mountPath: "/attachment-credentials"
               name: gcs-attachment-credentials
@@ -45,6 +55,18 @@ spec:
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
           env:
             {{- include "cas-bciers.backendEnvVars" . | nindent 12 }}
+            {{- if hasSuffix "-dev" .Release.Namespace }}
+            - name: DJANGO_SUPERUSER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: django-superuser
+            - name: DJANGO_SUPERUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: django-superuser
+            {{- end }}
             {{- if hasSuffix "-prod" .Release.Namespace }}
             - name: SENTRY_ENVIRONMENT
               value: {{ include "cas-bciers.namespaceSuffix" . }}

--- a/helm/cas-registration/templates/_helpers.tpl
+++ b/helm/cas-registration/templates/_helpers.tpl
@@ -140,16 +140,6 @@ Define environment variables for the application.
   value: '*'
 - name: BACKEND_HOST
   value: {{ .Values.backend.route.host }}
-- name: DJANGO_SUPERUSER_USERNAME
-  valueFrom:
-    secretKeyRef:
-      key: username
-      name: django-superuser
-- name: DJANGO_SUPERUSER_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      key: password
-      name: django-superuser
 - name: GS_BUCKET_NAME
   valueFrom:
     secretKeyRef:

--- a/helm/cas-registration/templates/backend/deployment.yaml
+++ b/helm/cas-registration/templates/backend/deployment.yaml
@@ -34,6 +34,16 @@ spec:
             - "create_superuser"
           env:
             {{- include "cas-registration.backendEnvVars" . | nindent 12 }}
+            - name: DJANGO_SUPERUSER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: django-superuser
+            - name: DJANGO_SUPERUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: django-superuser
           volumeMounts:
             - mountPath: "/attachment-credentials"
               name: gcs-attachment-credentials
@@ -45,6 +55,18 @@ spec:
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
           env:
             {{- include "cas-registration.backendEnvVars" . | nindent 12 }}
+            {{- if hasSuffix "-dev" .Release.Namespace }}
+            - name: DJANGO_SUPERUSER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: django-superuser
+            - name: DJANGO_SUPERUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: django-superuser
+            {{- end }}
             {{- if hasSuffix "-prod" .Release.Namespace }}
             - name: SENTRY_ENVIRONMENT
               value: {{ include "cas-registration.namespaceSuffix" . }}


### PR DESCRIPTION
I think there's also an issue with the superuser being in an init container & how we drop our database beforehand (which means the django auth admin tables don't exist).

This PR is just to fix the side effect of having envs in test/prod that reference a secret that isn't created in those environments, causing a container init config error on deploy. I created a stand-in secret in test to get around that for now. This PR makes those envs conditional on the dev environment.