### PR TITLE
test: playwright failures

### DIFF
--- a/.github/workflows/test-nx-project-e2e.yaml
+++ b/.github/workflows/test-nx-project-e2e.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: 📥 install Playwright Chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install  chromium
         working-directory: ./bciers/apps/${{ inputs.nx_project }}-e2e
 
       - name: 🎭 Run Playwright Tests

--- a/.github/workflows/test-registration1-e2e.yaml
+++ b/.github/workflows/test-registration1-e2e.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: 📥 install Playwright Chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
         working-directory: ./bciers/apps/registration1
 
       - name: 🎭 Run Playwright Tests

--- a/docs/developer-environment-setup.md
+++ b/docs/developer-environment-setup.md
@@ -106,7 +106,7 @@ In the `bciers` directory:
 
 - To run Vitest unit tests on a specific project: `yarn nx run {project}:test`.
 - To run Vitest unit tests on all projects: `yarn nx run-many -t test`.
-- To run playwright end-to-end tests: `nx run {project}:e2e` (For the first time, you may need to run `yarn playwright install --with-deps` to install the browsers)
+- To run playwright end-to-end tests: `nx run {project}:e2e` (For the first time, you may need to run `yarn playwright install ` to install the browsers)
 
 **Or**, you can use the scripts available in `bciers/package.json`
 

--- a/docs/frontend/testing/playwright.md
+++ b/docs/frontend/testing/playwright.md
@@ -132,7 +132,7 @@ Playwright will be re-testing the element with the test id of status until the f
 
 #### Prerequisites
 
-- To run playwright end-to-end tests for the first time, you may need to run `yarn playwright install --with-deps` to install the browsers
+- To run playwright end-to-end tests for the first time, you may need to run `yarn playwright install ` to install the browsers
   Ensure you have the configuration from file `bciers/bciers/.env.local.example` in `bciers/bciers/.env.local` with values reflecting instructions in file `bciers/bciers/.env.local.example`
 
   1.0 Ensure the server is running:

--- a/docs/frontend/testing/vitest.md
+++ b/docs/frontend/testing/vitest.md
@@ -4,7 +4,7 @@
 
 - To run Vitest unit tests on a specific project: `yarn nx run {project}:test`.
 - To run Vitest unit tests on all projects: `yarn nx run-many -t test`.
-- To run playwright end-to-end tests: `nx run {project}:e2e` (For the first time, you may need to run `yarn playwright install --with-deps` to install the browsers)
+- To run playwright end-to-end tests: `nx run {project}:e2e` (For the first time, you may need to run `yarn playwright install ` to install the browsers)
 
 **Or**, you can use the scripts available in `bciers/package.json`
 


### PR DESCRIPTION
Removes the --with-deps flag when installing playwright in CI. This appears to have fixed the `libasound2` error on install
Relevant github issue: https://github.com/microsoft/playwright/issues/30368