### PR TITLE
chore: update operator mock data

### DIFF
--- a/bc_obps/registration/fixtures/mock/operator.json
+++ b/bc_obps/registration/fixtures/mock/operator.json
@@ -113,7 +113,7 @@
       "website": "http://www.example2.com",
       "documents": [],
       "contacts": [1],
-      "status": "Draft",
+      "status": "Approved",
       "is_new": false,
       "verified_at": null,
       "verified_by": null
@@ -133,7 +133,7 @@
       "website": "http://www.example2.com",
       "documents": [],
       "contacts": [1],
-      "status": "Draft",
+      "status": "Approved",
       "is_new": true,
       "verified_at": null,
       "verified_by": null
@@ -153,7 +153,7 @@
       "website": "http://www.example2.com",
       "documents": [],
       "contacts": [1],
-      "status": "Draft",
+      "status": "Approved",
       "is_new": true,
       "verified_at": null,
       "verified_by": null
@@ -173,7 +173,7 @@
       "website": "http://www.example2.com",
       "documents": [],
       "contacts": [1],
-      "status": "Draft",
+      "status": "Approved",
       "is_new": true,
       "verified_at": null,
       "verified_by": null
@@ -193,7 +193,7 @@
       "website": "http://www.example2.com",
       "documents": [],
       "contacts": [1],
-      "status": "Draft",
+      "status": "Approved",
       "is_new": true,
       "verified_at": null,
       "verified_by": null
@@ -213,7 +213,7 @@
       "website": "http://www.example2.com",
       "documents": [],
       "contacts": [1],
-      "status": "Draft",
+      "status": "Approved",
       "is_new": true,
       "verified_at": null,
       "verified_by": null
@@ -233,7 +233,7 @@
       "website": "http://www.example2.com",
       "documents": [],
       "contacts": [1],
-      "status": "Draft",
+      "status": "Approved",
       "is_new": true,
       "verified_at": null,
       "verified_by": null
@@ -253,7 +253,7 @@
       "website": "http://www.example2.com",
       "documents": [],
       "contacts": [1],
-      "status": "Draft",
+      "status": "Approved",
       "is_new": true,
       "verified_at": null,
       "verified_by": null
@@ -273,7 +273,7 @@
       "website": "http://www.example2.com",
       "documents": [],
       "contacts": [1],
-      "status": "Pending",
+      "status": "Approved",
       "is_new": true,
       "verified_at": null,
       "verified_by": null


### PR DESCRIPTION
Is this going to break reg1 tests? No!

This PR changes some of the mock data operator's statuses to `Approved`. In reg2 all operators will be approved by default the moment they're created. However, the reg1 tests require some operators to be unapproved, so we have to leave some of the data in the old structure for them to pass.