### PR TITLE
422 remove fog and reporting only fields

### DIFF
--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionSummaryForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionSummaryForm.tsx
@@ -17,7 +17,6 @@ interface Props {
   summaryFormData: {
     attributableForReporting: string;
     attributableForReportingThreshold: string;
-    reportingOnlyEmission: string;
     emissionCategories: {
       flaring: string;
       fugitive: string;
@@ -36,7 +35,6 @@ interface Props {
     };
     otherExcluded: {
       lfoExcluded: string;
-      fogExcluded: string; // To be handled once we implement a way to capture FOG emissions
     };
   };
   taskListElements: TaskListElement[];

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionSummaryPage.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionSummaryPage.tsx
@@ -27,7 +27,6 @@ export default async function FacilityEmissionSummaryPage({
   const formData = {
     attributableForReporting: summaryData.attributable_for_reporting,
     attributableForReportingThreshold: summaryData.attributable_for_threshold,
-    reportingOnlyEmission: summaryData.reporting_only,
     emissionCategories: {
       flaring: summaryData.flaring,
       fugitive: summaryData.fugitive,
@@ -46,7 +45,6 @@ export default async function FacilityEmissionSummaryPage({
     },
     otherExcluded: {
       lfoExcluded: summaryData.lfo_excluded,
-      fogExcluded: "0", // To be handled once we implement a way to capture FOG emissions
     },
   };
 

--- a/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/emissionsSummaryFactoryItem.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/emissionsSummaryFactoryItem.ts
@@ -14,7 +14,6 @@ const emissionsSummaryFactoryItem: ReviewDataFactoryItem = async (
   const formData = {
     attributableForReporting: summaryData.attributable_for_reporting,
     attributableForReportingThreshold: summaryData.attributable_for_threshold,
-    reportingOnlyEmission: summaryData.reporting_only,
     emissionCategories: {
       flaring: summaryData.flaring,
       fugitive: summaryData.fugitive,
@@ -33,7 +32,6 @@ const emissionsSummaryFactoryItem: ReviewDataFactoryItem = async (
     },
     otherExcluded: {
       lfoExcluded: summaryData.lfo_excluded,
-      fogExcluded: "0", // To be handled once we implement a way to capture FOG emissions
     },
   };
 

--- a/bciers/apps/reporting/src/data/jsonSchema/facilityEmissionSummary.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/facilityEmissionSummary.ts
@@ -15,11 +15,6 @@ export const facilityEmissionSummarySchema: RJSFSchema = {
       title: "Emissions attributable for reporting threshold",
       minimum: 0,
     },
-    reportingOnlyEmission: {
-      type: "number",
-      title: "Reporting-only emissions",
-      minimum: 0,
-    },
     emissionCategories: {
       type: "object",
       title: "Emission Categories",
@@ -88,12 +83,6 @@ export const facilityEmissionSummarySchema: RJSFSchema = {
           type: "number",
           title:
             "Emissions from line tracing and non-processing and non-compression activities",
-          minimum: 0,
-        },
-        fogExcluded: {
-          type: "number",
-          title:
-            "Emissions from fat, oil and grease collection, refining and storage",
           minimum: 0,
         },
       },

--- a/bciers/apps/reporting/src/tests/components/facility/FacilityEmissionSummaryPage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/facility/FacilityEmissionSummaryPage.test.tsx
@@ -12,7 +12,6 @@ vi.mock("@bciers/actions", () => ({
 const mockSummaryData = {
   attributableForReporting: "777",
   attributableForReportingThreshold: "888",
-  reportingOnlyEmission: "999",
   emissionCategories: {
     flaring: "500",
     fugitive: "1000",
@@ -31,7 +30,6 @@ const mockSummaryData = {
   },
   otherExcluded: {
     lfoExcluded: "400",
-    fogExcluded: "0",
   },
 };
 
@@ -126,11 +124,6 @@ describe("FacilityEmissionSummaryForm", () => {
         "Emissions from line tracing and non-processing and non-compression activities",
       ).value,
     ).toBe("400");
-    expect(
-      screen.getByLabelText(
-        "Emissions from fat, oil and grease collection, refining and storage",
-      ).value,
-    ).toBe("0");
   });
 
   it("should render the attributable summary data", async () => {
@@ -150,6 +143,5 @@ describe("FacilityEmissionSummaryForm", () => {
       screen.getByLabelText("Emissions attributable for reporting threshold")
         .value,
     ).toBe("888");
-    expect(screen.getByLabelText("Reporting-only emissions").value).toBe("999");
   });
 });


### PR DESCRIPTION
[422](https://github.com/orgs/bcgov/projects/123/views/15?pane=issue&itemId=89929470&issue=bcgov%7Ccas-reporting%7C422)

- **chore: Remove fog and reporting only emission fields from alloc of emissions and emission summary pages**
- **test: update tests for fog and roe**
