### PR TITLE
2447 Edit and Delete transfer event

### DIFF
--- a/bc_obps/Makefile
+++ b/bc_obps/Makefile
@@ -132,6 +132,12 @@ pythontests_coverage: ## run Python tests with coverage
 pythontests_coverage:
 	$(POETRY_RUN) pytest --cov=. --cov-config=.coveragerc --cov-report=term-missing --no-cov-on-fail
 
+
+.PHONY: pythontests_parallel
+pythontests_parallel: ## run Python tests in parallel for faster execution
+pythontests_parallel:
+	$(POETRY_RUN) pytest -n auto
+
 .PHONY: clear_db
 clear_db: ## Clear all data in the datbase
 clear_db:

--- a/bc_obps/common/tests/endpoints/auth/test_endpoint_permissions.py
+++ b/bc_obps/common/tests/endpoints/auth/test_endpoint_permissions.py
@@ -403,6 +403,7 @@ class TestEndpointPermissions(TestCase):
             {"method": "get", "endpoint_name": "list_user_operators"},
             {"method": "get", "endpoint_name": "list_user_operators"},
             {"method": "get", "endpoint_name": "list_transfer_events"},
+            {"method": "get", "endpoint_name": "get_transfer_event", "kwargs": {"transfer_id": mock_uuid}},
         ],
         "approved_authorized_roles": [
             {
@@ -551,6 +552,8 @@ class TestEndpointPermissions(TestCase):
         ],
         "cas_analyst": [
             {"method": "post", "endpoint_name": "create_transfer_event"},
+            {"method": "patch", "endpoint_name": "update_transfer_event", "kwargs": {"transfer_id": mock_uuid}},
+            {"method": "delete", "endpoint_name": "delete_transfer_event", "kwargs": {"transfer_id": mock_uuid}},
         ],
     }
 

--- a/bc_obps/common/utils.py
+++ b/bc_obps/common/utils.py
@@ -1,5 +1,8 @@
+from typing import Optional
+
 from django.apps import apps
 from django.core.management import call_command
+from decimal import Decimal
 
 
 def reset_dashboard_data() -> None:
@@ -26,3 +29,17 @@ def reset_dashboard_data() -> None:
     # Load the fixtures
     for fixture in fixture_files:
         call_command('loaddata', fixture)
+
+
+def format_decimal(value: Decimal, decimal_places: int = 2) -> Optional[Decimal]:
+    """
+    Formats a Decimal or numeric value to the specified number of decimal places
+    without rounding (truncates the extra digits).
+    """
+    if value is None:
+        return None
+    try:
+        quantize_value = Decimal(f"1.{'0' * decimal_places}")
+        return value.quantize(quantize_value)
+    except (ValueError, TypeError):
+        raise ValueError(f"Cannot format the provided value: {value}")

--- a/bc_obps/registration/api/v2/__init__.py
+++ b/bc_obps/registration/api/v2/__init__.py
@@ -42,3 +42,4 @@ from ._user_operators._user_operator_id import update_status
 from .user import user_profile, user_app_role
 from ._users import user_id
 from . import transfer_events
+from ._transfer_events import transfer_id

--- a/bc_obps/registration/api/v2/_transfer_events/transfer_id.py
+++ b/bc_obps/registration/api/v2/_transfer_events/transfer_id.py
@@ -2,7 +2,6 @@ from typing import Literal, Tuple
 from uuid import UUID
 from django.http import HttpRequest
 from ninja.types import DictStrAny
-
 from registration.constants import TRANSFER_EVENT_TAGS
 from registration.models import TransferEvent
 from common.api.utils import get_current_user_guid

--- a/bc_obps/registration/api/v2/_transfer_events/transfer_id.py
+++ b/bc_obps/registration/api/v2/_transfer_events/transfer_id.py
@@ -32,7 +32,7 @@ def get_transfer_event(request: HttpRequest, transfer_id: UUID) -> Tuple[Literal
     response={200: DictStrAny, custom_codes_4xx: Message},
     tags=TRANSFER_EVENT_TAGS,
     description="""Deletes a transfer event by its ID.""",
-    auth=authorize("authorized_irc_user"),
+    auth=authorize("cas_analyst"),
 )
 @handle_http_errors()
 def delete_transfer_event(request: HttpRequest, transfer_id: UUID) -> Tuple[Literal[200], DictStrAny]:
@@ -45,10 +45,10 @@ def delete_transfer_event(request: HttpRequest, transfer_id: UUID) -> Tuple[Lite
     response={200: TransferEventOut, custom_codes_4xx: Message},
     tags=TRANSFER_EVENT_TAGS,
     description="""Updates the details of an existing transfer event by its ID.""",
-    auth=authorize("authorized_irc_user"),
+    auth=authorize("cas_analyst"),
 )
 @handle_http_errors()
-def update_facility(
+def update_transfer_event(
     request: HttpRequest, transfer_id: UUID, payload: TransferEventUpdateIn
 ) -> Tuple[Literal[200], TransferEvent]:
     return 200, TransferEventService.update_transfer_event(get_current_user_guid(request), transfer_id, payload)

--- a/bc_obps/registration/api/v2/_transfer_events/transfer_id.py
+++ b/bc_obps/registration/api/v2/_transfer_events/transfer_id.py
@@ -1,0 +1,54 @@
+from typing import Literal, Tuple
+from uuid import UUID
+from django.http import HttpRequest
+from ninja.types import DictStrAny
+
+from registration.constants import TRANSFER_EVENT_TAGS
+from registration.models import TransferEvent
+from common.api.utils import get_current_user_guid
+from common.permissions import authorize
+from registration.decorators import handle_http_errors
+from registration.api.router import router
+from registration.schema.generic import Message
+from registration.schema.v2.transfer_event import TransferEventOut, TransferEventUpdateIn
+from service.error_service.custom_codes_4xx import custom_codes_4xx
+from service.transfer_event_service import TransferEventService
+
+
+@router.get(
+    "/transfer-events/{uuid:transfer_id}",
+    response={200: TransferEventOut, custom_codes_4xx: Message},
+    tags=TRANSFER_EVENT_TAGS,
+    description="""Retrieves the details of a specific transfer event by its ID. The endpoint checks if the current user is authorized to access the transfer event.""",
+    auth=authorize("authorized_irc_user"),
+)
+@handle_http_errors()
+def get_transfer_event(request: HttpRequest, transfer_id: UUID) -> Tuple[Literal[200], TransferEvent]:
+    return 200, TransferEventService.get_if_authorized(get_current_user_guid(request), transfer_id)
+
+
+@router.delete(
+    "/transfer-events/{uuid:transfer_id}",
+    response={200: DictStrAny, custom_codes_4xx: Message},
+    tags=TRANSFER_EVENT_TAGS,
+    description="""Deletes a transfer event by its ID.""",
+    auth=authorize("authorized_irc_user"),
+)
+@handle_http_errors()
+def delete_transfer_event(request: HttpRequest, transfer_id: UUID) -> Tuple[Literal[200], DictStrAny]:
+    TransferEventService.delete_transfer_event(get_current_user_guid(request), transfer_id)
+    return 200, {"success": True}
+
+
+@router.patch(
+    "/transfer-events/{uuid:transfer_id}",
+    response={200: TransferEventOut, custom_codes_4xx: Message},
+    tags=TRANSFER_EVENT_TAGS,
+    description="""Updates the details of an existing transfer event by its ID.""",
+    auth=authorize("authorized_irc_user"),
+)
+@handle_http_errors()
+def update_facility(
+    request: HttpRequest, transfer_id: UUID, payload: TransferEventUpdateIn
+) -> Tuple[Literal[200], TransferEvent]:
+    return 200, TransferEventService.update_transfer_event(get_current_user_guid(request), transfer_id, payload)

--- a/bc_obps/registration/api/v2/operations.py
+++ b/bc_obps/registration/api/v2/operations.py
@@ -33,7 +33,7 @@ from registration.schema.v2.operation_timeline import OperationTimelineFilterSch
 def list_operations(
     request: HttpRequest,
     filters: OperationTimelineFilterSchema = Query(...),
-    sort_field: Optional[str] = "created_at",
+    sort_field: Optional[str] = "operation__created_at",
     sort_order: Optional[Literal["desc", "asc"]] = "desc",
     paginate_result: bool = Query(True, description="Whether to paginate the results"),
 ) -> QuerySet[OperationDesignatedOperatorTimeline]:

--- a/bc_obps/registration/fixtures/mock/transfer_event.json
+++ b/bc_obps/registration/fixtures/mock/transfer_event.json
@@ -43,5 +43,24 @@
       "status": "Complete",
       "effective_date": "2024-12-25T09:00:00Z"
     }
+  },
+  {
+    "model": "registration.transferevent",
+    "fields": {
+      "created_by": "00000000-0000-0000-0000-000000000028",
+      "created_at": "2025-01-10T23:42:44.039Z",
+      "updated_by": "00000000-0000-0000-0000-000000000028",
+      "updated_at": "2025-01-10T23:50:44.039Z",
+      "facilities": [
+        "f486f2fb-62ed-438d-bb3e-0819b51e3af3",
+        "f486f2fb-62ed-438d-bb3e-0819b51e3af4"
+      ],
+      "from_operator": "4242ea9d-b917-4129-93c2-db00b7451051",
+      "to_operator": "4242ea9d-b917-4129-93c2-db00b7451051",
+      "from_operation": "002d5a9e-32a6-4191-938c-2c02bfec592d",
+      "to_operation": "59d95661-c752-489b-9fd1-0c3fa3454dda",
+      "status": "To be transferred",
+      "effective_date": "2026-03-01T09:00:00Z"
+    }
   }
 ]

--- a/bc_obps/registration/schema/v2/operation_timeline.py
+++ b/bc_obps/registration/schema/v2/operation_timeline.py
@@ -39,3 +39,4 @@ class OperationTimelineFilterSchema(FilterSchema):
     )
     operator__legal_name: Optional[str] = Field(None, json_schema_extra={'q': 'operator__legal_name__icontains'})
     operator_id: Optional[UUID] = Field(None, json_schema_extra={'q': 'operator__id__exact'})
+    end_date: Optional[bool] = Field(None, json_schema_extra={'q': 'end_date__isnull'})

--- a/bc_obps/registration/schema/v2/transfer_event.py
+++ b/bc_obps/registration/schema/v2/transfer_event.py
@@ -85,7 +85,7 @@ class TransferEventOut(ModelSchema):
                 facility.latitude_of_largest_emissions is not None
                 and facility.longitude_of_largest_emissions is not None
             ):
-                return f"{facility.name} ({format_decimal(facility.latitude_of_largest_emissions, 1)}, {format_decimal(facility.longitude_of_largest_emissions, 1)})"
+                return f"{facility.name} ({format_decimal(facility.latitude_of_largest_emissions)}, {format_decimal(facility.longitude_of_largest_emissions)})"
             return facility.name
 
         if not obj.facilities.exists():

--- a/bc_obps/registration/tests/endpoints/v1/user/test_user_profile.py
+++ b/bc_obps/registration/tests/endpoints/v1/user/test_user_profile.py
@@ -106,10 +106,10 @@ class TestUserProfileEndpoint(CommonTestSetup):
         # Assert
         assert response.status_code == 200
 
-        # Additional Assertions (If BYPASS_ROLE_ASSIGNMENT is True, app_role should be cas_admin, otherwise cas_pending)
+        # Additional Assertions (If BYPASS_ROLE_ASSIGNMENT is True, app_role should be cas_analyst, otherwise cas_pending)
 
         assert (
-            'app_role' in content and content["app_role"]["role_name"] == 'cas_admin'
+            'app_role' in content and content["app_role"]["role_name"] == 'cas_analyst'
             if settings.BYPASS_ROLE_ASSIGNMENT
             else 'cas_pending'
         )

--- a/bc_obps/registration/tests/endpoints/v2/_transfer_events/test_transfer_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_transfer_events/test_transfer_id.py
@@ -1,0 +1,113 @@
+from unittest.mock import patch, MagicMock
+from uuid import uuid4
+from registration.models import AppRole, TransferEvent
+from registration.schema.v2.transfer_event import TransferEventUpdateIn
+from registration.tests.utils.helpers import CommonTestSetup, TestUtils
+from registration.utils import custom_reverse_lazy
+from model_bakery import baker
+from datetime import datetime
+
+
+class TestTransferIdEndpoint(CommonTestSetup):
+    @patch("service.transfer_event_service.TransferEventService.get_if_authorized")
+    def test_authorized_users_can_get_transfer_event(self, mock_get_if_authorized: MagicMock):
+        transfer_event = baker.make_recipe('utils.transfer_event', operation=baker.make_recipe('utils.operation'))
+        mock_get_if_authorized.return_value = transfer_event
+        for role in AppRole.get_authorized_irc_roles():
+            response = TestUtils.mock_get_with_auth_role(
+                self, role, custom_reverse_lazy('get_transfer_event', kwargs={'transfer_id': transfer_event.id})
+            )
+            mock_get_if_authorized.assert_called_once_with(self.user.pk, transfer_event.id)
+            mock_get_if_authorized.reset_mock()
+            assert response.status_code == 200
+            response_json = response.json()
+            assert set(response_json.keys()) == {
+                'transfer_entity',
+                'from_operator',
+                'from_operator_id',
+                'to_operator',
+                'operation_name',
+                'from_operation',
+                'from_operation_id',
+                'to_operation',
+                'existing_facilities',
+                'status',
+                'effective_date',
+                'operation',
+                'facilities',
+            }
+            assert response_json['transfer_entity'] == "Operation"
+            assert response_json['from_operator'] == transfer_event.from_operator.legal_name
+            assert response_json['from_operator_id'] == str(transfer_event.from_operator.id)
+            assert response_json['to_operator'] == transfer_event.to_operator.legal_name
+            assert response_json['operation_name'] == transfer_event.operation.name
+            assert response_json['from_operation'] is None
+            assert response_json['from_operation_id'] is None
+            assert response_json['to_operation'] is None
+            assert response_json['existing_facilities'] == []
+            # modify the effective date to match the format of the response
+            response_effective_date = datetime.strptime(response_json['effective_date'], "%Y-%m-%dT%H:%M:%S.%fZ")
+            mock_transfer_event_effective_date = datetime.fromisoformat(str(transfer_event.effective_date))
+            assert response_effective_date.replace(microsecond=0) == mock_transfer_event_effective_date.replace(
+                microsecond=0, tzinfo=None
+            )
+            assert response_json['operation'] == str(transfer_event.operation.id)
+            assert response_json['facilities'] == []
+            assert response_json['status'] == TransferEvent.Statuses.TO_BE_TRANSFERRED
+
+    @patch("service.transfer_event_service.TransferEventService.delete_transfer_event")
+    def test_cas_analyst_can_delete_transfer_event(self, mock_delete_transfer_event: MagicMock):
+        random_transfer_event_id = uuid4()
+        mock_delete_transfer_event.return_value = None
+        response = TestUtils.mock_delete_with_auth_role(
+            self,
+            "cas_analyst",
+            custom_reverse_lazy('delete_transfer_event', kwargs={'transfer_id': random_transfer_event_id}),
+        )
+        mock_delete_transfer_event.assert_called_once_with(self.user.pk, random_transfer_event_id)
+        assert response.status_code == 200
+        response_json = response.json()
+        assert response_json == {"success": True}
+
+    @patch("service.transfer_event_service.TransferEventService.update_transfer_event")
+    def test_cas_analyst_can_update_transfer_event(self, mock_update_transfer_event: MagicMock):
+        transfer_event = baker.make_recipe('utils.transfer_event', operation=baker.make_recipe('utils.operation'))
+        mock_update_transfer_event.return_value = transfer_event
+        mock_payload = {
+            "transfer_entity": "Operation",
+            "operation": uuid4(),
+            "effective_date": "2023-10-13",
+        }
+        response = TestUtils.mock_patch_with_auth_role(
+            self,
+            "cas_analyst",
+            self.content_type,
+            endpoint=custom_reverse_lazy('update_transfer_event', kwargs={'transfer_id': transfer_event.id}),
+            data=mock_payload,
+        )
+        mock_update_transfer_event.assert_called_once_with(
+            self.user.pk,
+            transfer_event.id,
+            TransferEventUpdateIn.model_construct(
+                transfer_entity=mock_payload['transfer_entity'],
+                operation=mock_payload['operation'],
+                effective_date=datetime.strptime(mock_payload['effective_date'], "%Y-%m-%d"),
+            ),
+        )
+        assert response.status_code == 200
+        response_json = response.json()
+        assert set(response_json.keys()) == {
+            'transfer_entity',
+            'from_operator',
+            'from_operator_id',
+            'to_operator',
+            'operation_name',
+            'from_operation',
+            'from_operation_id',
+            'to_operation',
+            'existing_facilities',
+            'status',
+            'effective_date',
+            'operation',
+            'facilities',
+        }

