### PR TITLE
Fix: form submit blocked after error

### DIFF
--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -128,8 +128,9 @@ export default function ActivityForm({
       "",
       {
         body: JSON.stringify({
-          /* formState needs to be used instead of the data passed to the handler, since this is a controlled component.
-             See FormBase implementation comments. */
+          /* formState needs to be used instead of the data passed to the handler, since this is a controlled component;
+             otherwise the data passed to the handler lags behind the changes.
+             See FormBase implementation comments for more details. */
           activity_data: formState,
         }),
       },
@@ -158,7 +159,6 @@ export default function ActivityForm({
       formData={formState}
       uiSchema={getUiSchema(currentActivity.slug)}
       onChange={debounce(handleFormChange, 200)}
-      onError={(e) => console.log("ERROR: ", e)}
       errors={errorList}
       backUrl={createUrl(false)}
       continueUrl={createUrl(true)}

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -10,7 +10,7 @@ import safeJsonParse from "@bciers/utils/src/safeJsonParse";
 import debounce from "lodash.debounce";
 import { useSearchParams } from "next/navigation";
 import MultiStepFormWithTaskList from "@bciers/components/form/MultiStepFormWithTaskList";
-import { multiStepHeaderSteps } from "../taskList/multiStepHeaderConfig";
+import { multiStepHeaderSteps } from "@reporting/src/app/components/taskList/multiStepHeaderConfig";
 import { customizeValidator } from "@rjsf/validator-ajv8";
 
 const CUSTOM_FIELDS = {

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -11,6 +11,7 @@ import debounce from "lodash.debounce";
 import { useSearchParams } from "next/navigation";
 import MultiStepFormWithTaskList from "@bciers/components/form/MultiStepFormWithTaskList";
 import { multiStepHeaderSteps } from "../taskList/multiStepHeaderConfig";
+import { customizeValidator } from "@rjsf/validator-ajv8";
 
 const CUSTOM_FIELDS = {
   fuelType: (props: FieldProps) => <FuelFields {...props} />,
@@ -45,7 +46,7 @@ export default function ActivityForm({
   let step = searchParams ? Number(searchParams.get("step")) : 0;
   // 🐜 To display errors
   const [errorList, setErrorList] = useState([] as any[]);
-  const [formState, setFormState] = useState(activityFormData as any);
+  const [formState, setFormState] = useState(activityFormData);
   const [jsonSchema, setJsonSchema] = useState(initialJsonSchema);
   const [selectedSourceTypeIds, setSelectedSourceTypeIds] = useState(
     initialSelectedSourceTypeIds,
@@ -118,11 +119,8 @@ export default function ActivityForm({
   };
 
   // 🛠️ Function to submit user form data to API
-  const submitHandler = async (data: { formData?: any }) => {
+  const submitHandler = async () => {
     setErrorList([]);
-
-    console.log(data.formData);
-    console.log(formState);
 
     const response = await actionHandler(
       `reporting/report-version/${reportVersionId}/facilities/${facilityId}/activity/${activityId}/report-activity`,
@@ -130,7 +128,9 @@ export default function ActivityForm({
       "",
       {
         body: JSON.stringify({
-          activity_data: data.formData,
+          /* formState needs to be used instead of the data passed to the handler, since this is a controlled component.
+             See FormBase implementation comments. */
+          activity_data: formState,
         }),
       },
     );
@@ -162,6 +162,8 @@ export default function ActivityForm({
       errors={errorList}
       backUrl={createUrl(false)}
       continueUrl={createUrl(true)}
+      validator={customizeValidator({})}
+      omitExtraData={false}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from "react";
 import MultiStepFormWithTaskList from "@bciers/components/form/MultiStepFormWithTaskList";
 import { RJSFSchema } from "@rjsf/utils";
-import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import {
   additionalReportingDataSchema,
   additionalReportingDataUiSchema,
@@ -11,6 +10,11 @@ import {
 } from "@reporting/src/data/jsonSchema/additionalReportingData/additionalReportingData";
 import { actionHandler } from "@bciers/actions";
 import { useSearchParams } from "next/navigation";
+import { multiStepHeaderSteps } from "@reporting/src/app/components/taskList/multiStepHeaderConfig";
+import {
+  ActivePage,
+  getAdditionalInformationTaskList,
+} from "../../taskList/3_additionalInformation";
 
 interface AdditionalReportingDataProps {
   versionId: number;
@@ -53,23 +57,6 @@ export default function AdditionalReportingDataForm({
     ? additionalReportingDataWithElectricityGeneratedSchema
     : additionalReportingDataSchema;
 
-  const taskListElements: TaskListElement[] = [
-    {
-      type: "Page",
-      title: "Additional reporting data",
-      isActive: true,
-      link: `/reports/${versionId}/additional-reporting-data`,
-    },
-  ];
-
-  if (isNewEntrant) {
-    taskListElements.push({
-      type: "Page",
-      title: "New entrant information",
-      link: `/reports/${versionId}/new-entrant-information`,
-    });
-  }
-
   const handleSubmit = async (data: any) => {
     const endpoint = `reporting/report-version/${versionId}/additional-data`;
     const method = "POST";
@@ -90,14 +77,12 @@ export default function AdditionalReportingDataForm({
   return (
     <MultiStepFormWithTaskList
       initialStep={2}
-      steps={[
-        "Operation Information",
-        "Report Information",
-        "Additional Information",
-        "Compliance Summary",
-        "Sign-off & Submit",
-      ]}
-      taskListElements={taskListElements}
+      steps={multiStepHeaderSteps}
+      taskListElements={getAdditionalInformationTaskList(
+        versionId,
+        ActivePage.AdditionalReportingData,
+        isNewEntrant,
+      )}
       schema={schema}
       uiSchema={additionalReportingDataUiSchema}
       formData={formData}

--- a/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
@@ -79,9 +79,12 @@ export default function AdditionalReportingDataForm({
       ...data.captured_emissions_section,
       ...data.additional_data_section,
     };
-    await actionHandler(endpoint, method, endpoint, {
+    const response = await actionHandler(endpoint, method, endpoint, {
       body: JSON.stringify(payload),
     });
+
+    if (response && !response.error) return true;
+    return false;
   };
 
   return (

--- a/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
@@ -44,6 +44,7 @@ export default function AdditionalReportingDataForm({
   isNewEntrant,
 }: AdditionalReportingDataProps) {
   const [formData, setFormData] = useState<FormData>(initialFormData);
+  const [errors, setErrors] = useState<string[]>();
 
   // 🛸 Set up routing urls
   const searchParams = useSearchParams();
@@ -70,8 +71,13 @@ export default function AdditionalReportingDataForm({
       body: JSON.stringify(payload),
     });
 
-    if (response && !response.error) return true;
-    return false;
+    if (response?.error) {
+      setErrors([response.error]);
+      return false;
+    }
+
+    setErrors(undefined);
+    return true;
   };
 
   return (
@@ -92,6 +98,7 @@ export default function AdditionalReportingDataForm({
       }}
       onSubmit={(data: any) => handleSubmit(data.formData)}
       continueUrl={saveAndContinueUrl}
+      errors={errors}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/additionalInformation/newEntrantInformation/NewEntrantInformation.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/newEntrantInformation/NewEntrantInformation.tsx
@@ -68,6 +68,7 @@ export default async function NewEntrantInformation({
   const taskListElements = getAdditionalInformationTaskList(
     version_id,
     ActivePage.NewEntrantInformation,
+    true,
   );
 
   return (

--- a/bciers/apps/reporting/src/app/components/additionalInformation/newEntrantInformation/NewEntrantInformationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/newEntrantInformation/NewEntrantInformationForm.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from "react";
 import MultiStepFormWithTaskList from "@bciers/components/form/MultiStepFormWithTaskList";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
-import { useRouter } from "next/navigation";
 
 import { actionHandler } from "@bciers/actions";
 import {
@@ -32,7 +31,6 @@ export default function NewEntrantInformationForm({
     !initialFormData.assertion_statement,
   );
 
-  const router = useRouter();
   const saveAndContinueUrl = `/reports/${version_id}/compliance-summary`;
 
   const handleChange = (e: IChangeEvent) => {
@@ -52,7 +50,7 @@ export default function NewEntrantInformationForm({
     });
     if (response.error) throw new Error(response.error);
 
-    router.push(saveAndContinueUrl);
+    return true;
   };
   return (
     <MultiStepFormWithTaskList

--- a/bciers/apps/reporting/src/app/components/additionalInformation/newEntrantInformation/NewEntrantInformationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/newEntrantInformation/NewEntrantInformationForm.tsx
@@ -27,6 +27,7 @@ export default function NewEntrantInformationForm({
   taskListElements,
 }: NewEntrantInfornationProps) {
   const [formData, setFormData] = useState(initialFormData || {});
+  const [errors, setErrors] = useState<string[]>();
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(
     !initialFormData.assertion_statement,
   );
@@ -48,8 +49,12 @@ export default function NewEntrantInformationForm({
     const response = await actionHandler(endpoint, method, endpoint, {
       body: JSON.stringify(data),
     });
-    if (response.error) throw new Error(response.error);
+    if (response?.error) {
+      setErrors([response.error]);
+      return false;
+    }
 
+    setErrors(undefined);
     return true;
   };
   return (
@@ -67,6 +72,7 @@ export default function NewEntrantInformationForm({
       submitButtonDisabled={submitButtonDisabled}
       formContext={formData}
       continueUrl={saveAndContinueUrl}
+      errors={errors}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummaryForm.tsx
+++ b/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummaryForm.tsx
@@ -10,6 +10,7 @@ import {
   complianceSummarySchema,
 } from "@reporting/src/data/jsonSchema/complianceSummary";
 import ReportingStepButtons from "@bciers/components/form/components/ReportingStepButtons";
+import { multiStepHeaderSteps } from "../taskList/multiStepHeaderConfig";
 
 interface Props {
   versionId: number;
@@ -44,14 +45,6 @@ const ComplianceSummaryForm: React.FC<Props> = ({
   summaryFormData,
   taskListElements,
 }) => {
-  const customStepNames = [
-    "Operation Information",
-    "Report Information",
-    "Additional Information",
-    "Compliance Summary",
-    "Sign-off & Submit",
-  ];
-
   const backUrl = `/reports/${versionId}/additional-reporting-data`;
   const verificationUrl = `/reports/${versionId}/verification`;
   const finalReviewUrl = `/reports/${versionId}/final-review`;
@@ -60,7 +53,7 @@ const ComplianceSummaryForm: React.FC<Props> = ({
   return (
     <Box sx={{ p: 3 }}>
       <div className="container mx-auto p-4" data-testid="compliance-summary">
-        <MultiStepHeader stepIndex={3} steps={customStepNames} />
+        <MultiStepHeader stepIndex={3} steps={multiStepHeaderSteps} />
       </div>
       <div className="w-full flex">
         <ReportingTaskList elements={taskListElements} />

--- a/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummaryPage.tsx
+++ b/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummaryPage.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { actionHandler } from "@bciers/actions";
 import ComplianceSummaryForm from "./ComplianceSummaryForm";
-import { tasklistData } from "./TaskListElements";
 import { HasReportVersion } from "@reporting/src/app/utils/defaultPageFactoryTypes";
 import { getReportNeedsVerification } from "@reporting/src/app/utils/getReportNeedsVerification";
+import { getComplianceSummaryTaskList } from "../taskList/4_complianceSummary";
 
 const getComplianceData = async (versionId: number) => {
   return actionHandler(
@@ -23,7 +23,7 @@ export default async function ComplianceSummaryPage({
       versionId={version_id}
       needsVerification={needsVerification}
       summaryFormData={complianceData}
-      taskListElements={tasklistData}
+      taskListElements={getComplianceSummaryTaskList()}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -244,10 +244,11 @@ export default function FacilityEmissionAllocationForm({
     });
 
     if (response?.error) {
-      setErrors(response.error);
+      setErrors([response.error]);
       return false;
     }
 
+    setErrors(undefined);
     return true;
   };
 

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -123,7 +123,7 @@ export default function FacilityEmissionAllocationForm({
   // State for submit button disable
   const errorMismatch =
     "All emissions must be allocated to 100% before saving and continuing";
-  const [error, setError] = useState<string | undefined>();
+  const [errors, setErrors] = useState<string[] | undefined>();
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
 
   // 🛸 Set up routing urls
@@ -141,7 +141,7 @@ export default function FacilityEmissionAllocationForm({
   // 🔄 Check for allocation mismatch on page load to prevent submit
   useEffect(() => {
     if (!validateEmissions(formData)) {
-      setError(errorMismatch);
+      setErrors([errorMismatch]);
     }
     setSubmitButtonDisabled(!validateEmissions(formData));
   }, [formData]);
@@ -152,7 +152,6 @@ export default function FacilityEmissionAllocationForm({
     const BASIC_CATEGORY_DATA = "basic_emission_allocation_data";
     const EXCLUDED_CATEGORY_DATA = "fuel_excluded_emission_allocation_data";
     const updatedDataKeys = [BASIC_CATEGORY_DATA, EXCLUDED_CATEGORY_DATA];
-    let errorMessage;
 
     // Initialize a map to store total allocated quantities by report_product_id
     const productAllocations: Record<string, number> = {};
@@ -198,14 +197,14 @@ export default function FacilityEmissionAllocationForm({
 
     // Validate the updated form data and set an error message if validation fails
     if (!validateEmissions(updatedFormData)) {
-      errorMessage = errorMismatch;
+      setErrors([errorMismatch]);
+      setSubmitButtonDisabled(true);
+    } else {
+      setSubmitButtonDisabled(false);
     }
 
     // Update the form data state
     setFormData(updatedFormData);
-
-    setError(errorMessage);
-    setSubmitButtonDisabled(!!errorMessage);
   }, []);
 
   // 🛠️ Handle form submit
@@ -236,17 +235,20 @@ export default function FacilityEmissionAllocationForm({
         })),
       ],
     };
-    const method = "POST";
+
     const endpoint = `reporting/report-version/${version_id}/facilities/${facility_id}/allocate-emissions`;
-    const pathToRevalidate = "reporting/reports";
     const payload = safeJsonParse(JSON.stringify(transformedPayload));
-    const response = await actionHandler(endpoint, method, pathToRevalidate, {
+
+    const response = await actionHandler(endpoint, "POST", "", {
       body: JSON.stringify(payload),
     });
 
     if (response?.error) {
-      setError(response.error);
+      setErrors(response.error);
+      return false;
     }
+
+    return true;
   };
 
   return (
@@ -258,12 +260,11 @@ export default function FacilityEmissionAllocationForm({
       uiSchema={emissionAllocationUiSchema}
       formData={formData}
       submitButtonDisabled={submitButtonDisabled}
-      cancelUrl="#"
       backUrl={backUrl}
       onChange={handleChange}
       onSubmit={handleSubmit}
       continueUrl={saveAndContinueUrl}
-      error={error}
+      errors={errors}
       formContext={{
         facility_emission_data: formData.basic_emission_allocation_data.concat(
           formData.fuel_excluded_emission_allocation_data,

--- a/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
@@ -28,6 +28,7 @@ const FinalReviewForm: React.FC<Props> = ({ version_id, taskListElements }) => {
       cancelUrl="#"
       backUrl={backUrl}
       continueUrl={saveAndContinueUrl}
+      noFormSave={submitHandler}
     >
       Placeholder for Final Review
       <br />

--- a/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
@@ -28,7 +28,7 @@ const FinalReviewForm: React.FC<Props> = ({ version_id, taskListElements }) => {
       cancelUrl="#"
       backUrl={backUrl}
       continueUrl={saveAndContinueUrl}
-      noFormSave={submitHandler}
+      noFormSave={() => {}}
     >
       Placeholder for Final Review
       <br />

--- a/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
@@ -53,7 +53,6 @@ export default function OperationReview({
   const [schema, setSchema] = useState<RJSFSchema>(operationReviewSchema);
   const [uiSchema, setUiSchema] = useState<RJSFSchema>(operationReviewUiSchema);
   const [formDataState, setFormDataState] = useState<any>(formData);
-  const [facilityId, setFacilityId] = useState<string | null>(null);
   const [operationType, setOperationType] = useState("");
   const [errors, setErrors] = useState<string[]>();
 
@@ -68,8 +67,8 @@ export default function OperationReview({
 
   const taskListElements = getOperationInformationTaskList(
     version_id,
-    facilityId,
     ActivePage.ReviewOperatorInfo,
+    operationType,
   );
 
   const prepareFormData = (formDataObject: any) => {
@@ -234,6 +233,7 @@ export default function OperationReview({
         onChange={onChangeHandler}
         backUrl={backUrl}
         continueUrl={saveAndContinueUrl}
+        errors={errors}
       />
     </>
   );

--- a/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
@@ -55,6 +55,7 @@ export default function OperationReview({
   const [formDataState, setFormDataState] = useState<any>(formData);
   const [facilityId, setFacilityId] = useState<string | null>(null);
   const [operationType, setOperationType] = useState("");
+  const [errors, setErrors] = useState<string[]>();
 
   // 🛸 Set up routing urls
   const backUrl = `/reports`;
@@ -144,8 +145,13 @@ export default function OperationReview({
       body: JSON.stringify(preparedData),
     });
 
-    if (response && !response.error) return true;
-    return false;
+    if (response?.error) {
+      setErrors([response?.error]);
+      return false;
+    }
+
+    setErrors(undefined);
+    return true;
   };
 
   const onChangeHandler = (data: { formData: any }) => {

--- a/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
@@ -54,6 +54,7 @@ export default function OperationReview({
   const [uiSchema, setUiSchema] = useState<RJSFSchema>(operationReviewUiSchema);
   const [formDataState, setFormDataState] = useState<any>(formData);
   const [facilityId, setFacilityId] = useState<string | null>(null);
+  const [operationType, setOperationType] = useState("");
 
   // 🛸 Set up routing urls
   const backUrl = `/reports`;
@@ -118,7 +119,7 @@ export default function OperationReview({
       );
     }
     if (facilityReport?.facility_id) {
-      setFacilityId(facilityReport.facility_id);
+      setOperationType(facilityReport.operation_type);
     }
   }, [
     formData,

--- a/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReview.tsx
@@ -139,11 +139,12 @@ export default function OperationReview({
 
     const formDataObject = safeJsonParse(JSON.stringify(data.formData));
     const preparedData = prepareFormData(formDataObject);
-    const response = await actionHandler(endpoint, method, endpoint, {
+    const response = await actionHandler(endpoint, method, "", {
       body: JSON.stringify(preparedData),
     });
 
-    return response;
+    if (response && !response.error) return true;
+    return false;
   };
 
   const onChangeHandler = (data: { formData: any }) => {

--- a/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsible.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsible.tsx
@@ -171,9 +171,11 @@ const PersonResponsible = ({ version_id }: Props) => {
       ...contactFormData,
     };
 
-    await actionHandler(endpoint, method, endpoint, {
+    const response = await actionHandler(endpoint, method, "", {
       body: JSON.stringify(payload),
     });
+
+    return response && !response.error;
   };
 
   const handleSync = async () => {

--- a/bciers/apps/reporting/src/app/components/operations/personResponsible/createPersonResponsibleSchema.ts
+++ b/bciers/apps/reporting/src/app/components/operations/personResponsible/createPersonResponsibleSchema.ts
@@ -16,7 +16,7 @@ import { createContactDetailsProperties } from "@reporting/src/data/jsonSchema/p
 export const createPersonResponsibleSchema = (
   schema: RJSFSchema,
   contactOptions: ContactRow[],
-  contactId: number | null,
+  contactId?: number,
   contactData?: Contact, // Renamed parameter
 ): RJSFSchema => {
   const localSchema = JSON.parse(JSON.stringify(schema));

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -31,6 +31,7 @@ const ProductionDataForm: React.FC<Props> = ({
   };
 
   const [formData, setFormData] = useState<any>(initialFormData);
+  const [errors, setErrors] = useState<string[]>();
 
   const onChange = (newFormData: {
     product_selection: string[];
@@ -50,11 +51,17 @@ const ProductionDataForm: React.FC<Props> = ({
   };
 
   const onSubmit = async (data: any) => {
-    await postProductionData(
+    const response = await postProductionData(
       report_version_id,
       facility_id,
       data.production_data,
     );
+
+    if (response.error) {
+      setErrors([response.error]);
+      return false;
+    }
+    return true;
   };
 
   const backUrl = `/reports/${report_version_id}/facilities/${facility_id}/emission-summary`;
@@ -74,6 +81,7 @@ const ProductionDataForm: React.FC<Props> = ({
       onSubmit={(data) => onSubmit(data.formData)}
       onChange={(data) => onChange(data.formData)}
       continueUrl={saveAndContinueUrl}
+      errors={errors}
     />
   );
 };

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -57,10 +57,12 @@ const ProductionDataForm: React.FC<Props> = ({
       data.production_data,
     );
 
-    if (response.error) {
+    if (response?.error) {
       setErrors([response.error]);
       return false;
     }
+
+    setErrors(undefined);
     return true;
   };
 

--- a/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.tsx
+++ b/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.tsx
@@ -80,10 +80,12 @@ export default function NonAttributableEmissionsForm({
       body: JSON.stringify(formData),
     });
 
-    if (response.error) {
+    if (response?.error) {
       setErrors([response.error]);
       return false;
     }
+
+    setErrors(undefined);
     return true;
   };
 

--- a/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributatbleEmissions.tsx
+++ b/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributatbleEmissions.tsx
@@ -1,10 +1,14 @@
-import { Suspense } from "react";
-import Loading from "@bciers/components/loading/SkeletonForm";
 import NonAttributableEmissionsForm from "@reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm";
 import { UUID } from "crypto";
 import { getAllGasTypes } from "@reporting/src/app/utils/getAllGasTypes";
 import { getAllEmissionCategories } from "@reporting/src/app/utils/getAllEmissionCategories";
 import { getNonAttributableEmissionsData } from "@reporting/src/app/utils/getNonAttributableEmissionsData";
+import { getOrderedActivities } from "@reporting/src/app/utils/getOrderedActivities";
+import {
+  ActivePage,
+  getFacilitiesInformationTaskList,
+} from "../../taskList/2_facilitiesInformation";
+import { Suspense } from "react";
 
 interface NonAttributableEmissionsProps {
   versionId: number;
@@ -20,6 +24,13 @@ export default async function NonAttributableEmissions({
   const emissionFormData = await getNonAttributableEmissionsData(
     versionId,
     facilityId,
+  );
+  const orderedActivities = await getOrderedActivities(versionId, facilityId);
+  const taskListElements = getFacilitiesInformationTaskList(
+    versionId,
+    facilityId,
+    orderedActivities,
+    ActivePage.NonAttributableEmission,
   );
 
   const gasTypeMap = gasTypes.reduce(
@@ -45,7 +56,7 @@ export default async function NonAttributableEmissions({
   );
 
   return (
-    <Suspense fallback={<Loading />}>
+    <Suspense>
       <NonAttributableEmissionsForm
         versionId={versionId}
         facilityId={facilityId}
@@ -54,6 +65,7 @@ export default async function NonAttributableEmissions({
         emissionCategories={emissionCategories}
         gasTypeMap={gasTypeMap} // Pass the map to the form component
         emissionCategoryMap={emissionCategoryMap} // Pass the map to the form component
+        taskListElements={taskListElements}
       />
     </Suspense>
   );

--- a/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributatbleEmissions.tsx
+++ b/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributatbleEmissions.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+import Loading from "@bciers/components/loading/SkeletonForm";
 import NonAttributableEmissionsForm from "@reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm";
 import { UUID } from "crypto";
 import { getAllGasTypes } from "@reporting/src/app/utils/getAllGasTypes";
@@ -8,7 +10,6 @@ import {
   ActivePage,
   getFacilitiesInformationTaskList,
 } from "../../taskList/2_facilitiesInformation";
-import { Suspense } from "react";
 
 interface NonAttributableEmissionsProps {
   versionId: number;
@@ -56,7 +57,7 @@ export default async function NonAttributableEmissions({
   );
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <NonAttributableEmissionsForm
         versionId={versionId}
         facilityId={facilityId}

--- a/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
@@ -48,7 +48,7 @@ export default function SignOffPage({ version_id }: HasReportVersion) {
     if (!submitButtonDisabled) {
       const response: any = await postSubmitReport(version_id);
 
-      if (response.error) {
+      if (response?.error) {
         setErrors([reportValidationMessages[response.error]]);
         return false;
       }

--- a/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
@@ -24,7 +24,7 @@ const cancelUrl = "/reports";
 
 export default function SignOffPage({ version_id }: HasReportVersion) {
   const [formState, setFormState] = useState({});
-  const [error, setError] = useState<string>();
+  const [errors, setErrors] = useState<string[]>();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
 
@@ -49,14 +49,15 @@ export default function SignOffPage({ version_id }: HasReportVersion) {
       const response: any = await postSubmitReport(version_id);
 
       if (response.error) {
-        setError(reportValidationMessages[response.error]);
-        throw new Error("Submit form returned errors.");
+        setErrors([reportValidationMessages[response.error]]);
+        return false;
       }
-      setError(undefined);
-
+      setErrors(undefined);
       setIsSubmitting(true);
       setSubmitButtonDisabled(true);
     }
+
+    return true;
   };
 
   return (
@@ -83,7 +84,7 @@ export default function SignOffPage({ version_id }: HasReportVersion) {
           submitButtonDisabled={submitButtonDisabled} // Disable button if not all checkboxes are checked
           continueUrl={""}
           backUrl={backUrl}
-          error={error}
+          errors={errors}
         />
       )}
     </>

--- a/bciers/apps/reporting/src/app/components/taskList/1_operationInformation.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/1_operationInformation.ts
@@ -6,17 +6,27 @@ export enum ActivePage {
   "ReviewFacilities",
 }
 
-/**
- *
- * @param versionId Int. The version ID
- * @param facilityId UUID. If applicable, the facility ID. A 'null' facility ID means the operation is an LFO
- * @returns The list of tasklist elements for the 'operation information' reporting step
- */
 export const getOperationInformationTaskList: (
   versionId: number,
-  facilityId?: string | null,
-  activeIndex?: ActivePage | number,
-) => TaskListElement[] = (versionId, facilityId, activeIndex) => {
+  activeIndex?: ActivePage,
+  operationType?: string, // "Single Facility Operation" or "Linear Facility Operation"
+) => TaskListElement[] = (
+  versionId,
+  activeIndex = 0,
+  operationType = "Single Facility Operation",
+) => {
+  const facilityReviewItem: TaskListElement[] =
+    operationType !== "Linear Facility Operation"
+      ? []
+      : [
+          {
+            type: "Page",
+            title: "Review facilities",
+            link: `/reports/${versionId}/facilities/lfo-facilities`,
+            isActive: activeIndex === ActivePage.ReviewFacilities,
+          },
+        ];
+
   return [
     {
       type: "Section",
@@ -35,14 +45,7 @@ export const getOperationInformationTaskList: (
           link: `/reports/${versionId}/person-responsible`,
           isActive: activeIndex === ActivePage.PersonResponsible,
         },
-        {
-          type: "Page",
-          title: "Review facilities",
-          link: facilityId
-            ? `/reports/${versionId}/facilities/${facilityId}/review`
-            : `/reports/${versionId}/facilities/lfo-facilities`,
-          isActive: activeIndex === ActivePage.ReviewFacilities,
-        },
+        ...facilityReviewItem,
       ],
     },
   ];

--- a/bciers/apps/reporting/src/app/components/taskList/3_additionalInformation.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/3_additionalInformation.ts
@@ -5,25 +5,27 @@ export enum ActivePage {
   "NewEntrantInformation",
 }
 
-export const getAdditionalInformationTaskList = (
+export const getAdditionalInformationTaskList: (
   versionId: number,
   activeIndex?: ActivePage | number,
-) => {
-  const taskListData: TaskListElement[] = [
-    {
-      type: "Page",
-      title: "Additional reporting data",
-      isChecked: true,
-      link: `/reports/${versionId}/additional-reporting-data`,
-      isActive: activeIndex === ActivePage.AdditionalReportingData,
-    },
-    {
-      type: "Page",
-      title: "New entrant information",
-      isActive: activeIndex === ActivePage.NewEntrantInformation,
-      link: `/reports/${versionId}/new-entrant-information`,
-    },
-  ];
+  isNewEntrant?: boolean,
+) => TaskListElement[] = (versionId, activeIndex, isNewEntrant) => {
+  const additionalReportingDataItem: TaskListElement = {
+    type: "Page",
+    title: "Additional reporting data",
+    isChecked: true,
+    link: `/reports/${versionId}/additional-reporting-data`,
+    isActive: activeIndex === ActivePage.AdditionalReportingData,
+  };
 
-  return taskListData;
+  const newEntrantItem: TaskListElement = {
+    type: "Page",
+    title: "New entrant information",
+    isActive: activeIndex === ActivePage.NewEntrantInformation,
+    link: `/reports/${versionId}/new-entrant-information`,
+  };
+
+  return isNewEntrant
+    ? [additionalReportingDataItem, newEntrantItem]
+    : [additionalReportingDataItem];
 };

--- a/bciers/apps/reporting/src/app/components/taskList/4_complianceSummary.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/4_complianceSummary.ts
@@ -1,10 +1,9 @@
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 
-export const tasklistData: TaskListElement[] = [
+export const getComplianceSummaryTaskList: () => TaskListElement[] = () => [
   {
     type: "Page",
     title: "Compliance Summary",
     isActive: true,
-    elements: [],
   },
 ];

--- a/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
@@ -11,7 +11,6 @@ import {
   cancelUrlReports,
 } from "@reporting/src/app/utils/constants";
 import { actionHandler } from "@bciers/actions";
-import safeJsonParse from "@bciers/utils/src/safeJsonParse";
 import serializeSearchParams from "@bciers/utils/src/serializeSearchParams";
 
 interface Props {
@@ -30,7 +29,7 @@ export default function VerificationForm({
   taskListElements,
 }: Props) {
   const [formData, setFormData] = useState(initialData);
-  const [error, setError] = useState(undefined);
+  const [errors, setErrors] = useState<string[]>();
   const searchParams = useSearchParams();
   const queryString = serializeSearchParams(searchParams);
 
@@ -47,16 +46,17 @@ export default function VerificationForm({
     const endpoint = `reporting/report-version/${version_id}/report-verification`;
     const method = "POST";
     const pathToRevalidate = "reporting/reports";
-    const payload = safeJsonParse(JSON.stringify(formData));
+
     const response = await actionHandler(endpoint, method, pathToRevalidate, {
-      body: JSON.stringify(payload),
+      body: JSON.stringify(formData),
     });
 
-    if (response?.error) {
-      setError(response.error);
-      return;
+    if (response.error) {
+      setErrors([response.error]);
+      return false;
     } else {
-      setError(undefined);
+      setErrors(undefined);
+      return true;
     }
   };
 
@@ -73,7 +73,7 @@ export default function VerificationForm({
       backUrl={backUrl}
       onChange={handleChange}
       onSubmit={handleSubmit}
-      error={error}
+      errors={errors}
       continueUrl={saveAndContinueUrl}
     />
   );

--- a/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
@@ -51,13 +51,13 @@ export default function VerificationForm({
       body: JSON.stringify(formData),
     });
 
-    if (response.error) {
+    if (response?.error) {
       setErrors([response.error]);
       return false;
-    } else {
-      setErrors(undefined);
-      return true;
     }
+
+    setErrors(undefined);
+    return true;
   };
 
   return (

--- a/bciers/apps/reporting/src/tests/components/complianceSummary/ComplianceSummaryPage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/complianceSummary/ComplianceSummaryPage.test.tsx
@@ -3,9 +3,9 @@ import ComplianceSummaryForm from "@reporting/src/app/components/complianceSumma
 import ComplianceSummaryPage from "@reporting/src/app/components/complianceSummary/ComplianceSummaryPage";
 import { actionHandler } from "@bciers/actions";
 import { getReportNeedsVerification } from "@reporting/src/app/utils/getReportNeedsVerification";
-import { tasklistData } from "@reporting/src/app/components/complianceSummary/TaskListElements";
 
 import { vi } from "vitest";
+import { getComplianceSummaryTaskList } from "@reporting/src/app/components/taskList/4_complianceSummary";
 
 // ✨ Mocks
 vi.mock(
@@ -50,7 +50,7 @@ describe("ComplianceSummaryPage", () => {
         versionId,
         needsVerification: false,
         summaryFormData: complianceData,
-        taskListElements: tasklistData,
+        taskListElements: getComplianceSummaryTaskList(),
       },
       {},
     );
@@ -73,7 +73,7 @@ describe("ComplianceSummaryPage", () => {
         versionId,
         needsVerification: true,
         summaryFormData: complianceData,
-        taskListElements: tasklistData,
+        taskListElements: getComplianceSummaryTaskList(),
       },
       {},
     );
@@ -96,7 +96,7 @@ describe("ComplianceSummaryPage", () => {
         versionId,
         needsVerification: true,
         summaryFormData: complianceData,
-        taskListElements: tasklistData,
+        taskListElements: getComplianceSummaryTaskList(),
       },
       {},
     );

--- a/bciers/apps/reporting/src/tests/components/reportInformation/NonAttributableEmissions.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/reportInformation/NonAttributableEmissions.test.tsx
@@ -48,6 +48,7 @@ describe("NonAttributableEmissionsForm Component", () => {
         emissionCategories={emissionCategories}
         gasTypeMap={{ 1: "CO2" }}
         emissionCategoryMap={{ 1: "Direct" }}
+        taskListElements={[]}
       />,
     );
 
@@ -69,6 +70,7 @@ describe("NonAttributableEmissionsForm Component", () => {
         emissionCategories={emissionCategories}
         gasTypeMap={{ 1: "CO2" }}
         emissionCategoryMap={{ 1: "Direct" }}
+        taskListElements={[]}
       />,
     );
 
@@ -88,6 +90,7 @@ describe("NonAttributableEmissionsForm Component", () => {
         emissionCategories={emissionCategories}
         gasTypeMap={{ 1: "CO2" }}
         emissionCategoryMap={{ 1: "Direct" }}
+        taskListElements={[]}
       />,
     );
 
@@ -118,6 +121,7 @@ describe("NonAttributableEmissionsForm Component", () => {
         emissionCategories={emissionCategories}
         gasTypeMap={{ 1: "CO2" }}
         emissionCategoryMap={{ 1: "Direct" }}
+        taskListElements={[]}
       />,
     );
 

--- a/bciers/libs/components/src/form/MultiStepFormWithTaskList.tsx
+++ b/bciers/libs/components/src/form/MultiStepFormWithTaskList.tsx
@@ -1,88 +1,19 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
 import MultiStepHeader from "./components/MultiStepHeader";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/ReportingTaskList";
-import { FormBase } from "@bciers/components/form/index";
-import { RJSFSchema } from "@rjsf/utils";
-import FormContext from "@rjsf/core";
-import { Alert, Box } from "@mui/material";
-import ReportingStepButtons from "./components/ReportingStepButtons";
-import { useRouter } from "next/navigation";
+import NavigationForm, { NavigationFormProps } from "./NavigationForm";
+import { Box } from "@mui/material";
 
-interface Props {
+interface Props extends NavigationFormProps {
   initialStep: number;
   steps: string[];
   taskListElements: TaskListElement[];
-  schema: RJSFSchema;
-  uiSchema: RJSFSchema;
-  formData: any;
-  baseUrl?: string;
-  cancelUrl?: string;
-  backUrl?: string;
-  continueUrl: string;
-  onSubmit: (data: any) => Promise<void>;
-  buttonText?: string;
-  onChange?: (data: any) => void;
-  error?: any;
-  saveButtonDisabled?: boolean;
-  submitButtonDisabled?: boolean;
-  formContext?: { [key: string]: any }; // used in RJSF schema for access to form data in custom templates
 }
 
-const MultiStepFormWithTaskList: React.FC<Props> = ({
-  initialStep,
-  steps,
-  taskListElements,
-  schema,
-  uiSchema,
-  formData,
-  backUrl,
-  continueUrl,
-  onSubmit,
-  onChange,
-  error,
-  saveButtonDisabled,
-  submitButtonDisabled,
-  buttonText,
-  formContext,
-}) => {
-  const [isSaving, setIsSaving] = useState(false);
-  const [isSuccess, setIsSuccess] = useState(false);
-  const [isRedirecting, setIsRedirecting] = useState(false);
-  const [canContinue, setCanContinue] = useState(false);
-  const formRef = useRef<FormContext>(null);
-  const router = useRouter();
-
-  const handleFormSave = async (data: any) => {
-    setIsSaving(true);
-    try {
-      await onSubmit(data);
-      if (canContinue) {
-        setIsRedirecting(true);
-        router.push(continueUrl);
-      } else {
-        setIsSuccess(true);
-        setTimeout(() => {
-          setIsSuccess(false);
-        }, 3000);
-      }
-    } catch {
-      setIsSuccess(false);
-      setIsRedirecting(false);
-    }
-    setIsSaving(false);
-  };
-
-  const submitExternallyToContinue = () => {
-    setCanContinue(true);
-  }; // Only submit after canContinue is set so the submitHandler can read the boolean
-  useEffect(() => {
-    if (formRef.current && canContinue) {
-      formRef.current.submit();
-    }
-  }, [canContinue]);
+const MultiStepFormWithTaskList: React.FC<Props> = (props) => {
+  const { initialStep, steps, taskListElements } = props;
 
   return (
     <Box sx={{ p: 3 }}>
@@ -95,31 +26,7 @@ const MultiStepFormWithTaskList: React.FC<Props> = ({
           <ReportingTaskList elements={taskListElements} />
         </div>
         <div className="w-full">
-          <FormBase
-            formRef={formRef}
-            schema={schema}
-            uiSchema={uiSchema}
-            onSubmit={handleFormSave}
-            formData={formData}
-            onChange={onChange}
-            onError={() => setCanContinue(false)}
-            formContext={formContext}
-          >
-            <ReportingStepButtons
-              backUrl={backUrl}
-              continueUrl={continueUrl}
-              isSaving={isSaving}
-              isSuccess={isSuccess}
-              isRedirecting={isRedirecting}
-              saveButtonDisabled={saveButtonDisabled}
-              submitButtonDisabled={submitButtonDisabled}
-              saveAndContinue={submitExternallyToContinue}
-              buttonText={buttonText}
-            />
-            <div className="min-h-[48px] box-border mt-4">
-              {error && <Alert severity="error">{error}</Alert>}
-            </div>
-          </FormBase>
+          <NavigationForm {...props} />
         </div>
       </div>
     </Box>

--- a/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
+++ b/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
@@ -26,7 +26,6 @@ interface Props {
   error?: string;
   isSaving?: boolean;
   isRedirecting?: boolean;
-  noFormSave?: () => void;
 }
 
 const MultiStepWrapperWithTaskList: React.FC<Props> = ({
@@ -41,7 +40,6 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
   error,
   isSaving,
   isRedirecting,
-  noFormSave,
 }) => {
   return (
     <Box sx={{ p: 3 }}>
@@ -67,7 +65,6 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
             saveAndContinue={onSubmit}
             isRedirecting={isRedirecting}
             isSaving={isSaving}
-            noFormSave={noFormSave}
           />
         </div>
       </div>

--- a/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
+++ b/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
@@ -17,7 +17,6 @@ interface Props {
   steps: string[];
   taskListElements: TaskListElement[];
   onSubmit: () => void;
-  noFormSave: () => void;
   children?: React.ReactNode;
   cancelUrl?: string;
   backUrl?: string;
@@ -27,6 +26,7 @@ interface Props {
   error?: string;
   isSaving?: boolean;
   isRedirecting?: boolean;
+  noFormSave?: () => void;
 }
 
 const MultiStepWrapperWithTaskList: React.FC<Props> = ({
@@ -34,7 +34,6 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
   steps,
   taskListElements,
   onSubmit,
-  noFormSave,
   children,
   backUrl,
   continueUrl,
@@ -42,6 +41,7 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
   error,
   isSaving,
   isRedirecting,
+  noFormSave,
 }) => {
   return (
     <Box sx={{ p: 3 }}>

--- a/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
+++ b/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
@@ -17,6 +17,7 @@ interface Props {
   steps: string[];
   taskListElements: TaskListElement[];
   onSubmit: () => void;
+  noFormSave: () => void;
   children?: React.ReactNode;
   cancelUrl?: string;
   backUrl?: string;
@@ -33,6 +34,7 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
   steps,
   taskListElements,
   onSubmit,
+  noFormSave,
   children,
   backUrl,
   continueUrl,
@@ -62,6 +64,7 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
             backUrl={backUrl}
             continueUrl={continueUrl}
             buttonText={submittingButtonText}
+            noFormSave={noFormSave}
             saveAndContinue={onSubmit}
             isRedirecting={isRedirecting}
             isSaving={isSaving}

--- a/bciers/libs/components/src/form/NavigationForm.tsx
+++ b/bciers/libs/components/src/form/NavigationForm.tsx
@@ -98,6 +98,7 @@ const NavigationForm: React.FC<NavigationFormProps> = (props) => {
       onSubmit={(data) => handleFormSave(data, false)}
     >
       <ReportingStepButtons
+        key="form-buttons"
         backUrl={backUrl}
         continueUrl={continueUrl}
         isSaving={isSaving}
@@ -109,9 +110,11 @@ const NavigationForm: React.FC<NavigationFormProps> = (props) => {
         buttonText={buttonText}
       />
       {errors && errors.length > 0 && (
-        <div className="min-h-[48px] box-border mt-4">
-          {errors.map((e) => (
-            <Alert severity="error">{e}</Alert>
+        <div key="form-alerts" className="min-h-[48px] box-border mt-4">
+          {errors.map((e, index) => (
+            <Alert key={index} severity="error">
+              {e}
+            </Alert>
           ))}
         </div>
       )}

--- a/bciers/libs/components/src/form/NavigationForm.tsx
+++ b/bciers/libs/components/src/form/NavigationForm.tsx
@@ -1,0 +1,100 @@
+import { useRef, useState } from "react";
+import FormBase, { FormPropsWithTheme } from "./FormBase";
+import Form from "@rjsf/core";
+import { useRouter } from "next/router";
+import { RJSFSchema, UiSchema } from "@rjsf/utils";
+import ReportingStepButtons from "./components/ReportingStepButtons";
+import { Alert } from "@mui/material";
+
+export interface NavigationFormProps extends FormPropsWithTheme<any> {
+  schema: RJSFSchema;
+  uiSchema: UiSchema;
+  formData: any;
+  baseUrl?: string;
+  cancelUrl?: string;
+  backUrl?: string;
+  continueUrl: string;
+  onSubmit: (data: any) => Promise<boolean>;
+  buttonText?: string;
+  onChange?: (data: any) => void;
+  error?: any;
+  saveButtonDisabled?: boolean;
+  submitButtonDisabled?: boolean;
+  formContext?: { [key: string]: any }; // used in RJSF schema for access to form data in custom templates
+}
+
+const NavigationForm: React.FC<NavigationFormProps> = ({
+  schema,
+  uiSchema,
+  formData,
+  backUrl,
+  continueUrl,
+  onSubmit,
+  onChange,
+  formContext,
+  saveButtonDisabled,
+  submitButtonDisabled,
+  buttonText,
+  error,
+}) => {
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [isRedirecting, setIsRedirecting] = useState(false);
+  const formRef = useRef<Form>(null);
+  const router = useRouter();
+
+  const handleFormSave = async (data: any, navigateAfterSubmit: boolean) => {
+    setIsSaving(true);
+    try {
+      await onSubmit(data);
+      if (navigateAfterSubmit) {
+        setIsRedirecting(true);
+        router.push(continueUrl);
+      } else {
+        setIsSuccess(true);
+        setTimeout(() => {
+          setIsSuccess(false);
+        }, 3000);
+      }
+    } catch {
+      setIsSuccess(false);
+      setIsRedirecting(false);
+    }
+    setIsSaving(false);
+  };
+
+  // Essentially a manual call to `submit()` with a context
+  const onSaveAndContinue = async () => {
+    if (formRef.current?.validateForm())
+      await handleFormSave(formRef.current.state.formData, true);
+  };
+
+  return (
+    <FormBase
+      formRef={formRef}
+      schema={schema}
+      uiSchema={uiSchema}
+      onSubmit={(data) => handleFormSave(data, false)}
+      formData={formData}
+      onChange={onChange}
+      formContext={formContext}
+    >
+      <ReportingStepButtons
+        backUrl={backUrl}
+        continueUrl={continueUrl}
+        isSaving={isSaving}
+        isSuccess={isSuccess}
+        isRedirecting={isRedirecting}
+        saveButtonDisabled={saveButtonDisabled}
+        submitButtonDisabled={submitButtonDisabled}
+        saveAndContinue={onSaveAndContinue}
+        buttonText={buttonText}
+      />
+      <div className="min-h-[48px] box-border mt-4">
+        {error && <Alert severity="error">{error}</Alert>}
+      </div>
+    </FormBase>
+  );
+};
+
+export default NavigationForm;

--- a/bciers/libs/components/src/form/NavigationForm.tsx
+++ b/bciers/libs/components/src/form/NavigationForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import FormBase, { FormPropsWithTheme } from "./FormBase";
 import Form from "@rjsf/core";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
@@ -45,21 +45,29 @@ const NavigationForm: React.FC<NavigationFormProps> = (props) => {
   const handleFormSave = async (data: any, navigateAfterSubmit: boolean) => {
     setIsSaving(true);
     const success = await onSubmit(data);
-    setIsSaving(false);
 
     if (success) {
       if (navigateAfterSubmit) {
         setIsRedirecting(true);
         router.push(continueUrl);
-        setIsRedirecting(false);
       } else {
         setIsSuccess(true);
         setTimeout(() => {
           setIsSuccess(false);
         }, 3000);
+        setIsSaving(false);
       }
+    } else {
+      setIsSaving(false);
     }
   };
+
+  useEffect(() => {
+    /** Effect triggers when navigation to another page is finished and this component reloads
+     *  Otherwise the spinner stops spinning before the page changes. */
+    setIsRedirecting(false);
+    setIsSaving(false);
+  }, [backUrl, continueUrl]);
 
   // Essentially a manual call to `submit()` with a context
   const onSaveAndContinue = async () => {

--- a/bciers/libs/components/src/form/NavigationForm.tsx
+++ b/bciers/libs/components/src/form/NavigationForm.tsx
@@ -25,20 +25,17 @@ export interface NavigationFormProps extends FormPropsWithTheme<any> {
   formContext?: { [key: string]: any }; // used in RJSF schema for access to form data in custom templates
 }
 
-const NavigationForm: React.FC<NavigationFormProps> = ({
-  schema,
-  uiSchema,
-  formData,
-  backUrl,
-  continueUrl,
-  onSubmit,
-  onChange,
-  formContext,
-  saveButtonDisabled,
-  submitButtonDisabled,
-  buttonText,
-  errors,
-}) => {
+const NavigationForm: React.FC<NavigationFormProps> = (props) => {
+  const {
+    backUrl,
+    continueUrl,
+    onSubmit,
+    saveButtonDisabled,
+    submitButtonDisabled,
+    buttonText,
+    errors,
+  } = props;
+
   const [isSaving, setIsSaving] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isRedirecting, setIsRedirecting] = useState(false);
@@ -48,23 +45,20 @@ const NavigationForm: React.FC<NavigationFormProps> = ({
   const handleFormSave = async (data: any, navigateAfterSubmit: boolean) => {
     setIsSaving(true);
     const success = await onSubmit(data);
+    setIsSaving(false);
 
     if (success) {
       if (navigateAfterSubmit) {
         setIsRedirecting(true);
         router.push(continueUrl);
+        setIsRedirecting(false);
       } else {
-        setIsSaving(false);
         setIsSuccess(true);
         setTimeout(() => {
           setIsSuccess(false);
         }, 3000);
       }
-      return;
     }
-
-    setIsSuccess(false);
-    setIsSaving(false);
   };
 
   // Essentially a manual call to `submit()` with a context
@@ -75,13 +69,9 @@ const NavigationForm: React.FC<NavigationFormProps> = ({
 
   return (
     <FormBase
+      {...props}
       formRef={formRef}
-      schema={schema}
-      uiSchema={uiSchema}
       onSubmit={(data) => handleFormSave(data, false)}
-      formData={formData}
-      onChange={onChange}
-      formContext={formContext}
     >
       <ReportingStepButtons
         backUrl={backUrl}

--- a/bciers/libs/components/src/form/NavigationForm.tsx
+++ b/bciers/libs/components/src/form/NavigationForm.tsx
@@ -46,13 +46,8 @@ const NavigationForm: React.FC<NavigationFormProps> = ({
   const router = useRouter();
 
   const handleFormSave = async (data: any, navigateAfterSubmit: boolean) => {
-    console.log("save", navigateAfterSubmit, continueUrl);
-
     setIsSaving(true);
-
     const success = await onSubmit(data);
-
-    console.log("success", success);
 
     if (success) {
       if (navigateAfterSubmit) {

--- a/bciers/libs/components/src/form/NavigationForm.tsx
+++ b/bciers/libs/components/src/form/NavigationForm.tsx
@@ -25,6 +25,19 @@ export interface NavigationFormProps extends FormPropsWithTheme<any> {
   formContext?: { [key: string]: any }; // used in RJSF schema for access to form data in custom templates
 }
 
+const useKey: () => [number, () => void] = () => {
+  /**
+   * Utility to manage a state meant to be used as a unique key to drive re-rendering of a component.
+   * Guaranteed to generate a different 'key' every time 'resetKey()' is called, by incrementing the previous value.
+   *
+   * Note: This is meant to be temporary until the implications of removing the FormBase `isSubmitting` guard
+   * on its formData are understood.
+   */
+  const [key, setKey] = useState(1);
+  const resetKey = () => setKey((prevKey) => prevKey + 1);
+  return [key, resetKey];
+};
+
 const NavigationForm: React.FC<NavigationFormProps> = (props) => {
   const {
     backUrl,
@@ -39,12 +52,14 @@ const NavigationForm: React.FC<NavigationFormProps> = (props) => {
   const [isSaving, setIsSaving] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isRedirecting, setIsRedirecting] = useState(false);
+  const [key, resetKey] = useKey();
   const formRef = useRef<Form>(null);
   const router = useRouter();
 
   const handleFormSave = async (data: any, navigateAfterSubmit: boolean) => {
     setIsSaving(true);
     const success = await onSubmit(data);
+    resetKey();
 
     if (success) {
       if (navigateAfterSubmit) {
@@ -78,6 +93,7 @@ const NavigationForm: React.FC<NavigationFormProps> = (props) => {
   return (
     <FormBase
       {...props}
+      key={key}
       formRef={formRef}
       onSubmit={(data) => handleFormSave(data, false)}
     >

--- a/bciers/libs/components/src/form/components/ReportingStepButtons.tsx
+++ b/bciers/libs/components/src/form/components/ReportingStepButtons.tsx
@@ -85,10 +85,9 @@ const ReportingStepButtons: React.FunctionComponent<StepButtonProps> = ({
         disabled={isSaving || submitButtonDisabled}
         sx={{ px: 4 }}
         onClick={() => {
-          if (saveAndContinue !== undefined) {
+          if (saveAndContinue) {
             saveAndContinue();
           } else {
-            isRedirecting = true;
             router.push(continueUrl);
           }
         }}


### PR DESCRIPTION
### Work done:
- Fixes the forms holding onto errors and prevending resubmissions when the server returned an error once.
- Refactored the navigation logic in a `NavigationForm` component, to avoid having to implement the funky `useEffect` everywhere it's needed
- Updated the various forms to do display server errors

### Notable change:
- `submitHandler` needs to return a boolean to indicate whether the submission succeeded, server-side


Fixes:
- #461 the facility item improperly showing up on the operation review task list