### PR TITLE
2524: fix places assigned display

### DIFF
--- a/bc_obps/registration/schema/v2/contact.py
+++ b/bc_obps/registration/schema/v2/contact.py
@@ -16,7 +16,7 @@ class PlacesAssigned(Schema):
 
 
 class ContactWithPlacesAssigned(ContactOut):
-    places_assigned: Optional[list[PlacesAssigned]]
+    places_assigned: Optional[list[PlacesAssigned]] = None
 
 
 class ContactListOutV2(ModelSchema):

--- a/bciers/libs/components/src/form/fields/PlacesAssignedFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/PlacesAssignedFieldTemplate.tsx
@@ -6,7 +6,7 @@ const PlacesAssignedFieldTemplate = ({
   formContext,
 }: ArrayFieldTemplateProps) => {
   if (items.length < 1) {
-    return <div>None</div>;
+    return <div className="w-full px-[14px] py-4 items-center">None</div>;
   }
   return (
     <div className="flex min-w-full flex-col">


### PR DESCRIPTION
card: https://github.com/bcgov/cas-registration/issues/2524#issuecomment-2617049496

This PR:
- the contact page was throwing an error because places_assigned in the ninja schema is optional but didn't have a default value, added the default
- fixed the space in the places assigned widget when no places are assigned