### PR TITLE
Fix/395 activity form state

### DIFF
--- a/bc_obps/reporting/json_schemas/2024/carbonates_use/carbonates_use.json
+++ b/bc_obps/reporting/json_schemas/2024/carbonates_use/carbonates_use.json
@@ -5,6 +5,7 @@
     "emissions": {
       "type": "array",
       "title": "Emissions",
+      "default": { "emissions": [{}] },
       "items": {
         "title": "Carbonate data",
         "type": "object",

--- a/bc_obps/reporting/json_schemas/2024/fuel_combustion_mobile/combustion_by_equipment.json
+++ b/bc_obps/reporting/json_schemas/2024/fuel_combustion_mobile/combustion_by_equipment.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "Fuel combustion by mobile equipment that is part of the facility",
+  "default": { "fuels": [{ "emissions": [{}] }] },
   "properties": {
     "fuels": {
       "title": "Fuel Data",

--- a/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/with_useful_energy.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "General stationary combustion of fuel or waste with production of useful energy",
+  "default": { "units": [{ "fuels": [{ "emissions": [{}] }] }] },
   "properties": {
     "units": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_excluding_line_tracing/without_useful_energy.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "General stationary combustion of waste without production of useful energy",
+  "default": { "units": [{ "fuels": [{ "emissions": [{}] }] }] },
   "properties": {
     "units": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/field_gas_process_vent_gas_at_lfo.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/field_gas_process_vent_gas_at_lfo.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "Field gas or process vent gas combustion at a linear facilities operation",
+  "default": { "units": [{ "fuels": [{ "emissions": [{}] }] }] },
   "properties": {
     "units": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/with_useful_energy.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "General stationary combustion of fuel or waste at a linear facilities operation resulting in the production of useful energy",
+  "default": { "units": [{ "fuels": [{ "emissions": [{}] }] }] },
   "properties": {
     "units": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_non_compression_non_combustion/without_useful_energy.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "General stationary combustion of fuel or waste at a linear facilities operation not resulting in the production of useful energy",
+  "default": { "units": [{ "fuels": [{ "emissions": [{}] }] }] },
   "properties": {
     "units": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "Field gas or process vent gas combustion at a linear facilities operation",
+  "default": { "units": [{ "fuels": [{ "emissions": [{}] }] }] },
   "properties": {
     "units": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "General stationary combustion of fuel or waste at a linear facilities operation resulting in the production of useful energy",
+  "default": { "units": [{ "fuels": [{ "emissions": [{}] }] }] },
   "properties": {
     "units": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "General stationary combustion of fuel or waste at a linear facilities operation not resulting in the production of useful energy",
+  "default": { "units": [{ "fuels": [{ "emissions": [{}] }] }] },
   "properties": {
     "units": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/with_useful_energy.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "General stationary combustion of fuel or waste with production of useful energy",
+  "default": { "units": [{ "fuels": [{ "emissions": [{}] }] }] },
   "properties": {
     "units": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_solely_for_line_tracing/without_useful_energy.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "General stationary combustion of waste without production of useful energy",
+  "default": { "units": [{ "fuels": [{ "emissions": [{}] }] }] },
   "properties": {
     "units": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/hydrogen_production/steam_reformation_or_gasification.json
+++ b/bc_obps/reporting/json_schemas/2024/hydrogen_production/steam_reformation_or_gasification.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "Steam reformation of hydrocarbons, partial oxidation of hydrocarbons or other transformation of hydrocarbon feedstock",
+  "default": { "emissions": [{}] },
   "properties": {
     "emissions": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/open_pit_coal_mining/coal_exposed_during_mining.json
+++ b/bc_obps/reporting/json_schemas/2024/open_pit_coal_mining/coal_exposed_during_mining.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "Coal when broken or exposed to the atmosphere during mining",
+  "default": { "emissions": [{}] },
   "properties": {
     "emissions": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/pulp_and_paper_production/pulp_and_paper_production.json
+++ b/bc_obps/reporting/json_schemas/2024/pulp_and_paper_production/pulp_and_paper_production.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "Emissions",
+  "default": { "emissions": [{}] },
   "properties": {
     "emissions": {
       "type": "array",

--- a/bc_obps/reporting/json_schemas/2024/refinery_fuel_gas/combustion_of_refinery_gas.json
+++ b/bc_obps/reporting/json_schemas/2024/refinery_fuel_gas/combustion_of_refinery_gas.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "Combustion of refinery fuel gas, still gas, flexigas or associated gas",
+  "default": { "fuels": [{ "emissions": [{}] }] },
   "properties": {
     "fuels": {
       "title": "Fuel Data",

--- a/bc_obps/reporting/json_schemas/2024/storage_of_petroleum_products/storage_of_petroleum_products.json
+++ b/bc_obps/reporting/json_schemas/2024/storage_of_petroleum_products/storage_of_petroleum_products.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "title": "Above-ground storage tanks",
+  "default": { "emissions": [{}] },
   "properties": {
     "emissions": {
       "type": "array",

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -5,23 +5,20 @@ import { actionHandler } from "@bciers/actions";
 import { Alert, Button } from "@mui/material";
 import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/ReportingTaskList";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
-import safeJsonParse from "@bciers/utils/src/safeJsonParse";
 import { FuelFields } from "./customFields/FuelFieldComponent";
 import { FieldProps } from "@rjsf/utils";
 import { getUiSchema } from "./uiSchemas/schemaMaps";
 import { UUID } from "crypto";
 import { withTheme } from "@rjsf/core";
 import formTheme from "@bciers/components/form/theme/defaultTheme";
+import { RJSFSchema } from "@rjsf/utils";
+import safeJsonParse from "@bciers/utils/src/safeJsonParse";
 
 const Form = withTheme(formTheme);
 
 const CUSTOM_FIELDS = {
   fuelType: (props: FieldProps) => <FuelFields {...props} />,
 };
-
-type EmptyWithUnits = { units: [{ fuels: [{ emissions: [{}] }] }] };
-type EmptyWithFuels = { fuels: [{ emissions: [{}] }] };
-type EmptyOnlyEmissions = { emissions: [{}] };
 
 interface Props {
   activityData: {
@@ -31,12 +28,10 @@ interface Props {
   activityFormData: object;
   currentActivity: { id: number; name: string; slug: string };
   taskListData: TaskListElement[];
-  defaultEmptySourceTypeState:
-    | EmptyWithUnits
-    | EmptyWithFuels
-    | EmptyOnlyEmissions;
   reportVersionId: number;
   facilityId: UUID;
+  initialJsonSchema: RJSFSchema;
+  initialSelectedSourceTypeIds: string[];
 }
 
 // 🧩 Main component
@@ -45,9 +40,10 @@ export default function ActivityForm({
   activityFormData,
   currentActivity,
   taskListData,
-  defaultEmptySourceTypeState,
   reportVersionId,
   facilityId,
+  initialJsonSchema,
+  initialSelectedSourceTypeIds,
 }: Readonly<Props>) {
   // 🐜 To display errors
   const [errorList, setErrorList] = useState([] as any[]);
@@ -56,77 +52,45 @@ export default function ActivityForm({
   // ✅ Success state for for the Submit button
   const [isSuccess, setIsSuccess] = useState(false);
   const [formState, setFormState] = useState(activityFormData as any);
-  const [jsonSchema, setJsonSchema] = useState({});
-  const [uiSchema, setUiSchema] = useState({});
-  const [previousActivityId, setPreviousActivityId] = useState<number>();
+  const [jsonSchema, setJsonSchema] = useState(initialJsonSchema);
+  const [selectedSourceTypeIds, setSelectedSourceTypeIds] = useState(
+    initialSelectedSourceTypeIds,
+  );
 
   const { activityId, sourceTypeMap } = activityData;
 
-  // Set useEffect dependency set from checked sourceTypes
-  const selectedSourceTypesArray = Object.values(sourceTypeMap).map(
-    (v) => formState?.[`${v}`] ?? false,
-  );
-  const numberOfSelectedSourceTypes = selectedSourceTypesArray.filter(
-    (x) => x === true,
-  ).length;
-  const dependencyArray = [numberOfSelectedSourceTypes, activityId];
-
   useEffect(() => {
-    let isFetching = true;
+    setJsonSchema(initialJsonSchema);
+    setFormState(activityFormData);
+    setSelectedSourceTypeIds(initialSelectedSourceTypeIds);
+  }, [currentActivity.id]);
 
-    const fetchSchemaData = async (
-      selectedSourceTypes: string,
-      selectedKeys: number[],
-    ) => {
-      // fetch data from server
-      const schemaData = await actionHandler(
-        `reporting/build-form-schema?activity=${activityId}&report_version_id=${reportVersionId}${selectedSourceTypes}`,
-        "GET",
-        "",
-      );
-      setJsonSchema(safeJsonParse(schemaData).schema);
-      const sourceTypeFormData = (formState?.sourceTypes as any) || {};
-      // Add an empty sourceType object by default if there is only one sourceType
-      if (Object.entries(sourceTypeMap).length === 1) {
-        sourceTypeFormData[`${Object.values(sourceTypeMap)[0]}`] =
-          defaultEmptySourceTypeState;
-      } else {
-        // Add an empty sourceType for each selected Source Type (show first item by default)
-        selectedKeys.forEach((k: number) => {
-          if (!formState?.sourceTypes?.[`${sourceTypeMap[k]}`])
-            sourceTypeFormData[`${sourceTypeMap[k]}`] =
-              defaultEmptySourceTypeState;
-        });
-      }
-      if (isFetching)
-        setFormState({ ...formState, sourceTypes: sourceTypeFormData });
-      setPreviousActivityId(activityId);
-      setUiSchema(getUiSchema(currentActivity.slug));
-    };
+  const validator = customizeValidator({});
 
-    let selectedSourceTypes = "";
-    const selectedKeys = [];
-    for (const [key, value] of Object.entries(sourceTypeMap)) {
-      if (formState?.[`${value}`]) {
-        selectedSourceTypes = selectedSourceTypes + `&source_types[]=${key}`;
-        selectedKeys.push(Number(key));
-      }
-    }
-    if (previousActivityId !== activityId) setFormState(activityFormData);
-    fetchSchemaData(selectedSourceTypes, selectedKeys);
-    return () => {
-      isFetching = false;
-    };
-  }, dependencyArray);
-
-  const customFormats = {
-    // Add any needed custom formats here like the example below
-    // phone: /\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}$/,
+  const fetchSchemaData = async (sourceTypeIds: string[]) => {
+    let sourceTypeQueryString = "";
+    sourceTypeIds.map((id) => {
+      sourceTypeQueryString += `&source_types[]=${id}`;
+    });
+    const schema = await actionHandler(
+      `reporting/build-form-schema?activity=${currentActivity.id}&report_version_id=${reportVersionId}${sourceTypeQueryString}`,
+      "GET",
+      "",
+    );
+    return schema;
   };
 
-  const validator = customizeValidator({ customFormats });
-
-  const handleFormChange = (c: any) => {
+  const handleFormChange = async (c: any) => {
+    const selectedSourceTypes = [];
+    // Checks for a change in source type selection & fetches the updated schema if they have changed.
+    for (const [k, v] of Object.entries(sourceTypeMap)) {
+      if (c.formData[`${v}`]) selectedSourceTypes.push(k);
+    }
+    if (selectedSourceTypes.length !== selectedSourceTypeIds.length) {
+      const schemaData = await fetchSchemaData(selectedSourceTypes);
+      setJsonSchema(safeJsonParse(schemaData).schema);
+      setSelectedSourceTypeIds(selectedSourceTypes);
+    }
     setFormState(c.formData);
   };
 
@@ -152,58 +116,45 @@ export default function ActivityForm({
     // 🛑 Set loading to false after the API call is completed
     setIsLoading(false);
 
-    // Apply new data to NextAuth JWT
-    console.log("SUBMITTED: ", JSON.stringify(data.formData, null, 2));
-    console.log("RESPONSE: ", response);
-
     if (response.error) {
       setErrorList([{ message: response.error }]);
       return;
     }
   };
 
-  const formIsLoading =
-    (Object.keys(jsonSchema).length === 0 &&
-      jsonSchema.constructor === Object) ||
-    previousActivityId !== activityId;
-
   return (
     <div className="w-full flex flex-row">
       <ReportingTaskList elements={taskListData} />
-      {formIsLoading ? (
-        "Loading Form..."
-      ) : (
-        <div className="w-full">
-          <Form
-            schema={jsonSchema}
-            fields={CUSTOM_FIELDS}
-            formData={formState}
-            uiSchema={uiSchema}
-            validator={validator}
-            onChange={handleFormChange}
-            onError={(e: any) => console.log("ERROR: ", e)}
-            onSubmit={submitHandler}
-          >
-            {errorList.length > 0 &&
-              errorList.map((e: any) => (
-                <Alert key={e.message} severity="error">
-                  {e?.stack ?? e.message}
-                </Alert>
-              ))}
-            <div className="flex justify-end gap-3">
-              {/* Disable the button when loading or when success state is true */}
-              <Button
-                variant="contained"
-                type="submit"
-                aria-disabled={isLoading}
-                disabled={isLoading}
-              >
-                {isSuccess ? "✅ Success" : "Submit"}
-              </Button>
-            </div>
-          </Form>
-        </div>
-      )}
+      <div className="w-full">
+        <Form
+          schema={jsonSchema}
+          fields={CUSTOM_FIELDS}
+          formData={formState}
+          uiSchema={getUiSchema(currentActivity.slug)}
+          validator={validator}
+          onChange={handleFormChange}
+          onError={(e: any) => console.log("ERROR: ", e)}
+          onSubmit={submitHandler}
+        >
+          {errorList.length > 0 &&
+            errorList.map((e: any) => (
+              <Alert key={e.message} severity="error">
+                {e?.stack ?? e.message}
+              </Alert>
+            ))}
+          <div className="flex justify-end gap-3">
+            {/* Disable the button when loading or when success state is true */}
+            <Button
+              variant="contained"
+              type="submit"
+              aria-disabled={isLoading}
+              disabled={isLoading}
+            >
+              {isSuccess ? "✅ Success" : "Submit"}
+            </Button>
+          </div>
+        </Form>
+      </div>
     </div>
   );
 }

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -6,12 +6,11 @@ import { Alert, Button } from "@mui/material";
 import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/ReportingTaskList";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import { FuelFields } from "./customFields/FuelFieldComponent";
-import { FieldProps } from "@rjsf/utils";
+import { FieldProps, RJSFSchema } from "@rjsf/utils";
 import { getUiSchema } from "./uiSchemas/schemaMaps";
 import { UUID } from "crypto";
 import { withTheme } from "@rjsf/core";
 import formTheme from "@bciers/components/form/theme/defaultTheme";
-import { RJSFSchema } from "@rjsf/utils";
 import safeJsonParse from "@bciers/utils/src/safeJsonParse";
 import debounce from "lodash.debounce";
 
@@ -70,7 +69,7 @@ export default function ActivityForm({
 
   const fetchSchemaData = async (sourceTypeIds: string[]) => {
     let sourceTypeQueryString = "";
-    sourceTypeIds.map((id) => {
+    sourceTypeIds.forEach((id) => {
       sourceTypeQueryString += `&source_types[]=${id}`;
     });
     const schema = await actionHandler(

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -59,14 +59,14 @@ export default function ActivityForm({
 
   const { activityId, sourceTypeMap } = activityData;
 
-  const arrayEquals = (a: string[], b: string[]) => {
-    a = a.sort();
-    b = b.sort();
+  const arrayEquals = (x: string[], y: string[]) => {
+    x = x.sort((a, b) => a.localeCompare(b));
+    y = y.sort((a, b) => a.localeCompare(b));
     return (
-      Array.isArray(a) &&
-      Array.isArray(b) &&
-      a.length === b.length &&
-      a.every((val, index) => val === b[index])
+      Array.isArray(x) &&
+      Array.isArray(y) &&
+      x.length === y.length &&
+      x.every((val, index) => val === y[index])
     );
   };
 
@@ -79,8 +79,9 @@ export default function ActivityForm({
   const validator = customizeValidator({});
 
   const fetchSchemaData = async (sourceTypeIds: string[]) => {
-    let sourceTypeQueryString = "";
-    sourceTypeIds.map((id) => `&source_types[]=${id}`).join();
+    const sourceTypeQueryString = sourceTypeIds
+      .map((id) => `&source_types[]=${id}`)
+      .join();
     const schema = await actionHandler(
       `reporting/build-form-schema?activity=${currentActivity.id}&report_version_id=${reportVersionId}${sourceTypeQueryString}`,
       "GET",

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -59,19 +59,28 @@ export default function ActivityForm({
 
   const { activityId, sourceTypeMap } = activityData;
 
+  const arrayEquals = (a: string[], b: string[]) => {
+    a = a.sort();
+    b = b.sort();
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((val, index) => val === b[index])
+    );
+  };
+
   useEffect(() => {
     setJsonSchema(initialJsonSchema);
     setFormState(activityFormData);
     setSelectedSourceTypeIds(initialSelectedSourceTypeIds);
-  }, [currentActivity.id]);
+  }, [currentActivity]);
 
   const validator = customizeValidator({});
 
   const fetchSchemaData = async (sourceTypeIds: string[]) => {
     let sourceTypeQueryString = "";
-    sourceTypeIds.forEach((id) => {
-      sourceTypeQueryString += `&source_types[]=${id}`;
-    });
+    sourceTypeIds.map((id) => `&source_types[]=${id}`).join();
     const schema = await actionHandler(
       `reporting/build-form-schema?activity=${currentActivity.id}&report_version_id=${reportVersionId}${sourceTypeQueryString}`,
       "GET",
@@ -86,7 +95,7 @@ export default function ActivityForm({
     for (const [k, v] of Object.entries(sourceTypeMap)) {
       if (c.formData[`${v}`]) selectedSourceTypes.push(k);
     }
-    if (selectedSourceTypes.length !== selectedSourceTypeIds.length) {
+    if (!arrayEquals(selectedSourceTypes, selectedSourceTypeIds)) {
       const schemaData = await fetchSchemaData(selectedSourceTypes);
       setJsonSchema(safeJsonParse(schemaData).schema);
       setSelectedSourceTypeIds(selectedSourceTypes);

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -13,6 +13,7 @@ import { withTheme } from "@rjsf/core";
 import formTheme from "@bciers/components/form/theme/defaultTheme";
 import { RJSFSchema } from "@rjsf/utils";
 import safeJsonParse from "@bciers/utils/src/safeJsonParse";
+import debounce from "lodash.debounce";
 
 const Form = withTheme(formTheme);
 
@@ -132,7 +133,7 @@ export default function ActivityForm({
           formData={formState}
           uiSchema={getUiSchema(currentActivity.slug)}
           validator={validator}
-          onChange={handleFormChange}
+          onChange={debounce(handleFormChange, 200)}
           onError={(e: any) => console.log("ERROR: ", e)}
           onSubmit={submitHandler}
         >

--- a/bciers/apps/reporting/src/app/components/activities/ActivityInit.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityInit.tsx
@@ -68,8 +68,10 @@ export default async function ActivityInit({
 
   let sourceTypeQueryString = "";
   for (const [k, v] of Object.entries(activityDataObject.sourceTypeMap)) {
-    if (formData[`${v}`]) sourceTypeIds.push(k);
-    sourceTypeQueryString += `&source_types[]=${k}`;
+    if (formData[`${v}`]) {
+      sourceTypeIds.push(k);
+      sourceTypeQueryString += `&source_types[]=${k}`;
+    }
   }
 
   const fetchSchema = async () => {

--- a/bciers/apps/reporting/src/app/components/activities/ActivityInit.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityInit.tsx
@@ -60,12 +60,7 @@ export default async function ActivityInit({
     currentActivityTaskListElement.isActive = true;
 
   // Determine which source types (if any) are selected in the loaded formData & fetch the jsonSchema accordingly
-  const sourceTypeObject = {} as any;
   const sourceTypeIds = [];
-  Object.values(activityDataObject.sourceTypeMap).forEach(
-    (v) => (sourceTypeObject[`${v}`] = formData[`${v}`] ? true : false),
-  );
-
   let sourceTypeQueryString = "";
   for (const [k, v] of Object.entries(activityDataObject.sourceTypeMap)) {
     if (formData[`${v}`]) {

--- a/bciers/apps/reporting/src/app/components/activities/ActivityInit.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityInit.tsx
@@ -1,7 +1,6 @@
 import { actionHandler } from "@bciers/actions";
 import { Suspense } from "react";
 import safeJsonParse from "@bciers/utils/src/safeJsonParse";
-import { defaultEmtpySourceTypeMap } from "./uiSchemas/schemaMaps";
 import ActivityForm from "./ActivityForm";
 import { UUID } from "crypto";
 import Loading from "@bciers/components/loading/SkeletonForm";
@@ -48,9 +47,6 @@ export default async function ActivityInit({
     currentActivity.id,
   );
 
-  const defaultEmptySourceTypeState =
-    defaultEmtpySourceTypeMap[currentActivity.slug];
-
   const taskListData = getFacilitiesInformationTaskList(
     versionId,
     facilityId,
@@ -63,6 +59,30 @@ export default async function ActivityInit({
   if (currentActivityTaskListElement)
     currentActivityTaskListElement.isActive = true;
 
+  // Determine which source types (if any) are selected in the loaded formData & fetch the jsonSchema accordingly
+  const sourceTypeObject = {} as any;
+  const sourceTypeIds = [];
+  Object.values(activityDataObject.sourceTypeMap).forEach(
+    (v) => (sourceTypeObject[`${v}`] = formData[`${v}`] ? true : false),
+  );
+
+  let sourceTypeQueryString = "";
+  for (const [k, v] of Object.entries(activityDataObject.sourceTypeMap)) {
+    if (formData[`${v}`]) sourceTypeIds.push(k);
+    sourceTypeQueryString += `&source_types[]=${k}`;
+  }
+
+  const fetchSchema = async () => {
+    const schema = await actionHandler(
+      `reporting/build-form-schema?activity=${currentActivity.id}&report_version_id=${versionId}${sourceTypeQueryString}`,
+      "GET",
+      "",
+    );
+    return schema;
+  };
+
+  const jsonSchema = await fetchSchema();
+
   return (
     <Suspense fallback={<Loading />}>
       <ActivityForm
@@ -70,9 +90,10 @@ export default async function ActivityInit({
         activityFormData={formData}
         currentActivity={currentActivity}
         taskListData={taskListData}
-        defaultEmptySourceTypeState={defaultEmptySourceTypeState}
         reportVersionId={versionId}
         facilityId={facilityId}
+        initialJsonSchema={safeJsonParse(jsonSchema).schema}
+        initialSelectedSourceTypeIds={sourceTypeIds}
       />
     </Suspense>
   );

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/schemaMaps.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/schemaMaps.tsx
@@ -14,14 +14,6 @@ type UiSchemaMap = {
   [key: string]: any;
 };
 
-type EmptyWithUnits = { units: [{ fuels: [{ emissions: [{}] }] }] };
-type EmptyWithFuels = { fuels: [{ emissions: [{}] }] };
-type EmptyOnlyEmissions = { emissions: [{}] };
-
-type DefaultEmptySourceTypeMap = {
-  [key: string]: EmptyWithUnits | EmptyWithFuels | EmptyOnlyEmissions;
-};
-
 // Activity slug & matching uiSchema
 export const uiSchemaMap: UiSchemaMap = {
   gsc_excluding_line_tracing: gscUiSchema,
@@ -40,24 +32,4 @@ export const uiSchemaMap: UiSchemaMap = {
 
 export const getUiSchema = (slug: string) => {
   return uiSchemaMap[slug];
-};
-
-const withUnits: EmptyWithUnits = { units: [{ fuels: [{ emissions: [{}] }] }] };
-const withFuels: EmptyWithFuels = { fuels: [{ emissions: [{}] }] };
-const onlyEmissions: EmptyOnlyEmissions = { emissions: [{}] };
-
-// Activity slug & matching shape of an empty Source Type
-export const defaultEmtpySourceTypeMap: DefaultEmptySourceTypeMap = {
-  gsc_excluding_line_tracing: withUnits,
-  gsc_solely_for_line_tracing: withUnits,
-  gsc_other_than_non_compression: withUnits,
-  gsc_non_compression: withUnits,
-  fuel_combustion_by_mobile: withFuels,
-  hydrogen_production: onlyEmissions,
-  pulp_and_paper: onlyEmissions,
-  refinery_fuel_gas: withFuels,
-  carbonate_use: onlyEmissions,
-  open_pit_coal_mining: onlyEmissions,
-  storage_petro_products: onlyEmissions,
-  aluminum_production: onlyEmissions,
 };

--- a/bciers/apps/reporting/src/tests/components/activities/ActivityForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/activities/ActivityForm.test.tsx
@@ -1,9 +1,7 @@
 import { act, render, screen } from "@testing-library/react";
 import { describe, expect, vi, it, beforeEach } from "vitest";
 import ActivityForm from "@reporting/src/app/components/activities/ActivityForm";
-import { actionHandler } from "@bciers/testConfig/mocks";
 
-type EmptyWithUnits = { units: [{ fuels: [{ emissions: [{}] }] }] };
 // Mock data
 const mockActivityData = {
   activityId: 1,
@@ -13,12 +11,9 @@ const mockActivityData = {
   },
 };
 
-const mockReportDate = "2024-01-01";
 const mockUUID = " 00000000-0000-0000-0000-000000000001";
 
-const mockdefaultSourceType = { units: [{ fuels: [{ emissions: [{}] }] }] };
-
-const response = {
+const activitySchema = {
   schema: {
     type: "object",
     title: "General stationary combustion excluding line tracing",
@@ -43,7 +38,6 @@ describe("ActivityForm component", () => {
   });
 
   it("renders the activity schema", async () => {
-    actionHandler.mockReturnValueOnce(JSON.stringify(response));
     render(
       <ActivityForm
         activityData={mockActivityData}
@@ -53,10 +47,11 @@ describe("ActivityForm component", () => {
           slug: "gsc_excluding_line_tracing",
         }}
         taskListData={[]}
-        reportDate={mockReportDate}
-        defaultEmptySourceTypeState={mockdefaultSourceType as EmptyWithUnits}
+        activityFormData={{}}
+        initialJsonSchema={activitySchema}
         reportVersionId={1}
         facilityId={mockUUID}
+        initialSelectedSourceTypeIds={[]}
       />,
     );
     await act(async () => {
@@ -64,11 +59,11 @@ describe("ActivityForm component", () => {
     });
 
     // Check if the source type booleans are rendered
-    expect(screen.getAllByText(/First Test Source Type Title/i).length).toBe(2);
-    expect(screen.getAllByText(/Second Title/i).length).toBe(2);
+    expect(screen.getAllByText(/First Test Source Type Title/i).length).toBe(1);
+    expect(screen.getAllByText(/Second Title/i).length).toBe(1);
   });
   it("renders the sourceType schema", async () => {
-    const response2 = {
+    const sourceTypeSchema = {
       schema: {
         type: "object",
         title: "General stationary combustion excluding line tracing",
@@ -102,7 +97,6 @@ describe("ActivityForm component", () => {
         },
       },
     };
-    actionHandler.mockReturnValueOnce(JSON.stringify(response2));
     render(
       <ActivityForm
         activityData={mockActivityData}
@@ -112,10 +106,11 @@ describe("ActivityForm component", () => {
           slug: "gsc_excluding_line_tracing",
         }}
         taskListData={[]}
-        reportDate={mockReportDate}
-        defaultEmptySourceTypeState={mockdefaultSourceType as EmptyWithUnits}
+        activityFormData={{}}
+        initialJsonSchema={sourceTypeSchema}
         reportVersionId={1}
         facilityId={mockUUID}
+        initialSelectedSourceTypeIds={[]}
       />,
     );
     await act(async () => {
@@ -123,7 +118,7 @@ describe("ActivityForm component", () => {
     });
 
     // Check if the units array within the source type schema is rendered
-    expect(screen.getAllByText(/Unit/i).length).toBe(1);
+    expect(screen.getAllByText(/test field/i).length).toBe(1);
   });
 
   // Will need additional tests once we're passing formData into this component & saving formData out of it


### PR DESCRIPTION
This PR addresses the clunky useEffect() in the ActivityForm component that was causing formState to be persisted across activity pages.

- Moves the responsibility of fetching the initial json schema to the ActivityInit component
- Removes the need to dynamically apply a `defaultEmptyFormState`, this has been moved into the schemas themselves as a default attribute. So the first source type form will still render by default.
- The useEffect() function in ActivityForm has been pared down to just a couple stateful updates that apply when the activity id changes in that component & the isFetching() async stuff is gone.
- The handleChange() function compares the length of a stateful array of selected source type IDs vs how many are checked when the RJSF onChange fires. If there is a mismatch, it triggers a re-fetch of the json schema and sets the new set of IDs in state.
- Added a debounce to the onChange function call, the inputs were feeling a little choppy locally


Testing the fix / improvements:
- Create a report with a few selected activities (I suggest at least one GSC, since they have source types to select/deselect)
- Select a source type, enter data & save.
- Move on to the next activity, enter data & save. <-- _This was where the error from persisted formState was firing_
- Go back to the first activity, the data that was saved should show up
- Check another source type (the new source type should load)