--- a/bc_obps/registration/tests/endpoints/v2/test_transfer_events.py
+++ b/bc_obps/registration/tests/endpoints/v2/test_transfer_events.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 from django.utils import timezone
 from bc_obps.settings import NINJA_PAGINATION_PER_PAGE
 from model_bakery import baker
-
 from registration.models import TransferEvent
 from registration.schema.v2.transfer_event import TransferEventCreateIn
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils

--- a/bc_obps/registration/tests/endpoints/v2/user/test_user_profile.py
+++ b/bc_obps/registration/tests/endpoints/v2/user/test_user_profile.py
@@ -106,10 +106,10 @@ class TestUserProfileEndpoint(CommonTestSetup):
         # Assert
         assert response.status_code == 200
 
-        # Additional Assertions (If BYPASS_ROLE_ASSIGNMENT is True, app_role should be cas_admin, otherwise cas_pending)
+        # Additional Assertions (If BYPASS_ROLE_ASSIGNMENT is True, app_role should be cas_analyst, otherwise cas_pending)
 
         assert (
-            'app_role' in content and content["app_role"]["role_name"] == 'cas_admin'
+            'app_role' in content and content["app_role"]["role_name"] == 'cas_analyst'
             if settings.BYPASS_ROLE_ASSIGNMENT
             else 'cas_pending'
         )

--- a/bc_obps/registration/tests/utils/helpers.py
+++ b/bc_obps/registration/tests/utils/helpers.py
@@ -76,6 +76,10 @@ class TestUtils:
             role=UserOperator.Roles.ADMIN,
         )
 
+    def mock_delete_with_auth_role(self, role_name, endpoint=None):
+        TestUtils.save_app_role(self, role_name)
+        return TestUtils.client.delete(endpoint or self.endpoint, HTTP_AUTHORIZATION=self.auth_header_dumps)
+
     def create_operator_and_operation(self):
         """
         Creates operator and operation instance for testing purposes.

--- a/bc_obps/service/data_access_service/transfer_event_service.py
+++ b/bc_obps/service/data_access_service/transfer_event_service.py
@@ -11,3 +11,21 @@ class TransferEventDataAccessService:
         transfer_event_data: DictStrAny,
     ) -> TransferEvent:
         return TransferEvent.objects.create(**transfer_event_data, created_by_id=user_guid)
+
+    @classmethod
+    def get_by_id(cls, transfer_id: UUID) -> TransferEvent:
+        return TransferEvent.objects.get(id=transfer_id)
+
+    @classmethod
+    def update_transfer_event(
+        cls,
+        user_guid: UUID,
+        transfer_id: UUID,
+        transfer_event_data: DictStrAny,
+    ) -> TransferEvent:
+        transfer_event = cls.get_by_id(transfer_id)
+        for key, value in transfer_event_data.items():
+            setattr(transfer_event, key, value)
+        transfer_event.save(update_fields=transfer_event_data.keys())
+        transfer_event.set_create_or_update(user_guid)
+        return transfer_event

--- a/bc_obps/service/tests/test_transfer_event_service.py
+++ b/bc_obps/service/tests/test_transfer_event_service.py
@@ -2,6 +2,8 @@ from datetime import datetime, timedelta
 from unittest.mock import patch, MagicMock
 from uuid import uuid4
 from zoneinfo import ZoneInfo
+
+from registration.constants import UNAUTHORIZED_MESSAGE
 from registration.models import TransferEvent, FacilityDesignatedOperationTimeline, OperationDesignatedOperatorTimeline
 from registration.schema.v2.transfer_event import TransferEventFilterSchema, TransferEventCreateIn
 from service.transfer_event_service import TransferEventService
@@ -62,6 +64,36 @@ class TestTransferEventService:
             TransferEventService.validate_no_overlapping_transfer_events(
                 facility_ids=[facility.id for facility in facilities]
             )
+
+        # Scenario 4: Overlapping operation but excluded by current_transfer_id
+        overlapping_operation = baker.make_recipe('utils.operation')
+        existing_transfer = baker.make_recipe(
+            'utils.transfer_event',
+            operation=overlapping_operation,
+            status=TransferEvent.Statuses.TO_BE_TRANSFERRED,
+        )
+        try:
+            TransferEventService.validate_no_overlapping_transfer_events(
+                operation_id=overlapping_operation.id,
+                current_transfer_id=existing_transfer.id,
+            )
+        except Exception as e:
+            pytest.fail(f"Unexpected exception raised: {e}")
+
+        # Scenario 5: Overlapping facilities but excluded by current_transfer_id
+        overlapping_facilities = baker.make_recipe('utils.facility', _quantity=2)
+        existing_transfer = baker.make_recipe(
+            'utils.transfer_event',
+            facilities=overlapping_facilities,
+            status=TransferEvent.Statuses.COMPLETE,
+        )
+        try:
+            TransferEventService.validate_no_overlapping_transfer_events(
+                facility_ids=[facility.id for facility in overlapping_facilities],
+                current_transfer_id=existing_transfer.id,
+            )
+        except Exception as e:
+            pytest.fail(f"Unexpected exception raised: {e}")
 
     @staticmethod
     @patch("service.data_access_service.user_service.UserDataAccessService.get_by_guid")
@@ -126,11 +158,12 @@ class TestTransferEventService:
             )
 
     @classmethod
+    @patch("service.transfer_event_service.TransferEventService._process_event_if_effective")
     @patch("service.transfer_event_service.TransferEventService.validate_no_overlapping_transfer_events")
     @patch("service.data_access_service.user_service.UserDataAccessService.get_by_guid")
     @patch("service.data_access_service.transfer_event_service.TransferEventDataAccessService.create_transfer_event")
     def test_create_transfer_event_operation(
-        cls, mock_create_transfer_event, mock_get_by_guid, mock_validate_no_overlap
+        cls, mock_create_transfer_event, mock_get_by_guid, mock_validate_no_overlap, mock_process_event_if_effective
     ):
         cas_analyst = baker.make_recipe('utils.cas_analyst')
         payload = cls._get_transfer_event_payload_for_operation()
@@ -156,6 +189,7 @@ class TestTransferEventService:
                 "operation_id": payload.operation,
             },
         )
+        mock_process_event_if_effective.assert_called_once_with(payload, mock_transfer_event, cas_analyst.user_guid)
         assert result == mock_transfer_event
 
     @classmethod
@@ -224,11 +258,12 @@ class TestTransferEventService:
             TransferEventService.create_transfer_event(cas_analyst.user_guid, payload_with_same_from_and_to_operation)
 
     @classmethod
+    @patch("service.transfer_event_service.TransferEventService._process_event_if_effective")
     @patch("service.transfer_event_service.TransferEventService.validate_no_overlapping_transfer_events")
     @patch("service.data_access_service.user_service.UserDataAccessService.get_by_guid")
     @patch("service.data_access_service.transfer_event_service.TransferEventDataAccessService.create_transfer_event")
     def test_create_transfer_event_facility(
-        cls, mock_create_transfer_event, mock_get_by_guid, mock_validate_no_overlap
+        cls, mock_create_transfer_event, mock_get_by_guid, mock_validate_no_overlap, mock_process_event_if_effective
     ):
         cas_analyst = baker.make_recipe("utils.cas_analyst")
         payload = cls._get_transfer_event_payload_for_facility()
@@ -255,6 +290,7 @@ class TestTransferEventService:
             },
         )
         mock_transfer_event.facilities.set.assert_called_once_with(payload.facilities)
+        mock_process_event_if_effective.assert_called_once_with(payload, mock_transfer_event, cas_analyst.user_guid)
         assert result == mock_transfer_event
 
     @classmethod
@@ -543,3 +579,141 @@ class TestTransferEventService:
             transfer_event.operation,
             transfer_event.to_operator.id,
         )
+
+    @staticmethod
+    @patch("service.transfer_event_service.TransferEventDataAccessService.get_by_id")
+    @patch("service.data_access_service.user_service.UserDataAccessService.get_by_guid")
+    def test_get_if_authorized(mock_get_by_guid, mock_get_by_id):
+        # Scenario 1: Unauthorized user
+        mock_get_by_id.return_value = transfer_event = MagicMock(id=uuid4())
+        mock_get_by_guid.return_value = unauthorized_user = MagicMock(user_guid=uuid4())
+        unauthorized_user.is_industry_user.return_value = True
+
+        with pytest.raises(Exception, match=UNAUTHORIZED_MESSAGE):
+            TransferEventService.get_if_authorized(unauthorized_user.user_guid, transfer_event.id)
+
+        # Scenario 2: Authorized user
+        mock_get_by_guid.return_value = cas_admin = baker.make_recipe('utils.cas_admin')
+        result = TransferEventService.get_if_authorized(cas_admin.user_guid, uuid4())
+        assert result == transfer_event
+
+    @staticmethod
+    @patch("service.transfer_event_service.TransferEventDataAccessService.get_by_id")
+    @patch("service.data_access_service.user_service.UserDataAccessService.get_by_guid")
+    def test_get_and_validate_transfer_event(mock_get_by_guid, mock_get_by_id):
+        # Scenario 1: Unauthorized user
+        mock_get_by_id.return_value = transfer_event = MagicMock(
+            id=uuid4(), status=TransferEvent.Statuses.TO_BE_TRANSFERRED
+        )
+        mock_get_by_guid.return_value = unauthorized_user = MagicMock(user_guid=uuid4())
+        unauthorized_user.is_cas_analyst.return_value = False
+
+        with pytest.raises(Exception, match=UNAUTHORIZED_MESSAGE):
+            TransferEventService._get_and_validate_transfer_event(transfer_event.id, unauthorized_user.user_guid)
+
+        # Scenario 2: Valid transfer event and authorized user
+        mock_get_by_guid.return_value = authorized_user = MagicMock()
+        authorized_user.is_cas_analyst.return_value = True
+
+        result = TransferEventService._get_and_validate_transfer_event(transfer_event.id, authorized_user.user_guid)
+        assert result == transfer_event
+
+        # Scenario 3: Invalid transfer event status
+        mock_get_by_id.return_value = invalid_transfer = MagicMock(id=uuid4(), status=TransferEvent.Statuses.COMPLETE)
+        mock_get_by_guid.return_value = authorized_user
+
+        with pytest.raises(Exception, match="Only transfer events with status 'To be transferred' can be modified."):
+            TransferEventService._get_and_validate_transfer_event(invalid_transfer.id, authorized_user.user_guid)
+
+    @staticmethod
+    @patch("service.transfer_event_service.TransferEventService._get_and_validate_transfer_event")
+    def test_delete_transfer_event(mock_get_and_validate_transfer_event):
+        transfer_event_mock = MagicMock(id=uuid4())
+        mock_get_and_validate_transfer_event.return_value = transfer_event_mock
+        user_guid = uuid4()
+        TransferEventService.delete_transfer_event(user_guid=user_guid, transfer_id=transfer_event_mock.id)
+        mock_get_and_validate_transfer_event.assert_called_once_with(transfer_event_mock.id, user_guid)
+        transfer_event_mock.delete.assert_called_once()
+
+    @staticmethod
+    @patch("service.transfer_event_service.TransferEventService.validate_no_overlapping_transfer_events")
+    @patch("service.transfer_event_service.TransferEventDataAccessService.update_transfer_event")
+    def test_update_operation_transfer_event(mock_update_transfer_event, mock_validate_no_overlapping):
+        user_guid = uuid4()
+        transfer_id = uuid4()
+        operation_id = uuid4()
+        payload = MagicMock(operation=operation_id, effective_date=datetime.now(ZoneInfo("UTC")))
+
+        # Test with valid operation ID
+        TransferEventService._update_operation_transfer_event(user_guid, transfer_id, payload)
+
+        mock_validate_no_overlapping.assert_called_once_with(operation_id=operation_id, current_transfer_id=transfer_id)
+        mock_update_transfer_event.assert_called_once_with(
+            user_guid, transfer_id, {"operation_id": operation_id, "effective_date": payload.effective_date}
+        )
+
+        # Test with missing operation ID
+        payload.operation = None
+        with pytest.raises(Exception, match="Operation is required for operation transfer events."):
+            TransferEventService._update_operation_transfer_event(user_guid, transfer_id, payload)
+
+    @staticmethod
+    @patch("service.transfer_event_service.TransferEventService.validate_no_overlapping_transfer_events")
+    @patch("service.transfer_event_service.TransferEventDataAccessService.update_transfer_event")
+    def test_update_facility_transfer_event(mock_update_transfer_event, mock_validate_no_overlapping):
+        user_guid = uuid4()
+        transfer_id = uuid4()
+        facility_ids = [uuid4(), uuid4()]
+        payload = MagicMock(facilities=facility_ids, effective_date=datetime.now(ZoneInfo("UTC")))
+
+        updated_transfer_event_mock = MagicMock()
+        mock_update_transfer_event.return_value = updated_transfer_event_mock
+
+        # Test with valid facility IDs
+        TransferEventService._update_facility_transfer_event(user_guid, transfer_id, payload)
+
+        mock_validate_no_overlapping.assert_called_once_with(facility_ids=facility_ids, current_transfer_id=transfer_id)
+        mock_update_transfer_event.assert_called_once_with(
+            user_guid, transfer_id, payload.dict(include=["effective_date"])
+        )
+        updated_transfer_event_mock.facilities.set.assert_called_once_with(facility_ids)
+
+        # Test with missing facility IDs
+        payload.facilities = []
+        with pytest.raises(Exception, match="Facilities are required for facility transfer events."):
+            TransferEventService._update_facility_transfer_event(user_guid, transfer_id, payload)
+
+    @staticmethod
+    @patch("service.transfer_event_service.TransferEventService._get_and_validate_transfer_event")
+    @patch("service.transfer_event_service.TransferEventService._update_operation_transfer_event")
+    @patch("service.transfer_event_service.TransferEventService._update_facility_transfer_event")
+    @patch("service.transfer_event_service.TransferEventService._process_event_if_effective")
+    def test_update_transfer_event(
+        mock_process_event_if_effective,
+        mock_update_facility_transfer_event,
+        mock_update_operation_transfer_event,
+        mock_get_and_validate_transfer_event,
+    ):
+        user_guid = uuid4()
+        transfer_id = uuid4()
+        transfer_event_mock = MagicMock()
+        mock_get_and_validate_transfer_event.return_value = transfer_event_mock
+
+        # Scenario 1: Updating an operation transfer event
+        payload_operation = MagicMock(transfer_entity="Operation", operation=uuid4(), effective_date="2025-01-20")
+        TransferEventService.update_transfer_event(user_guid, transfer_id, payload_operation)
+        mock_update_operation_transfer_event.assert_called_once_with(user_guid, transfer_id, payload_operation)
+        mock_process_event_if_effective.assert_called_once_with(payload_operation, transfer_event_mock, user_guid)
+
+        # Scenario 2: Updating a facility transfer event
+        payload_facility = MagicMock(
+            transfer_entity="Facility", facilities=[uuid4(), uuid4()], effective_date="2025-01-20"
+        )
+        TransferEventService.update_transfer_event(user_guid, transfer_id, payload_facility)
+        mock_update_facility_transfer_event.assert_called_once_with(user_guid, transfer_id, payload_facility)
+        mock_process_event_if_effective.assert_called_with(payload_facility, transfer_event_mock, user_guid)
+
+        # Scenario 3: Invalid transfer entity
+        payload_invalid = MagicMock(transfer_entity="Invalid", effective_date="2025-01-20")
+        with pytest.raises(KeyError):
+            TransferEventService.update_transfer_event(user_guid, transfer_id, payload_invalid)

--- a/bc_obps/service/transfer_event_service.py
+++ b/bc_obps/service/transfer_event_service.py
@@ -303,7 +303,7 @@ class TransferEventService:
         if not user.is_cas_analyst():
             raise Exception(UNAUTHORIZED_MESSAGE)
         if transfer_event.status != TransferEvent.Statuses.TO_BE_TRANSFERRED:
-            raise Exception("Only transfer events with status 'To be transferred' can be updated.")
+            raise Exception("Only transfer events with status 'To be transferred' can be modified.")
         return transfer_event
 
     @classmethod

--- a/bc_obps/service/transfer_event_service.py
+++ b/bc_obps/service/transfer_event_service.py
@@ -1,15 +1,20 @@
 import logging
 from datetime import datetime
-from typing import cast, List
+from typing import cast, List, Union
 from uuid import UUID
 from zoneinfo import ZoneInfo
 from django.db import transaction
 from django.db.models import QuerySet
-from registration.models import FacilityDesignatedOperationTimeline, OperationDesignatedOperatorTimeline
+from registration.constants import UNAUTHORIZED_MESSAGE
+from registration.models import FacilityDesignatedOperationTimeline, OperationDesignatedOperatorTimeline, User
 from registration.models.event.transfer_event import TransferEvent
 from typing import Optional
 from ninja import Query
-from registration.schema.v2.transfer_event import TransferEventCreateIn, TransferEventFilterSchema
+from registration.schema.v2.transfer_event import (
+    TransferEventCreateIn,
+    TransferEventFilterSchema,
+    TransferEventUpdateIn,
+)
 from service.data_access_service.facility_designated_operation_timeline_service import (
     FacilityDesignatedOperationTimelineDataAccessService,
 )
@@ -38,6 +43,7 @@ class TransferEventService:
         queryset = (
             filters.filter(TransferEvent.objects.order_by(sort_by))
             .values(
+                'id',
                 'effective_date',
                 'status',
                 'created_at',
@@ -52,36 +58,60 @@ class TransferEventService:
 
     @classmethod
     def validate_no_overlapping_transfer_events(
-        cls, operation_id: Optional[UUID] = None, facility_ids: Optional[List[UUID]] = None
+        cls,
+        operation_id: Optional[UUID] = None,
+        facility_ids: Optional[List[UUID]] = None,
+        current_transfer_id: Optional[UUID] = None,
     ) -> None:
         """
         Validates that there are no overlapping active transfer events for the given operation or facilities.
