### PR TITLE
2337 fix reg products

### DIFF
--- a/bciers/apps/registration/app/data/jsonSchema/operationInformation/registrationPurpose.ts
+++ b/bciers/apps/registration/app/data/jsonSchema/operationInformation/registrationPurpose.ts
@@ -5,7 +5,10 @@ import {
   getRegistrationPurposes,
   getRegulatedProducts,
 } from "@bciers/actions/api";
-import { RegistrationPurposes } from "@/registration/app/components/operations/registration/enums";
+import {
+  RegistrationPurposes,
+  regulatedOperationPurposes,
+} from "@/registration/app/components/operations/registration/enums";
 import { UUID } from "crypto";
 import SectionFieldTemplate from "@bciers/components/form/fields/SectionFieldTemplate";
 import {
@@ -62,10 +65,9 @@ export const createRegistrationPurposeSchema = async () => {
 
     dependencies: {
       registration_purpose: {
-        oneOf: registrationPurposes.map((purpose: string) => {
+        oneOf: registrationPurposes.map((purpose: RegistrationPurposes) => {
           const isRegulatedProducts =
-            purpose !== RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION &&
-            purpose !== RegistrationPurposes.POTENTIAL_REPORTING_OPERATION;
+            regulatedOperationPurposes.includes(purpose);
           return {
             ...(isRegulatedProducts && { required: ["regulated_products"] }),
             properties: {

--- a/bciers/apps/registration/tests/components/operations/OperationRegistrationPage.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/OperationRegistrationPage.test.tsx
@@ -5,6 +5,7 @@ import {
   useSearchParams,
   useSession,
 } from "@bciers/testConfig/mocks";
+import { regulatedOperationPurposes } from "@/registration/app/components/operations/registration/enums";
 
 export const fetchFormEnums = () => {
   // Regulated products
@@ -23,9 +24,10 @@ export const fetchFormEnums = () => {
   ]);
   // Purposes
   actionHandler.mockResolvedValueOnce([
-    "New Entrant Application",
+    ...regulatedOperationPurposes,
+    "Reporting Operation",
     "Potential Reporting Operation",
-    "OBPS Regulated Operation",
+    "Electricity Import Operation",
   ]);
   // Naics codes
   actionHandler.mockResolvedValueOnce([

--- a/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
@@ -113,10 +113,7 @@ describe("the OperationInformationForm component", () => {
       const purposeInput = screen.getByRole("combobox", {
         name: /The purpose of this registration+/i,
       });
-      await fillComboboxWidgetField(
-        purposeInput,
-        "Potential Reporting Operation",
-      );
+      await fillComboboxWidgetField(purposeInput, "Reporting Operation");
 
       expect(
         screen.queryByPlaceholderText(/select regulated product/i),
@@ -162,7 +159,7 @@ describe("the OperationInformationForm component", () => {
           "",
           {
             body: JSON.stringify({
-              registration_purpose: "Potential Reporting Operation",
+              registration_purpose: "Reporting Operation",
               operation: "b974a7fc-ff63-41aa-9d57-509ebe2553a4",
               name: "Existing Operation edited",
               type: "Single Facility Operation",


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=82482715&issue=bcgov%7Ccas-registration%7C2337

This PR:
- conditionally show the regulated products dropdown based on whether the purpose is in the regulated operations array
- regression test