### PR TITLE
Replace operation rep

### DIFF
--- a/bc_obps/registration/api/v2/_contacts/contact_id.py
+++ b/bc_obps/registration/api/v2/_contacts/contact_id.py
@@ -4,11 +4,12 @@ from django.http import HttpRequest
 from registration.constants import CONTACT_TAGS
 from registration.models.contact import Contact
 from registration.schema.v1.contact import ContactIn, ContactOut
-from service.contact_service import ContactService, ContactWithPlacesAssigned
 from common.api.utils import get_current_user_guid
 from registration.decorators import handle_http_errors
 from registration.api.router import router
 from registration.schema.generic import Message
+from service.contact_service_v2 import ContactServiceV2, ContactWithPlacesAssigned
+from service.contact_service import ContactService
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 
 
@@ -23,7 +24,7 @@ from service.error_service.custom_codes_4xx import custom_codes_4xx
 )
 @handle_http_errors()
 def get_contact(request: HttpRequest, contact_id: int) -> Tuple[Literal[200], Optional[ContactWithPlacesAssigned]]:
-    return 200, ContactService.get_with_places_assigned(get_current_user_guid(request), contact_id)
+    return 200, ContactServiceV2.get_with_places_assigned_v2(get_current_user_guid(request), contact_id)
 
 
 @router.put(

--- a/bc_obps/registration/api/v2/_contacts/contact_id.py
+++ b/bc_obps/registration/api/v2/_contacts/contact_id.py
@@ -15,7 +15,7 @@ from service.error_service.custom_codes_4xx import custom_codes_4xx
 
 @router.get(
     "/contacts/{contact_id}",
-    response={200: ContactOut, custom_codes_4xx: Message},
+    response={200: ContactWithPlacesAssigned, custom_codes_4xx: Message},
     tags=CONTACT_TAGS,
     description="""Retrieves the details of a specific contact by its ID. The endpoint checks if the current user is authorized to access the contact.
     Industry users can only access contacts that are associated with their own operator. If an unauthorized user attempts to access the contact, an error is raised.""",
@@ -24,7 +24,7 @@ from service.error_service.custom_codes_4xx import custom_codes_4xx
 )
 @handle_http_errors()
 def get_contact(request: HttpRequest, contact_id: int) -> Tuple[Literal[200], Optional[ContactWithPlacesAssigned]]:
-    return 200, ContactServiceV2.get_with_places_assigned_v2(get_current_user_guid(request), contact_id)
+    return 200, ContactServiceV2.get_with_places_assigned_v2(contact_id)
 
 
 @router.put(

--- a/bc_obps/registration/api/v2/_operations/operation_id.py
+++ b/bc_obps/registration/api/v2/_operations/operation_id.py
@@ -1,6 +1,10 @@
 from typing import Literal, Tuple
 from uuid import UUID
-from registration.schema.v2.operation import OperationOutV2, OperationInformationIn, OperationOutWithDocuments
+from registration.schema.v2.operation import (
+    OperationInformationInUpdate,
+    OperationOutV2,
+    OperationOutWithDocuments,
+)
 from common.permissions import authorize
 from django.http import HttpRequest
 from registration.constants import OPERATION_TAGS
@@ -57,6 +61,6 @@ def get_operation_with_documents(request: HttpRequest, operation_id: UUID) -> Tu
 )
 @handle_http_errors()
 def update_operation(
-    request: HttpRequest, operation_id: UUID, payload: OperationInformationIn
+    request: HttpRequest, operation_id: UUID, payload: OperationInformationInUpdate
 ) -> Tuple[Literal[200], Operation]:
     return 200, OperationServiceV2.update_operation(get_current_user_guid(request), payload, operation_id)

--- a/bc_obps/registration/fixtures/mock/address.json
+++ b/bc_obps/registration/fixtures/mock/address.json
@@ -208,5 +208,13 @@
       "province": "ON",
       "postal_code": "N2L 3G1"
     }
+  },
+  {
+    "model": "registration.address",
+    "pk": 21,
+    "fields": {
+      "street_address": "Incomplete address",
+      "municipality": "Grove"
+    }
   }
 ]

--- a/bc_obps/registration/fixtures/mock/contact.json
+++ b/bc_obps/registration/fixtures/mock/contact.json
@@ -4,11 +4,11 @@
     "pk": 1,
     "fields": {
       "business_role": "Operation Representative",
-      "first_name": "John",
-      "last_name": "Doe",
+      "first_name": "Alice",
+      "last_name": "Art",
       "position_title": "Manager",
       "address": 1,
-      "email": "john.doe@example.com",
+      "email": "alice.art@example.com",
       "phone_number": "+16044011234"
     }
   },
@@ -17,11 +17,11 @@
     "pk": 2,
     "fields": {
       "business_role": "Operation Representative",
-      "first_name": "Jane",
-      "last_name": "Smith",
+      "first_name": "Althea",
+      "last_name": "Ark",
       "position_title": "Manager",
       "address": 2,
-      "email": "jane.smith@example.com",
+      "email": "althea.ark@example.com",
       "phone_number": "+16044011234"
     }
   },
@@ -30,11 +30,11 @@
     "pk": 3,
     "fields": {
       "business_role": "Operation Representative",
-      "first_name": "Alice",
-      "last_name": "Johnson",
+      "first_name": "Bill",
+      "last_name": "Blue",
       "position_title": "Manager",
       "address": 3,
-      "email": "alice.johnson@example.com",
+      "email": "bill.blue@example.com",
       "phone_number": "+16044011235"
     }
   },
@@ -56,11 +56,10 @@
     "pk": 5,
     "fields": {
       "business_role": "Operation Representative",
-      "first_name": "Carol",
-      "last_name": "Davis",
+      "first_name": "Blair",
+      "last_name": "Balloons - no address",
       "position_title": "Manager",
-      "address": 5,
-      "email": "carol.davis@example.com",
+      "email": "blair.balloons@example.com",
       "phone_number": "+16044011237"
     }
   },
@@ -69,11 +68,11 @@
     "pk": 6,
     "fields": {
       "business_role": "Operation Representative",
-      "first_name": "Dave",
-      "last_name": "Evans",
+      "first_name": "Bart",
+      "last_name": "Banker - incomplete address",
       "position_title": "Manager",
-      "address": 6,
-      "email": "dave.evans@example.com",
+      "address": 21,
+      "email": "bart.banker@example.com",
       "phone_number": "+16044011238"
     }
   },

--- a/bc_obps/registration/fixtures/mock/contact.json
+++ b/bc_obps/registration/fixtures/mock/contact.json
@@ -135,9 +135,8 @@
     "fields": {
       "business_role": "Operation Representative",
       "first_name": "Ivy",
-      "last_name": "Jones",
+      "last_name": "Jones - no address",
       "position_title": "Manager",
-      "address": 11,
       "email": "ivy.jones@example.com",
       "phone_number": "+16044011243"
     }
@@ -148,9 +147,9 @@
     "fields": {
       "business_role": "Operation Representative",
       "first_name": "Jack",
-      "last_name": "King",
+      "last_name": "King - incomplete address",
       "position_title": "Manager",
-      "address": 12,
+      "address": 21,
       "email": "jack.king@example.com",
       "phone_number": "+16044011244"
     }

--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -14,7 +14,8 @@
       "bc_obps_regulated_operation": "24-0014",
       "created_at": "2024-2-01T15:27:00.000Z",
       "activities": [1, 5],
-      "registration_purpose": "Reporting Operation"
+      "registration_purpose": "Reporting Operation",
+      "contacts": [1, 2]
     }
   },
   {
@@ -34,8 +35,8 @@
       "bc_obps_regulated_operation": "24-0015",
       "created_at": "2024-2-02T15:27:00.000Z",
       "activities": [1, 5],
-      "contacts": [10],
-      "registration_purpose": "OBPS Regulated Operation"
+      "registration_purpose": "OBPS Regulated Operation",
+      "contacts": [3, 4]
     }
   },
   {
@@ -53,7 +54,6 @@
       "status": "Draft",
       "created_at": "2024-2-02T15:27:00.000Z",
       "activities": [1, 5],
-      "contacts": [10],
       "registration_purpose": "OBPS Regulated Operation"
     }
   },
@@ -75,8 +75,8 @@
       "bc_obps_regulated_operation": "23-0001",
       "created_at": "2024-1-31T15:27:00.000Z",
       "activities": [1, 3],
