### PR TITLE
2453 boro id restrictions

### DIFF
--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -370,6 +370,7 @@
       "bcghg_id": "23219990018",
       "regulated_products": [],
       "status": "Registered",
+      "registration_purpose": "OBPS Regulated Operation",
       "created_at": "2024-1-15T15:27:00.000Z",
       "activities": [1, 5]
     }

--- a/bc_obps/registration/models/operation.py
+++ b/bc_obps/registration/models/operation.py
@@ -293,3 +293,14 @@ class Operation(TimeStampedModel):
         Returns the current designated operator of the operation.
         """
         return self.designated_operators.get(end_date__isnull=True).operator
+
+    @property
+    def is_regulated_operation(self) -> bool:
+        """
+        Returns a boolean that describes whether the operation is regulated or not.
+        """
+        return self.registration_purpose in [
+            Operation.Purposes.OBPS_REGULATED_OPERATION,
+            Operation.Purposes.NEW_ENTRANT_OPERATION,
+            Operation.Purposes.OPTED_IN_OPERATION,
+        ]

--- a/bc_obps/registration/tests/endpoints/v1/_operations/_operation_id/test_operation_update_status.py
+++ b/bc_obps/registration/tests/endpoints/v1/_operations/_operation_id/test_operation_update_status.py
@@ -31,7 +31,7 @@ class TestUpdateOperationStatusEndpoint(CommonTestSetup):
         )
 
     def test_cas_admin_approves_operation(self):
-        operation = operation_baker()
+        operation = baker.make_recipe('utils.operation')
         assert operation.status == Operation.Statuses.NOT_STARTED
         url = custom_reverse_lazy("update_operation_status", kwargs={"operation_id": operation.id})
 

--- a/bc_obps/registration/tests/models/test_operation.py
+++ b/bc_obps/registration/tests/models/test_operation.py
@@ -42,7 +42,10 @@ class OperationModelTest(BaseTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.test_object = Operation.objects.filter(swrs_facility_id__isnull=False).first()
+        cls.test_object = baker.make_recipe(
+            'utils.operation', swrs_facility_id=6565, status=Operation.Statuses.REGISTERED
+        )
+        Operation.objects.filter(swrs_facility_id__isnull=False).first()
         cls.test_object.documents.set(
             [
                 Document.objects.get(id=1),

--- a/bc_obps/service/operation_service_v2.py
+++ b/bc_obps/service/operation_service_v2.py
@@ -415,14 +415,10 @@ class OperationServiceV2:
     @classmethod
     def generate_boro_id(cls, user_guid: UUID, operation_id: UUID) -> Optional[BcObpsRegulatedOperation]:
         operation = OperationService.get_if_authorized(user_guid, operation_id)
-        is_regulated_operation = operation.registration_purpose in [
-            Operation.Purposes.OBPS_REGULATED_OPERATION,
-            Operation.Purposes.NEW_ENTRANT_OPERATION,
-            Operation.Purposes.OPTED_IN_OPERATION,
-        ]
+
         if operation.bc_obps_regulated_operation:
             raise Exception('Operation already has a BORO ID.')
-        if not is_regulated_operation:
+        if not operation.is_regulated_operation:
             raise Exception('Non-regulated operations cannot be issued BORO IDs.')
         if operation.status != Operation.Statuses.REGISTERED:
             raise Exception('Operations must be registered before they can be issued a BORO ID.')

--- a/bc_obps/service/operation_service_v2.py
+++ b/bc_obps/service/operation_service_v2.py
@@ -415,11 +415,15 @@ class OperationServiceV2:
     @classmethod
     def generate_boro_id(cls, user_guid: UUID, operation_id: UUID) -> Optional[BcObpsRegulatedOperation]:
         operation = OperationService.get_if_authorized(user_guid, operation_id)
-        is_eio = operation.registration_purpose == Operation.Purposes.ELECTRICITY_IMPORT_OPERATION
+        is_regulated_operation = operation.registration_purpose in [
+            Operation.Purposes.OBPS_REGULATED_OPERATION,
+            Operation.Purposes.NEW_ENTRANT_OPERATION,
+            Operation.Purposes.OPTED_IN_OPERATION,
+        ]
         if operation.bc_obps_regulated_operation:
             raise Exception('Operation already has a BORO ID.')
-        if is_eio:
-            raise Exception('EIOs cannot be issued BORO IDs.')
+        if not is_regulated_operation:
+            raise Exception('Non-regulated operations cannot be issued BORO IDs.')
         if operation.status != Operation.Statuses.REGISTERED:
             raise Exception('Operations must be registered before they can be issued a BORO ID.')
 

--- a/bc_obps/service/tests/test_operation_service_v2.py
+++ b/bc_obps/service/tests/test_operation_service_v2.py
@@ -825,7 +825,7 @@ class TestGenerateBoroId:
         assert operation.bc_obps_regulated_operation.issued_by == approved_user_operator.user
 
     @staticmethod
-    def test_raises_exception_if_operation_is_eio():
+    def test_raises_exception_if_operation_is_non_regulated():
         approved_user_operator = baker.make_recipe('utils.approved_user_operator')
         operation = baker.make_recipe(
             'utils.operation',
@@ -834,7 +834,7 @@ class TestGenerateBoroId:
             registration_purpose=Operation.Purposes.ELECTRICITY_IMPORT_OPERATION,
         )
 
-        with pytest.raises(Exception, match="EIOs cannot be issued BORO IDs."):
+        with pytest.raises(Exception, match="Non-regulated operations cannot be issued BORO ID."):
             OperationServiceV2.generate_boro_id(approved_user_operator.user.user_guid, operation.id)
 
     @staticmethod
@@ -844,7 +844,7 @@ class TestGenerateBoroId:
             'utils.operation',
             operator=approved_user_operator.operator,
             status=Operation.Statuses.DRAFT,
-            registration_purpose=Operation.Purposes.POTENTIAL_REPORTING_OPERATION,
+            registration_purpose=Operation.Purposes.NEW_ENTRANT_OPERATION,
         )
 
         with pytest.raises(Exception, match="Operations must be registered before they can be issued a BORO ID."):
@@ -859,7 +859,7 @@ class TestGenerateBoroId:
             operator=approved_user_operator.operator,
             status=Operation.Statuses.REGISTERED,
             bc_obps_regulated_operation=boro_id,
-            registration_purpose=Operation.Purposes.POTENTIAL_REPORTING_OPERATION,
+            registration_purpose=Operation.Purposes.OBPS_REGULATED_OPERATION,
         )
 
         with pytest.raises(Exception, match="Operation already has a BORO ID."):

--- a/bc_obps/service/tests/test_operation_service_v2.py
+++ b/bc_obps/service/tests/test_operation_service_v2.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from registration.models.contact import Contact
-from registration.models.bc_obps_regulated_operation import BcObpsRegulatedOperation
 from registration.models.facility_designated_operation_timeline import FacilityDesignatedOperationTimeline
 from registration.models.document_type import DocumentType
 from registration.models.activity import Activity
@@ -849,23 +848,6 @@ class TestGenerateBoroId:
 
         with pytest.raises(Exception, match="Operations must be registered before they can be issued a BORO ID."):
             OperationServiceV2.generate_boro_id(approved_user_operator.user.user_guid, operation.id)
-
-    @staticmethod
-    def test_raises_exception_if_operation_already_has_boro_id():
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
-        boro_id = baker.make(BcObpsRegulatedOperation, id='21-0001')
-        operation = baker.make_recipe(
-            'utils.operation',
-            operator=approved_user_operator.operator,
-            status=Operation.Statuses.REGISTERED,
-            bc_obps_regulated_operation=boro_id,
-            registration_purpose=Operation.Purposes.OBPS_REGULATED_OPERATION,
-        )
-
-        with pytest.raises(Exception, match="Operation already has a BORO ID."):
-            OperationServiceV2.generate_boro_id(approved_user_operator.user.user_guid, operation.id)
-        operation.refresh_from_db()
-        assert operation.bc_obps_regulated_operation is not None
 
 
 class TestRemoveOperationRepresentative:

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -13,7 +13,7 @@ import {
 } from "./types";
 import { actionHandler } from "@bciers/actions";
 import { FormMode, FrontEndRoles } from "@bciers/utils/src/enums";
-import { RegistrationPurposes } from "apps/registration/app/components/operations/registration/enums";
+import { RegistrationPurposes, regulatedOperationPurposes } from "apps/registration/app/components/operations/registration/enums";
 
 const OperationInformationForm = ({
   formData,
@@ -82,8 +82,8 @@ const OperationInformationForm = ({
       formContext={{
         operationId,
         isInternalUser: isAuthorizedAdminUser,
-        isEio: formData.registration_purpose?.match(
-          RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION.valueOf(),
+        isRegulatedOperation: regulatedOperationPurposes.includes(
+          formData.registration_purpose as RegistrationPurposes,
         ),
         status: formData.status,
       }}

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -13,7 +13,10 @@ import {
 } from "./types";
 import { actionHandler } from "@bciers/actions";
 import { FormMode, FrontEndRoles } from "@bciers/utils/src/enums";
-import { RegistrationPurposes, regulatedOperationPurposes } from "apps/registration/app/components/operations/registration/enums";
+import {
+  RegistrationPurposes,
+  regulatedOperationPurposes,
+} from "apps/registration/app/components/operations/registration/enums";
 
 const OperationInformationForm = ({
   formData,

--- a/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
@@ -13,6 +13,7 @@ import { createAdministrationOperationInformationSchema } from "apps/administrat
 import { OperationStatus } from "@bciers/utils/src/enums";
 import { expect } from "vitest";
 import userEvent from "@testing-library/user-event";
+import { RegistrationPurposes } from "@/registration/app/components/operations/registration/enums";
 
 useSession.mockReturnValue({
   data: {
@@ -569,7 +570,11 @@ describe("the OperationInformationForm component", () => {
 
     render(
       <OperationInformationForm
-        formData={{ ...formData, status: OperationStatus.REGISTERED }}
+        formData={{
+          ...formData,
+          registration_purpose: RegistrationPurposes.OBPS_REGULATED_OPERATION,
+          status: OperationStatus.REGISTERED,
+        }}
         schema={{
           type: "object",
           properties: {

--- a/bciers/apps/registration/app/components/operations/registration/enums.ts
+++ b/bciers/apps/registration/app/components/operations/registration/enums.ts
@@ -33,13 +33,6 @@ export const regulatedOperationPurposes: ReadonlyArray<RegistrationPurposes> = [
   RegistrationPurposes.OPTED_IN_OPERATION,
 ];
 
-export const nonRegulatedOperationPurposes: ReadonlyArray<RegistrationPurposes> =
-  [
-    RegistrationPurposes.REPORTING_OPERATION,
-    RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION,
-    RegistrationPurposes.POTENTIAL_REPORTING_OPERATION,
-  ];
-
 export const RegistrationPurposeHelpText: {
   [key in RegistrationPurposes]: string;
 } = {

--- a/bciers/apps/registration/app/components/operations/registration/enums.ts
+++ b/bciers/apps/registration/app/components/operations/registration/enums.ts
@@ -27,6 +27,19 @@ export enum RegistrationPurposes {
   POTENTIAL_REPORTING_OPERATION = "Potential Reporting Operation",
 }
 
+export const regulatedOperationPurposes: ReadonlyArray<RegistrationPurposes> = [
+  RegistrationPurposes.OBPS_REGULATED_OPERATION,
+  RegistrationPurposes.NEW_ENTRANT_OPERATION,
+  RegistrationPurposes.OPTED_IN_OPERATION,
+];
+
+export const nonRegulatedOperationPurposes: ReadonlyArray<RegistrationPurposes> =
+  [
+    RegistrationPurposes.REPORTING_OPERATION,
+    RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION,
+    RegistrationPurposes.POTENTIAL_REPORTING_OPERATION,
+  ];
+
 export const RegistrationPurposeHelpText: {
   [key in RegistrationPurposes]: string;
 } = {

--- a/bciers/libs/components/src/form/widgets/BoroIdWidget.test.tsx
+++ b/bciers/libs/components/src/form/widgets/BoroIdWidget.test.tsx
@@ -28,17 +28,18 @@ const defaultFormContext = {
   operationId: "6d07d02a-1ad2-46ed-ad56-2f84313e98bf",
   isInternalUser: true,
   status: OperationStatus.REGISTERED,
+  isRegulatedOperation: true,
 };
 
 describe("RJSF boroIdWidget", () => {
-  it("should show Not Applicable when Operation is an EIO", () => {
+  it("should show Not Applicable when Operation is non-regulated", () => {
     const { container } = render(
       <FormBase
         schema={boroIdWidgetSchema}
         uiSchema={boroIdWidgetUiSchema}
         formContext={{
           ...defaultFormContext,
-          isEio: true,
+          isRegulatedOperation: false,
         }}
       />,
     );

--- a/bciers/libs/components/src/form/widgets/BoroIdWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/BoroIdWidget.tsx
@@ -21,7 +21,7 @@ const BoroIdWidget: React.FC<WidgetProps> = ({ id, value, formContext }) => {
   const [isSnackbarOpen, setIsSnackbarOpen] = useState(false);
   const [error, setError] = useState(undefined);
 
-  if (formContext.isEio) {
+  if (!formContext.isRegulatedOperation) {
     return (
       <div id={id} className="read-only-widget whitespace-pre-line">
         Not applicable


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=86401827&issue=bcgov%7Ccas-registration%7C2453

This PR:
- conditionally shows the boro id widget button only for regulated operations
- backend conditions on not creating boro ids for non-regulated operations
- updated mock data so we have Operation 19 eligible for BORO ID (needs to be registered and have an appropriate purpose)
- updated vitests and pytest