+        If we are updating an existing transfer event, we can exclude it from the check.
         """
         if operation_id:
             # Check for overlapping transfer events with the operation
-            overlapping_operation = TransferEvent.objects.filter(
+            overlapping_operation_query = TransferEvent.objects.filter(
                 operation_id=operation_id,
                 status__in=[
                     TransferEvent.Statuses.TO_BE_TRANSFERRED,
                     TransferEvent.Statuses.COMPLETE,
                 ],
             )
-            if overlapping_operation.exists():
+
+            if current_transfer_id:
+                overlapping_operation_query = overlapping_operation_query.exclude(id=current_transfer_id)
+
+            if overlapping_operation_query.exists():
                 raise Exception("An active transfer event already exists for the selected operation.")
 
         if facility_ids:
             # Check for overlapping transfer events with the facilities
-            overlapping_facilities = TransferEvent.objects.filter(
+            overlapping_facilities_query = TransferEvent.objects.filter(
                 facilities__id__in=facility_ids,
                 status__in=[
                     TransferEvent.Statuses.TO_BE_TRANSFERRED,
                     TransferEvent.Statuses.COMPLETE,
                 ],
             ).distinct()
-            if overlapping_facilities.exists():
+
+            if current_transfer_id:
+                overlapping_facilities_query = overlapping_facilities_query.exclude(id=current_transfer_id)
+
+            if overlapping_facilities_query.exists():
                 raise Exception(
                     "One or more facilities in this transfer event are already part of an active transfer event."
                 )
+
+    @classmethod
+    def _process_event_if_effective(
+        cls,
+        payload: Union[TransferEventCreateIn, TransferEventUpdateIn],
+        transfer_event: TransferEvent,
+        user_guid: UUID,
+    ) -> None:
+        # Check if the effective date is today or in the past and process the event
+        now = datetime.now(ZoneInfo("UTC"))
+        if payload.effective_date <= now:  # type: ignore[union-attr] # mypy not aware of model schema field in TransferEventCreateIn
+            cls._process_single_event(transfer_event, user_guid)
 
     @classmethod
     def create_transfer_event(cls, user_guid: UUID, payload: TransferEventCreateIn) -> TransferEvent:
@@ -142,10 +172,7 @@ class TransferEventService:
             if payload_facilities:
                 transfer_event.facilities.set(payload_facilities)
 
-        # Check if the effective date is today or in the past and process the event
-        now = datetime.now(ZoneInfo("UTC"))
-        if payload.effective_date <= now:  # type: ignore[attr-defined] # mypy not aware of model schema field
-            cls._process_single_event(transfer_event, user_guid)
+        cls._process_event_if_effective(payload, transfer_event, user_guid)
 
         return transfer_event
 
@@ -260,3 +287,62 @@ class TransferEventService:
 
         # update the operation's operator
         OperationServiceV2.update_operator(user_guid, event.operation, event.to_operator.id)  # type: ignore # we are sure that operation is not None
+
+    @classmethod
+    def get_if_authorized(cls, user_guid: UUID, transfer_id: UUID) -> TransferEvent:
+        transfer_event: TransferEvent = TransferEventDataAccessService.get_by_id(transfer_id)
+        user: User = UserDataAccessService.get_by_guid(user_guid)
+        if user.is_industry_user():
+            raise Exception(UNAUTHORIZED_MESSAGE)
+        return transfer_event
+
+    @classmethod
+    def _get_and_validate_transfer_event(cls, transfer_id: UUID, user_guid: UUID) -> TransferEvent:
+        transfer_event = TransferEventDataAccessService.get_by_id(transfer_id)
+        user = UserDataAccessService.get_by_guid(user_guid)
+        if not user.is_cas_analyst():
+            raise Exception(UNAUTHORIZED_MESSAGE)
+        if transfer_event.status != TransferEvent.Statuses.TO_BE_TRANSFERRED:
+            raise Exception("Only transfer events with status 'To be transferred' can be updated.")
+        return transfer_event
+
+    @classmethod
+    def delete_transfer_event(cls, user_guid: UUID, transfer_id: UUID) -> None:
+        transfer_event = cls._get_and_validate_transfer_event(transfer_id, user_guid)
+        transfer_event.delete()
+        return None
+
+    @classmethod
+    def _update_operation_transfer_event(
+        cls, user_guid: UUID, transfer_id: UUID, payload: TransferEventUpdateIn
+    ) -> None:
+        operation_id = payload.operation
+        if not operation_id:
+            raise Exception("Operation is required for operation transfer events.")
+        cls.validate_no_overlapping_transfer_events(operation_id=operation_id, current_transfer_id=transfer_id)
+        TransferEventDataAccessService.update_transfer_event(
+            user_guid, transfer_id, {"operation_id": operation_id, "effective_date": payload.effective_date}  # type: ignore[attr-defined] # mypy not aware of model schema field
+        )
+
+    @classmethod
+    def _update_facility_transfer_event(
+        cls, user_guid: UUID, transfer_id: UUID, payload: TransferEventUpdateIn
+    ) -> None:
+        facility_ids = payload.facilities
+        if not facility_ids:
+            raise Exception("Facilities are required for facility transfer events.")
+        cls.validate_no_overlapping_transfer_events(facility_ids=facility_ids, current_transfer_id=transfer_id)
+        updated_transfer_event = TransferEventDataAccessService.update_transfer_event(
+            user_guid, transfer_id, payload.dict(include=["effective_date"])
+        )
+        updated_transfer_event.facilities.set(facility_ids)  # type: ignore[arg-type] # mypy requires actual Facility objects but passing UUIDs is fine
+
+    @classmethod
+    @transaction.atomic
+    def update_transfer_event(cls, user_guid: UUID, transfer_id: UUID, payload: TransferEventUpdateIn) -> TransferEvent:
+        transfer_event = cls._get_and_validate_transfer_event(transfer_id, user_guid)
+        {"Operation": cls._update_operation_transfer_event, "Facility": cls._update_facility_transfer_event,}[
+            payload.transfer_entity
+        ](user_guid, transfer_id, payload)
+        cls._process_event_if_effective(payload, transfer_event, user_guid)
+        return transfer_event

--- a/bciers/apps/administration/app/components/facilities/types.ts
+++ b/bciers/apps/administration/app/components/facilities/types.ts
@@ -1,9 +1,11 @@
+import { UUID } from "crypto";
+
 export interface FacilityRow {
-  id: number;
+  id: UUID;
   facility__bcghg_id__id: string;
   facility__name: string;
   facility__type: string;
-  facility__id: number;
+  facility__id: UUID;
   status: string;
   facility__latitude_of_largest_emissions: string;
   facility__longitude_of_largest_emissions: string;

--- a/bciers/apps/registration/app/bceidbusiness/industry_user/event/page.tsx
+++ b/bciers/apps/registration/app/bceidbusiness/industry_user/event/page.tsx
@@ -1,5 +1,0 @@
-// 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-
-export default async function Page() {
-  return <> 😀 👋 </>;
-}

--- a/bciers/apps/registration/app/bceidbusiness/industry_user_admin/event/page.tsx
+++ b/bciers/apps/registration/app/bceidbusiness/industry_user_admin/event/page.tsx
@@ -1,5 +1,0 @@
-// 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-
-export default async function Page() {
-  return <> 😀 👋 </>;
-}

--- a/bciers/apps/registration/app/components/transfers/TransferDetailForm.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransferDetailForm.tsx
@@ -56,6 +56,7 @@ export default function TransferDetailForm({
   };
 
   const submitHandler = async (e: IChangeEvent) => {
+    setError(undefined);
     setIsSubmitting(true);
     const endpoint = `registration/transfer-events/${transferId}`;
     const pathToRevalidate = `/transfers/${transferId}`;

--- a/bciers/apps/registration/app/components/transfers/TransferDetailForm.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransferDetailForm.tsx
@@ -18,7 +18,7 @@ import { TransferEventStatus } from "@/registration/app/components/transfers/enu
 import { RJSFSchema } from "@rjsf/utils";
 import SnackBar from "@bciers/components/form/components/SnackBar";
 
-interface TransferFormProps {
+interface TransferDetailFormProps {
   formData: TransferDetailFormData;
   transferId: UUID;
   schema: RJSFSchema;
@@ -28,7 +28,7 @@ export default function TransferDetailForm({
   formData,
   transferId,
   schema,
-}: Readonly<TransferFormProps>) {
+}: Readonly<TransferDetailFormProps>) {
   // To get the user's role from the session
   const role = useSessionRole();
   const isCasAnalyst = role === FrontEndRoles.CAS_ANALYST;

--- a/bciers/apps/registration/app/components/transfers/TransferDetailForm.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransferDetailForm.tsx
@@ -102,7 +102,8 @@ export default function TransferDetailForm({
               variant="contained"
               onClick={() => {
                 setDisabled(false);
-                setKey(Math.random());
+                // force re-render to clear the form
+                setKey(Math.random()); // NOSONAR
               }}
             >
               Edit Details

--- a/bciers/apps/registration/app/components/transfers/TransferDetailForm.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransferDetailForm.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import FormBase from "@bciers/components/form/FormBase";
+import { Alert, Button } from "@mui/material";
+import SubmitButton from "@bciers/components/button/SubmitButton";
+import { useRouter } from "next/navigation";
+import { IChangeEvent } from "@rjsf/core";
+import { TransferDetailFormData } from "@/registration/app/components/transfers/types";
+import { editTransferUISchema } from "@/registration/app/data/jsonSchema/transfer/transferDetail";
+import TaskList from "@bciers/components/form/components/TaskList";
+import { actionHandler } from "@bciers/actions";
+import SimpleModal from "@bciers/components/modal/SimpleModal";
+import { UUID } from "crypto";
+import { useSessionRole } from "@bciers/utils/src/sessionUtils";
+import { FrontendMessages, FrontEndRoles } from "@bciers/utils/src/enums";
+import { TransferEventStatus } from "@/registration/app/components/transfers/enums";
+import { RJSFSchema } from "@rjsf/utils";
+import SnackBar from "@bciers/components/form/components/SnackBar";
+
+interface TransferFormProps {
+  formData: TransferDetailFormData;
+  transferId: UUID;
+  schema: RJSFSchema;
+}
+
+export default function TransferDetailForm({
+  formData,
+  transferId,
+  schema,
+}: Readonly<TransferFormProps>) {
+  // To get the user's role from the session
+  const role = useSessionRole();
+  const isCasAnalyst = role === FrontEndRoles.CAS_ANALYST;
+  const isEditable =
+    isCasAnalyst && formData.status === TransferEventStatus.TO_BE_TRANSFERRED;
+
+  const router = useRouter();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [error, setError] = useState(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [disabled, setDisabled] = useState(true);
+  const [isSnackbarOpen, setIsSnackbarOpen] = useState(false);
+
+  const handleCancelTransfer = async () => {
+    const endpoint = `registration/transfer-events/${transferId}`;
+    setIsSubmitting(true);
+    const response = await actionHandler(endpoint, "DELETE", "/transfers");
+    if (response?.error) {
+      setError(response.error as any);
+      setModalOpen(false);
+      setIsSubmitting(false);
+      return;
+    }
+    router.push("/transfers");
+  };
+
+  const submitHandler = async (e: IChangeEvent) => {
+    setIsSubmitting(true);
+    const endpoint = `registration/transfer-events/${transferId}`;
+    const pathToRevalidate = `/transfers/${transferId}`;
+    const response = await actionHandler(endpoint, "PATCH", pathToRevalidate, {
+      body: JSON.stringify({
+        ...e.formData,
+      }),
+    });
+    setIsSubmitting(false);
+    if (!response || response?.error) {
+      setDisabled(false);
+      setError(response.error as any);
+      return;
+    } else {
+      setDisabled(true);
+      setIsSnackbarOpen(true);
+    }
+  };
+
+  const backButton = (
+    <Button
+      variant="outlined"
+      type="button"
+      onClick={() => router.push("/transfers")}
+    >
+      Back
+    </Button>
+  );
+
+  return (
+    <div className="w-full flex flex-row mt-8">
+      <SnackBar
+        isSnackbarOpen={isSnackbarOpen}
+        message={FrontendMessages.SUBMIT_CONFIRMATION}
+        setIsSnackbarOpen={setIsSnackbarOpen}
+      />
+      <SimpleModal
+        title="Confirmation"
+        open={modalOpen}
+        onCancel={() => setModalOpen(false)}
+        onConfirm={handleCancelTransfer}
+        confirmText="Yes, cancel this transfer"
+        cancelText="No, don't cancel"
+        isSubmitting={isSubmitting}
+      >
+        Are you sure you want to cancel this transfer?
+      </SimpleModal>
+      <TaskList
+        // Hide the task list on mobile
+        className="hidden sm:block"
+        // hardcoding the task list items because we are not using the SingleStepTaskListForm
+        taskListItems={[{ section: "section", title: "Transfer Details" }]}
+      />
+      <div className="w-full">
+        <FormBase
+          disabled={disabled}
+          schema={schema}
+          uiSchema={editTransferUISchema}
+          formData={formData}
+          onSubmit={submitHandler}
+          omitExtraData={true}
+        >
+          <div className="min-h-6">
+            {error && <Alert severity="error">{error}</Alert>}
+          </div>
+          {isEditable ? (
+            <div className="flex justify-between mt-4">
+              <div>
+                {backButton}
+                <Button
+                  variant="contained"
+                  className="ml-4"
+                  type="button"
+                  onClick={() => setModalOpen(true)}
+                >
+                  Cancel Transfer
+                </Button>
+              </div>
+              {disabled ? (
+                <Button variant="contained" onClick={() => setDisabled(false)}>
+                  Edit Details
+                </Button>
+              ) : (
+                <SubmitButton disabled={disabled} isSubmitting={isSubmitting}>
+                  Transfer Entity
+                </SubmitButton>
+              )}
+            </div>
+          ) : (
+            <div className="text-end">{backButton}</div>
+          )}
+        </FormBase>
+      </div>
+    </div>
+  );
+}

--- a/bciers/apps/registration/app/components/transfers/TransferForm.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransferForm.tsx
@@ -101,6 +101,8 @@ export default function TransferForm({
     } = await fetchOperationsPageData({
       paginate_results: false,
       operator_id: operatorId,
+      end_date: true, // this indicates that the end_date is not null,
+      status: "Active", // only fetch active facilities
     });
     if (!response || "error" in response || !response.rows) {
       setError("Failed to fetch operations data!" as any);

--- a/bciers/apps/registration/app/components/transfers/TransferPage.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransferPage.tsx
@@ -1,22 +1,72 @@
 import TransferForm from "@/registration/app/components/transfers/TransferForm";
+import TransferDetailForm from "@/registration/app/components/transfers/TransferDetailForm";
 import fetchOperatorsPageData from "@/administration/app/components/operators/fetchOperatorsPageData";
 import { OperatorRow } from "@/administration/app/components/operators/types";
-import { TransferFormData } from "@/registration/app/components/transfers/types";
+import {
+  TransferDetailFormData,
+  TransferFormData,
+} from "@/registration/app/components/transfers/types";
+import { validate as isValidUUID } from "uuid";
+import { UUID } from "crypto";
+import getTransferEvent from "@/registration/app/components/transfers/getTransferEvent";
+import Loading from "@bciers/components/loading/SkeletonGrid";
+import { Suspense } from "react";
+import {
+  facilityEntitySchema,
+  operationEntitySchema,
+} from "@/registration/app/data/jsonSchema/transfer/transferDetail";
 
 // 🧩 Main component
-export default async function TransferPage() {
+export default async function TransferPage({
+  transferId,
+}: {
+  transferId?: UUID;
+}) {
+  let transferFormData: { [key: string]: any } | { error: string } = {};
+
+  // 🛠️ Fetch the operators data
   const operators: {
     rows: OperatorRow[];
     row_count: number;
   } = await fetchOperatorsPageData({ paginate_result: "False" });
-
   if (!operators || "error" in operators || !operators.rows)
     throw new Error("Failed to fetch operators data");
 
+  if (transferId) {
+    if (!isValidUUID(transferId))
+      throw new Error(`Invalid transfer id: ${transferId}`);
+
+    transferFormData = await getTransferEvent(transferId);
+    if (!transferFormData || "error" in transferFormData) {
+      throw new Error("Error fetching transfer information.");
+    }
+  }
+
   return (
-    <TransferForm
-      formData={{} as TransferFormData}
-      operators={operators.rows}
-    />
+    <Suspense fallback={<Loading />}>
+      {!!transferId ? (
+        <TransferDetailForm
+          formData={transferFormData as TransferDetailFormData}
+          transferId={transferId}
+          schema={
+            transferFormData.transfer_entity === "Operation"
+              ? await operationEntitySchema(
+                  transferFormData.operation,
+                  transferFormData.operation_name,
+                  transferFormData.from_operator_id,
+                )
+              : await facilityEntitySchema(
+                  transferFormData.existing_facilities,
+                  transferFormData.from_operation_id,
+                )
+          }
+        />
+      ) : (
+        <TransferForm
+          formData={{} as TransferFormData}
+          operators={operators.rows}
+        />
+      )}
+    </Suspense>
   );
 }

--- a/bciers/apps/registration/app/components/transfers/TransferPage.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransferPage.tsx
@@ -19,9 +19,9 @@ import {
 // 🧩 Main component
 export default async function TransferPage({
   transferId,
-}: {
+}: Readonly<{
   transferId?: UUID;
-}) {
+}>) {
   let transferFormData: { [key: string]: any } | { error: string } = {};
   let operators: {
     rows: OperatorRow[];

--- a/bciers/apps/registration/app/components/transfers/TransferPage.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransferPage.tsx
@@ -23,16 +23,12 @@ export default async function TransferPage({
   transferId?: UUID;
 }) {
   let transferFormData: { [key: string]: any } | { error: string } = {};
-
-  // 🛠️ Fetch the operators data
-  const operators: {
+  let operators: {
     rows: OperatorRow[];
     row_count: number;
-  } = await fetchOperatorsPageData({ paginate_result: "False" });
-  if (!operators || "error" in operators || !operators.rows)
-    throw new Error("Failed to fetch operators data");
-
+  } = { rows: [], row_count: 0 }; // Initialize operators with a default value
   if (transferId) {
+    // to show the transfer detail form
     if (!isValidUUID(transferId))
       throw new Error(`Invalid transfer id: ${transferId}`);
 
@@ -40,6 +36,19 @@ export default async function TransferPage({
     if (!transferFormData || "error" in transferFormData) {
       throw new Error("Error fetching transfer information.");
     }
+  } else {
+    // to show the new transfer form
+    const fetchedOperators = await fetchOperatorsPageData({
+      paginate_result: "False",
+    });
+    if (
+      !fetchedOperators ||
+      "error" in fetchedOperators ||
+      !fetchedOperators.rows
+    )
+      throw new Error("Failed to fetch operators data");
+
+    operators = fetchedOperators; // Populate operators
   }
 
   return (

--- a/bciers/apps/registration/app/components/transfers/TransfersDataGrid.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransfersDataGrid.tsx
@@ -52,6 +52,8 @@ const TransfersDataGrid = ({
       fetchPageData={fetchTransferEventsPageData}
       paginationMode="server"
       initialData={initialData}
+      // We need to generate a unique id for each row to avoid issues with the DataGrid(MUI requires a unique id for each row)
+      getRowId={(row) => `${row.transfer_id} - ${row.facilities__name}`}
     />
   );
 };

--- a/bciers/apps/registration/app/components/transfers/TransfersDataGrid.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransfersDataGrid.tsx
@@ -11,8 +11,12 @@ import transferGroupColumns from "@/registration/app/components/datagrid/models/
 import fetchTransferEventsPageData from "@/registration/app/components/transfers/fetchTransferEventsPageData";
 
 const TransfersActionCell = ActionCellFactory({
-  generateHref: (params: GridRenderCellParams) => {
-    return `/transfers/${params.row.id}`;
+  generateHref: ({ row }: GridRenderCellParams) => {
+    const title =
+      row.operation__name && row.operation__name !== "N/A"
+        ? row.operation__name
+        : row.facilities__name;
+    return `/transfers/${row.transfer_id}?transfers_title=${title}`;
   },
   cellText: "View Details",
 });

--- a/bciers/apps/registration/app/components/transfers/TransfersDataGridPage.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransfersDataGridPage.tsx
@@ -11,9 +11,9 @@ import { getSessionRole } from "@bciers/utils/src/sessionUtils";
 // 🧩 Main component
 export default async function TransfersDataGridPage({
   searchParams,
-}: {
+}: Readonly<{
   searchParams: TransfersSearchParams;
-}) {
+}>) {
   // Fetch transfers data
   const transfers: {
     rows: TransferRow[];
@@ -28,21 +28,21 @@ export default async function TransfersDataGridPage({
 
   // Render the DataGrid component
   return (
-    <Suspense fallback={<Loading />}>
-      <div className="mt-5">
-        <h2 className="text-bc-primary-blue">Transfers</h2>
-        {isCasAnalyst && (
-          <div className="text-right mb-4">
-            <Link href={`/transfers/transfer-entity`}>
-              {/* textTransform to remove uppercase text */}
-              <Button variant="contained" sx={{ textTransform: "none" }}>
-                Make a Transfer
-              </Button>
-            </Link>
-          </div>
-        )}
+    <div className="mt-5">
+      <h2 className="text-bc-primary-blue">Transfers</h2>
+      {isCasAnalyst && (
+        <div className="text-right mb-4">
+          <Link href={`/transfers/transfer-entity`}>
+            {/* textTransform to remove uppercase text */}
+            <Button variant="contained" sx={{ textTransform: "none" }}>
+              Make a Transfer
+            </Button>
+          </Link>
+        </div>
+      )}
+      <Suspense fallback={<Loading />}>
         <TransferDataGrid initialData={transfers} />
-      </div>
-    </Suspense>
+      </Suspense>
+    </div>
   );
 }

--- a/bciers/apps/registration/app/components/transfers/enums.ts
+++ b/bciers/apps/registration/app/components/transfers/enums.ts
@@ -1,0 +1,5 @@
+export enum TransferEventStatus {
+  COMPLETE = "Complete",
+  TO_BE_TRANSFERRED = "To be transferred",
+  TRANSFERRED = "Transferred",
+}

--- a/bciers/apps/registration/app/components/transfers/fetchTransferEventsPageData.ts
+++ b/bciers/apps/registration/app/components/transfers/fetchTransferEventsPageData.ts
@@ -15,8 +15,6 @@ export const formatTransferRows = (rows: GridRowsProp) => {
       created_at,
     }) => {
       return {
-        // We need to generate a unique id for each row to avoid issues with the DataGrid(MUI requires a unique id for each row)
-        id: Math.random(), // NOSONAR
         transfer_id: id,
         operation__name: operation__name || "N/A",
         facilities__name: facilities__name || "N/A",

--- a/bciers/apps/registration/app/components/transfers/fetchTransferEventsPageData.ts
+++ b/bciers/apps/registration/app/components/transfers/fetchTransferEventsPageData.ts
@@ -15,7 +15,7 @@ export const formatTransferRows = (rows: GridRowsProp) => {
       created_at,
     }) => {
       return {
-        id: Math.random(), // We need to generate a unique id for each row to avoid issues with the DataGrid(MUI requires a unique id for each row)
+        id: Math.random(), // We need to generate a unique id for each row to avoid issues with the DataGrid(MUI requires a unique id for each row) // NOSONAR
         transfer_id: id,
         operation__name: operation__name || "N/A",
         facilities__name: facilities__name || "N/A",

--- a/bciers/apps/registration/app/components/transfers/fetchTransferEventsPageData.ts
+++ b/bciers/apps/registration/app/components/transfers/fetchTransferEventsPageData.ts
@@ -15,7 +15,8 @@ export const formatTransferRows = (rows: GridRowsProp) => {
       created_at,
     }) => {
       return {
-        id: Math.random(), // We need to generate a unique id for each row to avoid issues with the DataGrid(MUI requires a unique id for each row) // NOSONAR
+        // We need to generate a unique id for each row to avoid issues with the DataGrid(MUI requires a unique id for each row)
+        id: Math.random(), // NOSONAR
         transfer_id: id,
         operation__name: operation__name || "N/A",
         facilities__name: facilities__name || "N/A",

--- a/bciers/apps/registration/app/components/transfers/fetchTransferEventsPageData.ts
+++ b/bciers/apps/registration/app/components/transfers/fetchTransferEventsPageData.ts
@@ -15,7 +15,8 @@ export const formatTransferRows = (rows: GridRowsProp) => {
       created_at,
     }) => {
       return {
-        id,
+        id: Math.random(), // We need to generate a unique id for each row to avoid issues with the DataGrid(MUI requires a unique id for each row)
+        transfer_id: id,
         operation__name: operation__name || "N/A",
         facilities__name: facilities__name || "N/A",
         status,

--- a/bciers/apps/registration/app/components/transfers/getTransferEvent.ts
+++ b/bciers/apps/registration/app/components/transfers/getTransferEvent.ts
@@ -1,0 +1,11 @@
+import { actionHandler } from "@bciers/actions";
+import { UUID } from "crypto";
+
+// 🛠️ Function to fetch a transfer event by uuid
+export default async function getTransferEvent(uuid: UUID) {
+  return actionHandler(
+    `registration/transfer-events/${uuid}`,
+    "GET",
+    `/transfers/${uuid}`,
+  );
+}

--- a/bciers/apps/registration/app/components/transfers/types.ts
+++ b/bciers/apps/registration/app/components/transfers/types.ts
@@ -2,7 +2,6 @@ import { UUID } from "crypto";
 import { TransferEventStatus } from "@/registration/app/components/transfers/enums";
 
 export interface TransferRow {
-  id: number; // random ID to avoid duplicate key error in the UI when rendering the table
   transfer_id: UUID; // actual transfer ID
   operation__name?: string;
   facilities__name?: string;

--- a/bciers/apps/registration/app/components/transfers/types.ts
+++ b/bciers/apps/registration/app/components/transfers/types.ts
@@ -1,4 +1,5 @@
 import { UUID } from "crypto";
+import { TransferEventStatus } from "@/registration/app/components/transfers/enums";
 
 export interface TransferRow {
   id: number; // random ID to avoid duplicate key error in the UI when rendering the table
@@ -54,4 +55,5 @@ export interface TransferDetailFormData {
   existing_facilities: ExistingFacilities[];
   to_operation?: string;
   effective_date: string;
+  status: TransferEventStatus;
 }

--- a/bciers/apps/registration/app/components/transfers/types.ts
+++ b/bciers/apps/registration/app/components/transfers/types.ts
@@ -1,5 +1,8 @@
+import { UUID } from "crypto";
+
 export interface TransferRow {
-  id: string;
+  id: string; // random ID to avoid duplicate key error in the UI when rendering the table
+  transfer_id: UUID; // actual transfer ID
   operation__name?: string;
   facilities__name?: string;
   status: string;
@@ -17,11 +20,38 @@ export interface TransfersSearchParams {
 export interface TransferFormData {
   [key: string]: string | number | undefined | string[];
   from_operator: string;
+  from_operator_id: UUID;
   to_operator: string;
+  to_operator_id: UUID;
   transfer_entity: string;
   operation?: string;
+  operation_id?: UUID;
   from_operation?: string;
+  from_operation_id?: UUID;
   facilities?: string[];
+  facilities_ids?: UUID[];
+  to_operation?: string;
+  to_operation_id?: UUID;
+  effective_date: string;
+}
+
+export interface ExistingFacilities {
+  id: UUID;
+  name: string;
+}
+
+export interface TransferDetailFormData {
+  [key: string]: string | number | undefined | string[] | ExistingFacilities[];
+  from_operator: string;
+  from_operator_id: UUID;
+  to_operator: string;
+  transfer_entity: string;
+  operation?: UUID;
+  operation_name?: string;
+  from_operation?: string;
+  from_operation_id?: UUID;
+  facilities?: UUID[];
+  existing_facilities: ExistingFacilities[];
   to_operation?: string;
   effective_date: string;
 }

--- a/bciers/apps/registration/app/components/transfers/types.ts
+++ b/bciers/apps/registration/app/components/transfers/types.ts
@@ -1,7 +1,7 @@
 import { UUID } from "crypto";
 
 export interface TransferRow {
-  id: string; // random ID to avoid duplicate key error in the UI when rendering the table
+  id: number; // random ID to avoid duplicate key error in the UI when rendering the table
   transfer_id: UUID; // actual transfer ID
   operation__name?: string;
   facilities__name?: string;

--- a/bciers/apps/registration/app/data/jsonSchema/transfer/transfer.ts
+++ b/bciers/apps/registration/app/data/jsonSchema/transfer/transfer.ts
@@ -161,10 +161,16 @@ export const createTransferSchema = (
     transferSchemaCopy.dependencies.transfer_entity.allOf[1].then.properties.facilities.items.enum =
       facilityOptions.map((facility) => facility.facility__id);
     transferSchemaCopy.dependencies.transfer_entity.allOf[1].then.properties.facilities.items.enumNames =
-      facilityOptions.map(
-        (facility) =>
-          `${facility.facility__name} - (${facility.facility__latitude_of_largest_emissions}, ${facility.facility__longitude_of_largest_emissions})`,
-      );
+      facilityOptions.map((facility: FacilityRow) => {
+        const {
+          facility__name: facilityName,
+          facility__latitude_of_largest_emissions: facilityLatitude,
+          facility__longitude_of_largest_emissions: facilityLongitude,
+        } = facility;
+        return facilityLatitude && facilityLongitude
+          ? `${facilityName} - (${facilityLatitude}, ${facilityLongitude})`
+          : facilityName;
+      });
   }
 
   return transferSchemaCopy;

--- a/bciers/apps/registration/app/data/jsonSchema/transfer/transferDetail.ts
+++ b/bciers/apps/registration/app/data/jsonSchema/transfer/transferDetail.ts
@@ -50,6 +50,8 @@ export const operationEntitySchema = async (
   const operationsByOperator = await fetchOperationsPageData({
     paginate_results: false,
     operator_id: fromOperatorId,
+    end_date: true, // this indicates that the end_date is not null,
+    status: "Active", // only fetch active facilities
   });
   if (
     !operationsByOperator ||
@@ -80,14 +82,19 @@ export const operationEntitySchema = async (
 
   return {
     type: "object",
-    title: "Transfer Entity",
-    required: ["operation", "effective_date"],
     properties: {
-      ...sharedSchemaProperties.properties,
-      operation: {
-        type: "string",
-        title: "Operation",
-        anyOf: operationOptions,
+      section: {
+        type: "object",
+        title: "Transfer Details",
+        required: ["operation", "effective_date"],
+        properties: {
+          ...sharedSchemaProperties.properties,
+          operation: {
+            type: "string",
+            title: "Operation",
+            anyOf: operationOptions,
+          },
+        },
       },
     },
   };
@@ -152,26 +159,31 @@ export const facilityEntitySchema = async (
 
   return {
     type: "object",
-    title: "Transfer Entity",
-    required: ["facilities", "effective_date"],
     properties: {
-      ...sharedSchemaProperties.properties,
-      from_operation: {
-        type: "string",
-        title: "Current operation",
-      },
-      facilities: {
-        type: "array",
-        title: "Facilities",
-        minItems: 1,
-        items: {
-          type: "string",
-          ...facilityEnum,
+      section: {
+        type: "object",
+        title: "Transfer Details",
+        required: ["facilities", "effective_date"],
+        properties: {
+          ...sharedSchemaProperties.properties,
+          from_operation: {
+            type: "string",
+            title: "Current operation",
+          },
+          facilities: {
+            type: "array",
+            title: "Facilities",
+            minItems: 1,
+            items: {
+              type: "string",
+              ...facilityEnum,
+            },
+          },
+          to_operation: {
+            type: "string",
+            title: "New operation",
+          },
         },
-      },
-      to_operation: {
-        type: "string",
-        title: "New operation",
       },
     },
   };
@@ -179,52 +191,55 @@ export const facilityEntitySchema = async (
 
 export const editTransferUISchema: UiSchema = {
   "ui:FieldTemplate": SectionFieldTemplate,
-  "ui:order": [
-    "transfer_header",
-    "from_operator",
-    "to_operator",
-    "transfer_entity",
-    "operation",
-    "from_operation",
-    "facilities",
-    "to_operation",
-    "effective_date",
-  ],
-  "ui:options": {
-    label: false,
-  },
-  transfer_header: {
-    "ui:FieldTemplate": FieldTemplate,
-    "ui:classNames": "form-heading mb-8",
-  },
-  from_operator: {
-    "ui:widget": "ReadOnlyWidget",
-  },
-  to_operator: {
-    "ui:widget": "ReadOnlyWidget",
-  },
-  transfer_entity: {
-    "ui:widget": "ReadOnlyRadioWidget",
-    "ui:classNames": "md:gap-20",
+  section: {
+    "ui:FieldTemplate": SectionFieldTemplate,
     "ui:options": {
-      inline: true,
+      label: false,
     },
-  },
-  operation: {
-    "ui:widget": "ComboBox",
-    "ui:placeholder": "Select the operation",
-  },
-  effective_date: {
-    "ui:widget": "DateWidget",
-  },
-  from_operation: {
-    "ui:widget": "ReadOnlyWidget",
-  },
-  facilities: {
-    "ui:widget": "MultiSelectWidget",
-    "ui:placeholder": "Select facilities",
-  },
-  to_operation: {
-    "ui:widget": "ReadOnlyWidget",
+    "ui:order": [
+      "transfer_header",
+      "from_operator",
+      "to_operator",
+      "transfer_entity",
+      "operation",
+      "from_operation",
+      "facilities",
+      "to_operation",
+      "effective_date",
+    ],
+    transfer_header: {
+      "ui:FieldTemplate": FieldTemplate,
+      "ui:classNames": "form-heading mb-8",
+    },
+    from_operator: {
+      "ui:widget": "ReadOnlyWidget",
+    },
+    to_operator: {
+      "ui:widget": "ReadOnlyWidget",
+    },
+    transfer_entity: {
+      "ui:widget": "ReadOnlyRadioWidget",
+      "ui:classNames": "md:gap-20",
+      "ui:options": {
+        inline: true,
+      },
+    },
+    operation: {
+      "ui:widget": "ComboBox",
+      "ui:placeholder": "Select the operation",
+    },
+    effective_date: {
+      "ui:widget": "DateWidget",
+    },
+    from_operation: {
+      "ui:widget": "ReadOnlyWidget",
+    },
+    facilities: {
+      "ui:widget": "MultiSelectWidget",
+      "ui:placeholder": "Select facilities",
+    },
+    to_operation: {
+      "ui:widget": "ReadOnlyWidget",
+    },
   },
 };

--- a/bciers/apps/registration/app/data/jsonSchema/transfer/transferDetail.ts
+++ b/bciers/apps/registration/app/data/jsonSchema/transfer/transferDetail.ts
@@ -1,0 +1,249 @@
+import { RJSFSchema, UiSchema } from "@rjsf/utils";
+import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
+import SectionFieldTemplate from "@bciers/components/form/fields/SectionFieldTemplate";
+import { FacilityRow } from "@/administration/app/components/facilities/types";
+import { OperationRow } from "@/administration/app/components/operations/types";
+import { fetchOperationsPageData } from "@bciers/actions/api";
+import fetchFacilitiesPageData from "@/administration/app/components/facilities/fetchFacilitiesPageData";
+import { ExistingFacilities } from "@/registration/app/components/transfers/types";
+
+export const operationEntitySchema = async (
+  existingOperationId: string,
+  existingOperationName: string,
+  fromOperatorId?: string,
+): Promise<RJSFSchema> => {
+  // Fetch the operations data based on the operator id
+  const operationsByOperator = await fetchOperationsPageData({
+    paginate_results: false,
+    operator_id: fromOperatorId,
+  });
+  if (
+    !operationsByOperator ||
+    "error" in operationsByOperator ||
+    !operationsByOperator.rows
+  )
+    throw new Error("Failed to fetch operations data!" as any);
+
+  /*
+    Add the existing operation to the operation options
+    For transferred operations, this option is no longer available from operationsByOperator, so we add it manually
+  */
+  const operationOptions = [
+    {
+      const: existingOperationId,
+      title: existingOperationName,
+    },
+    ...operationsByOperator.rows
+      .filter(
+        ({ operation__id }: OperationRow) =>
+          operation__id !== existingOperationId,
+      )
+      .map(({ operation__id, operation__name }: OperationRow) => ({
+        const: operation__id,
+        title: operation__name,
+      })),
+  ].sort((a: any, b: any) => a.title.localeCompare(b.title)); // Sort the operations alphabetically
+
+  return {
+    type: "object",
+    title: "Transfer Entity",
+    required: ["operation", "effective_date"],
+    properties: {
+      transfer_header: {
+        //Not an actual field in the db - this is just to make the form look like the wireframes
+        type: "object",
+        readOnly: true,
+        title: "Transfer Entity",
+      },
+      from_operator: {
+        type: "string",
+        readOnly: true,
+        title: "Current Operator",
+      },
+      to_operator: {
+        type: "string",
+        readOnly: true,
+        title: "New operator",
+      },
+      transfer_entity: {
+        type: "string",
+        readOnly: true,
+        title: "What is being transferred?",
+        oneOf: [
+          {
+            const: "Operation",
+            title: "Operation",
+          },
+          {
+            const: "Facility",
+            title: "Facility",
+          },
+        ],
+      },
+      operation: {
+        type: "string",
+        title: "Operation",
+        anyOf: operationOptions,
+      },
+      effective_date: {
+        type: "string",
+        title: "Effective date of transfer",
+      },
+    },
+  };
+};
+
+export const facilityEntitySchema = async (
+  existingFacilities: ExistingFacilities[],
+  fromOperationId: string,
+): Promise<RJSFSchema> => {
+  const facilitiesByOperation = await fetchFacilitiesPageData(fromOperationId, {
+    paginate_results: false,
+    end_date: true, // this indicates that the end_date is not null,
+    status: "Active", // only fetch active facilities
+  });
+  if (
+    !facilitiesByOperation ||
+    "error" in facilitiesByOperation ||
+    !facilitiesByOperation.rows
+  )
+    throw new Error("Failed to fetch facilities data!" as any);
+
+  /*
+    Add the existing facilities to the facility options
+    For transferred facilities, this option is no longer available from facilitiesByOperation, so we add it manually
+  */
+  // Extract existing facility IDs and names
+  const existingFacilityIds = existingFacilities.map((facility) => facility.id);
+  const existingFacilityNames = existingFacilities.map(
+    (facility) => facility.name,
+  );
+
+  // Initialize facility enum with existing facilities
+  let facilityEnum = {
+    enum: existingFacilityIds,
+    enumNames: existingFacilityNames,
+  };
+
+  // Filter and append new facilities from the fetched data
+  const newFacilities = facilitiesByOperation.rows.filter(
+    (facility: FacilityRow) =>
+      !existingFacilityIds.includes(facility.facility__id),
+  );
+
+  if (newFacilities.length > 0) {
+    facilityEnum = {
+      enum: facilityEnum.enum.concat(
+        newFacilities.map((facility: FacilityRow) => facility.facility__id),
+      ),
+      enumNames: facilityEnum.enumNames.concat(
+        newFacilities.map(
+          (facility: FacilityRow) =>
+            `${facility.facility__name} - (${facility.facility__latitude_of_largest_emissions}, ${facility.facility__longitude_of_largest_emissions})`,
+        ),
+      ),
+    };
+  }
+
+  return {
+    type: "object",
+    title: "Transfer Entity",
+    required: ["facilities", "effective_date"],
+    properties: {
+      // We don't need the sectioning here, but it's just to make the form look like the wireframes
+      transfer_header: {
+        //Not an actual field in the db - this is just to make the form look like the wireframes
+        type: "object",
+        readOnly: true,
+        title: "Transfer Entity",
+      },
+      from_operator: {
+        type: "string",
+        readOnly: true,
+        title: "Current Operator",
+      },
+      to_operator: {
+        type: "string",
+        readOnly: true,
+        title: "New operator",
+      },
+      transfer_entity: {
+        type: "string",
+        readOnly: true,
+        title: "What is being transferred?",
+        oneOf: [
+          {
+            const: "Operation",
+            title: "Operation",
+          },
+          {
+            const: "Facility",
+            title: "Facility",
+          },
+        ],
+      },
+      from_operation: {
+        type: "string",
+        title: "Select the operation that the facility(s) currently belongs to",
+      },
+      facilities: {
+        type: "array",
+        title: "Facilities",
+        minItems: 1,
+        items: {
+          type: "string",
+          ...facilityEnum,
+        },
+      },
+      to_operation: {
+        type: "string",
+        title: "Select the new operation the facility(s) will be allocated to",
+      },
+      effective_date: {
+        type: "string",
+        title: "Effective date of transfer",
+      },
+    },
+  };
+};
+
+export const editTransferUISchema: UiSchema = {
+  "ui:FieldTemplate": SectionFieldTemplate,
+  "ui:options": {
+    label: false,
+  },
+  transfer_header: {
+    "ui:FieldTemplate": FieldTemplate,
+    "ui:classNames": "form-heading mb-8",
+  },
+  from_operator: {
+    "ui:widget": "ReadOnlyWidget",
+  },
+  to_operator: {
+    "ui:widget": "ReadOnlyWidget",
+  },
+  transfer_entity: {
+    "ui:widget": "ReadOnlyRadioWidget",
+    "ui:classNames": "md:gap-20",
+    "ui:options": {
+      inline: true,
+    },
+  },
+  operation: {
+    "ui:widget": "ComboBox",
+    "ui:placeholder": "Select the operation",
+  },
+  effective_date: {
+    "ui:widget": "DateWidget",
+  },
+  from_operation: {
+    "ui:widget": "ReadOnlyWidget",
+  },
+  facilities: {
+    "ui:widget": "MultiSelectWidget",
+    "ui:placeholder": "Select facilities",
+  },
+  to_operation: {
+    "ui:widget": "ReadOnlyWidget",
+  },
+};

--- a/bciers/apps/registration/app/idir/cas_admin/event/page.tsx
+++ b/bciers/apps/registration/app/idir/cas_admin/event/page.tsx
@@ -1,5 +1,0 @@
-// 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-
-export default async function Page() {
-  return <> 😀 👋 </>;
-}

--- a/bciers/apps/registration/app/idir/cas_admin/transfers/[transferId]/page.tsx
+++ b/bciers/apps/registration/app/idir/cas_admin/transfers/[transferId]/page.tsx
@@ -1,0 +1,16 @@
+import { UUID } from "crypto";
+import { Suspense } from "react";
+import Loading from "@bciers/components/loading/SkeletonForm";
+import TransferPage from "@/registration/app/components/transfers/TransferPage";
+
+export default async function Page({
+  params: { transferId },
+}: Readonly<{
+  params: { transferId: UUID };
+}>) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <TransferPage transferId={transferId} />
+    </Suspense>
+  );
+}

--- a/bciers/apps/registration/app/idir/cas_analyst/event/page.tsx
+++ b/bciers/apps/registration/app/idir/cas_analyst/event/page.tsx
@@ -1,5 +1,0 @@
-// 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-
-export default async function Page() {
-  return <> 😀 👋 </>;
-}

--- a/bciers/apps/registration/app/idir/cas_analyst/transfers/[transferId]/page.tsx
+++ b/bciers/apps/registration/app/idir/cas_analyst/transfers/[transferId]/page.tsx
@@ -1,0 +1,16 @@
+import { UUID } from "crypto";
+import { Suspense } from "react";
+import Loading from "@bciers/components/loading/SkeletonForm";
+import TransferPage from "@/registration/app/components/transfers/TransferPage";
+
+export default async function Page({
+  params: { transferId },
+}: Readonly<{
+  params: { transferId: UUID };
+}>) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <TransferPage transferId={transferId} />
+    </Suspense>
+  );
+}

--- a/bciers/apps/registration/app/idir/cas_director/event/page.tsx
+++ b/bciers/apps/registration/app/idir/cas_director/event/page.tsx
@@ -1,5 +1,0 @@
-// 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-
-export default async function Page() {
-  return <> 😀 👋 </>;
-}

--- a/bciers/apps/registration/app/idir/cas_director/transfers/[transferId]/page.tsx
+++ b/bciers/apps/registration/app/idir/cas_director/transfers/[transferId]/page.tsx
@@ -1,0 +1,16 @@
+import { UUID } from "crypto";
+import { Suspense } from "react";
+import Loading from "@bciers/components/loading/SkeletonForm";
+import TransferPage from "@/registration/app/components/transfers/TransferPage";
+
+export default async function Page({
+  params: { transferId },
+}: Readonly<{
+  params: { transferId: UUID };
+}>) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <TransferPage transferId={transferId} />
+    </Suspense>
+  );
+}

--- a/bciers/apps/registration/app/idir/cas_view_only/event/page.tsx
+++ b/bciers/apps/registration/app/idir/cas_view_only/event/page.tsx
@@ -1,5 +1,0 @@
-// 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-
-export default async function Page() {
-  return <> 😀 👋 </>;
-}

--- a/bciers/apps/registration/app/idir/cas_view_only/transfers/[transferId]/page.tsx
+++ b/bciers/apps/registration/app/idir/cas_view_only/transfers/[transferId]/page.tsx
@@ -1,0 +1,16 @@
+import { UUID } from "crypto";
+import { Suspense } from "react";
+import Loading from "@bciers/components/loading/SkeletonForm";
+import TransferPage from "@/registration/app/components/transfers/TransferPage";
+
+export default async function Page({
+  params: { transferId },
+}: Readonly<{
+  params: { transferId: UUID };
+}>) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <TransferPage transferId={transferId} />
+    </Suspense>
+  );
+}

--- a/bciers/apps/registration/tests/components/transfers/TransferDetailForm.test.tsx
+++ b/bciers/apps/registration/tests/components/transfers/TransferDetailForm.test.tsx
@@ -1,0 +1,399 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import expectButton from "@bciers/testConfig/helpers/expectButton";
+import { actionHandler, useRouter, useSession } from "@bciers/testConfig/mocks";
+import { fetchOperationsPageData } from "@/administration/tests/components/operations/mocks";
+import { fetchFacilitiesPageData } from "@/administration/tests/components/facilities/mocks";
+import TransferDetailForm from "@/registration/app/components/transfers/TransferDetailForm";
+import { Session } from "@bciers/testConfig/types";
+import { randomUUID, UUID } from "crypto";
+import {
+  facilityEntitySchema,
+  operationEntitySchema,
+} from "@/registration/app/data/jsonSchema/transfer/transferDetail";
+import { TransferEventStatus } from "@/registration/app/components/transfers/enums";
+import { ExistingFacilities } from "@/registration/app/components/transfers/types";
+import { FrontEndRoles } from "@bciers/utils/src/enums";
+import userEvent from "@testing-library/user-event";
+import expectComboBox from "@bciers/testConfig/helpers/expectComboBox";
+
+const mockRouterPush = vi.fn();
+useRouter.mockReturnValue({
+  query: {},
+  push: mockRouterPush,
+});
+
+useSession.mockReturnValue({
+  data: {
+    user: {
+      app_role: "cas_analyst",
+    },
+  },
+} as Session);
+
+const transferId = randomUUID();
+
+const mockFacilities = {
+  rows: [
+    {
+      facility__id: "8be4c7aa-6ab3-4aad-9206-0ef914fea067" as UUID,
+      facility__name: "Name 1",
+      facility__latitude_of_largest_emissions: 11.0,
+      facility__longitude_of_largest_emissions: 22.0,
+    },
+    {
+      facility__id: "8be4c7aa-6ab3-4aad-9206-0ef914fea068" as UUID,
+      facility__name: "Name 2",
+      facility__latitude_of_largest_emissions: 33.0,
+      facility__longitude_of_largest_emissions: 44.0,
+    },
+    {
+      facility__id: "8be4c7aa-6ab3-4aad-9206-0ef914fea069" as UUID,
+      facility__name: "Name 3",
+      facility__latitude_of_largest_emissions: 55.0,
+      facility__longitude_of_largest_emissions: 66.0,
+    },
+    {
+      facility__id: "8be4c7aa-6ab3-4aad-9206-0ef914fea070" as UUID,
+      facility__name: "Name 4",
+      facility__latitude_of_largest_emissions: 77.0,
+      facility__longitude_of_largest_emissions: 88.0,
+    },
+  ],
+  row_count: 4,
+};
+
+const mockOperations = {
+  rows: [
+    {
+      operation__id: "8be4c7aa-6ab3-4aad-9206-0ef914fea065" as UUID,
+      operation__name: "Operation 1",
+    },
+    {
+      operation__id: "8be4c7aa-6ab3-4aad-9206-0ef914fea066" as UUID,
+      operation__name: "Operation 2",
+    },
+  ],
+  row_count: 2,
+};
+
+const operationEntityTransferFormData = {
+  from_operator: "Operator 1",
+  from_operator_id: "8be4c7aa-6ab3-4aad-9206-0ef914fea063" as UUID,
+  to_operator: "Operator 2",
+  transfer_entity: "Operation",
+  operation: "8be4c7aa-6ab3-4aad-9206-0ef914fea065" as UUID,
+  operation_name: "Operation 1",
+  existing_facilities: [],
+  effective_date: "2022-12-31",
+  status: TransferEventStatus.TO_BE_TRANSFERRED,
+};
+
+const facilityEntityTransferFormData = {
+  from_operator: "Operator 1",
+  from_operator_id: "8be4c7aa-6ab3-4aad-9206-0ef914fea063" as UUID,
+  to_operator: "Operator 2",
+  transfer_entity: "Facility",
+  from_operation: "Operation 1",
+  from_operation_id: "8be4c7aa-6ab3-4aad-9206-0ef914fea065" as UUID,
+  to_operation: "Operation 2",
+  facilities: [
+    "8be4c7aa-6ab3-4aad-9206-0ef914fea067" as UUID,
+    "8be4c7aa-6ab3-4aad-9206-0ef914fea068" as UUID,
+  ],
+  existing_facilities: [
+    {
+      id: "8be4c7aa-6ab3-4aad-9206-0ef914fea067" as UUID,
+      name: "Name 1 - (11, 22)",
+    },
+    {
+      id: "8be4c7aa-6ab3-4aad-9206-0ef914fea068" as UUID,
+      name: "Name 2 - (33, 44)",
+    },
+  ] as ExistingFacilities[],
+  effective_date: "2022-12-31",
+  status: TransferEventStatus.TO_BE_TRANSFERRED,
+};
+
+const renderOperationEntityTransferDetailForm = async (
+  formData: any = operationEntityTransferFormData,
+) => {
+  fetchOperationsPageData.mockResolvedValue(mockOperations);
+  const schema = await operationEntitySchema(
+    formData.operation,
+    formData.operation_name,
+    formData.from_operator_id,
+  );
+  render(
+    <TransferDetailForm
+      formData={formData}
+      transferId={transferId}
+      schema={schema}
+    />,
+  );
+};
+
+const renderFacilityEntityTransferDetailForm = async () => {
+  fetchFacilitiesPageData.mockResolvedValue(mockFacilities);
+  const schema = await facilityEntitySchema(
+    facilityEntityTransferFormData.existing_facilities,
+    facilityEntityTransferFormData.from_operator_id,
+  );
+  render(
+    <TransferDetailForm
+      formData={facilityEntityTransferFormData}
+      transferId={transferId}
+      schema={schema}
+    />,
+  );
+};
+
+const checkButtons = (editable: boolean = true) => {
+  expectButton("Back");
+  if (editable) {
+    expectButton("Edit Details");
+    expectButton("Cancel Transfer");
+  } else {
+    expect(screen.queryByRole("button", { name: /edit details/i })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /cancel transfer/i }),
+    ).toBeNull();
+  }
+};
+
+const checkFormFieldsAndLabels = (fields: string[]) => {
+  fields.forEach((field: string) => {
+    const fieldRegex = new RegExp(field, "i");
+    expect(screen.getByText(fieldRegex)).toBeVisible();
+  });
+};
+
+describe("The TransferDetailForm component", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the TransferDetailForm component for an operation entity transfer", async () => {
+    await renderOperationEntityTransferDetailForm();
+    const formFieldsAndLabels = [
+      "current operator",
+      "operator 1",
+      "new operator",
+      "operator 2",
+      "what is being transferred?",
+      "operation 1",
+      "effective date of transfer",
+      "2022-12-31",
+    ];
+    checkFormFieldsAndLabels(formFieldsAndLabels);
+    checkButtons();
+  });
+
+  it("should render the TransferDetailForm component for a facility entity transfer", async () => {
+    await renderFacilityEntityTransferDetailForm();
+    const formFieldsAndLabels = [
+      "current operator",
+      "operator 1",
+      "new operator",
+      "operator 2",
+      "what is being transferred?",
+      "facility",
+      "current operation",
+      "operation 1",
+      "facilities",
+      "name 1 - \\(11, 22\\), name 2 - \\(33, 44\\)",
+      "new operation",
+      "effective date of transfer",
+      "2022-12-31",
+    ];
+
+    checkFormFieldsAndLabels(formFieldsAndLabels);
+    checkButtons();
+  });
+
+  it("should not render the edit details and cancel transfer buttons when the transfer status is not TO_BE_TRANSFERRED", async () => {
+    const modifiedFormData = {
+      ...operationEntityTransferFormData,
+      status: TransferEventStatus.COMPLETE,
+    };
+    await renderOperationEntityTransferDetailForm(modifiedFormData);
+    checkButtons(false);
+  });
+
+  it("should take the user back to the transfer requests table when the back button is clicked", async () => {
+    await renderOperationEntityTransferDetailForm();
+    await userEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(mockRouterPush).toHaveBeenCalledWith("/transfers");
+  });
+
+  it("should allow the user to cancel the transfer", async () => {
+    await renderOperationEntityTransferDetailForm();
+    await userEvent.click(
+      screen.getByRole("button", { name: /cancel transfer/i }),
+    );
+    // make sure the modal is displayed
+    expect(
+      screen.getByRole("heading", {
+        name: /confirmation/i,
+      }),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/are you sure you want to cancel this transfer\?/i),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: /no, don't cancel/i,
+      }),
+    ).toBeVisible();
+    expect(screen.getByText(/yes, cancel this transfer/i)).toBeVisible();
+    await userEvent.click(
+      screen.getByRole("button", { name: /yes, cancel this transfer/i }),
+    );
+    // make sure the action is called
+    expect(actionHandler).toHaveBeenCalledWith(
+      `registration/transfer-events/${transferId}`,
+      "DELETE",
+      "/transfers",
+    );
+    // make sure the user is redirected to the transfers table
+    expect(mockRouterPush).toHaveBeenCalledWith("/transfers");
+  });
+
+  it("should allow the user to edit the details of the transfer - Operation Entity", async () => {
+    actionHandler.mockResolvedValueOnce({}); // to handle the PATCH request response
+    fetchOperationsPageData.mockResolvedValue(mockOperations);
+    await renderOperationEntityTransferDetailForm();
+    await userEvent.click(
+      screen.getByRole("button", { name: /edit details/i }),
+    );
+    expectComboBox(/operation\*/i, "Operation 1");
+    await userEvent.type(
+      screen.getByRole("combobox", { name: /operation\*/i }),
+      "op",
+    );
+
+    // make sure the current operation is displayed in the options
+    await waitFor(() => {
+      expect(
+        screen.getByRole("option", {
+          name: /operation 1/i,
+        }),
+      ).toBeVisible();
+      expect(
+        screen.getByRole("option", {
+          name: /operation 2/i,
+        }),
+      ).toBeVisible();
+    });
+    await userEvent.click(screen.getByText(/operation 2/i));
+    expectComboBox(/operation\*/i, "Operation 2");
+    expect(
+      screen.getByRole("textbox", { name: /effective date of transfer/i }),
+    ).toHaveValue("2022-12-31");
+
+    // submit the form
+    await userEvent.click(
+      screen.getByRole("button", { name: /transfer entity/i }),
+    );
+    expect(actionHandler).toHaveBeenCalledWith(
+      `registration/transfer-events/${transferId}`,
+      "PATCH",
+      `/transfers/${transferId}`,
+      {
+        body: JSON.stringify({
+          from_operator: "Operator 1",
+          to_operator: "Operator 2",
+          transfer_entity: "Operation",
+          effective_date: "2022-12-31",
+          operation: "8be4c7aa-6ab3-4aad-9206-0ef914fea066",
+        }),
+      },
+    );
+    // make sure the snackbar is displayed
+    expect(
+      screen.getByText(/all changes have been successfully saved/i),
+    ).toBeVisible();
+  });
+
+  it("should allow the user to edit the details of the transfer - Facility Entity", async () => {
+    actionHandler.mockResolvedValueOnce({}); // to handle the PATCH request response
+    await renderFacilityEntityTransferDetailForm();
+    await userEvent.click(
+      screen.getByRole("button", { name: /edit details/i }),
+    );
+
+    // make sure existing facilities are displayed and included when editing the form
+    expect(
+      screen.getByRole("button", {
+        name: /name 1 \- \(11, 22\)/i,
+      }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: /name 2 \- \(33, 44\)/i,
+      }),
+    ).toBeVisible();
+
+    // make sure the existing facilities are displayed in the options
+    await userEvent.click(
+      screen.getByRole("combobox", { name: /facilities/i }),
+    );
+    const options = [
+      "Name 1 - (11, 22)",
+      "Name 2 - (33, 44)",
+      "Name 3 - (55, 66)",
+      "Name 4 - (77, 88)",
+    ];
+    options.forEach((option) => {
+      expect(screen.getByText(option)).toBeVisible();
+    });
+
+    // add the last facility
+    await userEvent.click(screen.getByText("Name 4 - (77, 88)"));
+
+    // make sure the facility is added to the list
+    expect(screen.getByText("Name 4 - (77, 88)")).toBeVisible();
+
+    // submit the form
+    await userEvent.click(
+      screen.getByRole("button", { name: /transfer entity/i }),
+    );
+    expect(actionHandler).toHaveBeenCalledWith(
+      `registration/transfer-events/${transferId}`,
+      "PATCH",
+      `/transfers/${transferId}`,
+      {
+        body: JSON.stringify({
+          from_operator: "Operator 1",
+          to_operator: "Operator 2",
+          transfer_entity: "Facility",
+          effective_date: "2022-12-31",
+          from_operation: "Operation 1",
+          facilities: [
+            "8be4c7aa-6ab3-4aad-9206-0ef914fea067",
+            "8be4c7aa-6ab3-4aad-9206-0ef914fea068",
+            "8be4c7aa-6ab3-4aad-9206-0ef914fea070",
+          ],
+          to_operation: "Operation 2",
+        }),
+      },
+    );
+
+    // make sure the snackbar is displayed
+    expect(
+      screen.getByText(/all changes have been successfully saved/i),
+    ).toBeVisible();
+  });
+
+  it("should not render the edit details and cancel transfer buttons for a user with a role other than CAS_ANALYST", async () => {
+    const userAppRole = FrontEndRoles.CAS_ADMIN;
+    useSession.mockReturnValue({
+      data: {
+        user: {
+          app_role: userAppRole,
+        },
+      },
+    } as Session);
+    await renderOperationEntityTransferDetailForm();
+    checkButtons(false);
+  });
+});

--- a/bciers/apps/registration/tests/components/transfers/TransferForm.test.tsx
+++ b/bciers/apps/registration/tests/components/transfers/TransferForm.test.tsx
@@ -3,6 +3,7 @@ import { UUID } from "crypto";
 import { expect } from "vitest";
 import expectButton from "@bciers/testConfig/helpers/expectButton";
 import expectRadio from "@bciers/testConfig/helpers/expectRadio";
+import expectComboBox from "@bciers/testConfig/helpers/expectComboBox";
 import { actionHandler } from "@bciers/testConfig/mocks";
 import { fetchOperationsPageData } from "@/administration/tests/components/operations/mocks";
 import { fetchFacilitiesPageData } from "@/administration/tests/components/facilities/mocks";
@@ -41,11 +42,6 @@ const mockOperations = {
 
 const renderTransferForm = () => {
   render(<TransferForm formData={{} as any} operators={mockOperators} />);
-};
-
-const checkComboBoxExists = (label: RegExp) => {
-  expect(screen.getByLabelText(label)).toBeVisible();
-  expect(screen.getByRole("combobox", { name: label })).toBeVisible();
 };
 
 const selectOperator = (label: RegExp, operatorName: string) => {
@@ -132,8 +128,8 @@ describe("The TransferForm component", () => {
       "Transfer Entity",
     );
     expect(screen.getByText(/select the operators involved/i)).toBeVisible();
-    checkComboBoxExists(/current operator/i);
-    checkComboBoxExists(/select the new operator/i);
+    expectComboBox(/current operator/i);
+    expectComboBox(/select the new operator/i);
     expect(screen.getByText(/what is being transferred?/i)).toBeVisible();
     expectRadio(/operation/i);
     expectRadio(/facility/i);

--- a/bciers/apps/registration/tests/components/transfers/TransferForm.test.tsx
+++ b/bciers/apps/registration/tests/components/transfers/TransferForm.test.tsx
@@ -166,12 +166,16 @@ describe("The TransferForm component", () => {
     expect(fetchOperationsPageData).toHaveBeenCalledWith({
       operator_id: "8be4c7aa-6ab3-4aad-9206-0ef914fea063",
       paginate_results: false,
+      end_date: true,
+      status: "Active",
     });
     selectOperator(/current operator\*/i, "Operator 2");
     expect(fetchOperationsPageData).toHaveBeenCalledTimes(2);
     expect(fetchOperationsPageData).toHaveBeenCalledWith({
       operator_id: "8be4c7aa-6ab3-4aad-9206-0ef914fea064",
       paginate_results: false,
+      end_date: true,
+      status: "Active",
     });
   });
 

--- a/bciers/apps/registration/tests/components/transfers/TransferPage.test.tsx
+++ b/bciers/apps/registration/tests/components/transfers/TransferPage.test.tsx
@@ -1,6 +1,9 @@
+import { randomUUID } from "crypto";
 import { render, screen } from "@testing-library/react";
-import { fetchOperatorsPageData } from "apps/administration/tests/components/operators/mocks";
+import { getTransferEvent } from "@/registration/tests/components/transfers/mocks";
+import { fetchOperatorsPageData } from "@/administration/tests/components/operators/mocks";
 import TransferPage from "@/registration/app/components/transfers/TransferPage";
+import { operationEntitySchema } from "@/registration/app/data/jsonSchema/transfer/transferDetail";
 
 describe("Transfer page", () => {
   beforeEach(async () => {
@@ -33,5 +36,52 @@ describe("Transfer page", () => {
     expect(
       screen.getByText(/select the operators involved/i),
     ).toBeInTheDocument();
+  });
+  it("throws an error when transferId is not a valid UUID", async () => {
+    await expect(async () => {
+      const transferId = "invalid-uuid";
+      // @ts-ignore
+      render(await TransferPage({ transferId }));
+    }).rejects.toThrow("Invalid transfer id: invalid-uuid");
+  });
+  it("throws an error when there's a problem fetching transfer information", async () => {
+    getTransferEvent.mockResolvedValue({ error: "error" });
+    await expect(async () => {
+      render(await TransferPage({ transferId: randomUUID() }));
+    }).rejects.toThrow("Error fetching transfer information.");
+  });
+  it("renders the TransferDetailForm if transferId is provided", async () => {
+    // Mocking the TransferDetailForm component
+    vi.mock(
+      "apps/registration/app/components/transfers/TransferDetailForm",
+      () => ({
+        default: () => <div>Mocked TransferDetailForm</div>,
+      }),
+    );
+
+    // Mocking the operationEntitySchema function
+    vi.mock(
+      "apps/registration/app/data/jsonSchema/transfer/transferDetail",
+      () => ({
+        operationEntitySchema: vi.fn(),
+      }),
+    );
+    const mockOperationEntitySchema = operationEntitySchema as ReturnType<
+      typeof vi.fn
+    >;
+    const [operationId, fromOperatorId] = [randomUUID(), randomUUID()];
+    getTransferEvent.mockResolvedValue({
+      transfer_entity: "Operation",
+      operation: operationId,
+      operation_name: "Operation name",
+      from_operator_id: fromOperatorId,
+    });
+    render(await TransferPage({ transferId: randomUUID() }));
+    expect(screen.getByText("Mocked TransferDetailForm")).toBeInTheDocument();
+    expect(mockOperationEntitySchema).toHaveBeenCalledWith(
+      operationId,
+      "Operation name",
+      fromOperatorId,
+    );
   });
 });

--- a/bciers/apps/registration/tests/components/transfers/TransferPage.test.tsx
+++ b/bciers/apps/registration/tests/components/transfers/TransferPage.test.tsx
@@ -13,7 +13,7 @@ describe("Transfer page", () => {
       row_count: undefined,
     });
     await expect(async () => {
-      render(await TransferPage());
+      render(await TransferPage({})); // passing empty object as props so that it doesn't throw an error when destructuring
     }).rejects.toThrow("Failed to fetch operators data");
   });
 
@@ -26,7 +26,7 @@ describe("Transfer page", () => {
       ],
       row_count: 1,
     });
-    render(await TransferPage());
+    render(await TransferPage({})); // passing empty object as props so that it doesn't throw an error when destructuring
     expect(screen.getByTestId("field-template-label")).toHaveTextContent(
       "Transfer Entity",
     );

--- a/bciers/apps/registration/tests/components/transfers/TransfersDataGrid.test.tsx
+++ b/bciers/apps/registration/tests/components/transfers/TransfersDataGrid.test.tsx
@@ -17,6 +17,7 @@ const mockResponse = {
   rows: [
     {
       id: "3b5b95ea-2a1a-450d-8e2e-2e15feed96c9",
+      transfer_id: "3b5b95ea-2a1a-450d-8e2e-2e15feed96c1",
       operation__name: "Operation 1",
       facilities__name: "N/A",
       status: "Transferred",
@@ -25,6 +26,7 @@ const mockResponse = {
     },
     {
       id: "d99725a7-1c3a-47cb-a59b-e2388ce0fa18",
+      transfer_id: "3b5b95ea-2a1a-450d-8e2e-2e15feed96c2",
       operation__name: "Operation 2",
       facilities__name: "N/A",
       status: "To be transferred",
@@ -33,6 +35,7 @@ const mockResponse = {
     },
     {
       id: "f486f2fb-62ed-438d-bb3e-0819b51e3aeb",
+      transfer_id: "3b5b95ea-2a1a-450d-8e2e-2e15feed96c3",
       operation__name: "N/A",
       facilities__name: "Facility 1",
       status: "Completed",
@@ -41,6 +44,7 @@ const mockResponse = {
     },
     {
       id: "459b80f9-b5f3-48aa-9727-90c30eaf3a58",
+      transfer_id: "3b5b95ea-2a1a-450d-8e2e-2e15feed96c4",
       operation__name: "N/A",
       facilities__name: "Facility 2",
       status: "Completed",
@@ -89,22 +93,36 @@ describe("TransfersDataGrid component", () => {
       within(operation1Row).getByText("Feb 1, 2025 1:00:00 a.m. PST"),
     ).toBeInTheDocument();
     expect(within(operation1Row).getByText("View Details")).toBeInTheDocument();
+    // check generated href for view details
+    expect(
+      within(operation1Row).getByRole("link", { name: "View Details" }),
+    ).toHaveAttribute(
+      "href",
+      "/transfers/3b5b95ea-2a1a-450d-8e2e-2e15feed96c1?transfers_title=Operation 1",
+    );
 
-    const opeartion2Row = rows[3];
+    const operation2Row = rows[3];
     expect(
-      within(opeartion2Row).getByText("Jul 5, 2024 4:25:37 p.m. PDT"),
+      within(operation2Row).getByText("Jul 5, 2024 4:25:37 p.m. PDT"),
     ).toBeInTheDocument();
-    expect(within(opeartion2Row).getByText("Operation 2")).toBeInTheDocument();
-    expect(within(opeartion2Row).getByText("N/A")).toBeInTheDocument();
+    expect(within(operation2Row).getByText("Operation 2")).toBeInTheDocument();
+    expect(within(operation2Row).getByText("N/A")).toBeInTheDocument();
     expect(
-      within(opeartion2Row).getByText("To be transferred"),
+      within(operation2Row).getByText("To be transferred"),
     ).toBeInTheDocument();
     expect(
-      within(opeartion2Row).getByText("Aug 21, 2024 2:00:00 a.m. PDT"),
+      within(operation2Row).getByText("Aug 21, 2024 2:00:00 a.m. PDT"),
     ).toBeInTheDocument();
-    expect(within(opeartion2Row).getByText("View Details")).toBeInTheDocument();
+    expect(within(operation2Row).getByText("View Details")).toBeInTheDocument();
+    // check generated href for view details
+    expect(
+      within(operation2Row).getByRole("link", { name: "View Details" }),
+    ).toHaveAttribute(
+      "href",
+      "/transfers/3b5b95ea-2a1a-450d-8e2e-2e15feed96c2?transfers_title=Operation 2",
+    );
+
     const facility1Row = rows[4];
-
     expect(
       within(facility1Row).getByText("Jul 5, 2024 4:25:37 p.m. PDT"),
     ).toBeInTheDocument();
@@ -115,6 +133,13 @@ describe("TransfersDataGrid component", () => {
       within(facility1Row).getByText("Dec 25, 2024 1:00:00 a.m. PST"),
     ).toBeInTheDocument();
     expect(within(facility1Row).getByText("View Details")).toBeInTheDocument();
+    // check generated href for view details
+    expect(
+      within(facility1Row).getByRole("link", { name: "View Details" }),
+    ).toHaveAttribute(
+      "href",
+      "/transfers/3b5b95ea-2a1a-450d-8e2e-2e15feed96c3?transfers_title=Facility 1",
+    );
 
     const facility2Row = rows[5];
     expect(
@@ -127,5 +152,12 @@ describe("TransfersDataGrid component", () => {
       within(facility2Row).getByText("Dec 25, 2024 1:00:00 a.m. PST"),
     ).toBeInTheDocument();
     expect(within(facility2Row).getByText("View Details")).toBeInTheDocument();
+    // check generated href for view details
+    expect(
+      within(facility2Row).getByRole("link", { name: "View Details" }),
+    ).toHaveAttribute(
+      "href",
+      "/transfers/3b5b95ea-2a1a-450d-8e2e-2e15feed96c4?transfers_title=Facility 2",
+    );
   });
 });

--- a/bciers/apps/registration/tests/components/transfers/mocks.ts
+++ b/bciers/apps/registration/tests/components/transfers/mocks.ts
@@ -1,0 +1,7 @@
+const getTransferEvent = vi.fn();
+
+vi.mock("@/registration/app/components/transfers/getTransferEvent", () => ({
+  default: getTransferEvent,
+}));
+
+export { getTransferEvent };

--- a/bciers/apps/reporting/src/app/components/operations/OperationReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReviewForm.tsx
@@ -239,10 +239,8 @@ export default function OperationReviewForm({
         onConfirm={confirmReportTypeChange}
         confirmText="Change report type"
       >
-        <p>
-          Are you sure you want to change your report type? If you proceed, all
-          of the form data you have entered will be lost.
-        </p>
+        Are you sure you want to change your report type? If you proceed, all of
+        the form data you have entered will be lost.
       </SimpleModal>
       <MultiStepFormWithTaskList
         initialStep={0}

--- a/bciers/libs/components/src/form/SingleStepTaskListForm.tsx
+++ b/bciers/libs/components/src/form/SingleStepTaskListForm.tsx
@@ -6,10 +6,12 @@ import { IChangeEvent } from "@rjsf/core";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import FormBase from "@bciers/components/form/FormBase";
 import TaskList from "@bciers/components/form/components/TaskList";
-import { createNestedFormData, createUnnestedFormData } from "./formDataUtils";
-import { FormMode } from "@bciers/utils/src/enums";
+import {
+  createNestedFormData,
+  createUnnestedFormData,
+} from "@bciers/components/form/formDataUtils";
+import { FormMode, FrontendMessages } from "@bciers/utils/src/enums";
 import SnackBar from "@bciers/components/form/components/SnackBar";
-import { FrontendMessages } from "@bciers/utils/src/enums";
 import SubmitButton from "@bciers/components/button/SubmitButton";
 
 interface SingleStepTaskListFormProps {
@@ -27,6 +29,7 @@ interface SingleStepTaskListFormProps {
   formContext?: { [key: string]: any };
   showTasklist?: boolean;
   showCancelButton?: boolean;
+  customButtonSection?: React.ReactNode;
 }
 
 const SingleStepTaskListForm = ({
@@ -44,6 +47,7 @@ const SingleStepTaskListForm = ({
   formContext,
   showTasklist = true,
   showCancelButton = true,
+  customButtonSection,
 }: SingleStepTaskListFormProps) => {
   const hasFormData = Object.keys(rawFormData).length > 0;
   const formData = hasFormData ? createNestedFormData(rawFormData, schema) : {};
@@ -120,40 +124,42 @@ const SingleStepTaskListForm = ({
           <div className="min-h-6">
             {error && <Alert severity="error">{error}</Alert>}
           </div>
-          <div className="w-full flex justify-end mt-8">
-            {allowEdit && (
-              <div>
-                {isDisabled ? (
-                  <Button
-                    variant="contained"
-                    onClick={() => {
-                      setIsDisabled(false);
-                      setIsSnackbarOpen(false);
-                    }}
-                  >
-                    Edit
-                  </Button>
-                ) : (
-                  <SubmitButton
-                    disabled={isSubmitting}
-                    isSubmitting={isSubmitting}
-                  >
-                    Submit
-                  </SubmitButton>
-                )}
-              </div>
-            )}
-            {showCancelButton && (
-              <Button
-                className="ml-4"
-                variant="outlined"
-                type="button"
-                onClick={onCancel}
-              >
-                Cancel
-              </Button>
-            )}
-          </div>
+          {customButtonSection || (
+            <div className="w-full flex justify-end mt-8">
+              {allowEdit && (
+                <div>
+                  {isDisabled ? (
+                    <Button
+                      variant="contained"
+                      onClick={() => {
+                        setIsDisabled(false);
+                        setIsSnackbarOpen(false);
+                      }}
+                    >
+                      Edit
+                    </Button>
+                  ) : (
+                    <SubmitButton
+                      disabled={isSubmitting}
+                      isSubmitting={isSubmitting}
+                    >
+                      Submit
+                    </SubmitButton>
+                  )}
+                </div>
+              )}
+              {showCancelButton && (
+                <Button
+                  className="ml-4"
+                  variant="outlined"
+                  type="button"
+                  onClick={onCancel}
+                >
+                  Cancel
+                </Button>
+              )}
+            </div>
+          )}
         </FormBase>
       </div>
     </div>

--- a/bciers/libs/components/src/form/widgets/DateWidget.test.tsx
+++ b/bciers/libs/components/src/form/widgets/DateWidget.test.tsx
@@ -231,7 +231,7 @@ describe("RJSF DateWidget", () => {
       dateWidgetLabelRequired,
     );
   });
-  it("should trigger validation error when user clicks the clear button", async () => {
+  it("should trigger validation error when user clears the field and tries to submit", async () => {
     render(
       <FormBase
         schema={dateWidgetFieldSchema}

--- a/bciers/libs/components/src/form/widgets/DateWidget.test.tsx
+++ b/bciers/libs/components/src/form/widgets/DateWidget.test.tsx
@@ -223,12 +223,34 @@ describe("RJSF DateWidget", () => {
   });
 
   it("should have the correct styles when the validation error is shown", async () => {
-    checkTextWidgetValidationStyles(
+    await checkTextWidgetValidationStyles(
       <FormBase
         schema={dateWidgetFieldSchema}
         uiSchema={dateWidgetFieldUiSchema}
       />,
       dateWidgetLabelRequired,
     );
+  });
+  it("should trigger validation error when user clicks the clear button", async () => {
+    render(
+      <FormBase
+        schema={dateWidgetFieldSchema}
+        formData={{ dateWidgetTestField: "2024-07-05T09:00:00.000Z" }}
+        uiSchema={dateWidgetFieldUiSchema}
+      />,
+    );
+    // select the date widget
+    const dateWidgetClickElement = screen.getByTestId("CalendarIcon")
+      .parentElement as HTMLElement;
+    await userEvent.click(dateWidgetClickElement);
+    // select the clear button
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: /clear/i,
+      }),
+    );
+    const submitButton = screen.getByRole("button", { name: "Submit" });
+    await userEvent.click(submitButton);
+    expect(screen.getByText("Required field")).toBeVisible();
   });
 });

--- a/bciers/libs/components/src/form/widgets/DateWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/DateWidget.tsx
@@ -23,7 +23,9 @@ const DateWidget: React.FC<WidgetProps> = ({
   const simpleDateFormat = options?.simpleDateFormat || false;
 
   const handleChange = (d: Dayjs | null) => {
-    if (!d || !d.isValid()) {
+    if (d === null) return onChange(undefined);
+
+    if (!d.isValid()) {
       return onChange("invalid date");
     }
 

--- a/bciers/libs/components/src/modal/SimpleModal.tsx
+++ b/bciers/libs/components/src/modal/SimpleModal.tsx
@@ -1,5 +1,6 @@
 import { Button, DialogActions, DialogContentText } from "@mui/material";
 import Modal from "./Modal";
+import SubmitButton from "@bciers/components/button/SubmitButton";
 
 interface Props extends React.PropsWithChildren {
   open: boolean;
@@ -8,6 +9,8 @@ interface Props extends React.PropsWithChildren {
   onConfirm: () => void;
   confirmText?: string;
   cancelText?: string;
+  dialogContentClassName?: string;
+  isSubmitting?: boolean;
 }
 
 const SimpleModal: React.FC<Props> = ({
@@ -18,17 +21,21 @@ const SimpleModal: React.FC<Props> = ({
   confirmText = "Confirm",
   cancelText = "Cancel",
   children,
+  dialogContentClassName,
+  isSubmitting = false,
 }) => {
   return (
     <Modal open={open} title={title}>
-      <DialogContentText>{children}</DialogContentText>
+      <DialogContentText className={`m-4 ${dialogContentClassName}`}>
+        {children}
+      </DialogContentText>
       <DialogActions>
         <Button variant="outlined" color="primary" onClick={onCancel}>
           {cancelText}
         </Button>
-        <Button variant="contained" color="primary" onClick={onConfirm}>
+        <SubmitButton isSubmitting={isSubmitting} onClick={onConfirm}>
           {confirmText}
-        </Button>
+        </SubmitButton>
       </DialogActions>
     </Modal>
   );

--- a/bciers/libs/testConfig/src/helpers/expectComboBox.ts
+++ b/bciers/libs/testConfig/src/helpers/expectComboBox.ts
@@ -1,0 +1,13 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { screen } from "@testing-library/react";
+
+export const expectComboBox = (label: RegExp, expectedValue?: string) => {
+  expect(screen.getByLabelText(label)).toBeVisible();
+  expect(screen.getByRole("combobox", { name: label })).toBeVisible();
+
+  if (expectedValue) {
+    expect(screen.getByLabelText(label)).toHaveValue(expectedValue);
+  }
+};
+
+export default expectComboBox;

--- a/bciers/libs/utils/src/formatTimestamp.ts
+++ b/bciers/libs/utils/src/formatTimestamp.ts
@@ -11,7 +11,6 @@ const formatTimestamp = (timestamp: string) => {
   const timeWithTimeZone = new Date(timestamp).toLocaleString("en-CA", {
     hour: "numeric",
     minute: "numeric",
-    second: "numeric",
     timeZoneName: "short",
     timeZone: "America/Vancouver",
   });


### PR DESCRIPTION
[ISSUE 2447](https://github.com/bcgov/cas-registration/issues/2447)
&&
[ISSUE 2640](https://github.com/bcgov/cas-registration/issues/2640)




🗒️ **NOTES:**

- Added util to format decimals
- Removed redundant pages
- Improved simple modal styling and resolved the modal child issue (p tag being used inside another p tag)
- Added more transfer event fixture
- Removed Second from timestamp util
- Fixed clearing functionality of `DateWidget`(It was preventing the widget to raise form error)
- Added new make target to run tests in parallel mode (`make pythontests_parallel`)

🧪 **TEST:**

- Log in as `cas_analyst`
- Click the Transfers link from the dashboard
- Click the view details link on one of the transfer events where the status is `To be transferred`
- Click the `Edit Details` button to edit the transfer
- OR Click `Cancel Transfer` and then confirm to cancel a transfer