-      "contacts": [14, 15],
-      "registration_purpose": "OBPS Regulated Operation"
+      "registration_purpose": "OBPS Regulated Operation",
+      "contacts": [3, 4]
     }
   },
   {
@@ -97,8 +97,8 @@
       "bc_obps_regulated_operation": "23-0002",
       "created_at": "2024-1-30T15:27:00.000Z",
       "activities": [1, 5],
-      "contacts": [10, 11, 12],
-      "registration_purpose": "OBPS Regulated Operation"
+      "registration_purpose": "OBPS Regulated Operation",
+      "contacts": [1]
     }
   },
   {
@@ -120,7 +120,8 @@
       "bc_obps_regulated_operation": "24-0003",
       "created_at": "2024-1-29T15:27:00.000Z",
       "activities": [1, 5],
-      "operation_has_multiple_operators": true
+      "operation_has_multiple_operators": true,
+      "contacts": [3]
     }
   },
   {
@@ -141,7 +142,8 @@
       "bc_obps_regulated_operation": "24-0004",
       "created_at": "2024-1-28T15:27:00.000Z",
       "activities": [1, 5],
-      "registration_purpose": "Opted-in Operation"
+      "registration_purpose": "Opted-in Operation",
+      "contacts": [1]
     }
   },
   {
@@ -161,7 +163,8 @@
       "bc_obps_regulated_operation": "24-0005",
       "created_at": "2024-1-27T15:27:00.000Z",
       "activities": [1, 5],
-      "registration_purpose": "Potential Reporting Operation"
+      "registration_purpose": "Potential Reporting Operation",
+      "contacts": [2]
     }
   },
   {
@@ -181,7 +184,8 @@
       "bc_obps_regulated_operation": "24-0006",
       "created_at": "2024-1-26T15:27:00.000Z",
       "activities": [1, 5],
-      "registration_purpose": "Electricity Import Operation"
+      "registration_purpose": "Electricity Import Operation",
+      "contacts": [1]
     }
   },
   {
@@ -202,7 +206,8 @@
       "bc_obps_regulated_operation": "24-0007",
       "created_at": "2024-1-25T15:27:00.000Z",
       "activities": [1, 5],
-      "registration_purpose": "New Entrant Operation"
+      "registration_purpose": "New Entrant Operation",
+      "contacts": [1]
     }
   },
   {
@@ -221,7 +226,8 @@
       "bc_obps_regulated_operation": "24-0008",
       "created_at": "2024-1-24T15:27:00.000Z",
       "activities": [1, 5],
-      "registration_purpose": "Reporting Operation"
+      "registration_purpose": "Reporting Operation",
+      "contacts": [2]
     }
   },
   {
@@ -242,7 +248,8 @@
       "bc_obps_regulated_operation": "24-0009",
       "created_at": "2024-1-23T15:27:00.000Z",
       "activities": [1, 5],
-      "registration_purpose": "OBPS Regulated Operation"
+      "registration_purpose": "OBPS Regulated Operation",
+      "contacts": [1, 2]
     }
   },
   {
@@ -262,7 +269,8 @@
       "bc_obps_regulated_operation": "24-0010",
       "created_at": "2024-1-22T15:27:00.000Z",
       "activities": [1, 5],
-      "registration_purpose": "Reporting Operation"
+      "registration_purpose": "Reporting Operation",
+      "contacts": [1, 2]
     }
   },
   {
@@ -282,7 +290,8 @@
       "bc_obps_regulated_operation": "24-0011",
       "created_at": "2024-1-21T15:27:00.000Z",
       "activities": [1, 5],
-      "registration_purpose": "OBPS Regulated Operation"
+      "registration_purpose": "OBPS Regulated Operation",
+      "contacts": [1]
     }
   },
   {
@@ -360,7 +369,8 @@
       "bc_obps_regulated_operation": "24-0012",
       "created_at": "2024-1-17T15:27:00.000Z",
       "activities": [1, 5],
-      "registration_purpose": "OBPS Regulated Operation"
+      "registration_purpose": "OBPS Regulated Operation",
+      "contacts": [3]
     }
   },
   {
@@ -399,7 +409,8 @@
       "bc_obps_regulated_operation": "24-0013",
       "registration_purpose": "New Entrant Operation",
       "created_at": "2024-1-15T15:27:00.000Z",
-      "activities": [1, 3]
+      "activities": [1, 3],
+      "contacts": [4]
     }
   },
   {
@@ -419,7 +430,8 @@
       "bc_obps_regulated_operation": "24-0016",
       "created_at": "2024-1-14T15:27:00.000Z",
       "registration_purpose": "Reporting Operation",
-      "activities": [1, 5]
+      "activities": [1, 5],
+      "contacts": [3]
     }
   },
   {
@@ -438,7 +450,8 @@
       "bc_obps_regulated_operation": "24-0017",
       "created_at": "2024-1-13T15:27:00.000Z",
       "registration_purpose": "Reporting Operation",
-      "activities": [1, 5]
+      "activities": [1, 5],
+      "contacts": [3]
     }
   },
   {
@@ -457,7 +470,8 @@
       "bc_obps_regulated_operation": "24-0018",
       "created_at": "2024-1-12T15:27:00.000Z",
       "registration_purpose": "Reporting Operation",
-      "activities": [1, 5]
+      "activities": [1, 5],
+      "contacts": [4]
     }
   },
   {

--- a/bc_obps/registration/fixtures/mock/operator.json
+++ b/bc_obps/registration/fixtures/mock/operator.json
@@ -8,7 +8,8 @@
       "bc_corporate_registry_number": "abc1234567",
       "business_structure": "Sole Proprietorship",
       "status": "Approved",
-      "is_new": false
+      "is_new": false,
+      "contacts": [1, 2]
     }
   },
   {
@@ -20,9 +21,9 @@
       "bc_corporate_registry_number": "def1234567",
       "business_structure": "General Partnership",
       "mailing_address": 3,
-      "contacts": [10, 11, 12, 13, 14, 15],
       "status": "Approved",
-      "is_new": false
+      "is_new": false,
+      "contacts": [3, 4, 5, 6]
     }
   },
   {
@@ -34,7 +35,6 @@
       "bc_corporate_registry_number": "ghi1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -48,7 +48,6 @@
       "bc_corporate_registry_number": "jkl1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1, 2],
       "status": "Approved",
       "is_new": false
     }
@@ -62,7 +61,6 @@
       "bc_corporate_registry_number": "mno1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -76,7 +74,6 @@
       "bc_corporate_registry_number": "pqr1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -90,7 +87,6 @@
       "bc_corporate_registry_number": "stu1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -104,7 +100,6 @@
       "bc_corporate_registry_number": "vwx1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -118,7 +113,6 @@
       "bc_corporate_registry_number": "yza1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -132,7 +126,6 @@
       "bc_corporate_registry_number": "bcd1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -146,7 +139,6 @@
       "bc_corporate_registry_number": "efg1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -160,7 +152,6 @@
       "bc_corporate_registry_number": "hij1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -174,7 +165,6 @@
       "bc_corporate_registry_number": "klm1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -188,7 +178,6 @@
       "bc_corporate_registry_number": "nop1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -202,7 +191,6 @@
       "bc_corporate_registry_number": "qrs1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }
@@ -216,7 +204,6 @@
       "bc_corporate_registry_number": "qrs1234567",
       "business_structure": "BC Corporation",
       "mailing_address": 4,
-      "contacts": [1],
       "status": "Approved",
       "is_new": false
     }

--- a/bc_obps/registration/schema/v2/contact.py
+++ b/bc_obps/registration/schema/v2/contact.py
@@ -2,6 +2,21 @@ from typing import Optional
 from ninja import ModelSchema, Field
 from registration.models import Contact
 from ninja import FilterSchema
+from uuid import UUID
+
+
+from registration.schema.v1.contact import ContactOut
+from ninja import Schema
+
+
+class PlacesAssigned(Schema):
+    role_name: str
+    operation_name: str
+    operation_id: UUID
+
+
+class ContactWithPlacesAssigned(ContactOut):
+    places_assigned: Optional[list[PlacesAssigned]]
 
 
 class ContactListOutV2(ModelSchema):

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -112,6 +112,10 @@ class OperationInformationIn(ModelSchema):
         fields = ["name", 'type']
 
 
+class OperationInformationInUpdate(OperationInformationIn):
+    operation_representatives: List[int]
+
+
 class OptedInOperationDetailOut(ModelSchema):
     class Meta:
         model = OptedInOperationDetail
@@ -153,6 +157,11 @@ class OperationOutV2(ModelSchema):
     date_of_first_shipment: Optional[str] = None
     new_entrant_application: Optional[str] = None
     bcghg_id: Optional[str] = Field(None, alias="bcghg_id.id")
+    operation_representatives: Optional[List[int]] = []
+
+    @staticmethod
+    def resolve_operation_representatives(obj: Operation) -> List[int]:
+        return list(obj.contacts.filter(business_role='Operation Representative').values_list('id', flat=True))
 
     @staticmethod
     def resolve_multiple_operators_array(obj: Operation) -> List[MultipleOperator]:
@@ -176,7 +185,17 @@ class OperationOutV2(ModelSchema):
 
     class Meta:
         model = Operation
-        fields = ["id", 'name', 'type', 'opt_in', 'regulated_products', 'status', 'activities', 'opted_in_operation']
+        fields = [
+            "id",
+            'name',
+            'type',
+            'opt_in',
+            'regulated_products',
+            'status',
+            'activities',
+            'opted_in_operation',
+            'contacts',
+        ]
         from_attributes = True
 
 

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -194,7 +194,7 @@ class OperationOutV2(ModelSchema):
             'status',
             'activities',
             'opted_in_operation',
-            'contacts',
+            # 'contacts',
         ]
         from_attributes = True
 

--- a/bc_obps/registration/schema/v2/operation.py
+++ b/bc_obps/registration/schema/v2/operation.py
@@ -194,7 +194,6 @@ class OperationOutV2(ModelSchema):
             'status',
             'activities',
             'opted_in_operation',
-            # 'contacts',
         ]
         from_attributes = True
 

--- a/bc_obps/registration/tests/endpoints/v2/_contacts/test_contact_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_contacts/test_contact_id.py
@@ -36,7 +36,7 @@ class TestContactIdEndpoint(CommonTestSetup):
 
         response = TestUtils.mock_get_with_auth_role(
             self,
-            endpoint=custom_reverse_lazy("v1_get_contact", kwargs={"contact_id": contact.id}),
+            endpoint=custom_reverse_lazy("get_contact", kwargs={"contact_id": contact.id}),
             role_name="industry_user",
         )
         assert response.status_code == 200
