### PR TITLE
507 bug emission allocation fails with other

### DIFF
--- a/bc_obps/reporting/migrations/0039_reportproductemissionallocation_and_more.py
+++ b/bc_obps/reporting/migrations/0039_reportproductemissionallocation_and_more.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 (
                     'allocation_methodology',
                     models.CharField(
-                        choices=[('Calculator', 'Calculator'), ('other', 'Other')],
+                        choices=[('Calculator', 'Calculator'), ('Other', 'Other')],
                         default='Calculator',
                         db_comment='The methodology used to calculate the allocated emissions',
                         max_length=255,
@@ -126,12 +126,12 @@ class Migration(migrations.Migration):
             model_name='reportproductemissionallocation',
             constraint=models.CheckConstraint(
                 check=models.Q(
-                    ('allocation_methodology', 'other'),
+                    ('allocation_methodology', 'Other'),
                     ('allocation_other_methodology_description__isnull', True),
                     _negated=True,
                 ),
                 name='allocation_other_methodology_must_have_description',
-                violation_error_message="A value for allocation_other_methodology_description must be provided if the allocation_methodology is 'other'",
+                violation_error_message="A value for allocation_other_methodology_description must be provided if the allocation_methodology is 'Other'",
             ),
         ),
     ]

--- a/bc_obps/reporting/models/report_product_emission_allocation.py
+++ b/bc_obps/reporting/models/report_product_emission_allocation.py
@@ -69,7 +69,7 @@ class ReportProductEmissionAllocation(TimeStampedModel):
             ),
             models.CheckConstraint(
                 name="allocation_other_methodology_must_have_description",
-                check=~Q(allocation_methodology="other", allocation_other_methodology_description__isnull=True),
-                violation_error_message="A value for allocation_other_methodology_description must be provided if the allocation_methodology is 'other'",
+                check=~Q(allocation_methodology="Other", allocation_other_methodology_description__isnull=True),
+                violation_error_message="A value for allocation_other_methodology_description must be provided if the allocation_methodology is 'Other'",
             ),
         ]

--- a/bc_obps/reporting/models/report_product_emission_allocation.py
+++ b/bc_obps/reporting/models/report_product_emission_allocation.py
@@ -14,7 +14,7 @@ class ReportProductEmissionAllocation(TimeStampedModel):
 
     class AllocationMethodologyChoices(models.TextChoices):
         CALCULATOR = ("Calculator",)
-        OTHER = "other"
+        OTHER = "Other"
 
     report_version = models.ForeignKey(
         report_version.ReportVersion,

--- a/bc_obps/reporting/tests/models/test_report_product_emission_allocation.py
+++ b/bc_obps/reporting/tests/models/test_report_product_emission_allocation.py
@@ -28,7 +28,7 @@ class ReportProductEmissionAllocationModelTest(BaseTestCase):
             report_product=report_product,
             emission_category=emission_category,
             allocated_quantity=Decimal('300.4151'),
-            allocation_methodology='other',
+            allocation_methodology='Other',
             allocation_other_methodology_description='Test description',
         )
         cls.field_data = [
@@ -56,7 +56,7 @@ class ReportProductEmissionAllocationModelTest(BaseTestCase):
 
         with pytest.raises(
             ValidationError,
-            match="A value for allocation_other_methodology_description must be provided if the allocation_methodology is 'other'",
+            match="A value for allocation_other_methodology_description must be provided if the allocation_methodology is 'Other'",
         ):
             make(
                 ReportProductEmissionAllocation,
@@ -67,6 +67,21 @@ class ReportProductEmissionAllocationModelTest(BaseTestCase):
                 allocated_quantity=Decimal('300.4151'),
                 allocation_methodology=ReportProductEmissionAllocation.AllocationMethodologyChoices.OTHER,
                 allocation_other_methodology_description=None,
+            )
+
+        with pytest.raises(
+            ValidationError,
+            match="Value 'other' is not a valid choice.",
+        ):
+            make(
+                ReportProductEmissionAllocation,
+                report_version=facility_report.report_version,
+                facility_report=facility_report,
+                report_product=report_product,
+                emission_category=emission_category,
+                allocated_quantity=Decimal('300.4151'),
+                allocation_methodology='other',
+                allocation_other_methodology_description='test',
             )
 
         # This should not raise

--- a/bc_obps/reporting/tests/models/test_report_product_emission_allocation.py
+++ b/bc_obps/reporting/tests/models/test_report_product_emission_allocation.py
@@ -69,21 +69,6 @@ class ReportProductEmissionAllocationModelTest(BaseTestCase):
                 allocation_other_methodology_description=None,
             )
 
-        with pytest.raises(
-            ValidationError,
-            match="Value 'other' is not a valid choice.",
-        ):
-            make(
-                ReportProductEmissionAllocation,
-                report_version=facility_report.report_version,
-                facility_report=facility_report,
-                report_product=report_product,
-                emission_category=emission_category,
-                allocated_quantity=Decimal('300.4151'),
-                allocation_methodology='other',
-                allocation_other_methodology_description='test',
-            )
-
         # This should not raise
         make(
             ReportProductEmissionAllocation,

--- a/bc_obps/reporting/tests/service/test_report_emission_allocation_service.py
+++ b/bc_obps/reporting/tests/service/test_report_emission_allocation_service.py
@@ -160,7 +160,7 @@ class TestReportEmissionAllocationService(TestCase):
                     "allocated_quantity": self.ALLOCATION_AMOUNT_2,
                 },
             ],
