### PR TITLE
2270 operation grid link

### DIFF
--- a/bc_obps/common/management/commands/load_fixtures.py
+++ b/bc_obps/common/management/commands/load_fixtures.py
@@ -18,6 +18,7 @@ class Command(BaseCommand):
             f'{fixture_base_dir}/bc_greenhouse_gas_id.json',
             f'{fixture_base_dir}/operator.json',
             f'{fixture_base_dir}/operation.json',
+            f'{fixture_base_dir}/multiple_operator.json',
             f'{fixture_base_dir}/document.json',
             f'{fixture_base_dir}/user_operator.json',
             f'{fixture_base_dir}/facility.json',

--- a/bc_obps/common/tests/endpoints/auth/test_endpoint_permissions.py
+++ b/bc_obps/common/tests/endpoints/auth/test_endpoint_permissions.py
@@ -114,6 +114,11 @@ class TestEndpointPermissions(TestCase):
                 "kwargs": {"report_version_id": mock_int, "facility_id": mock_uuid},
             },
             {
+                "method": "get",
+                "endpoint_name": "register_get_operation_information",
+                "kwargs": {"operation_id": mock_uuid},
+            },
+            {
                 "method": "put",
                 "endpoint_name": "register_edit_operation_information",
                 "kwargs": {"operation_id": mock_uuid},

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
@@ -21,6 +21,7 @@ from registration.schema.generic import Message
     description="""Gets the registration purpose, regulated products (if applicable), and select data of a specific operation by its ID.
     The endpoint ensures that only authorized industry users can access operations belonging to their operator. Unauthorized access attempts raise an error.""",
     auth=authorize('approved_industry_user'),
+    exclude_none=True,
 )
 @handle_http_errors()
 def register_get_operation_information(request: HttpRequest, operation_id: UUID) -> Tuple[Literal[200], Operation]:

--- a/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
+++ b/bc_obps/registration/api/v2/_operations/_operation_id/_registration/operation.py
@@ -1,10 +1,8 @@
 from typing import Literal, Tuple
 from uuid import UUID
 from django.http import HttpRequest
-from registration.schema.v2.operation import (
-    OperationInformationIn,
-    OperationUpdateOut,
-)
+from service.operation_service import OperationService
+from registration.schema.v2.operation import OperationInformationIn, OperationUpdateOut, OperationRegistrationOut
 from service.operation_service_v2 import OperationServiceV2
 from registration.constants import V2
 from common.permissions import authorize
@@ -14,6 +12,19 @@ from registration.models import Operation
 from registration.decorators import handle_http_errors
 from registration.api.router import router
 from registration.schema.generic import Message
+
+##### GET #####
+@router.get(
+    "/v2/operations/{uuid:operation_id}/registration/operation",
+    response={200: OperationRegistrationOut, custom_codes_4xx: Message},
+    tags=V2,
+    description="""Gets the registration purpose, regulated products (if applicable), and select data of a specific operation by its ID.
+    The endpoint ensures that only authorized industry users can access operations belonging to their operator. Unauthorized access attempts raise an error.""",
+    auth=authorize('approved_industry_user'),
+)
+@handle_http_errors()
+def register_get_operation_information(request: HttpRequest, operation_id: UUID) -> Tuple[Literal[200], Operation]:
+    return 200, OperationService.get_if_authorized(get_current_user_guid(request), operation_id)
 
 
 ##### PUT #####

--- a/bc_obps/registration/fixtures/mock/multiple_operator.json
+++ b/bc_obps/registration/fixtures/mock/multiple_operator.json
@@ -1,0 +1,14 @@
+[
+  {
+    "model": "registration.multipleoperator",
+    "fields": {
+      "operation": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488e",
+      "legal_name": "Multiple Operator Legal Name",
+      "trade_name": "Multiple Operator Trade Name",
+      "cra_business_number": 123456789,
+      "bc_corporate_registry_number": "abc1234567",
+      "business_structure": "Sole Proprietorship",
+      "attorney_address": 1
+    }
+  }
+]

