### PR TITLE
chore: added contact page to open in new tab

### DIFF
--- a/bciers/apps/reporting/src/data/jsonSchema/personResponsibleInfoText.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/personResponsibleInfoText.tsx
@@ -14,6 +14,8 @@ export const infoNote = (
         it here in{" "}
         <Link
           href="/administration/contacts"
+          target="_blank"
+          rel="noopener noreferrer"
           sx={{ color: "inherit", textDecoration: "none" }}
         >
           Contacts.


### PR DESCRIPTION
Card: N/A
A quick PR , so that when user clicks on contact on Person Responsible page, it opens it in a new tab. 