### PR TITLE
chore:fixed activity page bug

### DIFF
--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -89,7 +89,7 @@ export default function ActivityForm({
   const fetchSchemaData = async (sourceTypeIds: string[]) => {
     const sourceTypeQueryString = sourceTypeIds
       .map((id) => `&source_types[]=${id}`)
-      .join();
+      .join("");
     const schema = await actionHandler(
       `reporting/build-form-schema?activity=${currentActivity.id}&report_version_id=${reportVersionId}${sourceTypeQueryString}`,
       "GET",


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/439
Changes:- fixed url for buildSchema 
Since we were using join and when use .join() without a separator, the default separator is a comma (,), so adding a separator. 