### PR TITLE
chore: give industry_user create access to contacts

### DIFF
--- a/bciers/apps/administration/app/bceidbusiness/industry_user/contacts/add-contact/page.tsx
+++ b/bciers/apps/administration/app/bceidbusiness/industry_user/contacts/add-contact/page.tsx
@@ -1,0 +1,11 @@
+import ContactPage from "@/administration/app/components/contacts/ContactPage";
+import { Suspense } from "react";
+import Loading from "@bciers/components/loading/SkeletonForm";
+
+export default function Page() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <ContactPage />
+    </Suspense>
+  );
+}

--- a/bciers/apps/administration/app/components/contacts/ContactPage.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactPage.tsx
@@ -6,7 +6,6 @@ import getUserOperatorUsers from "./getUserOperatorUsers";
 import { createContactSchema } from "./createContactSchema";
 import Note from "@bciers/components/layout/Note";
 import { auth } from "@/dashboard/auth";
-import { FrontEndRoles } from "@bciers/utils/src/enums";
 
 // 🧩 Main component
 export default async function ContactPage({
@@ -52,7 +51,7 @@ export default async function ContactPage({
         )}
         formData={contactFormData}
         isCreating={isCreating}
-        allowEdit={role === FrontEndRoles.INDUSTRY_USER_ADMIN}
+        allowEdit={role.includes("industry")}
       />
     </>
   );

--- a/bciers/apps/administration/app/components/contacts/ContactsPage.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactsPage.tsx
@@ -4,12 +4,10 @@ import ContactsDataGrid from "./ContactsDataGrid";
 import Note from "@bciers/components/layout/Note";
 import Link from "next/link";
 import { Button } from "@mui/material";
-import { auth } from "@/dashboard/auth";
-import { FrontEndRoles } from "@bciers/utils/src/enums";
 import { Suspense } from "react";
 import Loading from "@bciers/components/loading/SkeletonGrid";
 
-const ExternalContactsLayout = ({ isAdmin }: { isAdmin: boolean }) => {
+const ExternalContactsLayout = () => {
   return (
     <>
       <Note>
@@ -18,13 +16,12 @@ const ExternalContactsLayout = ({ isAdmin }: { isAdmin: boolean }) => {
         up to date here.
       </Note>
       <h2 className="text-bc-primary-blue">Contacts</h2>
-      {isAdmin && (
-        <div className="text-right">
-          <Link href={`/contacts/add-contact`}>
-            <Button variant="contained">Add Contact</Button>
-          </Link>
-        </div>
-      )}
+
+      <div className="text-right">
+        <Link href={`/contacts/add-contact`}>
+          <Button variant="contained">Add Contact</Button>
+        </Link>
+      </div>
     </>
   );
 };
@@ -58,20 +55,10 @@ export default async function ContactsPage({
     return <div>No contacts data in database.</div>;
   }
 
-  // To get the user's role from the session
-  const session = await auth();
-  const role = session?.user?.app_role ?? "";
-
   // Render the DataGrid component
   return (
     <>
-      {isExternalUser ? (
-        <ExternalContactsLayout
-          isAdmin={role === FrontEndRoles.INDUSTRY_USER_ADMIN}
-        />
-      ) : (
-        <InternalContactsLayout />
-      )}
+      {isExternalUser ? <ExternalContactsLayout /> : <InternalContactsLayout />}
       <Suspense fallback={<Loading />}>
         <div className="mt-5">
           <ContactsDataGrid


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=91260610&issue=bcgov%7Ccas-registration%7C2605

This PR:
- adds a `page.tsx` for add-contacts for the industry_user (reporter) role
- removes conditionality that only allowed admin industry users to add contacts