### PR TITLE
2374 transfer instructions

### DIFF
--- a/bc_obps/common/fixtures/dashboard/administration/external.json
+++ b/bc_obps/common/fixtures/dashboard/administration/external.json
@@ -76,6 +76,20 @@
             ]
           },
           {
+            "title": "Report transfer of operation or facility",
+            "icon": "Layers",
+            "content": "Report a transfer in control, ownership or direction of your operation or facility(s).",
+            "href": "/administration/transfers",
+            "conditions": [
+              {
+                "api": "registration/user-operators/current/operator",
+                "field": "error",
+                "operator": "notExists",
+                "value": true
+              }
+            ]
+          },
+          {
             "title": "Contacts",
             "icon": "Users",
             "content": "View the contacts of your operator, or to add new contact for your operator here.",

--- a/bc_obps/common/fixtures/dashboard/bciers/external.json
+++ b/bc_obps/common/fixtures/dashboard/bciers/external.json
@@ -74,6 +74,18 @@
                 ]
               },
               {
+                "title": "Report transfer of operation or facility",
+                "href": "/administration/transfers",
+                "conditions": [
+                  {
+                    "api": "registration/user-operators/current/operator",
+                    "field": "error",
+                    "operator": "notExists",
+                    "value": true
+                  }
+                ]
+              },
+              {
                 "title": "Contacts",
                 "href": "/administration/contacts",
                 "conditions": [

--- a/bciers/apps/administration/app/bceidbusiness/industry_user/transfers/page.tsx
+++ b/bciers/apps/administration/app/bceidbusiness/industry_user/transfers/page.tsx
@@ -1,0 +1,13 @@
+// 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
+
+import { Suspense } from "react";
+import Loading from "@bciers/components/loading/SkeletonForm";
+import ExternalTransferPage from "@/administration/app/components/transfers/ExternalTransferPage";
+
+export default async function Page() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <ExternalTransferPage />
+    </Suspense>
+  );
+}

--- a/bciers/apps/administration/app/bceidbusiness/industry_user_admin/transfers/page.tsx
+++ b/bciers/apps/administration/app/bceidbusiness/industry_user_admin/transfers/page.tsx
@@ -1,0 +1,7 @@
+// 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
+
+import IndustryUserTransferPage from "../../industry_user/transfers/page";
+
+export default async function Page() {
+  return <IndustryUserTransferPage />;
+}

--- a/bciers/apps/administration/app/components/transfers/ExternalTransferPage.tsx
+++ b/bciers/apps/administration/app/components/transfers/ExternalTransferPage.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+
+// 🧩 Main component
+export default async function ExternalTransferPage() {
+  return (
+    <div>
+      <h1 className="form-heading mt-4">Report Transfers and Closures</h1>
+      The Greenhouse Gas Emission Reporting Regulation requires an operator to
+      report the following events:
+      <ul>
+        <li>A closure or temporary shutdown;</li>
+        <li>An acquisition or divestment;</li>
+        <li>A change in the operator having control or direction; or</li>
+        <li>A transfer of control and direction to the operator</li>
+      </ul>
+      To report any of these events, please click report an event below.
+      <Link
+        className="link-button-blue my-8"
+        href={
+          "https://submit.digital.gov.bc.ca/app/form/submit?f=d26fb011-2846-44ed-9f5c-26e2756a758f"
+        }
+      >
+        Report an Event
+      </Link>
+      Staff will review the information provided and administer changes in
+      BCIERS as needed.
+      <p>
+        For questions reach out to{" "}
+        <Link href={"mailto:GHGRegulator@gov.bc.ca"}>
+          GHGRegulator@gov.bc.ca
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/bciers/apps/administration/tests/components/transfers/ExternalTransferPage.test.tsx
+++ b/bciers/apps/administration/tests/components/transfers/ExternalTransferPage.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import ExternalTransferPage from "@/administration/app/components/transfers/ExternalTransferPage";
+
+describe("ExternalTransferPage component", () => {
+  beforeEach(async () => {
+    vi.resetAllMocks();
+  });
+
+  it("renders the external transfers apge", async () => {
+    render(await ExternalTransferPage());
+    expect(
+      screen.getByRole("heading", { name: /Report Transfers and Closures/i }),
+    ).toBeVisible();
+    // Note component
+    expect(
+      screen.getByRole("link", { name: "Report an Event" }),
+    ).toHaveAttribute(
+      "href",
+      "https://submit.digital.gov.bc.ca/app/form/submit?f=d26fb011-2846-44ed-9f5c-26e2756a758f",
+    );
+
+    expect(
+      screen.getByRole("link", { name: "GHGRegulator@gov.bc.ca" }),
+    ).toHaveAttribute("href", "mailto:GHGRegulator@gov.bc.ca");
+  });
+});


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=83628015&issue=bcgov%7Ccas-registration%7C2374

This PR:
- creates a page.tsx for both industry_user and industry_user admin
- adds links to the dashboard that are only accessible once a user is approved
- creates the transfers info page
- vitest for the transfers page