-            "allocation_methodology": "other",
+            "allocation_methodology": "Other",
             "allocation_other_methodology_description": "test",
         }
 
@@ -168,7 +168,7 @@ class TestReportEmissionAllocationService(TestCase):
             report_product_emission_allocations=self.create_mock_allocation_array(
                 report_product1=report_product_1, report_product2=report_product_2, test_stage=2
             ),
-            allocation_methodology="other",
+            allocation_methodology="Other",
             allocation_other_methodology_description="test",
         )
 
@@ -176,7 +176,7 @@ class TestReportEmissionAllocationService(TestCase):
             report_product_emission_allocations=self.create_mock_allocation_array(
                 report_product1=report_product_1, report_product2=report_product_2, test_stage=3
             ),
-            allocation_methodology="other",
+            allocation_methodology="Other",
             allocation_other_methodology_description="test",
         )
 
@@ -200,7 +200,7 @@ class TestReportEmissionAllocationService(TestCase):
                 report_product=product,
                 emission_category_id=data["category"],
                 allocated_quantity=data["quantity"],
-                allocation_methodology="other",
+                allocation_methodology="Other",
                 allocation_other_methodology_description="test",
             )
         # Arrange: Create an emission allocation to an excluded category
@@ -211,7 +211,7 @@ class TestReportEmissionAllocationService(TestCase):
             report_product=report_products[1],
             emission_category_id=self.WOODY_BIOMASS_CATEGORY_ID,
             allocated_quantity=self.ALLOCATION_AMOUNT_3,
-            allocation_methodology="other",
+            allocation_methodology="Other",
             allocation_other_methodology_description="test",
         )
 
@@ -345,7 +345,6 @@ class TestReportEmissionAllocationService(TestCase):
             )
 
     def test_save_emission_allocation(self):
-
         # Act:  Use the service to save some emission allocation data (payload includes data for 2 allocations)
         ReportEmissionAllocationService.save_emission_allocation_data(
             self.test_infrastructure.report_version.pk,

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -52,6 +52,43 @@ const validateEmissions = (formData: FormData): boolean => {
   });
 };
 
+const validateMethodology = (formData: FormData): boolean => {
+  return (
+    formData.allocation_methodology !== undefined &&
+    formData.allocation_methodology !== ""
+  );
+};
+
+const validateMethodologyOther = (formData: FormData): boolean => {
+  return formData.allocation_methodology !== "Other"
+    ? true
+    : formData.allocation_other_methodology_description !== undefined &&
+        formData.allocation_other_methodology_description !== "";
+};
+
+const validateFormData = (formData: FormData) => {
+  const errorMismatch =
+    "All emissions must be allocated to 100% before saving and continuing";
+  const errorMethodology =
+    "A methodology must be selected before saving and continuing";
+  const errorMethodologyOther =
+    "A description must be provided for the selected methodology";
+
+  const newErrors: string[] = [];
+
+  if (!validateEmissions(formData)) {
+    newErrors.push(errorMismatch);
+  }
+  if (!validateMethodology(formData)) {
+    newErrors.push(errorMethodology);
+  }
+  if (!validateMethodologyOther(formData)) {
+    newErrors.push(errorMethodologyOther);
+  }
+
+  return newErrors;
+};
+
 export default function FacilityEmissionAllocationForm({
   version_id,
   facility_id,
@@ -78,8 +115,7 @@ export default function FacilityEmissionAllocationForm({
   }));
 
   // State for submit button disable
-  const errorMismatch =
-    "All emissions must be allocated to 100% before saving and continuing";
+
   const [errors, setErrors] = useState<string[] | undefined>();
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
 
@@ -97,10 +133,9 @@ export default function FacilityEmissionAllocationForm({
 
   // 🔄 Check for allocation mismatch on page load to prevent submit
   useEffect(() => {
-    if (!validateEmissions(formData)) {
-      setErrors([errorMismatch]);
-    }
-    setSubmitButtonDisabled(!validateEmissions(formData));
+    const newErrors = validateFormData(formData);
+    setErrors(newErrors);
+    setSubmitButtonDisabled(newErrors.length > 0);
   }, [formData]);
 
   // 🛠️ Handle changes to the form data, validates emissions, and updates the error state and submit button state.
@@ -151,14 +186,10 @@ export default function FacilityEmissionAllocationForm({
           }),
         );
     }
-
     // Validate the updated form data and set an error message if validation fails
-    if (!validateEmissions(updatedFormData)) {
-      setErrors([errorMismatch]);
-      setSubmitButtonDisabled(true);
-    } else {
-      setSubmitButtonDisabled(false);
-    }
+    const newErrors = validateFormData(updatedFormData);
+    setErrors(newErrors);
+    setSubmitButtonDisabled(newErrors.length > 0);
 
     // Update the form data state
     setFormData(updatedFormData);
@@ -205,7 +236,6 @@ export default function FacilityEmissionAllocationForm({
       return false;
     }
 
-    setErrors(undefined);
     return true;
   };
 


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/507

#### Part 1: Allocations not saving when methodology == 'other'

Updated model to expect 'Other'
Updated tests to use 'Other'
Added test to verify that 'Other' works and 'other' does not

#### Part 2: Missing methodology on page but error still shows "need 100% allocation"

Added validations and errors for methodology and methodology_description fields