### PR TITLE
reporting buttons fixes

### DIFF
--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user/reports/[version_id]/sign-off/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user/reports/[version_id]/sign-off/page.tsx
@@ -1,5 +1,4 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 import SignOffPage from "@reporting/src/app/components/signOff/SignOffPage";
 
-export default async function Page() {
-  return <SignOffPage />;
-}
+export default defaultPageFactory(SignOffPage);

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/reports/[version_id]/sign-off/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/reports/[version_id]/sign-off/page.tsx
@@ -1,5 +1,4 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 import SignOffPage from "@reporting/src/app/components/signOff/SignOffPage";
 
-export default async function Page() {
-  return <SignOffPage />;
-}
+export default defaultPageFactory(SignOffPage);

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -119,7 +119,7 @@ export default function ActivityForm({
     if (taskListLength && step === -1) step = taskListLength - 1;
 
     if (step === 0 && !isContinue)
-      return `/reports/${reportVersionId}/facilities/${facilityId}/review?facilities_title=Facility`; // Facility review page
+      return `/reports/${reportVersionId}/facilities/${facilityId}/review`; // Facility review page
     if (taskListLength && step + 1 >= taskListLength && isContinue)
       return "non-attributable"; // Activities done, go to Non-attributable emissions
 

--- a/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
@@ -108,7 +108,7 @@ export default function AdditionalReportingDataForm({
         setFormData(data.formData);
       }}
       onSubmit={(data: any) => handleSubmit(data.formData)}
-      continueUrl={""}
+      continueUrl={saveAndContinueUrl}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
@@ -108,7 +108,7 @@ export default function AdditionalReportingDataForm({
         setFormData(data.formData);
       }}
       onSubmit={(data: any) => handleSubmit(data.formData)}
-      continueUrl={saveAndContinueUrl}
+      continueUrl={""}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
@@ -4,16 +4,13 @@ import React, { useState } from "react";
 import MultiStepFormWithTaskList from "@bciers/components/form/MultiStepFormWithTaskList";
 import { RJSFSchema } from "@rjsf/utils";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
-import { useRouter } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import {
   additionalReportingDataSchema,
   additionalReportingDataUiSchema,
   additionalReportingDataWithElectricityGeneratedSchema,
 } from "@reporting/src/data/jsonSchema/additionalReportingData/additionalReportingData";
 import { actionHandler } from "@bciers/actions";
-
-const baseUrl = "/reports";
-const cancelUrl = "/reports";
 
 interface AdditionalReportingDataProps {
   versionId: number;
@@ -43,8 +40,10 @@ export default function AdditionalReportingDataForm({
       capture_emissions: false,
     },
   });
-
-  const router = useRouter();
+  // 🛸 Set up routing urls
+  const searchParams = useSearchParams();
+  const facilityId = searchParams.get("facility_id");
+  const backUrl = `/reports/${versionId}/facilities/${facilityId}/allocation-of-emissions`;
   const saveAndContinueUrl = `/reports/${versionId}/new-entrant-information`;
 
   const schema: RJSFSchema = includeElectricityGenerated
@@ -80,12 +79,9 @@ export default function AdditionalReportingDataForm({
       ...data.additional_data_section,
     };
 
-    const response = await actionHandler(endpoint, method, endpoint, {
+    await actionHandler(endpoint, method, endpoint, {
       body: JSON.stringify(payload),
     });
-    if (response) {
-      router.push(saveAndContinueUrl);
-    }
   };
 
   return (
@@ -102,13 +98,13 @@ export default function AdditionalReportingDataForm({
       schema={schema}
       uiSchema={additionalReportingDataUiSchema}
       formData={formData}
-      baseUrl={baseUrl}
-      cancelUrl={cancelUrl}
+      cancelUrl="#"
+      backUrl={backUrl}
       onChange={(data: any) => {
         setFormData(data.formData);
       }}
       onSubmit={(data: any) => handleSubmit(data.formData)}
-      continueUrl={""}
+      continueUrl={saveAndContinueUrl}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/attachments/AttachmentsForm.tsx
+++ b/bciers/apps/reporting/src/app/components/attachments/AttachmentsForm.tsx
@@ -23,7 +23,7 @@ const AttachmentsForm: React.FC<Props> = ({
 }) => {
   const router = useRouter();
   const saveAndContinueUrl = `/reports/${version_id}/final-review`;
-  const backURL = `/reports/${version_id}/verification`;
+  const backUrl = `/reports/${version_id}/verification`;
 
   const [canContinue, setCanContinue] = useState<boolean>(false);
   const [isSaving, setIsSaving] = useState<boolean>(false);
@@ -112,7 +112,7 @@ const AttachmentsForm: React.FC<Props> = ({
         taskListElements={taskListElements}
         onSubmit={submitExternallyToContinue}
         cancelUrl="#"
-        backUrl={backURL}
+        backUrl={backUrl}
         continueUrl={saveAndContinueUrl}
         error={error}
         isSaving={isSaving}

--- a/bciers/apps/reporting/src/app/components/attachments/AttachmentsForm.tsx
+++ b/bciers/apps/reporting/src/app/components/attachments/AttachmentsForm.tsx
@@ -3,7 +3,7 @@ import { multiStepHeaderSteps } from "../taskList/multiStepHeaderConfig";
 import { HasReportVersion } from "../../utils/defaultPageFactoryTypes";
 import postAttachments from "@reporting/src/app/utils/postAttachments";
 import AttachmentElement from "./AttachmentElement";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { UploadedAttachment } from "./types";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import MultiStepWrapperWithTaskList from "@bciers/components/form/MultiStepWrapperWithTaskList";
@@ -23,6 +23,11 @@ const AttachmentsForm: React.FC<Props> = ({
 }) => {
   const router = useRouter();
   const saveAndContinueUrl = `/reports/${version_id}/final-review`;
+  const backURL = `/reports/${version_id}/verification`;
+
+  const [canContinue, setCanContinue] = useState<boolean>(false);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [isRedirecting, setIsRedirecting] = useState<boolean>(false);
 
   const [error, setError] = useState<string>();
   const [pendingUploadFiles, setPendingUploadFiles] = useState<{
@@ -40,9 +45,13 @@ const AttachmentsForm: React.FC<Props> = ({
 
   const handleSubmit = async () => {
     // Nothing to submit
-    if (Object.keys(pendingUploadFiles).length === 0) return;
+    if (Object.keys(pendingUploadFiles).length === 0) {
+      if (canContinue) router.push(saveAndContinueUrl);
+      else return;
+    }
 
     const formData = new FormData();
+    setIsSaving(true);
 
     for (const [fileType, file] of Object.entries(pendingUploadFiles)) {
       formData.append("files", file);
@@ -53,9 +62,13 @@ const AttachmentsForm: React.FC<Props> = ({
 
     if (response.error) {
       setError(response.error);
-    } else {
+    }
+
+    if (canContinue) {
+      setIsRedirecting(true);
       router.push(saveAndContinueUrl);
     }
+    setIsSaving(false);
   };
 
   // Returns the id of the file if it has been saved,
@@ -82,16 +95,29 @@ const AttachmentsForm: React.FC<Props> = ({
     />
   );
 
+  const submitExternallyToContinue = () => {
+    setCanContinue(true);
+  }; // Only submit after canContinue is set so the submitHandler can read the boolean
+  useEffect(() => {
+    if (canContinue) {
+      handleSubmit();
+    }
+  }, [canContinue]);
+
   return (
     <>
       <MultiStepWrapperWithTaskList
         steps={multiStepHeaderSteps}
         initialStep={4}
         taskListElements={taskListElements}
-        onSubmit={handleSubmit}
+        onSubmit={submitExternallyToContinue}
         cancelUrl="#"
-        submittingButtonText="Uploading..."
+        backUrl={backURL}
+        continueUrl={saveAndContinueUrl}
         error={error}
+        isSaving={isSaving}
+        isRedirecting={isRedirecting}
+        noFormSave={handleSubmit}
       >
         <p>
           Please upload any of the documents below that is applicable to your

--- a/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummary.tsx
+++ b/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummary.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { Box, Button } from "@mui/material";
+import { Box } from "@mui/material";
 import MultiStepHeader from "@bciers/components/form/components/MultiStepHeader";
 import FormBase from "@bciers/components/form/FormBase";
 import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/ReportingTaskList";
@@ -9,7 +9,7 @@ import {
   complianceSummaryUiSchema,
   complianceSummarySchema,
 } from "@reporting/src/data/jsonSchema/complianceSummary";
-import Link from "next/link";
+import ReportingStepButtons from "@bciers/components/form/components/ReportingStepButtons";
 
 interface Props {
   versionId: number;
@@ -51,7 +51,7 @@ const ComplianceSummary: React.FC<Props> = ({
   ];
 
   const backRef = `/reports/${versionId}/additional-reporting-data`;
-  const continueRef = `/reports/${versionId}/sign-off`;
+  const continueRef = `/reports/${versionId}/verification`;
 
   return (
     <Box sx={{ p: 3 }}>
@@ -66,16 +66,11 @@ const ComplianceSummary: React.FC<Props> = ({
             uiSchema={complianceSummaryUiSchema}
             formData={summaryFormData}
           >
-            <Box display="flex" justifyContent="space-between" mt={3}>
-              <Link href={backRef} passHref>
-                <Button variant="outlined">Back</Button>
-              </Link>
-              <Link href={continueRef} passHref>
-                <Button variant="contained" color="primary">
-                  Continue
-                </Button>
-              </Link>
-            </Box>
+            <ReportingStepButtons
+              backUrl={backRef}
+              continueUrl={continueRef}
+              saveButtonDisabled={true}
+            />
           </FormBase>
         </div>
       </div>

--- a/bciers/apps/reporting/src/app/components/datagrid/models/operations/operationColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/operations/operationColumns.tsx
@@ -83,11 +83,7 @@ const ActionCell = (params: GridRenderCellParams) => {
     return (
       <Button
         color="primary"
-        onClick={() =>
-          router.push(
-            `reports/${reportId}/review-operator-data?reports_title=${params.row.name}`,
-          )
-        }
+        onClick={() => router.push(`reports/${reportId}/review-operator-data`)}
       >
         Continue
       </Button>
@@ -103,9 +99,7 @@ const ActionCell = (params: GridRenderCellParams) => {
           OperationId,
           reportingYearObj.reporting_year,
         );
-        router.push(
-          `reports/${newReportId}/review-operator-data?reports_title=${params.row.name}`,
-        );
+        router.push(`reports/${newReportId}/review-operator-data`);
       }}
     >
       Start

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import serializeSearchParams from "@bciers/utils/src/serializeSearchParams";
 import { actionHandler } from "@bciers/actions";
 import safeJsonParse from "@bciers/utils/src/safeJsonParse";
@@ -114,10 +114,10 @@ export default function FacilityEmissionAllocationForm({
   const [error, setError] = useState<string | undefined>();
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
 
-  const router = useRouter();
   const searchParams = useSearchParams();
   const queryString = serializeSearchParams(searchParams);
-  const saveAndContinueUrl = `/reports/${version_id}/facilities/${facility_id}/additional-reporting-data${queryString}`;
+  const saveAndContinueUrl = `/reports/${version_id}/additional-reporting-data${queryString}`;
+  const backURL = `/reports/${version_id}/facilities/${facility_id}/production-data${queryString}`;
 
   // 📋 Get the task list elements for the form
   const taskListElements = getFacilitiesInformationTaskList(
@@ -236,8 +236,6 @@ export default function FacilityEmissionAllocationForm({
     setSubmitButtonDisabled(false);
     if (response?.error) {
       setError(response.error);
-    } else {
-      router.push(saveAndContinueUrl);
     }
   };
 
@@ -252,6 +250,7 @@ export default function FacilityEmissionAllocationForm({
       submitButtonDisabled={submitButtonDisabled}
       baseUrl="#"
       cancelUrl="#"
+      backUrl={backURL}
       onChange={handleChange}
       onSubmit={handleSubmit}
       error={error}

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
-import serializeSearchParams from "@bciers/utils/src/serializeSearchParams";
 import { actionHandler } from "@bciers/actions";
 import safeJsonParse from "@bciers/utils/src/safeJsonParse";
 import MultiStepFormWithTaskList from "@bciers/components/form/MultiStepFormWithTaskList";
@@ -114,10 +112,9 @@ export default function FacilityEmissionAllocationForm({
   const [error, setError] = useState<string | undefined>();
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
 
-  const searchParams = useSearchParams();
-  const queryString = serializeSearchParams(searchParams);
-  const saveAndContinueUrl = `/reports/${version_id}/additional-reporting-data${queryString}`;
-  const backURL = `/reports/${version_id}/facilities/${facility_id}/production-data${queryString}`;
+  // 🛸 Set up routing urls
+  const backUrl = `/reports/${version_id}/facilities/${facility_id}/production-data`;
+  const saveAndContinueUrl = `/reports/${version_id}/additional-reporting-data?facility_id=${facility_id}`;
 
   // 📋 Get the task list elements for the form
   const taskListElements = getFacilitiesInformationTaskList(
@@ -250,7 +247,7 @@ export default function FacilityEmissionAllocationForm({
       submitButtonDisabled={submitButtonDisabled}
       baseUrl="#"
       cancelUrl="#"
-      backUrl={backURL}
+      backUrl={backUrl}
       onChange={handleChange}
       onSubmit={handleSubmit}
       continueUrl={saveAndContinueUrl}

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -24,7 +24,7 @@ interface Props {
 
 interface Product {
   allocated_quantity: number;
-  product_id: number;
+  report_product_id: number;
   product_name: string;
 }
 
@@ -144,7 +144,7 @@ export default function FacilityEmissionAllocationForm({
     ];
     let errorMessage;
 
-    // Initialize a map to store total allocated quantities by product_id
+    // Initialize a map to store total allocated quantities by report_product_id
     const productAllocations: Record<string, number> = {};
 
     // Iterate through each category and recalculate allocated emissions data for the category
@@ -156,9 +156,10 @@ export default function FacilityEmissionAllocationForm({
             const allocatedQuantity =
               parseFloat(product.allocated_quantity as any) || 0;
 
-            // Accumulate the allocated quantity for this product_id
-            productAllocations[product.product_id] =
-              (productAllocations[product.product_id] || 0) + allocatedQuantity;
+            // Accumulate the allocated quantity for this report_product_id
+            productAllocations[product.report_product_id] =
+              (productAllocations[product.report_product_id] || 0) +
+              allocatedQuantity;
 
             return {
               ...product,
@@ -173,11 +174,11 @@ export default function FacilityEmissionAllocationForm({
     if (updatedFormData.total_emission_allocations?.products) {
       updatedFormData.total_emission_allocations.products =
         updatedFormData.total_emission_allocations.products.map(
-          (product: { product_id: number }) => ({
+          (product: { report_product_id: number }) => ({
             ...product,
             allocated_quantity: String(
               parseFloat(
-                (productAllocations[product.product_id] || 0).toFixed(4),
+                (productAllocations[product.report_product_id] || 0).toFixed(4),
               ),
             ),
           }),
@@ -233,7 +234,6 @@ export default function FacilityEmissionAllocationForm({
       body: JSON.stringify(payload),
     });
 
-    setSubmitButtonDisabled(false);
     if (response?.error) {
       setError(response.error);
     }
@@ -253,8 +253,8 @@ export default function FacilityEmissionAllocationForm({
       backUrl={backURL}
       onChange={handleChange}
       onSubmit={handleSubmit}
-      error={error}
       continueUrl={saveAndContinueUrl}
+      error={error}
       formContext={{
         facility_emission_data: formData.basic_emission_allocation_data.concat(
           formData.fuel_excluded_emission_allocation_data,

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -196,7 +196,6 @@ export default function FacilityEmissionAllocationForm({
 
   // 🛠️ Handle form submit
   const handleSubmit = async () => {
-    setSubmitButtonDisabled(true);
     // Transform formData to match the schema in structure
     const transformedPayload = {
       allocation_methodology: formData.allocation_methodology,
@@ -245,7 +244,6 @@ export default function FacilityEmissionAllocationForm({
       uiSchema={emissionAllocationUiSchema}
       formData={formData}
       submitButtonDisabled={submitButtonDisabled}
-      baseUrl="#"
       cancelUrl="#"
       backUrl={backUrl}
       onChange={handleChange}

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReview.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReview.tsx
@@ -60,8 +60,7 @@ const FacilityReview: React.FC<Props> = ({ version_id, facility_id }) => {
   });
   const [activityList, setActivityList] = useState<Activity[]>([]);
   const queryString = serializeSearchParams(useSearchParams());
-  const reportsTitle = useSearchParams().get("reports_title");
-  const backUrl = `/reports/${version_id}/person-responsible?reports_title=${reportsTitle}`;
+  const backUrl = `/reports/${version_id}/person-responsible`;
   const continueURL = `activities${queryString}`;
   const router = useRouter();
   const formRef = useRef<FormContext>(null);
@@ -153,7 +152,6 @@ const FacilityReview: React.FC<Props> = ({ version_id, facility_id }) => {
         }, 3000);
       }
     } catch (error: any) {
-      console.error("Error updating facility:", error);
       setErrorList([error.message || "An error occurred"]);
     } finally {
       setIsSaving(false);

--- a/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
@@ -13,7 +13,7 @@ interface Props extends HasReportVersion {
 const FinalReviewForm: React.FC<Props> = ({ version_id, taskListElements }) => {
   const router = useRouter();
   const saveAndContinueUrl = `/reports/${version_id}/sign-off`;
-  const backURL = `/reports/${version_id}/attachments`;
+  const backUrl = `/reports/${version_id}/attachments`;
 
   const submitHandler = async () => {
     router.push(saveAndContinueUrl);
@@ -26,7 +26,7 @@ const FinalReviewForm: React.FC<Props> = ({ version_id, taskListElements }) => {
       onSubmit={submitHandler}
       taskListElements={taskListElements}
       cancelUrl="#"
-      backUrl={backURL}
+      backUrl={backUrl}
       continueUrl={saveAndContinueUrl}
     >
       Placeholder for Final Review

--- a/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
@@ -13,6 +13,7 @@ interface Props extends HasReportVersion {
 const FinalReviewForm: React.FC<Props> = ({ version_id, taskListElements }) => {
   const router = useRouter();
   const saveAndContinueUrl = `/reports/${version_id}/sign-off`;
+  const backURL = `/reports/${version_id}/attachments`;
 
   const submitHandler = async () => {
     router.push(saveAndContinueUrl);
@@ -25,6 +26,8 @@ const FinalReviewForm: React.FC<Props> = ({ version_id, taskListElements }) => {
       onSubmit={submitHandler}
       taskListElements={taskListElements}
       cancelUrl="#"
+      backUrl={backURL}
+      continueUrl={saveAndContinueUrl}
     >
       Placeholder for Final Review
       <br />

--- a/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect, useState } from "react";
 import MultiStepFormWithTaskList from "@bciers/components/form/MultiStepFormWithTaskList";
 import { RJSFSchema } from "@rjsf/utils";
-import { useSearchParams } from "next/navigation";
 import {
   operationReviewSchema,
   operationReviewUiSchema,
@@ -13,7 +12,6 @@ import { TaskListElement } from "@bciers/components/navigation/reportingTaskList
 import { actionHandler } from "@bciers/actions";
 import { formatDate } from "@reporting/src/app/utils/formatDate";
 import safeJsonParse from "@bciers/utils/src/safeJsonParse";
-import serializeSearchParams from "@bciers/utils/src/serializeSearchParams";
 
 interface Props {
   formData: any;

--- a/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
@@ -35,9 +35,6 @@ interface Props {
   };
 }
 
-const baseUrl = "/reports";
-const cancelUrl = "/reports";
-
 export default function OperationReview({
   formData,
   version_id,
@@ -53,8 +50,10 @@ export default function OperationReview({
   const [formDataState, setFormDataState] = useState<any>(formData);
   const [facilityId, setFacilityId] = useState<number | null>(null);
   const [operationType, setOperationType] = useState("");
-  const queryString = serializeSearchParams(useSearchParams());
-  const continueUrl = `/reporting/reports/${version_id}/person-responsible${queryString}`;
+
+  // 🛸 Set up routing urls
+  const backUrl = `/reports`;
+  const saveAndContinueUrl = `/reports/${version_id}/person-responsible`;
 
   const reportingWindowEnd = formatDate(
     reportingYear.reporting_window_end,
@@ -158,7 +157,7 @@ export default function OperationReview({
     reportVersionId: number,
   ) => {
     const method = "POST";
-    const endpoint = `reporting/report-version/${reportVersionId}/report-operation`;
+    const endpoint = `/reporting/report-version/${reportVersionId}/report-operation`;
 
     const formDataObject = safeJsonParse(JSON.stringify(data.formData));
     const preparedData = prepareFormData(formDataObject);
@@ -217,12 +216,11 @@ export default function OperationReview({
       schema={schema}
       uiSchema={uiSchema}
       formData={formDataState}
-      baseUrl={baseUrl}
-      cancelUrl={cancelUrl}
+      cancelUrl="#"
       onSubmit={(data: { formData?: any }) => saveHandler(data, version_id)}
       onChange={onChangeHandler}
-      backUrl={cancelUrl}
-      continueUrl={continueUrl}
+      backUrl={backUrl}
+      continueUrl={saveAndContinueUrl}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsible.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsible.tsx
@@ -14,12 +14,10 @@ import {
   Contact,
   ContactRow,
 } from "@reporting/src/app/components/operations/types";
-import { useSearchParams } from "next/navigation";
 import { actionHandler } from "@bciers/actions";
 import { createPersonResponsibleSchema } from "@reporting/src/app/components/operations/personResponsible/createPersonResponsibleSchema";
 import { getReportingPersonResponsible } from "@reporting/src/app/utils/getReportingPersonResponsible";
 import { getFacilityReport } from "@reporting/src/app/utils/getFacilityReport";
-import serializeSearchParams from "@bciers/utils/src/serializeSearchParams";
 
 interface Props {
   version_id: number;
@@ -42,12 +40,11 @@ const PersonResponsible = ({ version_id }: Props) => {
 
   const [schema, setSchema] = useState<RJSFSchema>(personResponsibleSchema);
 
-  const queryString = serializeSearchParams(useSearchParams());
   const continueUrl =
     operationType === "Linear Facility Operation"
-      ? `/reporting/reports/${version_id}/facilities/lfo-facilities${queryString}`
-      : `/reporting/reports/${version_id}/facilities/${facilityId}/review${queryString}&facilities_title=Facility`;
-  const backUrl = `/reports/${version_id}/review-operator-data${queryString}`;
+      ? `/reports/${version_id}/facilities/lfo-facilities`
+      : `/reports/${version_id}/facilities/${facilityId}/review`;
+  const backUrl = `/reports/${version_id}/review-operator-data`;
 
   const taskListElements: TaskListElement[] = [
     {

--- a/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsible.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsible.tsx
@@ -227,7 +227,6 @@ const PersonResponsible = ({ version_id }: Props) => {
         formData={formData}
         onChange={handleContactSelect}
         onSubmit={handleSave}
-        saveButtonDisabled={!selectedContactId}
       />
     </>
   );

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -7,7 +7,6 @@ import { productionDataUiSchema } from "@reporting/src/data/jsonSchema/productio
 import { ProductData } from "@bciers/types/form/productionData";
 import { postProductionData } from "@bciers/actions/api";
 import { multiStepHeaderSteps } from "../taskList/multiStepHeaderConfig";
-import { useRouter } from "next/navigation";
 
 interface Props {
   report_version_id: number;
@@ -26,10 +25,6 @@ const ProductionDataForm: React.FC<Props> = ({
   initialData,
   taskListElements,
 }) => {
-  const router = useRouter();
-
-  const saveAndContinueUrl = `reports/${report_version_id}/facilities/${facility_id}/allocation-of-emissions`;
-
   const initialFormData = {
     product_selection: initialData.map((i) => i.product_name),
     production_data: initialData,
@@ -60,12 +55,10 @@ const ProductionDataForm: React.FC<Props> = ({
       facility_id,
       data.production_data,
     );
-
-    router.push(saveAndContinueUrl);
   };
 
   const backURL = `/reports/${report_version_id}/facilities/${facility_id}/emission-summary`;
-  const continueURL = `/reports/${report_version_id}/facilities/${facility_id}/allocation-of-emissions`; // Update when page complete
+  const saveAndContinueUrl = `/reports/${report_version_id}/facilities/${facility_id}/allocation-of-emissions`;
 
   return (
     <MultiStepFormWithTaskList
@@ -77,10 +70,10 @@ const ProductionDataForm: React.FC<Props> = ({
       formData={formData}
       baseUrl={"#"}
       cancelUrl={"#"}
+      backUrl={backURL}
       onSubmit={(data) => onSubmit(data.formData)}
       onChange={(data) => onChange(data.formData)}
-      backUrl={backURL}
-      continueUrl={continueURL}
+      continueUrl={saveAndContinueUrl}
     />
   );
 };

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -57,7 +57,7 @@ const ProductionDataForm: React.FC<Props> = ({
     );
   };
 
-  const backURL = `/reports/${report_version_id}/facilities/${facility_id}/emission-summary`;
+  const backUrl = `/reports/${report_version_id}/facilities/${facility_id}/emission-summary`;
   const saveAndContinueUrl = `/reports/${report_version_id}/facilities/${facility_id}/allocation-of-emissions`;
 
   return (
@@ -70,7 +70,7 @@ const ProductionDataForm: React.FC<Props> = ({
       formData={formData}
       baseUrl={"#"}
       cancelUrl={"#"}
-      backUrl={backURL}
+      backUrl={backUrl}
       onSubmit={(data) => onSubmit(data.formData)}
       onChange={(data) => onChange(data.formData)}
       continueUrl={saveAndContinueUrl}

--- a/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.tsx
+++ b/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.tsx
@@ -11,9 +11,6 @@ import {
 } from "@reporting/src/data/jsonSchema/nonAttributableEmissions/nonAttributableEmissions";
 import { actionHandler } from "@bciers/actions";
 
-const BASE_URL = "/reporting/reports";
-const CANCEL_URL = "/reports";
-
 interface ActivityData {
   id: number;
   activity: string;
@@ -71,8 +68,8 @@ export default function NonAttributableEmissionsForm({
 
   const router = useRouter();
 
-  const SAVE_AND_CONTINUE_URL = `${BASE_URL}/${versionId}/facilities/${facilityId}/emission-summary`;
-  const BACK_URL = `activities?step=-1`;
+  const saveAndContinueUrl = `/reports/${versionId}/facilities/${facilityId}/emission-summary`;
+  const backUrl = `activities?step=-1`;
 
   const schema = generateUpdatedSchema(gasTypes, emissionCategories);
   const taskListElements: TaskListElement[] = [
@@ -103,9 +100,6 @@ export default function NonAttributableEmissionsForm({
     const response = await actionHandler(endpoint, "POST", endpoint, {
       body: JSON.stringify(formData),
     });
-    if (response) {
-      router.push(SAVE_AND_CONTINUE_URL);
-    }
   };
 
   return (
@@ -122,12 +116,11 @@ export default function NonAttributableEmissionsForm({
       schema={schema}
       uiSchema={nonAttributableEmissionUiSchema}
       formData={formData}
-      baseUrl={BASE_URL}
-      cancelUrl={CANCEL_URL}
+      cancelUrl="#"
       onChange={(data) => setFormData(data.formData)}
       onSubmit={() => handleSubmit()}
-      backUrl={BACK_URL}
-      continueUrl={SAVE_AND_CONTINUE_URL}
+      backUrl={backUrl}
+      continueUrl={saveAndContinueUrl}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.tsx
+++ b/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.tsx
@@ -94,7 +94,7 @@ export default function NonAttributableEmissionsForm({
 
   const handleSubmit = async () => {
     const endpoint = `reporting/report-version/${versionId}/facilities/${facilityId}/non-attributable`;
-    const response = await actionHandler(endpoint, "POST", endpoint, {
+    await actionHandler(endpoint, "POST", endpoint, {
       body: JSON.stringify(formData),
     });
   };

--- a/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.tsx
+++ b/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from "react";
 import MultiStepFormWithTaskList from "@bciers/components/form/MultiStepFormWithTaskList";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
-import { useRouter } from "next/navigation";
 import { UUID } from "crypto";
 import {
   generateUpdatedSchema,
@@ -65,8 +64,6 @@ export default function NonAttributableEmissionsForm({
           emissions_exceeded: false,
         },
   );
-
-  const router = useRouter();
 
   const saveAndContinueUrl = `/reports/${versionId}/facilities/${facilityId}/emission-summary`;
   const backUrl = `activities?step=-1`;

--- a/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
@@ -35,7 +35,7 @@ export default function SignOffPage({ version_id }: HasReportVersion) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
 
-  const backURL = `/reports/${version_id}/final-review`;
+  const backUrl = `/reports/${version_id}/final-review`;
 
   const allChecked = (formData: SignOffFormData) => {
     return Object.values(formData).every((value) => value);
@@ -83,7 +83,7 @@ export default function SignOffPage({ version_id }: HasReportVersion) {
           saveButtonDisabled={true}
           submitButtonDisabled={submitButtonDisabled} // Disable button if not all checkboxes are checked
           continueUrl={""}
-          backUrl={backURL}
+          backUrl={backUrl}
         />
       )}
     </>

--- a/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
@@ -11,6 +11,7 @@ import { IChangeEvent } from "@rjsf/core";
 import { SignOffFormData } from "@reporting/src/app/components/signOff/types";
 import ReportSubmission from "@reporting/src/app/components/signOff/Success";
 import { getTodaysDateForReportSignOff } from "@reporting/src/app/utils/formatDate";
+import { HasReportVersion } from "../../utils/defaultPageFactoryTypes";
 const baseUrl = "/reports";
 const cancelUrl = "/reports";
 
@@ -29,10 +30,12 @@ const taskListElements: TaskListElement[] = [
   },
 ];
 
-export default function SignOffPage() {
+const SignOffPage: React.FC<HasReportVersion> = ({ version_id }) => {
   const [formState, setFormState] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
+
+  const backURL = `/reports/${version_id}/final-review`;
 
   const allChecked = (formData: SignOffFormData) => {
     return Object.values(formData).every((value) => value);
@@ -80,8 +83,11 @@ export default function SignOffPage() {
           saveButtonDisabled={true}
           submitButtonDisabled={submitButtonDisabled} // Disable button if not all checkboxes are checked
           continueUrl={""}
+          backUrl={backURL}
         />
       )}
     </>
   );
-}
+};
+
+export default SignOffPage;

--- a/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
@@ -30,7 +30,7 @@ const taskListElements: TaskListElement[] = [
   },
 ];
 
-const SignOffPage: React.FC<HasReportVersion> = ({ version_id }) => {
+export default function SignOffPage({ version_id }: HasReportVersion) {
   const [formState, setFormState] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
@@ -88,6 +88,4 @@ const SignOffPage: React.FC<HasReportVersion> = ({ version_id }) => {
       )}
     </>
   );
-};
-
-export default SignOffPage;
+}

--- a/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
@@ -35,7 +35,7 @@ export default function VerificationForm({
   const queryString = serializeSearchParams(searchParams);
 
   const saveAndContinueUrl = `/reports/${version_id}/attachments${queryString}`;
-  const backURL = `/reports/${version_id}/compliance-summary${queryString}`;
+  const backUrl = `/reports/${version_id}/compliance-summary${queryString}`;
 
   const handleChange = (e: IChangeEvent) => {
     const updatedData = { ...e.formData };
@@ -70,7 +70,7 @@ export default function VerificationForm({
       formData={formData}
       baseUrl={baseUrlReports}
       cancelUrl={cancelUrlReports}
-      backUrl={backURL}
+      backUrl={backUrl}
       onChange={handleChange}
       onSubmit={handleSubmit}
       error={error}

--- a/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
@@ -35,6 +35,7 @@ export default function VerificationForm({
   const queryString = serializeSearchParams(searchParams);
 
   const saveAndContinueUrl = `/reports/${version_id}/attachments${queryString}`;
+  const backURL = `/reports/${version_id}/compliance-summary${queryString}`;
 
   const handleChange = (e: IChangeEvent) => {
     const updatedData = { ...e.formData };
@@ -69,7 +70,7 @@ export default function VerificationForm({
       formData={formData}
       baseUrl={baseUrlReports}
       cancelUrl={cancelUrlReports}
-      backUrl={cancelUrlReports}
+      backUrl={backURL}
       onChange={handleChange}
       onSubmit={handleSubmit}
       error={error}

--- a/bciers/apps/reporting/src/data/jsonSchema/facility/facilityEmissionAllocation.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/facility/facilityEmissionAllocation.tsx
@@ -304,7 +304,7 @@ export const emissionAllocationUiSchema: UiSchema = {
   ],
   allocation_methodology: {
     "ui:widget": "SelectWidget",
-    "ui:placeholder": "Select the allocation_methodology",
+    "ui:placeholder": "Select the allocation methodology",
   },
   allocation_other_methodology_description: {
     "ui:widget": "textarea",

--- a/bciers/apps/reporting/src/tests/components/additionalInformation/AdditionalReportingData.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/additionalInformation/AdditionalReportingData.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { useRouter } from "next/navigation";
+
+import { useRouter, useSearchParams } from "next/navigation";
 import { actionHandler } from "@bciers/actions";
 import { getRegistrationPurpose } from "@reporting/src/app/utils/getRegistrationPurpose";
 import AdditionalReportingDataForm from "@reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm";
@@ -20,11 +21,11 @@ vi.mock("@reporting/src/app/utils/getRegistrationPurpose", () => ({
 
 describe("AdditionalReportingData Component", () => {
   const versionId = 1;
-  const facilityId = "abc";
   const mockPush = vi.fn();
 
   beforeEach(() => {
     // Use vi's type-safe mock instead of jest.Mock
+    // Mock useRouter
     (useRouter as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       push: mockPush,
       replace: vi.fn(),
@@ -32,9 +33,15 @@ describe("AdditionalReportingData Component", () => {
       back: vi.fn(),
     });
 
+    // Mock actionHandler
     (actionHandler as ReturnType<typeof vi.fn>).mockResolvedValue({
       success: true,
     });
+
+    // Mock useSearchParams to return `?facility_id=abc`
+    (useSearchParams as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      new URLSearchParams("?facility_id=abc"),
+    );
   });
 
   afterEach(() => {
@@ -86,29 +93,35 @@ describe("AdditionalReportingData Component", () => {
     expect(element).toBeInTheDocument();
   });
 
-  it("submits form data and redirects on success", async () => {
-    render(
-      <AdditionalReportingDataForm
-        versionId={versionId}
-        includeElectricityGenerated={false}
-      />,
-    );
+  it(
+    "submits form data and redirects on success",
+    {
+      timeout: 10000,
+    },
+    async () => {
+      render(
+        <AdditionalReportingDataForm
+          versionId={versionId}
+          includeElectricityGenerated={false}
+        />,
+      );
 
-    await waitFor(() => {
+      await waitFor(() => {
+        const submitButton = screen.getByRole("button", {
+          name: /Save & Continue/i,
+        });
+        expect(submitButton).toBeInTheDocument(); // Confirm it's in the document
+      });
+
       const submitButton = screen.getByRole("button", {
         name: /Save & Continue/i,
       });
-      expect(submitButton).toBeInTheDocument(); // Confirm it's in the document
-    });
+      fireEvent.click(submitButton);
 
-    const submitButton = screen.getByRole("button", {
-      name: /Save & Continue/i,
-    });
-    fireEvent.click(submitButton);
-
-    await waitFor(() => expect(actionHandler).toHaveBeenCalled());
-    expect(mockPush).toHaveBeenCalledWith(
-      `/reports/${versionId}/new-entrant-information`,
-    );
-  });
+      await waitFor(() => expect(actionHandler).toHaveBeenCalled());
+      expect(mockPush).toHaveBeenCalledWith(
+        `/reports/${versionId}/new-entrant-information`,
+      );
+    },
+  );
 });

--- a/bciers/apps/reporting/src/tests/components/additionalInformation/AdditionalReportingData.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/additionalInformation/AdditionalReportingData.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@reporting/src/app/utils/getRegistrationPurpose", () => ({
 
 describe("AdditionalReportingData Component", () => {
   const versionId = 1;
+  const facilityId = "abc";
   const mockPush = vi.fn();
 
   beforeEach(() => {

--- a/bciers/apps/reporting/src/tests/components/attachments/AttachmentsForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/attachments/AttachmentsForm.test.tsx
@@ -131,7 +131,7 @@ describe("The attachments form", () => {
     });
 
     await act(() => {
-      fireEvent.click(screen.getByText("Save and Continue"));
+      fireEvent.click(screen.getByText("Save & Continue"));
     });
 
     expect(mockPostAttachments).toHaveBeenCalledOnce();

--- a/bciers/apps/reporting/src/tests/components/dataGrid/model/operations/operationColumns.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/dataGrid/model/operations/operationColumns.test.tsx
@@ -151,7 +151,7 @@ describe("operationColumns function", () => {
     await user.click(screen.getByText("Continue"));
 
     expect(useRouter().push).toHaveBeenCalledWith(
-      `reports/15/review-operator-data?reports_title=Operation with report`,
+      `reports/15/review-operator-data`,
     );
   });
 });

--- a/bciers/apps/reporting/src/tests/components/operations/OperationReview.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/operations/OperationReview.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, expect, it, beforeEach, vi } from "vitest";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { actionHandler } from "@bciers/actions";
 import OperationReview from "@reporting/src/app/components/operations/OperationReview";
 
@@ -14,9 +14,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 const mockUseRouter = useRouter as vi.MockedFunction<typeof useRouter>;
-const mockUseSearchParams = useSearchParams as vi.MockedFunction<
-  typeof useSearchParams
->;
+
 const mockActionHandler = actionHandler as vi.MockedFunction<
   typeof actionHandler
 >;
@@ -24,9 +22,6 @@ const mockActionHandler = actionHandler as vi.MockedFunction<
 describe("OperationReview Component", () => {
   beforeEach(() => {
     mockUseRouter.mockReturnValue({ push: vi.fn() });
-    mockUseSearchParams.mockReturnValue(
-      "reports_title=Operation+3&facilities_title=Facility",
-    );
     mockActionHandler.mockResolvedValue(true); // Mock the action handler to always resolve successfully
   });
 
@@ -108,9 +103,7 @@ describe("OperationReview Component", () => {
           body: expect.any(String),
         }),
       );
-      expect(push).toHaveBeenCalledWith(
-        "/reporting/reports/1/person-responsible?",
-      );
+      expect(push).toHaveBeenCalledWith("/reports/1/person-responsible");
     });
   });
 

--- a/bciers/apps/reporting/src/tests/components/operations/OperationReview.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/operations/OperationReview.test.tsx
@@ -61,51 +61,59 @@ describe("OperationReview Component", () => {
     expect(screen.getByText(/Save & Continue/i)).toBeInTheDocument();
   });
 
-  it("submits the form and navigates to the next page", async () => {
-    const { push } = useRouter();
+  it(
+    "submits the form and navigates to the next page",
+    {
+      timeout: 10000,
+    },
+    async () => {
+      const { push } = useRouter();
 
-    render(
-      <OperationReview
-        formData={{
-          activities: [1],
-          regulated_products: [1],
-          operation_representative_name: "John Doe",
-          operation_bcghgid: "your-bcghg-id",
-          operation_name: "Operation Name",
-          operation_type: "Test Operation",
-        }}
-        version_id={1}
-        reportType={{ report_type: "Annual Report" }}
-        reportingYear={{
-          reporting_year: 2024,
-          report_due_date: "2024-12-31",
-          reporting_window_end: "2024-12-31",
-        }}
-        allActivities={[{ id: 1, name: "Activity 1" }]}
-        allRegulatedProducts={[{ id: 1, name: "Product 1" }]}
-        registrationPurpose="Test Purpose"
-        facilityReport={{
-          facility_id: 2344,
-          operation_type: "Single Facility Operation",
-        }}
-      />,
-    );
-
-    // Simulate form submission
-    fireEvent.click(screen.getByText(/Save & Continue/i));
-
-    await waitFor(() => {
-      expect(mockActionHandler).toHaveBeenCalledWith(
-        expect.stringContaining("reporting/report-version/1/report-operation"),
-        expect.any(String),
-        expect.any(String),
-        expect.objectContaining({
-          body: expect.any(String),
-        }),
+      render(
+        <OperationReview
+          formData={{
+            activities: [1],
+            regulated_products: [1],
+            operation_representative_name: "John Doe",
+            operation_bcghgid: "your-bcghg-id",
+            operation_name: "Operation Name",
+            operation_type: "Test Operation",
+          }}
+          version_id={1}
+          reportType={{ report_type: "Annual Report" }}
+          reportingYear={{
+            reporting_year: 2024,
+            report_due_date: "2024-12-31",
+            reporting_window_end: "2024-12-31",
+          }}
+          allActivities={[{ id: 1, name: "Activity 1" }]}
+          allRegulatedProducts={[{ id: 1, name: "Product 1" }]}
+          registrationPurpose="Test Purpose"
+          facilityReport={{
+            facility_id: 2344,
+            operation_type: "Single Facility Operation",
+          }}
+        />,
       );
-      expect(push).toHaveBeenCalledWith("/reports/1/person-responsible");
-    });
-  });
+
+      // Simulate form submission
+      fireEvent.click(screen.getByText(/Save & Continue/i));
+
+      await waitFor(() => {
+        expect(mockActionHandler).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "reporting/report-version/1/report-operation",
+          ),
+          expect.any(String),
+          expect.any(String),
+          expect.objectContaining({
+            body: expect.any(String),
+          }),
+        );
+        expect(push).toHaveBeenCalledWith("/reports/1/person-responsible");
+      });
+    },
+  );
 
   it("shows helper text for Simple Report", async () => {
     render(

--- a/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
@@ -43,9 +43,6 @@ describe("The ProductionDataForm component", () => {
     const calledProps = mockMultiStepFormWithTaskList.mock.calls[0][0];
     await calledProps.onSubmit({ formData: { production_data: "test" } });
     expect(mockPostProductionData).toHaveBeenCalledWith(1000, "abcd", "test");
-    expect(mockPush).toHaveBeenCalledWith(
-      "reports/1000/facilities/abcd/allocation-of-emissions",
-    );
   });
 
   it("on change, adds an item to the form data when a checkbox is checked", async () => {

--- a/bciers/apps/reporting/src/tests/components/reportInformation/NonAttributableEmissions.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/reportInformation/NonAttributableEmissions.test.tsx
@@ -100,7 +100,7 @@ describe("NonAttributableEmissionsForm Component", () => {
 
     await waitFor(() => expect(actionHandler).toHaveBeenCalled());
     expect(mockPush).toHaveBeenCalledWith(
-      `/reporting/reports/${versionId}/facilities/${facilityId}/emission-summary`,
+      `/reports/${versionId}/facilities/${facilityId}/emission-summary`,
     );
   });
 

--- a/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
+++ b/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/ReportingTaskList";
-import { Alert, Box, Button } from "@mui/material";
+import { Alert, Box } from "@mui/material";
 import MultiStepHeader from "@bciers/components/form/components/MultiStepHeader";
-import Link from "next/link";
+import ReportingStepButtons from "./components/ReportingStepButtons";
 
 /**
  * Similar to the MultiStepFormWithTaskList,
@@ -16,12 +16,17 @@ interface Props {
   initialStep: number;
   steps: string[];
   taskListElements: TaskListElement[];
-  onSubmit: () => Promise<void>;
+  onSubmit: () => void;
   children?: React.ReactNode;
   cancelUrl?: string;
+  backUrl?: string;
+  continueUrl: string;
   saveButtonText?: string;
   submittingButtonText?: string;
   error?: string;
+  isSaving?: boolean;
+  isRedirecting?: boolean;
+  noFormSave?: () => void;
 }
 
 const MultiStepWrapperWithTaskList: React.FC<Props> = ({
@@ -30,19 +35,14 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
   taskListElements,
   onSubmit,
   children,
-  cancelUrl,
-  saveButtonText,
+  backUrl,
+  continueUrl,
   submittingButtonText,
   error,
+  isSaving,
+  isRedirecting,
+  noFormSave,
 }) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleSubmit = async () => {
-    setIsSubmitting(true);
-    await onSubmit();
-    setIsSubmitting(false);
-  };
-
   return (
     <Box sx={{ p: 3 }}>
       <div className="container mx-auto p-4" data-testid="facility-review">
@@ -60,24 +60,15 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
         </div>
         <div className="w-full">
           {children}
-          <Box display="flex" justifyContent="space-between" mt={3}>
-            {cancelUrl && (
-              <Link href={cancelUrl} passHref>
-                <Button variant="outlined">Cancel</Button>
-              </Link>
-            )}
-            <Button
-              variant="contained"
-              color="primary"
-              type="submit"
-              disabled={isSubmitting}
-              onClick={handleSubmit}
-            >
-              {isSubmitting
-                ? submittingButtonText ?? "Saving..."
-                : saveButtonText ?? "Save and Continue"}
-            </Button>
-          </Box>
+          <ReportingStepButtons
+            backUrl={backUrl}
+            continueUrl={continueUrl}
+            buttonText={submittingButtonText}
+            saveAndContinue={onSubmit}
+            isRedirecting={isRedirecting}
+            isSaving={isSaving}
+            noFormSave={noFormSave}
+          />
         </div>
       </div>
     </Box>

--- a/bciers/libs/components/src/form/components/ReportingStepButtons.tsx
+++ b/bciers/libs/components/src/form/components/ReportingStepButtons.tsx
@@ -13,6 +13,7 @@ interface StepButtonProps {
   submitButtonDisabled?: boolean;
   saveAndContinue?: () => void;
   buttonText?: string;
+  noFormSave?: () => void;
 }
 
 const ReportingStepButtons: React.FunctionComponent<StepButtonProps> = ({
@@ -25,6 +26,7 @@ const ReportingStepButtons: React.FunctionComponent<StepButtonProps> = ({
   submitButtonDisabled,
   saveAndContinue,
   buttonText,
+  noFormSave,
 }) => {
   const router = useRouter();
   const saveButtonContent = isSaving ? (
@@ -70,6 +72,9 @@ const ReportingStepButtons: React.FunctionComponent<StepButtonProps> = ({
           disabled={isSaving || saveButtonDisabled}
           sx={{ mx: 3 }}
           type="submit"
+          onClick={() => {
+            if (noFormSave) noFormSave();
+          }}
         >
           {saveButtonContent}
         </Button>
@@ -80,8 +85,9 @@ const ReportingStepButtons: React.FunctionComponent<StepButtonProps> = ({
         disabled={isSaving || submitButtonDisabled}
         sx={{ px: 4 }}
         onClick={() => {
-          if (saveAndContinue !== undefined) saveAndContinue();
-          else {
+          if (saveAndContinue !== undefined) {
+            saveAndContinue();
+          } else {
             isRedirecting = true;
             router.push(continueUrl);
           }


### PR DESCRIPTION
#2570

- fix: Fix reporting step buttons on attachments and allocation pages
- test: update tests after reporting step buttons update



### 🔬 SH Post Review - Testing:

1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd bciers && yarn dev-all
```  


1. Navigate to http://localhost:3000
2. Click button "Log in with Business BCeID"
3. Navigate to http://localhost:3000/reporting/reports
**Expected Results**
- Reporting grid displays with rows having action buttons `Start` or  `Continue`
5. Click `Operator 3` row button `Start`
**Expected Results**
- Url does NOT display any query parameters  such as`..?reports_title=...1
- Router navigates to form: `Review operation information` 
- Form has buttons: `Back`; `Save`; `Save & Continue`
6. Navigate to http://localhost:3000/reporting/reports
7.  Click `Operator 3` row button `Continue`
**Expected Results**
- Url does NOT display any query parameters  such as`..?reports_title=...1
- Router navigates to form: `Review operation information` 
- Form has buttons: `Back`; `Save`; `Save & Continue`
8. Click button `Back`
**Expected Results**
- Router navigates to the previous next step
9.  Click `Operator 3` row button `Continue`
10. Click button  `Save`
**Expected Results**
- Form POST data to the server
- Router does not navigate to the next step
11. Click button `Save & Continue`
**Expected Results**
- Form POST data to the server
- Router navigates to form: `Person Responsible`
- Form has buttons: `Back`; `Save`; `Save & Continue`
12. Click button `Back`
**Expected Results**
- Router navigates to the previous next step
13. Click button `Save & Continue`
- Form POST data to the server
- Router navigates to form: `Person Responsible`
14. Complete form and click button `Save`
**Expected Results**
- Form POST data to the server
- Router does not navigate to the next step
15. Click button `Save & Continue`
**Expected Results**
- Form POST data to the server
- Router navigates to form: `Review facility information`
- Form has buttons: `Back`; `Save`; `Save & Continue`
16. Click button `Back`
**Expected Results**
- Router navigates to the previous next step
17. Click button `Save & Continue`
- Form POST data to the server
- Router navigates to form: `Review facility information`
18. Complete form and click button `Save`
**Expected Results**
- Form POST data to the server
- Router does not navigate to the next step
19. Click button `Save & Continue`
**Expected Results**
- Form POST data to the server
- Router navigates to form: `General stationary combustion excluding line tracing`
- Form has buttons: `Back`; `Save`; `Save & Continue`
20. Click button `Back`
**Expected Results**
- Router navigates to the previous next step
21. Click button `Save & Continue`
- Form POST data to the server
- Router navigates to form: `General stationary combustion excluding line tracing`
22. Complete form and click button `Save`
**Expected Results**
- Form POST data to the server
- Router does not navigate to the next step
23. Click button `Save & Continue`
**Expected Results**
- Form POST data to the server
- Router navigates to form: `Activities` (currently "Something went wrong...")
24. Navigate to http://localhost:3000/reporting/reports/3/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/non-attributable
- Router navigates to form: `Non-Attributable Emissions`
- Form has buttons: `Back`; `Save`; `Save & Continue`
25. Complete form and click button `Save`
**Expected Results**
- Form POST data to the server
- Router does not navigate to the next step
26. Click button `Save & Continue`
**Expected Results**
- Form POST data to the server
- Router navigates to form: `Emission Summary`
- Form has buttons: `Back`; `Save`; `Continue`
- Button `Save` is disabled
27. Click button `Continue`
**Expected Results**
- Router navigates to form: `Production Data`
- Form has buttons: `Back`; `Save`; `Save & Continue`
29. Click button `Back`
**Expected Results**
- Router navigates to the 'Emission Summary`
30. Click button `Continue`
**Expected Results**
- Router navigates to form: `Production Data`
31. Complete form and click button `Save`
**Expected Results**
- Form POST data to the server
- Router does not navigate to the next step
32. Click button `Save & Continue`
**Expected Results**
- Form POST data to the server
- Router navigates to form; `Allocation Of Emissions`
- Form has buttons: `Back`; `Save`; `Save & Continue`
33. Click button `Back`
**Expected Results**
- Router navigates to the previous next step
34. Click button `Save & Continue`
- Form POST data to the server
- Router navigates to form: `Allocation Of Emissions`
35. Complete form and click button `Save`
**Expected Results**
- Form POST data to the server
- Router does not navigate to the next step
36. Click button `Save & Continue`
**Expected Results**
- Form POST data to the server
- Router navigates to form: `Additional Reporting Data`
- Form has buttons: `Back`; `Save`; `Save & Continue`
37. Click button `Back`
**Expected Results**
- Router navigates to the previous next step
38. Click button `Save & Continue`
- Form POST data to the server
- Router navigates to form: `Additional Reporting Data`
39. Complete form and click button `Save`
**Expected Results**
- Form POST data to the server
- Router does not navigate to the next step
40. Click button `Save & Continue`
**Expected Results**
- Form POST data to the server
- Router navigates to form: `new-entrant-information` (coming soon)
- Form has buttons: `Back`; `Save`; `Save & Continue`
 41. Navigate to http://localhost:3000/reporting/reports/3/verification
**Expected Results**
- Router navigates to form: `Verification`
- Form has buttons: `Back`; `Save`; `Save & Continue`
42. Complete form and click button `Save`
**Expected Results**
- Form POST data to the server
- Router does not navigate to the next step
43. Click button `Save & Continue`
**Expected Results**
- Form POST data to the server
- Router navigates to form; `Attachments`
- Form has buttons: `Back`; `Save`; `Save & Continue`
44. Click button `Back`
**Expected Results**
- Router navigates to the previous next step
45. Click button `Save & Continue`
- Form POST data to the server
- Router navigates to form: `Attachments`
46. Complete form and click button `Save`
**Expected Results**
- Form POST data to the server
- Router does not navigate to the next step
47. Click button `Save & Continue`
**Expected Results**
- Form POST data to the server
- Router navigates to form; `Final Review`
- Form has buttons: `Back`; `Save`; `Save & Continue`
48. Click button `Back`
**Expected Results**
- Router navigates to the previous next step
49. Click button `Save & Continue`
- Form POST data to the server
- Router navigates to form: `Final Review`
50. Complete form and click button `Save`
**Expected Results**
- Router does not navigate to the next step
51. Click button `Save & Continue`
**Expected Results**
- Router navigates to form; `Sign Off`
- Form has buttons: `Back`; `Save`; `Save & Continue`
- Button `Save` is disabled
52. Click button `Back`
**Expected Results**
- Router navigates to the previous next step
53. Click button `Save & Continue`
- Router navigates to form; `Sign Off`
54. Complete form and click button `Save & Continue`
**Expected Results**
- `Successful Submission` displays