--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -84,6 +84,7 @@
   },
   {
     "model": "registration.operation",
+    "pk": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488e",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "documents": [],
@@ -94,7 +95,7 @@
       "naics_code": 21,
       "opt_in": false,
       "bcghg_id": "23219990001",
-      "regulated_products": [],
+      "regulated_products": [1, 2],
       "status": "Draft",
       "created_at": "2024-1-29T15:27:00.000Z",
       "activities": [1, 5]
@@ -102,6 +103,7 @@
   },
   {
     "model": "registration.operation",
+
     "pk": "d99725a7-1c3a-47cb-a59b-e2388ce0fa18",
     "fields": {
       "operator": "685d581b-5698-411f-ae00-de1d97334a71",

--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -98,7 +98,8 @@
       "regulated_products": [1, 2],
       "status": "Draft",
       "created_at": "2024-1-29T15:27:00.000Z",
-      "activities": [1, 5]
+      "activities": [1, 5],
+      "operation_has_multiple_operators": true
     }
   },
   {

--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -96,6 +96,7 @@
       "opt_in": false,
       "bcghg_id": "23219990001",
       "regulated_products": [1, 2],
+      "registration_purpose": "OBPS Regulated Operation",
       "status": "Draft",
       "created_at": "2024-1-29T15:27:00.000Z",
       "activities": [1, 5],

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -19,6 +19,28 @@ from ninja.types import DictStrAny
 #### Operation schemas
 
 
+class OperationRegistrationOut(ModelSchema):
+    operation: UUID = Field(..., alias="id")
+    naics_code_id: Optional[int] = Field(None, alias="naics_code.id")
+    secondary_naics_code_id: Optional[int] = Field(None, alias="secondary_naics_code.id")
+    tertiary_naics_code_id: Optional[int] = Field(None, alias="tertiary_naics_code.id")
+    multiple_operators_array: Optional[List[MultipleOperatorOut]] = []
+    operation_has_multiple_operators: Optional[bool] = False
+    boundary_map: Optional[str] = None
+    process_flow_diagram: Optional[str] = None
+
+    @staticmethod
+    def resolve_multiple_operators_array(obj: Operation) -> Optional[List[MultipleOperator]]:
+        if obj.multiple_operators.exists():
+            return [
+                multiple_operator for multiple_operator in obj.multiple_operators.select_related("attorney_address")
+            ]
+        return None
+
+    class Meta:
+        model = Operation
+        fields = ["name", 'type']
+
 class OperationRepresentativeIn(ModelSchema):
     existing_contact_id: Optional[int] = None
     street_address: str

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -30,6 +30,20 @@ class OperationRegistrationOut(ModelSchema):
     process_flow_diagram: Optional[str] = None
 
     @staticmethod
+    def resolve_boundary_map(obj: Operation) -> Optional[str]:
+        boundary_map = obj.get_boundary_map()
+        if boundary_map:
+            return file_to_data_url(boundary_map)
+        return None
+
+    @staticmethod
+    def resolve_process_flow_diagram(obj: Operation) -> Optional[str]:
+        process_flow_diagram = obj.get_process_flow_diagram()
+        if process_flow_diagram:
+            return file_to_data_url(process_flow_diagram)
+        return None
+
+    @staticmethod
     def resolve_multiple_operators_array(obj: Operation) -> Optional[List[MultipleOperator]]:
         if obj.multiple_operators.exists():
             return [
@@ -39,7 +53,8 @@ class OperationRegistrationOut(ModelSchema):
 
     class Meta:
         model = Operation
-        fields = ["name", 'type']
+        fields = ["name", 'type', 'registration_purpose', 'regulated_products', 'activities']
+
 
 class OperationRepresentativeIn(ModelSchema):
     existing_contact_id: Optional[int] = None

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation.py
@@ -94,16 +94,16 @@ class TestGetOperationRegistrationInformationEndpoint(CommonTestSetup):
 
         # Assert
         assert response.status_code == 200
-        assert list(response.json().keys()) == [
+        # keys don't include optional values (exclude_none=True is set in the endpoint) or attachments (GCS isn't set up in CI for testing)
+        assert set(response.json().keys()) == {
+            'registration_purpose',
             'operation',
             'naics_code_id',
-            'secondary_naics_code_id',
-            'tertiary_naics_code_id',
             'multiple_operators_array',
             'operation_has_multiple_operators',
-            'boundary_map',
-            'process_flow_diagram',
+            'activities',
             'name',
             'type',
-        ]
+            'regulated_products',
+        }
         assert len(response.json()['multiple_operators_array']) == 1

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation.py
@@ -5,7 +5,7 @@ from model_bakery import baker
 import json
 
 
-class TestOperationRegistrationInformationEndpoint(CommonTestSetup):
+class TestPutOperationRegistrationInformationEndpoint(CommonTestSetup):
     mock_payload = {
         "registration_purpose": "Reporting Operation",
         "regulated_products": [1],
@@ -66,3 +66,44 @@ class TestOperationRegistrationInformationEndpoint(CommonTestSetup):
 
         # Assert
         assert response.status_code == 422
+
+
+class TestGetOperationRegistrationInformationEndpoint(CommonTestSetup):
+    def test_users_cannot_get_other_users_operations(self):
+        # authorize current user
+        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe(
+            'utils.operation',
+        )
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "industry_user",
+            custom_reverse_lazy("register_get_operation_information", kwargs={'operation_id': operation.id}),
+        )
+        assert response.status_code == 401
+
+    def test_register_get_operation_information_endpoint_success(self):
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        baker.make_recipe('utils.multiple_operator', operation=operation)
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            "industry_user",
+            custom_reverse_lazy("register_get_operation_information", kwargs={'operation_id': operation.id}),
+        )
+
+        # Assert
+        assert response.status_code == 200
+        assert list(response.json().keys()) == [
+            'operation',
+            'naics_code_id',
+            'secondary_naics_code_id',
+            'tertiary_naics_code_id',
+            'multiple_operators_array',
+            'operation_has_multiple_operators',
+            'boundary_map',
+            'process_flow_diagram',
+            'name',
+            'type',
+        ]
+        assert len(response.json()['multiple_operators_array']) == 1

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/operationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/operationInformation.ts
@@ -90,10 +90,12 @@ export const createOperationInformationSchema = async (
       process_flow_diagram: {
         type: "string",
         title: "Process Flow Diagram",
+        format: "data-url",
       },
       boundary_map: {
         type: "string",
         title: "Boundary Map",
+        format: "data-url",
       },
       ...(app === Apps.ADMINISTRATION
         ? {
@@ -140,15 +142,11 @@ export const operationInformationUISchema: UiSchema = {
   },
   process_flow_diagram: {
     "ui:widget": "FileWidget",
-    "ui:options": {
-      filePreview: true,
-    },
+    "ui:options": {},
   },
   boundary_map: {
     "ui:widget": "FileWidget",
-    "ui:options": {
-      filePreview: true,
-    },
+    "ui:options": {},
   },
   bc_obps_regulated_operation: {
     "ui:widget": "BoroIdWidget",

--- a/bciers/apps/administration/tests/components/operations/OperationDataGrid.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationDataGrid.test.tsx
@@ -213,7 +213,7 @@ describe("OperationsDataGrid component", () => {
     );
   });
 
-  it("renders the correct url for the operation information link", async () => {
+  it("renders the correct url for the operation information link for internal users", async () => {
     render(
       <OperationDataGrid isInternalUser={true} initialData={mockResponse} />,
     );
@@ -224,11 +224,44 @@ describe("OperationsDataGrid component", () => {
 
     expect(operationInfoLinks[0]).toHaveAttribute(
       "href",
-      "/operations/1?operations_title=Operation+1",
+      "../administration/operations/1?operations_title=Operation 1",
     );
     expect(operationInfoLinks[1]).toHaveAttribute(
       "href",
-      "/operations/2?operations_title=Operation+2",
+      "../administration/operations/2?operations_title=Operation 2",
+    );
+  });
+
+  it("renders the correct url for the operation information link for external users", async () => {
+    render(
+      <OperationDataGrid isInternalUser={false} initialData={mockResponse} />,
+    );
+
+    expect(
+      screen.getByRole("link", {
+        name: /Start registration/i,
+      }),
+    ).toHaveAttribute("href", "../registration/register-an-operation");
+    expect(
+      screen.getByRole("link", {
+        name: /view operation/i,
+      }),
+    ).toHaveAttribute(
+      "href",
+      "../administration/operations/2?operations_title=Operation 2",
+    );
+
+    const continueRegistrationlinks = screen.getAllByRole("link", {
+      name: /continue registration/i,
+    });
+
+    expect(continueRegistrationlinks[0]).toHaveAttribute(
+      "href",
+      "../registration/register-an-operation/1/1",
+    );
+    expect(continueRegistrationlinks[1]).toHaveAttribute(
+      "href",
+      "../registration/register-an-operation/4/1",
     );
   });
 });

--- a/bciers/apps/registration/app/components/operations/registration/OperationInformationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/OperationInformationForm.tsx
@@ -6,7 +6,7 @@ import { actionHandler } from "@bciers/actions";
 import { RJSFSchema } from "@rjsf/utils";
 import { useState } from "react";
 import { IChangeEvent } from "@rjsf/core";
-import { getOperationV2 } from "@bciers/actions/api";
+import { getOperationRegistration } from "@bciers/actions/api";
 import {
   createNestedFormData,
   createUnnestedFormData,
@@ -95,7 +95,7 @@ const OperationInformationForm = ({
   const handleSelectOperationChange = async (data: any) => {
     const operationId = data.section1.operation;
     setSelectedOperation(operationId);
-    const operationData = await getOperationV2(operationId);
+    const operationData = await getOperationRegistration(operationId);
     if (operationData?.error) {
       setError("Failed to fetch operation data!" as any);
     }

--- a/bciers/apps/registration/app/components/operations/registration/OperationInformationPage.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/OperationInformationPage.tsx
@@ -1,5 +1,5 @@
 import { createRegistrationOperationInformationSchema } from "@/registration/app/data/jsonSchema/operationInformation/registrationOperationInformation";
-import { getOperationV2 } from "@bciers/actions/api";
+import { getOperationRegistration } from "@bciers/actions/api";
 import OperationInformationForm from "apps/registration/app/components/operations/registration/OperationInformationForm";
 import { UUID } from "crypto";
 import { validate as isValidUUID } from "uuid";
@@ -16,7 +16,7 @@ const OperationInformationPage = async ({
 }) => {
   let formData: OperationInformationFormData | { error: string } | {} = {};
   if (operation && isValidUUID(operation))
-    formData = await getOperationV2(operation);
+    formData = await getOperationRegistration(operation);
 
   if (formData && "error" in formData)
     // using dot notation for error raises a TS error

--- a/bciers/apps/registration/app/components/operations/registration/OperationInformationPage.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/OperationInformationPage.tsx
@@ -1,16 +1,29 @@
 import { createRegistrationOperationInformationSchema } from "@/registration/app/data/jsonSchema/operationInformation/registrationOperationInformation";
+import { getOperationV2 } from "@bciers/actions/api";
 import OperationInformationForm from "apps/registration/app/components/operations/registration/OperationInformationForm";
+import { UUID } from "crypto";
+import { validate as isValidUUID } from "uuid";
+import { OperationInformationFormData } from "./types";
 
 const OperationInformationPage = async ({
   step,
   steps,
+  operation,
 }: {
   step: number;
   steps: string[];
+  operation: UUID;
 }) => {
+  let formData: OperationInformationFormData | { error: string } | {} = {};
+  if (operation && isValidUUID(operation))
+    formData = await getOperationV2(operation);
+
+  if (formData && "error" in formData)
+    // using dot notation for error raises a TS error
+    throw new Error("Failed to fetch operation data");
   return (
     <OperationInformationForm
-      rawFormData={{}}
+      rawFormData={formData}
       schema={await createRegistrationOperationInformationSchema()}
       step={step}
       steps={steps}

--- a/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
@@ -71,7 +71,7 @@ describe("the OperationInformationForm component", () => {
     await waitFor(() => {
       // LastCalledWith because fetchFormEnums calls the actionHandler multiple times to populate the dropdown options in the form schema
       expect(actionHandler).toHaveBeenLastCalledWith(
-        "registration/v2/operations/uuid1",
+        "registration/v2/operations/uuid1/registration/operation",
         "GET",
         "",
       );

--- a/bciers/libs/actions/src/api/getOperationRegistration.ts
+++ b/bciers/libs/actions/src/api/getOperationRegistration.ts
@@ -1,0 +1,11 @@
+import { actionHandler } from "@bciers/actions";
+
+async function getOperationRegistration(id: string) {
+  return actionHandler(
+    `registration/v2/operations/${id}/registration/operation`,
+    "GET",
+    "",
+  );
+}
+
+export default getOperationRegistration;

--- a/bciers/libs/actions/src/api/getRegistrationPurposes.ts
+++ b/bciers/libs/actions/src/api/getRegistrationPurposes.ts
@@ -1,7 +1,11 @@
 import { actionHandler } from "@bciers/actions";
 
 async function getRegistrationPurposes() {
-  return actionHandler("registration/registration_purposes", "GET", "");
+  return actionHandler(
+    "registration/v2/operations/registration-purposes",
+    "GET",
+    "",
+  );
 }
 
 export default getRegistrationPurposes;

--- a/bciers/libs/actions/src/api/index.ts
+++ b/bciers/libs/actions/src/api/index.ts
@@ -9,6 +9,7 @@ export { default as getRegulatedProducts } from "./getRegulatedProducts";
 export { default as getReportingActivities } from "./getReportingActivities";
 export { default as getRegistrationPurposes } from "./getRegistrationPurposes";
 export { default as getOptedInOperationDetail } from "./getOptedInOperationDetail";
+export { default as getOperationRegistration } from "./getOperationRegistration";
 export { default as getContact } from "./getContact";
 export { default as getContacts } from "./getContacts";
 export { default as getOperationRepresentatives } from "./getOperationRepresentatives";

--- a/bciers/libs/components/src/datagrid/cells/operations/OperationsActionCell.tsx
+++ b/bciers/libs/components/src/datagrid/cells/operations/OperationsActionCell.tsx
@@ -1,35 +1,28 @@
-import Link from "next/link";
 import { GridRenderCellParams } from "@mui/x-data-grid";
 import { OperationStatus } from "@bciers/utils/src/enums";
 
 const OperationsActionCell = (isInternalUser: boolean) => {
   const renderCell = (params: GridRenderCellParams) => {
     let actionText = "View Operation";
+    let url = `../administration/operations/${params.row.id}?operations_title=${params.row.name}`;
     if (!isInternalUser) {
       switch (params.row.status) {
         case OperationStatus.NOT_STARTED:
           actionText = "Start Registration";
+          url = "../registration/register-an-operation";
           break;
         case OperationStatus.DRAFT:
           actionText = "Continue Registration";
+          url = `../registration/register-an-operation/${params.row.id}/1`;
           break;
       }
     }
-
     return (
       <div>
-        {/* 🔗 Add link with href query parameter with row's descriptive text*/}
-        <Link
-          className="action-cell-text"
-          href={{
-            pathname: `/operations/${params.row.id}`,
-            query: {
-              operations_title: `${params.row.name}`,
-            },
-          }}
-        >
+        {/* We have to use <a /> instead of <Link> because we're going from the admin to the reg model */}
+        <a className="action-cell-text" href={url}>
           {actionText}
-        </Link>
+        </a>
       </div>
     );
   };


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=80782303&issue=bcgov%7Ccas-registration%7C2270

This PR:
- fixes the links on the operation grid so they go to the right places (admin views, or beginning of reg flow)
- updates mock data to create an in-progress operation (Operation 5) with multiple operators (I was suspicious that the schema wasn't properly fetching multiple operators)
- if a registration is in progress, fetches existing data and pre-fills the first page of the form. Currently can't fetch registration purpose because there are multiple; this will be fixed in Andrea's PR. We can't fetch docs in our mock data because GCS isn't set up for CI
- This PR doesn't include a put route, so if you "continue" Operation 5, you're actually creating a new registration (to figure out how to best organize this work with Andrea)