@@ -44,7 +44,13 @@ class TestContactIdEndpoint(CommonTestSetup):
         assert response_json.get('first_name') == contact.first_name
         assert response_json.get('last_name') == contact.last_name
         assert response_json.get('email') == contact.email
-        assert response_json.get('places_assigned') == [f"Operation Representative - {operation.name}"]
+        assert response_json.get('places_assigned') == [
+            {
+                'role_name': 'Operation Representative',
+                'operation_name': operation.name,
+                'operation_id': str(operation.id),
+            }
+        ]
 
     def test_industry_users_cannot_get_contacts_not_associated_with_their_operator(self):
         contact = contact_baker()

--- a/bc_obps/registration/tests/endpoints/v2/_operations/test_operation_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/test_operation_id.py
@@ -2,6 +2,7 @@ from model_bakery import baker
 from registration.models import (
     UserOperator,
 )
+from registration.models.operation import Operation
 from registration.tests.constants import MOCK_DATA_URL
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.tests.utils.bakers import operation_baker, operator_baker
@@ -106,7 +107,9 @@ class TestOperationIdEndpoint(CommonTestSetup):
 
     def test_operations_endpoint_put_success(self):
         approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        operation = baker.make_recipe(
+            'utils.operation', operator=approved_user_operator.operator, status=Operation.Statuses.REGISTERED
+        )
         contact = baker.make_recipe('utils.contact')
         self.test_payload["operation_representatives"] = [contact.id]
         response = TestUtils.mock_put_with_auth_role(

--- a/bc_obps/registration/tests/endpoints/v2/_operations/test_operation_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/test_operation_id.py
@@ -107,6 +107,8 @@ class TestOperationIdEndpoint(CommonTestSetup):
     def test_operations_endpoint_put_success(self):
         approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
         operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        contact = baker.make_recipe('utils.contact')
+        self.test_payload["operation_representatives"] = [contact.id]
         response = TestUtils.mock_put_with_auth_role(
             self,
             "industry_user",

--- a/bc_obps/registration/tests/utils/baker_recipes.py
+++ b/bc_obps/registration/tests/utils/baker_recipes.py
@@ -128,7 +128,11 @@ opted_in_operation_detail = Recipe(
     meets_notification_to_director_on_criteria_change=False,
 )
 contact = Recipe(
-    Contact, business_role=BusinessRole.objects.first(), address=foreign_key(address), first_name=seq('Firstname 0')
+    Contact,
+    business_role=BusinessRole.objects.first(),
+    address=foreign_key(address),
+    first_name=seq('Firstname 0'),
+    last_name=seq('Lastname 0'),
 )
 
 

--- a/bc_obps/service/contact_service_v2.py
+++ b/bc_obps/service/contact_service_v2.py
@@ -8,6 +8,25 @@ from registration.schema.v2.contact import ContactFilterSchemaV2
 from service.data_access_service.contact_service import ContactDataAccessService
 from service.data_access_service.user_service import UserDataAccessService
 from ninja import Query
+from uuid import UUID
+
+
+from registration.constants import UNAUTHORIZED_MESSAGE
+from registration.models.contact import Contact
+from registration.schema.v1.contact import ContactOut
+from service.data_access_service.contact_service import ContactDataAccessService
+from service.data_access_service.user_service import UserDataAccessService
+from ninja import Schema
+
+
+class PlacesAssigned(Schema):
+    role_name: str
+    operation_name: str
+    operation_id: UUID
+
+
+class ContactWithPlacesAssigned(ContactOut):
+    places_assigned: Optional[list[PlacesAssigned]]
 
 
 class ContactServiceV2:
@@ -31,3 +50,30 @@ class ContactServiceV2:
             .distinct()
         )
         return cast(QuerySet[Contact], queryset)
+
+    def get_if_authorized_v2(cls, user_guid: UUID, contact_id: int) -> Optional[Contact]:
+        user = UserDataAccessService.get_by_guid(user_guid)
+        user_contacts = ContactDataAccessService.get_all_contacts_for_user(user)
+        contact = user_contacts.filter(id=contact_id).first()
+        if user.is_industry_user() and not contact:
+            raise Exception(UNAUTHORIZED_MESSAGE)
+        return contact
+
+    @classmethod
+    def get_with_places_assigned_v2(cls, user_guid: UUID, contact_id: int) -> Optional[ContactWithPlacesAssigned]:
+        contact = cls.get_if_authorized_v2(user_guid, contact_id)
+        places_assigned = []
+        if contact:
+            role_name = contact.business_role.role_name
+            for operation in contact.operations_contacts.all():
+                place = PlacesAssigned(
+                    role_name=role_name,
+                    operation_name=operation.name,
+                    operation_id=operation.id,
+                )
+                places_assigned.append(place)
+            result = cast(ContactWithPlacesAssigned, contact)
+            if places_assigned:
+                result.places_assigned = places_assigned
+            return result
+        return None

--- a/bc_obps/service/contact_service_v2.py
+++ b/bc_obps/service/contact_service_v2.py
@@ -4,25 +4,10 @@ from uuid import UUID
 
 
 from registration.models.contact import Contact
-from registration.schema.v2.contact import ContactFilterSchemaV2
+from registration.schema.v2.contact import ContactFilterSchemaV2, ContactWithPlacesAssigned, PlacesAssigned
 from service.data_access_service.contact_service import ContactDataAccessService
 from service.data_access_service.user_service import UserDataAccessService
 from ninja import Query
-
-
-from registration.constants import UNAUTHORIZED_MESSAGE
-from registration.schema.v1.contact import ContactOut
-from ninja import Schema
-
-
-class PlacesAssigned(Schema):
-    role_name: str
-    operation_name: str
-    operation_id: UUID
-
-
-class ContactWithPlacesAssigned(ContactOut):
-    places_assigned: Optional[list[PlacesAssigned]]
 
 
 class ContactServiceV2:
@@ -48,17 +33,12 @@ class ContactServiceV2:
         return cast(QuerySet[Contact], queryset)
 
     @classmethod
-    def get_if_authorized_v2(cls, user_guid: UUID, contact_id: int) -> Optional[Contact]:
-        user = UserDataAccessService.get_by_guid(user_guid)
-        user_contacts = ContactDataAccessService.get_all_contacts_for_user(user)
-        contact = user_contacts.filter(id=contact_id).first()
-        if user.is_industry_user() and not contact:
-            raise Exception(UNAUTHORIZED_MESSAGE)
-        return contact
+    def get_by_id(cls, contact_id: int) -> Contact:
+        return Contact.objects.get(id=contact_id)
 
     @classmethod
-    def get_with_places_assigned_v2(cls, user_guid: UUID, contact_id: int) -> Optional[ContactWithPlacesAssigned]:
-        contact = cls.get_if_authorized_v2(user_guid, contact_id)
+    def get_with_places_assigned_v2(cls, contact_id: int) -> Optional[ContactWithPlacesAssigned]:
+        contact = cls.get_by_id(contact_id)
         places_assigned = []
         if contact:
             role_name = contact.business_role.role_name
@@ -74,3 +54,15 @@ class ContactServiceV2:
                 result.places_assigned = places_assigned
             return result
         return None
+
+    @classmethod
+    def raise_exception_if_contact_missing_address_information(cls, contact_id: int) -> None:
+        """This function checks that a contact has a complete address record (contact.address exists and all fields in the address model have a value). In general in the app, address is not mandatory, but in certain cases (e.g., when a contact is assigned to an operation as the Operation Representative), the business area requires the contact to have an address."""
+        contact = cls.get_by_id(contact_id)
+        address = contact.address
+        if not address or any(
+            not getattr(address, field, None) for field in ['street_address', 'municipality', 'province', 'postal_code']
+        ):
+            raise Exception(
+                f'The contact {contact.first_name} {contact.last_name} is missing address information. Please return to Contacts and fill in their address information before assigning them as an Operation Representative here.'
+            )

--- a/bc_obps/service/contact_service_v2.py
+++ b/bc_obps/service/contact_service_v2.py
@@ -33,12 +33,8 @@ class ContactServiceV2:
         return cast(QuerySet[Contact], queryset)
 
     @classmethod
-    def get_by_id(cls, contact_id: int) -> Contact:
-        return Contact.objects.get(id=contact_id)
-
-    @classmethod
     def get_with_places_assigned_v2(cls, contact_id: int) -> Optional[ContactWithPlacesAssigned]:
-        contact = cls.get_by_id(contact_id)
+        contact = ContactDataAccessService.get_by_id(contact_id)
         places_assigned = []
         if contact:
             role_name = contact.business_role.role_name
@@ -58,7 +54,7 @@ class ContactServiceV2:
     @classmethod
     def raise_exception_if_contact_missing_address_information(cls, contact_id: int) -> None:
         """This function checks that a contact has a complete address record (contact.address exists and all fields in the address model have a value). In general in the app, address is not mandatory, but in certain cases (e.g., when a contact is assigned to an operation as the Operation Representative), the business area requires the contact to have an address."""
-        contact = cls.get_by_id(contact_id)
+        contact = ContactDataAccessService.get_by_id(contact_id)
         address = contact.address
         if not address or any(
             not getattr(address, field, None) for field in ['street_address', 'municipality', 'province', 'postal_code']

--- a/bc_obps/service/contact_service_v2.py
+++ b/bc_obps/service/contact_service_v2.py
@@ -8,14 +8,10 @@ from registration.schema.v2.contact import ContactFilterSchemaV2
 from service.data_access_service.contact_service import ContactDataAccessService
 from service.data_access_service.user_service import UserDataAccessService
 from ninja import Query
-from uuid import UUID
 
 
 from registration.constants import UNAUTHORIZED_MESSAGE
-from registration.models.contact import Contact
 from registration.schema.v1.contact import ContactOut
-from service.data_access_service.contact_service import ContactDataAccessService
-from service.data_access_service.user_service import UserDataAccessService
 from ninja import Schema
 
 
@@ -51,6 +47,7 @@ class ContactServiceV2:
         )
         return cast(QuerySet[Contact], queryset)
 
+    @classmethod
     def get_if_authorized_v2(cls, user_guid: UUID, contact_id: int) -> Optional[Contact]:
         user = UserDataAccessService.get_by_guid(user_guid)
         user_contacts = ContactDataAccessService.get_all_contacts_for_user(user)

--- a/bc_obps/service/operation_service.py
+++ b/bc_obps/service/operation_service.py
@@ -218,9 +218,11 @@ class OperationService:
         base_qs = OperationDataAccessService.get_all_operations_for_user(user)
         list_of_filters = [
             Q(bcghg_id__id__icontains=bcghg_id) if bcghg_id else Q(),
-            Q(bc_obps_regulated_operation__id__icontains=bc_obps_regulated_operation)
-            if bc_obps_regulated_operation
-            else Q(),
+            (
+                Q(bc_obps_regulated_operation__id__icontains=bc_obps_regulated_operation)
+                if bc_obps_regulated_operation
+                else Q()
+            ),
             Q(name__icontains=name) if name else Q(),
             Q(operator__legal_name__icontains=operator) if operator else Q(),
             Q(status__icontains=status) if status else Q(),

--- a/bc_obps/service/operation_service_v2.py
+++ b/bc_obps/service/operation_service_v2.py
@@ -383,14 +383,20 @@ class OperationServiceV2:
         payload: OperationInformationIn,
         operation_id: UUID,
     ) -> Operation:
-        OperationService.get_if_authorized(user_guid, operation_id)
+        """
+        This service is used for updating an operation after it's been registered. During registration, we use the endpoints in cas-registration/bc_obps/registration/api/v2/_operations/_operation_id/_registration
+        """
+        operation = OperationService.get_if_authorized(user_guid, operation_id)
 
-        operation: Operation = cls.create_or_update_operation_v2(
+        if not operation.status == Operation.Statuses.REGISTERED:
+            raise Exception('Operation must be registered')
+
+        updated_operation: Operation = cls.create_or_update_operation_v2(
             user_guid,
             payload,
             operation_id,
         )
-        return operation
+        return updated_operation
 
     @classmethod
     def is_operation_opt_in_information_complete(cls, operation: Operation) -> bool:

--- a/bc_obps/service/operation_service_v2.py
+++ b/bc_obps/service/operation_service_v2.py
@@ -1,6 +1,7 @@
 from typing import Optional, Tuple, Callable, Generator, Union
 from django.db.models import QuerySet
 from registration.schema.v2.operation_timeline import OperationTimelineFilterSchema
+from service.contact_service_v2 import ContactServiceV2
 from service.data_access_service.operation_designated_operator_timeline_service import (
     OperationDesignatedOperatorTimelineDataAccessService,
 )
@@ -234,18 +235,7 @@ class OperationServiceV2:
 
         if isinstance(payload, OperationInformationInUpdate):
             for contact_id in payload.operation_representatives:
-                contact = Contact.objects.get(id=contact_id)
-                address = contact.address
-                if (
-                    not address
-                    or not address.street_address
-                    or not address.municipality
-                    or not address.province
-                    or not address.postal_code
-                ):
-                    raise Exception(
-                        f'The contact {contact.first_name} {contact.last_name} is missing address information. Please return to Contacts and fill in their address information before assigning them as an Operation Representative here.'
-                    )
+                ContactServiceV2.raise_exception_if_contact_missing_address_information(contact_id)
 
             operation.contacts.set(payload.operation_representatives)
 

--- a/bc_obps/service/tests/test_contact_service_v2.py
+++ b/bc_obps/service/tests/test_contact_service_v2.py
@@ -1,11 +1,8 @@
 from registration.schema.v1.contact import ContactFilterSchema
 import pytest
-from service.contact_service_v2 import ContactServiceV2
+from service.contact_service_v2 import ContactServiceV2, PlacesAssigned
 from model_bakery import baker
 from registration.models.business_role import BusinessRole
-import pytest
-from model_bakery import baker
-from service.contact_service_v2 import ContactServiceV2
 
 pytestmark = pytest.mark.django_db
 
@@ -52,7 +49,9 @@ class TestContactService:
 
         result = ContactServiceV2.get_with_places_assigned_v2(approved_user_operator.user.user_guid, contact.id)
         assert result.places_assigned == [
-            f"Operation Representative - {operation.name}",
+            PlacesAssigned(
+                role_name=contact.business_role.role_name, operation_name=operation.name, operation_id=operation.id
+            )
         ]
 
     @staticmethod

--- a/bc_obps/service/tests/test_contact_service_v2.py
+++ b/bc_obps/service/tests/test_contact_service_v2.py
@@ -2,6 +2,10 @@ from registration.schema.v1.contact import ContactFilterSchema
 import pytest
 from service.contact_service_v2 import ContactServiceV2
 from model_bakery import baker
+from registration.models.business_role import BusinessRole
+import pytest
+from model_bakery import baker
+from service.contact_service_v2 import ContactServiceV2
 
 pytestmark = pytest.mark.django_db
 
@@ -31,3 +35,34 @@ class TestListContactService:
             ).count()
             == 3
         )
+
+
+class TestContactService:
+    @staticmethod
+    def test_get_with_places_assigned_with_contacts():
+        contact = baker.make_recipe(
+            'utils.contact', business_role=BusinessRole.objects.get(role_name='Operation Representative')
+        )
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        # add contact to operator (they have to be associated with the operator or will throw unauthorized)
+        approved_user_operator.operator.contacts.set([contact])
+        # add contact to operation
+        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        operation.contacts.set([contact])
+
+        result = ContactServiceV2.get_with_places_assigned_v2(approved_user_operator.user.user_guid, contact.id)
+        assert result.places_assigned == [
+            f"Operation Representative - {operation.name}",
+        ]
+
+    @staticmethod
+    def test_get_with_places_assigned_with_no_contacts():
+        contact = baker.make_recipe(
+            'utils.contact', business_role=BusinessRole.objects.get(role_name='Operation Representative')
+        )
+        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        # add contact to operator (they have to be associated with the operator or will throw unauthorized)
+        approved_user_operator.operator.contacts.set([contact])
+
+        result = ContactServiceV2.get_with_places_assigned_v2(approved_user_operator.user.user_guid, contact.id)
+        assert not hasattr(result, 'places_assigned')

--- a/bc_obps/service/tests/test_contact_service_v2.py
+++ b/bc_obps/service/tests/test_contact_service_v2.py
@@ -47,7 +47,7 @@ class TestContactService:
         operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
         operation.contacts.set([contact])
 
-        result = ContactServiceV2.get_with_places_assigned_v2(approved_user_operator.user.user_guid, contact.id)
+        result = ContactServiceV2.get_with_places_assigned_v2(contact.id)
         assert result.places_assigned == [
             PlacesAssigned(
                 role_name=contact.business_role.role_name, operation_name=operation.name, operation_id=operation.id
@@ -63,7 +63,7 @@ class TestContactService:
         # add contact to operator (they have to be associated with the operator or will throw unauthorized)
         approved_user_operator.operator.contacts.set([contact])
 
-        result = ContactServiceV2.get_with_places_assigned_v2(approved_user_operator.user.user_guid, contact.id)
+        result = ContactServiceV2.get_with_places_assigned_v2(contact.id)
         assert not hasattr(result, 'places_assigned')
 
     @staticmethod

--- a/bc_obps/service/tests/test_operation_service_v2.py
+++ b/bc_obps/service/tests/test_operation_service_v2.py
@@ -622,7 +622,7 @@ class TestOperationServiceV2CreateOrUpdateOperation:
     @staticmethod
     def test_update_operation_with_operation_representatives_with_address():
         approved_user_operator = baker.make_recipe('utils.approved_user_operator')
-        existing_operation = baker.make_recipe('utils.operation')
+        existing_operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
         contacts = baker.make_recipe(
             'utils.contact', business_role=BusinessRole.objects.get(role_name='Operation Representative'), _quantity=3
         )
@@ -640,6 +640,7 @@ class TestOperationServiceV2CreateOrUpdateOperation:
             boundary_map=MOCK_DATA_URL,
             operation_representatives=[contact.id for contact in contacts],
         )
+
         operation = OperationServiceV2.create_or_update_operation_v2(
             approved_user_operator.user.user_guid,
             payload,
@@ -654,7 +655,7 @@ class TestOperationServiceV2CreateOrUpdateOperation:
     @staticmethod
     def test_update_operation_with_operation_representative_without_address():
         approved_user_operator = baker.make_recipe('utils.approved_user_operator')
-        existing_operation = baker.make_recipe('utils.operation')
+        existing_operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
         # create contacts with incomplete address data
         contacts = baker.make_recipe(
             'utils.contact', business_role=BusinessRole.objects.get(role_name='Operation Representative'), _quantity=5

--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -7,6 +7,7 @@ import { actionHandler } from "@bciers/actions";
 import { ContactFormData } from "./types";
 import { FormMode } from "@bciers/utils/src/enums";
 import { contactsUiSchema } from "@/administration/app/data/jsonSchema/contact";
+import { useSessionRole } from "@bciers/utils/src/sessionUtils";
 
 interface Props {
   schema: any;
@@ -32,6 +33,7 @@ export default function ContactForm({
   const [formState, setFormState] = useState(formData ?? {});
   const [isCreatingState, setIsCreatingState] = useState(isCreating);
   const [key, setKey] = useState(Math.random());
+  const role = useSessionRole();
 
   return (
     <SingleStepTaskListForm
@@ -40,9 +42,12 @@ export default function ContactForm({
       schema={schema}
       uiSchema={contactsUiSchema}
       formData={formState}
+      formContext={{ userRole: role }}
       mode={isCreatingState ? FormMode.CREATE : FormMode.READ_ONLY}
       allowEdit={allowEdit}
-      inlineMessage={isCreatingState && <NewOperationMessage />}
+      inlineMessage={
+        isCreatingState && !role.includes("cas") && <NewOperationMessage />
+      }
       onSubmit={async (data: { formData?: any }) => {
         const updatedFormData = { ...formState, ...data.formData };
         setFormState(updatedFormData);

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -51,6 +51,7 @@ const OperationInformationForm = ({
     );
 
     if (response?.error) {
+      // Users get this error when they select a contact that's missing address information. We include a link to the Contacts page because the user has to fix the error from there, not here in the operation form.
       if (response.error.includes("Please return to Contacts")) {
         const splitError = response.error.split("Contacts");
         response.error = (
@@ -81,7 +82,7 @@ const OperationInformationForm = ({
   };
   return (
     <>
-      {isRedirectedFromContacts && (
+      {isRedirectedFromContacts && !role.includes("cas_") && (
         <Note variant="important">
           To remove the current operation representative, please select a new
           contact to replace them.

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -19,6 +19,7 @@ import {
 import { FormMode, FrontEndRoles } from "@bciers/utils/src/enums";
 import { useSessionRole } from "@bciers/utils/src/sessionUtils";
 import Note from "@bciers/components/layout/Note";
+import Link from "next/link";
 
 const OperationInformationForm = ({
   formData,
@@ -49,6 +50,15 @@ const OperationInformationForm = ({
     );
 
     if (response?.error) {
+      if (response.error.includes("Please return to Contacts")) {
+        const splitError = response.error.split("Contacts");
+        response.error = (
+          <>
+            {splitError[0]} <Link href={"/contacts"}>Contacts</Link>
+            {splitError[1]}
+          </>
+        );
+      }
       setError(response.error);
       return { error: response.error };
     }

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -40,6 +40,7 @@ const OperationInformationForm = ({
   const handleSubmit = async (data: {
     formData?: OperationInformationFormData;
   }) => {
+    setError(undefined);
     const response = await actionHandler(
       `registration/operations/${operationId}`,
       "PUT",

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { UUID } from "crypto";
 import SingleStepTaskListForm from "@bciers/components/form/SingleStepTaskListForm";
@@ -18,6 +18,7 @@ import {
 } from "apps/registration/app/components/operations/registration/enums";
 import { FormMode, FrontEndRoles } from "@bciers/utils/src/enums";
 import { useSessionRole } from "@bciers/utils/src/sessionUtils";
+import Note from "@bciers/components/layout/Note";
 
 const OperationInformationForm = ({
   formData,
@@ -29,11 +30,11 @@ const OperationInformationForm = ({
   schema: RJSFSchema;
 }) => {
   const [error, setError] = useState(undefined);
-
   const router = useRouter();
-
   // To get the user's role from the session
   const role = useSessionRole();
+  const searchParams = useSearchParams();
+  const isRedirectedFromContacts = searchParams.get("from_contacts") as string;
 
   const handleSubmit = async (data: {
     formData?: OperationInformationFormData;
@@ -67,29 +68,36 @@ const OperationInformationForm = ({
       return { error: response2.error };
     }
   };
-
   return (
-    <SingleStepTaskListForm
-      allowEdit={!role.includes("cas_")}
-      mode={FormMode.READ_ONLY}
-      error={error}
-      schema={schema}
-      uiSchema={administrationOperationInformationUiSchema}
-      formData={formData ?? {}}
-      onSubmit={handleSubmit}
-      onCancel={() => router.push("/operations")}
-      formContext={{
-        operationId,
-        isRegulatedOperation: regulatedOperationPurposes.includes(
-          formData.registration_purpose as RegistrationPurposes,
-        ),
-        isCasDirector: role === FrontEndRoles.CAS_DIRECTOR,
-        isEio: formData.registration_purpose?.match(
-          RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION.valueOf(),
-        ),
-        status: formData.status,
-      }}
-    />
+    <>
+      {isRedirectedFromContacts && (
+        <Note variant="important">
+          To remove the current operation representative, please select a new
+          contact to replace them.
+        </Note>
+      )}
+      <SingleStepTaskListForm
+        allowEdit={!role.includes("cas_")}
+        mode={FormMode.READ_ONLY}
+        error={error}
+        schema={schema}
+        uiSchema={administrationOperationInformationUiSchema}
+        formData={formData ?? {}}
+        onSubmit={handleSubmit}
+        onCancel={() => router.push("/operations")}
+        formContext={{
+          operationId,
+          isRegulatedOperation: regulatedOperationPurposes.includes(
+            formData.registration_purpose as RegistrationPurposes,
+          ),
+          isCasDirector: role === FrontEndRoles.CAS_DIRECTOR,
+          isEio: formData.registration_purpose?.match(
+            RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION.valueOf(),
+          ),
+          status: formData.status,
+        }}
+      />
+    </>
   );
 };
 

--- a/bciers/apps/administration/app/data/jsonSchema/contact.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/contact.ts
@@ -1,7 +1,7 @@
 import { RJSFSchema } from "@rjsf/utils";
 import provinceOptions from "@bciers/data/provinces.json";
 import SectionFieldTemplate from "@bciers/components/form/fields/SectionFieldTemplate";
-import { ArrayFieldTemplate } from "@bciers/components/form/fields";
+import { PlacesAssignedFieldTemplate } from "@bciers/components/form/fields";
 
 const section1: RJSFSchema = {
   type: "object",
@@ -18,11 +18,15 @@ const section1: RJSFSchema = {
     },
     places_assigned: {
       type: "array",
-      default: ["None"],
       title: "Places assigned",
       readOnly: true,
       items: {
-        type: "string",
+        type: "object",
+        properties: {
+          role_name: { type: "string" },
+          operation_name: { type: "string" },
+          operation_id: { type: "string" },
+        },
       },
     },
   },
@@ -104,15 +108,27 @@ export const contactsUiSchema = {
     "ui:FieldTemplate": SectionFieldTemplate,
     "ui:order": ["selected_user", "first_name", "last_name", "places_assigned"],
     places_assigned: {
-      "ui:ArrayFieldTemplate": ArrayFieldTemplate,
-      "ui:options": {
-        note: "You cannot delete this contact unless you replace them with other contact(s) in the place(s) above.",
-        addable: false,
-        removable: false,
-      },
+      "ui:ArrayFieldTemplate": PlacesAssignedFieldTemplate,
       "ui:classNames": "[&>div:last-child]:w-2/3",
       items: {
         "ui:widget": "ReadOnlyWidget",
+        "ui:options": {
+          label: false,
+          inline: true,
+        },
+        role_name: {
+          "ui:options": {
+            label: false,
+          },
+        },
+        operation_name: {
+          "ui:options": {
+            label: false,
+          },
+        },
+        operation_id: {
+          "ui:widget": "hidden",
+        },
       },
     },
   },

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationOperationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationOperationInformation.ts
@@ -45,6 +45,7 @@ export const administrationOperationInformationUiSchema: UiSchema = {
   section3: {
     ...registrationInformationUiSchema,
     "ui:order": [
+      "operation_representatives",
       "registration_purpose",
       "regulated_operation_preface",
       "regulated_products",

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
@@ -1,7 +1,7 @@
 import SectionFieldTemplate from "@bciers/components/form/fields/SectionFieldTemplate";
 import { TitleOnlyFieldTemplate } from "@bciers/components/form/fields";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
-import { getRegulatedProducts } from "@bciers/actions/api";
+import { getRegulatedProducts, getContacts } from "@bciers/actions/api";
 import { RegistrationPurposes } from "apps/registration/app/components/operations/registration/enums";
 
 export const createAdministrationRegistrationInformationSchema = async (
@@ -10,7 +10,8 @@ export const createAdministrationRegistrationInformationSchema = async (
   // fetch db values that are dropdown options
   const regulatedProducts: { id: number; name: string }[] =
     await getRegulatedProducts();
-
+  const contacts: { id: number; first_name: string; last_name: string }[] =
+    await getContacts();
   const isRegulatedProducts =
     registrationPurposeValue ===
     RegistrationPurposes.OBPS_REGULATED_OPERATION.valueOf();
@@ -23,7 +24,10 @@ export const createAdministrationRegistrationInformationSchema = async (
   const registrationInformationSchema: RJSFSchema = {
     title: "Registration Information",
     type: "object",
-    required: isRegulatedProducts ? ["regulated_products"] : [],
+    required: [
+      "operation_representatives",
+      ...(isRegulatedProducts ? ["regulated_products"] : []),
+    ],
     properties: {
       registration_purpose: {
         type: "string",
@@ -47,6 +51,19 @@ export const createAdministrationRegistrationInformationSchema = async (
           },
         },
       }),
+      operation_representatives: {
+        title: "Operation Representative(s)",
+        type: "array",
+        minItems: 1,
+        items: {
+          enum: contacts.items.map((contact) => contact.id),
+          // Ts-ignore until we refactor enumNames https://github.com/bcgov/cas-registration/issues/2176
+          // @ts-ignore
+          enumNames: contacts.items.map(
+            (contact) => `${contact.first_name} ${contact.last_name}`,
+          ),
+        },
+      },
       ...(isOptIn && {
         opted_in_preface: {
           // Not an actual field, just used to display a message
@@ -114,6 +131,10 @@ export const registrationInformationUiSchema: UiSchema = {
     "new_entrant_application",
   ],
   "ui:FieldTemplate": SectionFieldTemplate,
+  // brianna why doesn't error show, looks exactly the same as regulated_products
+  operation_representatives: {
+    "ui:widget": "MultiSelectWidget",
+  },
   regulated_operation_preface: {
     "ui:classNames": "text-bc-bg-blue text-lg",
     "ui:FieldTemplate": TitleOnlyFieldTemplate,

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
@@ -10,8 +10,9 @@ export const createAdministrationRegistrationInformationSchema = async (
   // fetch db values that are dropdown options
   const regulatedProducts: { id: number; name: string }[] =
     await getRegulatedProducts();
-  const contacts: { id: number; first_name: string; last_name: string }[] =
-    await getContacts();
+  const contacts: {
+    items: [{ id: number; first_name: string; last_name: string }];
+  } = await getContacts();
   const isRegulatedProducts =
     registrationPurposeValue ===
     RegistrationPurposes.OBPS_REGULATED_OPERATION.valueOf();
@@ -131,7 +132,6 @@ export const registrationInformationUiSchema: UiSchema = {
     "new_entrant_application",
   ],
   "ui:FieldTemplate": SectionFieldTemplate,
-  // brianna why doesn't error show, looks exactly the same as regulated_products
   operation_representatives: {
     "ui:widget": "MultiSelectWidget",
   },

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationRegistrationInformation.ts
@@ -10,9 +10,14 @@ export const createAdministrationRegistrationInformationSchema = async (
   // fetch db values that are dropdown options
   const regulatedProducts: { id: number; name: string }[] =
     await getRegulatedProducts();
+  if (regulatedProducts && "error" in regulatedProducts)
+    throw new Error("Failed to retrieve regulated products information");
   const contacts: {
     items: [{ id: number; first_name: string; last_name: string }];
   } = await getContacts();
+  if (contacts && "error" in contacts)
+    throw new Error("Failed to retrieve contacts information");
+
   const isRegulatedProducts =
     registrationPurposeValue ===
     RegistrationPurposes.OBPS_REGULATED_OPERATION.valueOf();

--- a/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { actionHandler, useRouter } from "@bciers/testConfig/mocks";
+import { actionHandler, useRouter, useSession } from "@bciers/testConfig/mocks";
 import {
   contactsSchema,
   contactsUiSchema,
@@ -98,6 +98,13 @@ export const fillContactForm = async () => {
 describe("ContactForm component", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    useSession.mockReturnValue({
+      data: {
+        user: {
+          app_role: "industry_user_admin",
+        },
+      },
+    });
   });
 
   it("renders the empty contact form when creating a new contact", async () => {
@@ -123,7 +130,14 @@ describe("ContactForm component", () => {
     expect(screen.getByRole("button", { name: /submit/i })).toBeEnabled();
     expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
   });
-  it("loads existing readonly contact form data", async () => {
+  it("loads existing readonly contact form data for an internal user", async () => {
+    useSession.mockReturnValue({
+      data: {
+        user: {
+          app_role: "industry_user_admin",
+        },
+      },
+    });
     const readOnlyContactSchema = createContactSchema(contactsSchema, false);
     const { container } = render(
       <ContactForm
@@ -132,11 +146,13 @@ describe("ContactForm component", () => {
         isCreating={false}
       />,
     );
-    // form fields
+
+    // Inline message
     expect(
-      screen.queryByText(/Is this contact a user in BCIERS/i),
+      screen.queryByText(
+        /To assign this representative to an operation, go to the operation information form/i,
+      ),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText(/Select the user/i)).not.toBeInTheDocument();
 
     expect(
       container.querySelector("#root_section1_first_name"),

--- a/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
@@ -26,7 +26,13 @@ const contactFormData = {
   municipality: "Cityville",
   province: "ON",
   postal_code: "A1B 2C3",
-  places_assigned: ["Operation Representative - Operation 1"],
+  places_assigned: [
+    {
+      role_name: "Operation Representative",
+      operation_name: "Operation 1",
+      operation_id: "c0743c09-82fa-4186-91aa-4b5412e3415c",
+    },
+  ],
 };
 
 export const checkEmptyContactForm = () => {
@@ -141,9 +147,11 @@ describe("ContactForm component", () => {
     ).toHaveTextContent("Doe");
 
     expect(screen.getByText(/Places Assigned/i)).toBeVisible();
-    expect(
-      screen.getByText(/Operation Representative - Operation 1/i),
-    ).toBeVisible();
+    expect(screen.getByText(/Operation Representative/i)).toBeVisible();
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/operations/c0743c09-82fa-4186-91aa-4b5412e3415c?operations_title=Operation 1&from_contacts=true",
+    );
 
     expect(
       container.querySelector("#root_section2_position_title"),
@@ -407,7 +415,13 @@ describe("ContactForm component", () => {
         body: JSON.stringify({
           first_name: "John updated",
           last_name: "Doe updated",
-          places_assigned: ["Operation Representative - Operation 1"],
+          places_assigned: [
+            {
+              role_name: "Operation Representative",
+              operation_name: "Operation 1",
+              operation_id: "c0743c09-82fa-4186-91aa-4b5412e3415c",
+            },
+          ],
           position_title: "Senior Officer",
           email: "john.doe@example.com",
           phone_number: "+16044011234",

--- a/bciers/apps/administration/tests/components/contacts/ContactPage.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactPage.test.tsx
@@ -3,10 +3,6 @@ import { useSession, useRouter } from "@bciers/testConfig/mocks";
 import { getContact, getUserOperatorUsers } from "./mocks";
 import ContactPage from "apps/administration/app/components/contacts/ContactPage";
 
-useSession.mockReturnValue({
-  get: vi.fn(),
-});
-
 useRouter.mockReturnValue({
   query: {},
   replace: vi.fn(),
@@ -29,6 +25,14 @@ const contactFormData = {
 describe("Contact component", () => {
   beforeEach(async () => {
     vi.resetAllMocks();
+    useSession.mockReturnValue({
+      get: vi.fn(),
+      data: {
+        user: {
+          app_role: "industry_user_admin",
+        },
+      },
+    });
   });
 
   it("renders the appropriate error component when getContact fails", async () => {

--- a/bciers/apps/administration/tests/components/contacts/mocks.ts
+++ b/bciers/apps/administration/tests/components/contacts/mocks.ts
@@ -1,6 +1,7 @@
 const fetchContactsPageData = vi.fn();
 const getContact = vi.fn();
 const getUserOperatorUsers = vi.fn();
+const getContacts = vi.fn();
 
 vi.mock(
   "apps/administration/app/components/contacts/fetchContactsPageData",
@@ -20,4 +21,8 @@ vi.mock(
   }),
 );
 
-export { fetchContactsPageData, getContact, getUserOperatorUsers };
+vi.mock("libs/actions/src/api/getContacts", () => ({
+  default: getContacts,
+}));
+
+export { fetchContactsPageData, getContact, getUserOperatorUsers, getContacts };

--- a/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
@@ -12,13 +12,13 @@ import {
   getOperationWithDocuments,
   getRegulatedProducts,
   getReportingActivities,
-  getContacts,
 } from "./mocks";
 import { createAdministrationOperationInformationSchema } from "apps/administration/app/data/jsonSchema/operationInformation/administrationOperationInformation";
 import { FrontEndRoles, OperationStatus } from "@bciers/utils/src/enums";
 import { expect } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { RegistrationPurposes } from "@/registration/app/components/operations/registration/enums";
+import { getContacts } from "../contacts/mocks";
 
 useSession.mockReturnValue({
   data: {

--- a/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
@@ -1,13 +1,18 @@
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { RJSFSchema } from "@rjsf/utils";
 import OperationInformationForm from "@/administration/app/components/operations/OperationInformationForm";
-import { actionHandler, useSession } from "@bciers/testConfig/mocks";
+import {
+  actionHandler,
+  useSearchParams,
+  useSession,
+} from "@bciers/testConfig/mocks";
 import {
   getBusinessStructures,
   getNaicsCodes,
   getOperationWithDocuments,
   getRegulatedProducts,
   getReportingActivities,
+  getContacts,
 } from "./mocks";
 import { createAdministrationOperationInformationSchema } from "apps/administration/app/data/jsonSchema/operationInformation/administrationOperationInformation";
 import { FrontEndRoles, OperationStatus } from "@bciers/utils/src/enums";
@@ -22,6 +27,10 @@ useSession.mockReturnValue({
     },
   },
 });
+useSearchParams.mockReturnValue({
+  get: vi.fn(),
+});
+
 const mockDataUri = "data:application/pdf;name=testpdf.pdf;base64,ZHVtbXk=";
 
 export const fetchFormEnums = () => {
@@ -63,6 +72,25 @@ export const fetchFormEnums = () => {
     { id: 1, name: "BC-specific refinery complexity throughput" },
     { id: 2, name: "Cement equivalent" },
   ]);
+
+  // Contacts
+  getContacts.mockResolvedValue({
+    items: [
+      {
+        id: 1,
+        first_name: "Ivy",
+        last_name: "Jones",
+        email: "ivy.jones@example.com",
+      },
+      {
+        id: 2,
+        first_name: "Jack",
+        last_name: "King",
+        email: "jack.king@example.com",
+      },
+    ],
+    count: 2,
+  });
 
   // Registration purposes
   actionHandler.mockResolvedValue(["Potential Reporting Operation"]);
@@ -162,7 +190,7 @@ const formData = {
   naics_code_id: 1,
   secondary_naics_code_id: 2,
   operation_has_multiple_operators: true,
-  activities: [1, 2, 3, 4, 5],
+  activities: [1, 2],
   multiple_operators_array: [
     {
       mo_is_extraprovincial_company: false,
@@ -178,7 +206,7 @@ const formData = {
     },
   ],
   registration_purpose: "Reporting Operation",
-  regulated_products: [6],
+  regulated_products: [2],
   opt_in: false,
 };
 
@@ -800,5 +828,153 @@ describe("the OperationInformationForm component", () => {
         }),
       },
     );
+  });
+
+  it("should not allow external users to remove their operation rep", async () => {
+    useSession.mockReturnValue({
+      data: {
+        user: {
+          app_role: "industry_user_admin",
+        },
+      },
+    });
+
+    fetchFormEnums();
+    const createdFormSchema =
+      await createAdministrationOperationInformationSchema(
+        formData.registration_purpose,
+        OperationStatus.REGISTERED,
+      );
+
+    render(
+      <OperationInformationForm
+        formData={formData}
+        schema={createdFormSchema}
+        operationId={operationId}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const cancelChipIcon = screen.getAllByTestId("CancelIcon");
+    await userEvent.click(cancelChipIcon[2]); // 0-1 are activities
+    expect(screen.queryByText(/ivy/i)).not.toBeInTheDocument();
+
+    const submitButton = screen.getByRole("button", {
+      name: "Submit",
+    });
+    await userEvent.click(submitButton);
+    expect(actionHandler).toHaveBeenCalledTimes(0);
+    expect(screen.getByText(/Must not have fewer than 1 items/i)).toBeVisible();
+  });
+
+  it("should allow external users to replace their operation rep", async () => {
+    const testFormData = {
+      name: "Operation 3",
+      type: "Single Facility Operation",
+      naics_code_id: 1,
+      secondary_naics_code_id: 2,
+      operation_has_multiple_operators: false,
+      activities: [1, 2],
+      registration_purpose: "Reporting Operation",
+      regulated_products: [1],
+      opt_in: false,
+      operation_representatives: [1],
+      boundary_map: mockDataUri,
+      process_flow_diagram: mockDataUri,
+    };
+    useSession.mockReturnValue({
+      data: {
+        user: {
+          app_role: "industry_user_admin",
+        },
+      },
+    });
+
+    fetchFormEnums();
+    const createdFormSchema =
+      await createAdministrationOperationInformationSchema(
+        testFormData.registration_purpose,
+        OperationStatus.REGISTERED,
+      );
+
+    render(
+      <OperationInformationForm
+        formData={testFormData}
+        schema={createdFormSchema}
+        operationId={operationId}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const cancelChipIcon = screen.getAllByTestId("CancelIcon");
+    await userEvent.click(cancelChipIcon[2]); // 0-1 are activities
+    expect(screen.queryByText(/ivy/i)).not.toBeInTheDocument();
+    const operationRepresentativesComboBoxInput = screen.getByRole("combobox", {
+      name: /Operation Representative(s)*/i,
+    });
+    const openOperationReps = operationRepresentativesComboBoxInput
+      .parentElement?.children[1]?.children[0] as HTMLInputElement;
+    await userEvent.click(openOperationReps);
+    await userEvent.type(
+      operationRepresentativesComboBoxInput,
+      "Jack King{enter}",
+    );
+
+    const submitButton = screen.getByRole("button", {
+      name: "Submit",
+    });
+    await userEvent.click(submitButton);
+    expect(actionHandler).toHaveBeenCalledTimes(1);
+    expect(actionHandler).toHaveBeenCalledWith(
+      `registration/operations/${operationId}`,
+      "PUT",
+      "",
+      {
+        body: JSON.stringify({
+          name: "Operation 3",
+          type: "Single Facility Operation",
+          naics_code_id: 1,
+          secondary_naics_code_id: 2,
+          activities: [1, 2],
+          process_flow_diagram: mockDataUri,
+          boundary_map: mockDataUri,
+          operation_has_multiple_operators: false,
+          registration_purpose: "Reporting Operation",
+          operation_representatives: [2],
+        }),
+      },
+    );
+  });
+
+  it("should show a note if user navigated to operation from the contacts form", async () => {
+    useSession.mockReturnValue({
+      data: {
+        user: {
+          app_role: "industry_user_admin",
+        },
+      },
+    });
+    const mockGet = vi.fn();
+    useSearchParams.mockReturnValue({
+      get: mockGet,
+    });
+    mockGet.mockReturnValue("true");
+    fetchFormEnums();
+    const createdFormSchema =
+      await createAdministrationOperationInformationSchema(
+        formData.registration_purpose,
+        OperationStatus.REGISTERED,
+      );
+
+    render(
+      <OperationInformationForm
+        formData={{}}
+        schema={createdFormSchema}
+        operationId={operationId}
+      />,
+    );
+    expect(
+      screen.getByText(
+        /To remove the current operation representative, please select a new contact to replace them./i,
+      ),
+    ).toBeVisible();
   });
 });

--- a/bciers/apps/administration/tests/components/operations/OperationInformationPage.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import OperationInformationPage from "@/administration/app/components/operations/OperationInformationPage";
 import { getOperationWithDocuments } from "./mocks";
-import { useSession } from "@bciers/testConfig/mocks";
+import { useSearchParams, useSession } from "@bciers/testConfig/mocks";
 import { fetchFormEnums } from "./OperationInformationForm.test";
 import { beforeAll } from "vitest";
 import { OperationStatus } from "@bciers/utils/src/enums";
@@ -45,6 +45,9 @@ describe("the OperationInformationPage component", () => {
           app_role: "industry_user_admin",
         },
       },
+    });
+    useSearchParams.mockReturnValue({
+      get: vi.fn(),
     });
   });
   it("renders the OperationInformationPage component without Registration Information", async () => {

--- a/bciers/apps/administration/tests/components/operations/mocks.ts
+++ b/bciers/apps/administration/tests/components/operations/mocks.ts
@@ -6,7 +6,6 @@ const getRegulatedProducts = vi.fn();
 const getRegistrationPurposes = vi.fn();
 const getBusinessStructures = vi.fn();
 const fetchOperationsPageData = vi.fn();
-const getContacts = vi.fn();
 
 vi.mock("libs/actions/src/api/getOperation", () => ({
   default: getOperation,
@@ -35,9 +34,6 @@ vi.mock("libs/actions/src/api/getRegistrationPurposes", () => ({
 vi.mock("libs/actions/src/api/getBusinessStructures", () => ({
   default: getBusinessStructures,
 }));
-vi.mock("libs/actions/src/api/getContacts", () => ({
-  default: getContacts,
-}));
 
 vi.mock("libs/actions/src/api/fetchOperationsPageData", () => ({
   default: fetchOperationsPageData,
@@ -52,5 +48,4 @@ export {
   getRegistrationPurposes,
   getBusinessStructures,
   fetchOperationsPageData,
-  getContacts,
 };

--- a/bciers/apps/administration/tests/components/operations/mocks.ts
+++ b/bciers/apps/administration/tests/components/operations/mocks.ts
@@ -6,6 +6,7 @@ const getRegulatedProducts = vi.fn();
 const getRegistrationPurposes = vi.fn();
 const getBusinessStructures = vi.fn();
 const fetchOperationsPageData = vi.fn();
+const getContacts = vi.fn();
 
 vi.mock("libs/actions/src/api/getOperation", () => ({
   default: getOperation,
@@ -34,6 +35,9 @@ vi.mock("libs/actions/src/api/getRegistrationPurposes", () => ({
 vi.mock("libs/actions/src/api/getBusinessStructures", () => ({
   default: getBusinessStructures,
 }));
+vi.mock("libs/actions/src/api/getContacts", () => ({
+  default: getContacts,
+}));
 
 vi.mock("libs/actions/src/api/fetchOperationsPageData", () => ({
   default: fetchOperationsPageData,
@@ -48,4 +52,5 @@ export {
   getRegistrationPurposes,
   getBusinessStructures,
   fetchOperationsPageData,
+  getContacts,
 };

--- a/bciers/libs/components/src/form/fields/PlacesAssignedFieldTemplate.test.tsx
+++ b/bciers/libs/components/src/form/fields/PlacesAssignedFieldTemplate.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { RJSFSchema } from "@rjsf/utils";
+import FormBase from "@bciers/components/form/FormBase";
+import PlacesAssignedFieldTemplate from "./PlacesAssignedFieldTemplate";
+
+const mockSchema: RJSFSchema = {
+  type: "object",
+  properties: {
+    places_assigned: {
+      type: "array",
+      title: "Places assigned",
+      readOnly: true,
+      items: {
+        type: "object",
+        properties: {
+          role_name: { type: "string" },
+          operation_name: { type: "string" },
+          operation_id: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+const mockUiSchema = {
+  places_assigned: {
+    "ui:ArrayFieldTemplate": PlacesAssignedFieldTemplate,
+    "ui:classNames": "[&>div:last-child]:w-2/3",
+    items: {
+      "ui:widget": "ReadOnlyWidget",
+      "ui:options": {
+        label: false,
+        inline: true,
+      },
+      role_name: {
+        "ui:options": {
+          label: false,
+        },
+      },
+      operation_name: {
+        "ui:options": {
+          label: false,
+        },
+      },
+      operation_id: {
+        "ui:widget": "hidden",
+      },
+    },
+  },
+};
+
+const mockFormData = {
+  places_assigned: [
+    {
+      role_name: "testrole",
+      operation_name: "testoperation",
+      operation_id: "uuid1",
+    },
+  ],
+};
+
+describe("RJSF PlacesAssignedFieldTemplate", () => {
+  it("should render the field template when there are no places assigned", async () => {
+    render(
+      <FormBase schema={mockSchema} uiSchema={mockUiSchema} formData={{}} />,
+    );
+    expect(screen.getByText("None")).toBeVisible();
+  });
+  it("should render the field template when formData is provided", async () => {
+    render(
+      <FormBase
+        schema={mockSchema}
+        uiSchema={mockUiSchema}
+        formData={mockFormData}
+      />,
+    );
+    expect(screen.getByText("testrole -")).toBeVisible();
+    expect(screen.getByText("testoperation")).toBeVisible();
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/operations/uuid1?operations_title=testoperation&from_contacts=true",
+    );
+    expect(
+      screen.getByText(
+        "You cannot delete this contact unless you replace them with other contact(s) in the place(s) above.",
+      ),
+    ).toBeVisible();
+  });
+
+  it("should throw an error if given bad formData", async () => {
+    expect(() =>
+      render(
+        <FormBase
+          schema={mockSchema}
+          uiSchema={mockUiSchema}
+          formData={{ places_assigned: ["garbage"] }}
+        />,
+      ),
+    ).toThrow("Invalid places assigned data");
+  });
+});

--- a/bciers/libs/components/src/form/fields/PlacesAssignedFieldTemplate.test.tsx
+++ b/bciers/libs/components/src/form/fields/PlacesAssignedFieldTemplate.test.tsx
@@ -62,16 +62,22 @@ const mockFormData = {
 describe("RJSF PlacesAssignedFieldTemplate", () => {
   it("should render the field template when there are no places assigned", async () => {
     render(
-      <FormBase schema={mockSchema} uiSchema={mockUiSchema} formData={{}} />,
+      <FormBase
+        schema={mockSchema}
+        uiSchema={mockUiSchema}
+        formData={{}}
+        formContext={{ userRole: "industry_user" }}
+      />,
     );
     expect(screen.getByText("None")).toBeVisible();
   });
-  it("should render the field template when formData is provided", async () => {
+  it("should render the field template when formData is provided for an external user", async () => {
     render(
       <FormBase
         schema={mockSchema}
         uiSchema={mockUiSchema}
         formData={mockFormData}
+        formContext={{ userRole: "industry_user" }}
       />,
     );
     expect(screen.getByText("testrole -")).toBeVisible();
@@ -87,6 +93,23 @@ describe("RJSF PlacesAssignedFieldTemplate", () => {
     ).toBeVisible();
   });
 
+  it("should render the field template when formData is provided for an internal user (no note)", async () => {
+    render(
+      <FormBase
+        schema={mockSchema}
+        uiSchema={mockUiSchema}
+        formData={mockFormData}
+        formContext={{ userRole: "cas_director" }}
+      />,
+    );
+
+    expect(
+      screen.queryByText(
+        "You cannot delete this contact unless you replace them with other contact(s) in the place(s) above.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("should throw an error if given bad formData", async () => {
     expect(() =>
       render(
@@ -94,6 +117,7 @@ describe("RJSF PlacesAssignedFieldTemplate", () => {
           schema={mockSchema}
           uiSchema={mockUiSchema}
           formData={{ places_assigned: ["garbage"] }}
+          formContext={{ userRole: "industry_user" }}
         />,
       ),
     ).toThrow("Invalid places assigned data");

--- a/bciers/libs/components/src/form/fields/PlacesAssignedFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/PlacesAssignedFieldTemplate.tsx
@@ -1,0 +1,38 @@
+import { ArrayFieldTemplateProps } from "@rjsf/utils";
+import Link from "next/link";
+
+const PlacesAssignedFieldTemplate = ({ items }: ArrayFieldTemplateProps) => {
+  if (items.length < 1) {
+    return <div>None</div>;
+  }
+  return (
+    <div className="flex min-w-full flex-col">
+      {items?.map((item) => {
+        const formData = item.children.props.formData;
+        if (
+          !formData.role_name ||
+          !formData.operation_name ||
+          !formData.operation_id
+        ) {
+          throw new Error(`Invalid places assigned data`);
+        }
+        return (
+          <div key={item.key} className="w-full px-[14px] py-4 items-center">
+            {formData.role_name} -{" "}
+            <Link
+              href={`/operations/${formData.operation_id}?operations_title=${formData.operation_name}&from_contacts=true`}
+            >
+              {formData.operation_name}
+            </Link>
+          </div>
+        );
+      })}
+      <div className="w-full px-[14px] py-4 items-center">
+        <b>Note:</b> You cannot delete this contact unless you replace them with
+        other contact(s) in the place(s) above.
+      </div>
+    </div>
+  );
+};
+
+export default PlacesAssignedFieldTemplate;

--- a/bciers/libs/components/src/form/fields/PlacesAssignedFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/PlacesAssignedFieldTemplate.tsx
@@ -1,36 +1,39 @@
 import { ArrayFieldTemplateProps } from "@rjsf/utils";
 import Link from "next/link";
 
-const PlacesAssignedFieldTemplate = ({ items }: ArrayFieldTemplateProps) => {
+const PlacesAssignedFieldTemplate = ({
+  items,
+  formContext,
+}: ArrayFieldTemplateProps) => {
   if (items.length < 1) {
     return <div>None</div>;
   }
   return (
     <div className="flex min-w-full flex-col">
       {items?.map((item) => {
-        const formData = item.children.props.formData;
-        if (
-          !formData.role_name ||
-          !formData.operation_name ||
-          !formData.operation_id
-        ) {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        const { role_name, operation_name, operation_id } =
+          item.children.props.formData;
+        if (!role_name || !operation_name || !operation_id) {
           throw new Error(`Invalid places assigned data`);
         }
         return (
           <div key={item.key} className="w-full px-[14px] py-4 items-center">
-            {formData.role_name} -{" "}
+            {role_name} -{" "}
             <Link
-              href={`/operations/${formData.operation_id}?operations_title=${formData.operation_name}&from_contacts=true`}
+              href={`/operations/${operation_id}?operations_title=${operation_name}&from_contacts=true`}
             >
-              {formData.operation_name}
+              {operation_name}
             </Link>
           </div>
         );
       })}
-      <div className="w-full px-[14px] py-4 items-center">
-        <b>Note:</b> You cannot delete this contact unless you replace them with
-        other contact(s) in the place(s) above.
-      </div>
+      {!formContext.userRole.includes("cas") && (
+        <div className="w-full px-[14px] py-4 items-center">
+          <b>Note:</b> You cannot delete this contact unless you replace them
+          with other contact(s) in the place(s) above.
+        </div>
+      )}
     </div>
   );
 };

--- a/bciers/libs/components/src/form/fields/index.ts
+++ b/bciers/libs/components/src/form/fields/index.ts
@@ -1,5 +1,6 @@
 export { default as ArrayFieldTemplate } from "./ArrayFieldTemplate";
 export { default as InlineArrayFieldTemplate } from "./InlineArrayFieldTemplate";
+export { default as PlacesAssignedFieldTemplate } from "./PlacesAssignedFieldTemplate";
 
 export { default as FieldTemplate } from "./FieldTemplate";
 export { default as FieldTemplateWithSubmitButton } from "./FieldTemplateWithSubmitButton";


### PR DESCRIPTION
https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=88758186&issue=bcgov%7Ccas-registration%7C2524

Notes: 
- I've used a url param to decide whether or not to show the alert on the contact page. As far as I could find online (e.g. https://medium.com/@awayyao/keep-page-state-between-page-navigation-in-nextjs-13-using-app-router-schema-f6eacd0300ad), the next router doesn't store any state or history. window.history doesn't store the previous url, and document.referer only gives the origin.
- Updated the mock data so that contacts are more representative of how the app works (e.g., operations can only have contacts that belong to their operators; all registered operations have to have a contact)
- because of ^, I noticed you can get to the operation administration page before the operation is registered if you go via the URL. I added a check in the endpoint
- I wrote a couple comments in the card about where I haven't followed the card exactly