### PR TITLE
chore: use full baker recipe path in tests

### DIFF
--- a/bc_obps/registration/tests/endpoints/v1/_contacts/test_contact_id.py
+++ b/bc_obps/registration/tests/endpoints/v1/_contacts/test_contact_id.py
@@ -26,12 +26,13 @@ class TestContactIdEndpoint(CommonTestSetup):
 
     def test_industry_users_can_get_contacts_associated_with_their_operator(self):
         contact = baker.make_recipe(
-            'utils.contact', business_role=BusinessRole.objects.get(role_name='Operation Representative')
+            'registration.tests.utils.contact',
+            business_role=BusinessRole.objects.get(role_name='Operation Representative'),
         )
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         # add contact to operator and operation
         approved_user_operator.operator.contacts.set([contact])
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         operation.contacts.set([contact])
 
         response = TestUtils.mock_get_with_auth_role(
@@ -99,8 +100,8 @@ class TestContactIdEndpoint(CommonTestSetup):
         assert response.json().get('message') == 'Email: Enter a valid email address.'
 
     def test_industry_user_admin_update_contact_and_address(self):
-        operator = baker.make_recipe('utils.operator')
-        contact = baker.make_recipe('utils.contact', operator=operator)
+        operator = baker.make_recipe('registration.tests.utils.operator')
+        contact = baker.make_recipe('registration.tests.utils.contact', operator=operator)
         TestUtils.authorize_current_user_as_operator_user(self, operator)
         # Assert that we have only one contact(to make sure we are updating the contact and not creating a new one)
         assert Contact.objects.count() == 1
@@ -133,8 +134,8 @@ class TestContactIdEndpoint(CommonTestSetup):
         assert response_json.get('postal_code') == self.valid_contact_data.get('postal_code')
 
     def test_industry_user_admin_update_contact_and_remove_address(self):
-        operator = baker.make_recipe('utils.operator')
-        contact = baker.make_recipe('utils.contact', operator=operator)
+        operator = baker.make_recipe('registration.tests.utils.operator')
+        contact = baker.make_recipe('registration.tests.utils.contact', operator=operator)
         TestUtils.authorize_current_user_as_operator_user(self, operator)
         # Assert that we have only one contact(to make sure we are updating the contact and not creating a new one)
         assert Contact.objects.count() == 1
@@ -173,8 +174,8 @@ class TestContactIdEndpoint(CommonTestSetup):
         assert Contact.objects.first().address is None
 
     def test_industry_user_admin_update_contact_by_adding_address(self):
-        operator = baker.make_recipe('utils.operator')
-        contact = baker.make_recipe('utils.contact', operator=operator, address=None)
+        operator = baker.make_recipe('registration.tests.utils.operator')
+        contact = baker.make_recipe('registration.tests.utils.contact', operator=operator, address=None)
         TestUtils.authorize_current_user_as_operator_user(self, operator)
         # Assert that we have only one contact(to make sure we are updating the contact and not creating a new one)
         assert Contact.objects.count() == 1

--- a/bc_obps/registration/tests/endpoints/v1/_operations/_operation_id/test_operation_update_status.py
+++ b/bc_obps/registration/tests/endpoints/v1/_operations/_operation_id/test_operation_update_status.py
@@ -31,7 +31,7 @@ class TestUpdateOperationStatusEndpoint(CommonTestSetup):
         )
 
     def test_cas_admin_approves_operation(self):
-        operation = baker.make_recipe('utils.operation')
+        operation = baker.make_recipe('registration.tests.utils.operation')
         assert operation.status == Operation.Statuses.NOT_STARTED
         url = custom_reverse_lazy("v1_update_operation_status", kwargs={"operation_id": operation.id})
 

--- a/bc_obps/registration/tests/endpoints/v1/_operations/test_operation_id.py
+++ b/bc_obps/registration/tests/endpoints/v1/_operations/test_operation_id.py
@@ -262,11 +262,13 @@ class TestOperationIdEndpoint(CommonTestSetup):
         assert response.status_code == 422
 
     def test_industry_user_update_operation_with_updated_point_of_contact(self):
-        contact1 = baker.make_recipe('utils.contact')
+        contact1 = baker.make_recipe('registration.tests.utils.contact')
         # contact2 is a new contact, even though they have the same email as contact1
-        contact2 = baker.make_recipe('utils.contact', email=contact1.email)
-        operator = baker.make_recipe('utils.operator')
-        operation = baker.make_recipe('utils.operation', operator=operator, point_of_contact=contact2)
+        contact2 = baker.make_recipe('registration.tests.utils.contact', email=contact1.email)
+        operator = baker.make_recipe('registration.tests.utils.operator')
+        operation = baker.make_recipe(
+            'registration.tests.utils.operation', operator=operator, point_of_contact=contact2
+        )
 
         update = OperationUpdateIn(
             name='Springfield Nuclear Power Plant',

--- a/bc_obps/registration/tests/endpoints/v1/test_operations.py
+++ b/bc_obps/registration/tests/endpoints/v1/test_operations.py
@@ -127,9 +127,15 @@ class TestOperationsEndpoint(CommonTestSetup):
         # Endpoint ignores user_operator records with a 'DECLINED' status
         operator1 = operator_baker()
         operator2 = operator_baker()
-        baker.make_recipe('utils.operation', operator_id=operator1.id, status=Operation.Statuses.PENDING)
-        baker.make_recipe('utils.operation', operator_id=operator2.id, status=Operation.Statuses.APPROVED)
-        baker.make_recipe('utils.operation', operator_id=operator2.id, status=Operation.Statuses.NOT_STARTED)
+        baker.make_recipe(
+            'registration.tests.utils.operation', operator_id=operator1.id, status=Operation.Statuses.PENDING
+        )
+        baker.make_recipe(
+            'registration.tests.utils.operation', operator_id=operator2.id, status=Operation.Statuses.APPROVED
+        )
+        baker.make_recipe(
+            'registration.tests.utils.operation', operator_id=operator2.id, status=Operation.Statuses.NOT_STARTED
+        )
         baker.make(
             UserOperator, user_id=self.user.user_guid, status=UserOperator.Statuses.DECLINED, operator_id=operator1.id
         )
@@ -143,7 +149,12 @@ class TestOperationsEndpoint(CommonTestSetup):
 
     def test_operations_endpoint_get_method_paginated(self):
         operator1 = operator_baker()
-        baker.make_recipe('utils.operation', operator_id=operator1.id, status=Operation.Statuses.PENDING, _quantity=60)
+        baker.make_recipe(
+            'registration.tests.utils.operation',
+            operator_id=operator1.id,
+            status=Operation.Statuses.PENDING,
+            _quantity=60,
+        )
         # Get the default page 1 response
         response = TestUtils.mock_get_with_auth_role(self, "cas_admin")
         assert response.status_code == 200
@@ -187,25 +198,25 @@ class TestOperationsEndpoint(CommonTestSetup):
             id='21-0001',
         )
         baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator_id=operator1.id,
             name='Springfield Nuclear Power Plant',
             status=Operation.Statuses.PENDING,
             _quantity=10,
         )
         baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator_id=operator2.id,
             name='Krusty Burger',
             status=Operation.Statuses.APPROVED,
             _quantity=10,
         )
         baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator_id=operator2.id,
             name='Kwik-E-Mart',
             status=Operation.Statuses.DECLINED,
-            bcghg_id=baker.make_recipe('utils.bcghg_id'),
+            bcghg_id=baker.make_recipe('registration.tests.utils.bcghg_id'),
             bc_obps_regulated_operation_id='21-0001',
         )
 
@@ -310,7 +321,7 @@ class TestOperationsEndpoint(CommonTestSetup):
 
     def test_post_existing_operation_with_same_bcghg_id(self):
         operation_instance = operation_baker()
-        bcghg_id = baker.make_recipe('utils.bcghg_id')
+        bcghg_id = baker.make_recipe('registration.tests.utils.bcghg_id')
         operation_instance.bcghg_id = bcghg_id
         operation_instance.save(update_fields=['bcghg_id'])
         mock_operation2 = TestUtils.mock_create_operation_v1_payload()

--- a/bc_obps/registration/tests/endpoints/v1/test_user_operators.py
+++ b/bc_obps/registration/tests/endpoints/v1/test_user_operators.py
@@ -282,7 +282,7 @@ class TestCreateUserOperator(CommonTestSetup):
 
 class TestUserOperatorListFromUserEndpoint(CommonTestSetup):
     def test_get_an_operators_user_operators_by_users_list(self):
-        operator = baker.make_recipe('utils.operator')
+        operator = baker.make_recipe('registration.tests.utils.operator')
         # two UserOperator with the same operator
         user_operator_1 = baker.make(
             UserOperator,
@@ -293,7 +293,9 @@ class TestUserOperatorListFromUserEndpoint(CommonTestSetup):
         )
         user_operator_2 = baker.make(
             UserOperator,
-            user=baker.make_recipe('utils.industry_operator_user', business_guid=self.user.business_guid),
+            user=baker.make_recipe(
+                'registration.tests.utils.industry_operator_user', business_guid=self.user.business_guid
+            ),
             operator=operator,
             role=UserOperator.Roles.PENDING,
             status=UserOperator.Statuses.PENDING,
@@ -301,8 +303,8 @@ class TestUserOperatorListFromUserEndpoint(CommonTestSetup):
         # a UserOperator with a different operator and business_guid
         baker.make(
             UserOperator,
-            user=baker.make_recipe('utils.industry_operator_user'),
-            operator=baker.make_recipe('utils.operator'),
+            user=baker.make_recipe('registration.tests.utils.industry_operator_user'),
+            operator=baker.make_recipe('registration.tests.utils.operator'),
             role=UserOperator.Roles.ADMIN,
             status=UserOperator.Statuses.APPROVED,
         )

--- a/bc_obps/registration/tests/endpoints/v2/_contacts/test_contact_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_contacts/test_contact_id.py
@@ -26,12 +26,13 @@ class TestContactIdEndpoint(CommonTestSetup):
 
     def test_industry_users_can_get_contacts_associated_with_their_operator(self):
         contact = baker.make_recipe(
-            'utils.contact', business_role=BusinessRole.objects.get(role_name='Operation Representative')
+            'registration.tests.utils.contact',
+            business_role=BusinessRole.objects.get(role_name='Operation Representative'),
         )
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         # add contact to operator and operation
         approved_user_operator.operator.contacts.set([contact])
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         operation.contacts.set([contact])
 
         response = TestUtils.mock_get_with_auth_role(
@@ -105,8 +106,8 @@ class TestContactIdEndpoint(CommonTestSetup):
         assert response.json().get('message') == 'Email: Enter a valid email address.'
 
     def test_industry_user_admin_update_contact_and_address(self):
-        operator = baker.make_recipe('utils.operator')
-        contact = baker.make_recipe('utils.contact', operator=operator)
+        operator = baker.make_recipe('registration.tests.utils.operator')
+        contact = baker.make_recipe('registration.tests.utils.contact', operator=operator)
         TestUtils.authorize_current_user_as_operator_user(self, operator)
         # Assert that we have only one contact(to make sure we are updating the contact and not creating a new one)
         assert Contact.objects.count() == 1
@@ -139,8 +140,8 @@ class TestContactIdEndpoint(CommonTestSetup):
         assert response_json.get('postal_code') == self.valid_contact_data.get('postal_code')
 
     def test_industry_user_admin_update_contact_and_remove_address(self):
-        operator = baker.make_recipe('utils.operator')
-        contact = baker.make_recipe('utils.contact', operator=operator)
+        operator = baker.make_recipe('registration.tests.utils.operator')
+        contact = baker.make_recipe('registration.tests.utils.contact', operator=operator)
         TestUtils.authorize_current_user_as_operator_user(self, operator)
         # Assert that we have only one contact(to make sure we are updating the contact and not creating a new one)
         assert Contact.objects.count() == 1
@@ -179,8 +180,8 @@ class TestContactIdEndpoint(CommonTestSetup):
         assert Contact.objects.first().address is None
 
     def test_industry_user_admin_update_contact_by_adding_address(self):
-        operator = baker.make_recipe('utils.operator')
-        contact = baker.make_recipe('utils.contact', operator=operator, address=None)
+        operator = baker.make_recipe('registration.tests.utils.operator')
+        contact = baker.make_recipe('registration.tests.utils.contact', operator=operator, address=None)
         TestUtils.authorize_current_user_as_operator_user(self, operator)
         # Assert that we have only one contact(to make sure we are updating the contact and not creating a new one)
         assert Contact.objects.count() == 1

--- a/bc_obps/registration/tests/endpoints/v2/_facilities/_facility_id/test_facility_bcghg_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_facilities/_facility_id/test_facility_bcghg_id.py
@@ -6,7 +6,7 @@ from model_bakery import baker
 
 class TestFacilityBcghgIdEndpoint(CommonTestSetup):
     def test_authorized_role_can_issue_id(self):
-        timeline = baker.make_recipe('utils.facility_designated_operation_timeline', end_date=None)
+        timeline = baker.make_recipe('registration.tests.utils.facility_designated_operation_timeline', end_date=None)
         response = TestUtils.mock_patch_with_auth_role(
             self,
             'cas_director',

--- a/bc_obps/registration/tests/endpoints/v2/_facilities/test_facility_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_facilities/test_facility_id.py
@@ -70,7 +70,7 @@ class TestFacilityIdEndpoint(CommonTestSetup):
         operator = operator_baker()
         TestUtils.authorize_current_user_as_operator_user(self, operator)
         owning_operation: Operation = operation_baker(operator.id)
-        facility = baker.make_recipe('utils.facility')
+        facility = baker.make_recipe('registration.tests.utils.facility')
 
         baker.make(FacilityDesignatedOperationTimeline, operation=owning_operation, facility=facility)
         response = TestUtils.mock_get_with_auth_role(
@@ -82,7 +82,7 @@ class TestFacilityIdEndpoint(CommonTestSetup):
         assert response.json().get('name') is not None
 
     def test_industry_users_cannot_get_other_users_facilities(self):
-        facility = baker.make_recipe('utils.facility')
+        facility = baker.make_recipe('registration.tests.utils.facility')
         baker.make(FacilityDesignatedOperationTimeline, operation=operation_baker(), facility=facility)
 
         response = TestUtils.mock_get_with_auth_role(

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_new_entrant_application.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_new_entrant_application.py
@@ -11,9 +11,9 @@ from service.document_service_v2 import DocumentServiceV2
 
 class TestGetOperationNewEntrantApplicationEndpoint(CommonTestSetup):
     def test_get_register_operation_new_entrant_application_endpoint_users_can_only_get_their_operation(self):
-        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         operation: Operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
         )
         response = TestUtils.mock_get_with_auth_role(
             self,
@@ -24,9 +24,9 @@ class TestGetOperationNewEntrantApplicationEndpoint(CommonTestSetup):
         assert response.json()['message'] == "Unauthorized."
 
     def test_get_register_operation_new_entrant_application_endpoint_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             date_of_first_shipment=Operation.DateOfFirstShipmentChoices.ON_OR_AFTER_APRIL_1_2024,
         )
@@ -61,7 +61,7 @@ class TestPutOperationNewEntrantApplicationSubmissionEndpoint(CommonTestSetup):
         self,
     ):
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
         )
         TestUtils.authorize_current_user_as_operator_user(self, operator_baker())
         response = TestUtils.mock_put_with_auth_role(
@@ -81,8 +81,8 @@ class TestPutOperationNewEntrantApplicationSubmissionEndpoint(CommonTestSetup):
         reason="This test passes locally but will fail in CI since we don't have Google Cloud Storage set up for CI"
     )
     def test_put_register_operation_new_entrant_application_submission_endpoint(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
 
         # Act
         payload_with_no_date_of_first_shipment = {

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation.py
@@ -21,9 +21,9 @@ class TestPutOperationRegistrationInformationEndpoint(CommonTestSetup):
 
     def test_users_cannot_update_other_users_operations(self):
         # authorize current user
-        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
         )
         response = TestUtils.mock_put_with_auth_role(
             self,
@@ -35,8 +35,8 @@ class TestPutOperationRegistrationInformationEndpoint(CommonTestSetup):
         assert response.status_code == 401
 
     def test_register_edit_operation_information_endpoint_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         response = TestUtils.mock_put_with_auth_role(
             self,
             "industry_user",
@@ -52,8 +52,8 @@ class TestPutOperationRegistrationInformationEndpoint(CommonTestSetup):
         assert response_json['id'] == str(operation.id)
 
     def test_register_edit_operation_information_endpoint_fail(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         response = TestUtils.mock_put_with_auth_role(
             self,
             "industry_user",
@@ -71,9 +71,9 @@ class TestPutOperationRegistrationInformationEndpoint(CommonTestSetup):
 class TestGetOperationRegistrationInformationEndpoint(CommonTestSetup):
     def test_users_cannot_get_other_users_operations(self):
         # authorize current user
-        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
         )
         response = TestUtils.mock_get_with_auth_role(
             self,
@@ -83,9 +83,9 @@ class TestGetOperationRegistrationInformationEndpoint(CommonTestSetup):
         assert response.status_code == 401
 
     def test_register_get_operation_information_endpoint_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
-        baker.make_recipe('utils.multiple_operator', operation=operation)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
+        baker.make_recipe('registration.tests.utils.multiple_operator', operation=operation)
         response = TestUtils.mock_get_with_auth_role(
             self,
             "industry_user",

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation_representative.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_operation_representative.py
@@ -6,9 +6,9 @@ from model_bakery import baker
 class TestOperationRepresentativePostEndpoint(CommonTestSetup):
     def test_users_cannot_update_other_users_operations(self):
         # authorize current user
-        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
         )
 
         response = TestUtils.mock_post_with_auth_role(
@@ -33,10 +33,10 @@ class TestOperationRepresentativePostEndpoint(CommonTestSetup):
         assert response.json().get('message') == 'Unauthorized.'
 
     def test_operation_representative_endpoint_existing_contact_changing_prohibited_fields(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         users_operator = approved_user_operator.operator
-        operation = baker.make_recipe('utils.operation', operator=users_operator)
-        contact = baker.make_recipe('utils.contact', address=None)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=users_operator)
+        contact = baker.make_recipe('registration.tests.utils.contact', address=None)
         users_operator.contacts.add(contact)
         data = {
             'existing_contact_id': contact.id,
@@ -62,10 +62,10 @@ class TestOperationRepresentativePostEndpoint(CommonTestSetup):
         assert response.json().get('message') == "Cannot update first name, last name, or email of existing contact."
 
     def test_operation_representative_endpoint_existing_contact_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         users_operator = approved_user_operator.operator
-        operation = baker.make_recipe('utils.operation', operator=users_operator)
-        contact = baker.make_recipe('utils.contact', address=None)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=users_operator)
+        contact = baker.make_recipe('registration.tests.utils.contact', address=None)
         users_operator.contacts.add(contact)
         data = {
             'existing_contact_id': contact.id,
@@ -102,8 +102,8 @@ class TestOperationRepresentativePostEndpoint(CommonTestSetup):
         assert operation_contact_address.postal_code == "H0H 0H0"
 
     def test_operation_representative_endpoint_new_contact_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         data = {
             'first_name': 'John',
             'last_name': 'Doe',
@@ -142,8 +142,8 @@ class TestOperationRepresentativePostEndpoint(CommonTestSetup):
         assert approved_user_operator.operator.contacts.filter(id=new_contact_id).exists()
 
     def test_register_operation_operation_representative_endpoint_bad_data(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         response = TestUtils.mock_post_with_auth_role(
             self,
             "industry_user",
@@ -159,10 +159,10 @@ class TestOperationRepresentativePostEndpoint(CommonTestSetup):
 class TestOperationRepresentativePutEndpoint(CommonTestSetup):
     def test_users_cannot_update_other_users_operations(self):
         # authorize current user
-        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         # create operation not belonging to current user
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
         )
 
         response = TestUtils.mock_put_with_auth_role(
@@ -176,10 +176,10 @@ class TestOperationRepresentativePutEndpoint(CommonTestSetup):
         assert response.json().get('message') == 'Unauthorized.'
 
     def test_remove_operation_representative_endpoint_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         users_operator = approved_user_operator.operator
-        operation = baker.make_recipe('utils.operation', operator=users_operator)
-        contact = baker.make_recipe('utils.contact')
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=users_operator)
+        contact = baker.make_recipe('registration.tests.utils.contact')
         users_operator.contacts.add(contact)
         data = {
             'id': contact.id,
@@ -196,8 +196,8 @@ class TestOperationRepresentativePutEndpoint(CommonTestSetup):
         assert operation.contacts.count() == 0
 
     def test_remove_operation_representative_endpoint_bad_data(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         response = TestUtils.mock_post_with_auth_role(
             self,
             "industry_user",

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_opted_in_operation.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_opted_in_operation.py
@@ -6,9 +6,9 @@ from model_bakery import baker
 
 class TestOperationRegistrationOptedInOperationEndpoints(CommonTestSetup):
     def test_opted_in_operation_detail_endpoint_users_can_only_get_their_operation(self):
-        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         operation: Operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
         )
         response = TestUtils.mock_get_with_auth_role(
             self,
@@ -21,12 +21,14 @@ class TestOperationRegistrationOptedInOperationEndpoints(CommonTestSetup):
         assert response.json()['message'] == "Unauthorized."
 
     def test_get_opted_in_operation_detail_endpoint_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         opted_in_operation = baker.make_recipe(
-            'utils.opted_in_operation_detail',
+            'registration.tests.utils.opted_in_operation_detail',
         )
         operation: Operation = baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator, opted_in_operation=opted_in_operation
+            'registration.tests.utils.operation',
+            operator=approved_user_operator.operator,
+            opted_in_operation=opted_in_operation,
         )
         response = TestUtils.mock_get_with_auth_role(
             self,
@@ -50,9 +52,9 @@ class TestOperationRegistrationOptedInOperationEndpoints(CommonTestSetup):
     # PUT
     def test_opted_in_operation_detail_endpoint_users_can_only_update_their_operation(self):
         # authorize current user
-        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
         )
         response = TestUtils.mock_put_with_auth_role(
             self,
@@ -76,13 +78,15 @@ class TestOperationRegistrationOptedInOperationEndpoints(CommonTestSetup):
         assert response.json()['message'] == "Unauthorized."
 
     def test_update_opted_in_operation_detail_endpoint_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         opted_in_operation = baker.make_recipe(
-            'utils.opted_in_operation_detail',
+            'registration.tests.utils.opted_in_operation_detail',
             created_by=self.user,
         )
         operation: Operation = baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator, opted_in_operation=opted_in_operation
+            'registration.tests.utils.operation',
+            operator=approved_user_operator.operator,
+            opted_in_operation=opted_in_operation,
         )
         response = TestUtils.mock_put_with_auth_role(
             self,
@@ -119,13 +123,15 @@ class TestOperationRegistrationOptedInOperationEndpoints(CommonTestSetup):
         assert updated_operation.opted_in_operation.updated_at is not None
 
     def test_update_opted_in_operation_detail_endpoint_malformed_data(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         opted_in_operation = baker.make_recipe(
-            'utils.opted_in_operation_detail',
+            'registration.tests.utils.opted_in_operation_detail',
             created_by=self.user,
         )
         operation: Operation = baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator, opted_in_operation=opted_in_operation
+            'registration.tests.utils.operation',
+            operator=approved_user_operator.operator,
+            opted_in_operation=opted_in_operation,
         )
         response = TestUtils.mock_put_with_auth_role(
             self,

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_submission.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/_registration/test_submission.py
@@ -9,7 +9,7 @@ from model_bakery import baker
 class TestOperationRegistrationSubmissionEndpoint(CommonTestSetup):
     def test_submission_endpoint_users_can_only_update_their_operations(self):
         # user is approved to access endpoint
-        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
 
         # create operation that does not belong to user
         operation = set_up_valid_mock_operation(Operation.Purposes.POTENTIAL_REPORTING_OPERATION)
@@ -29,7 +29,7 @@ class TestOperationRegistrationSubmissionEndpoint(CommonTestSetup):
 
     def test_submission_endpoint_raises_exception_if_not_all_checkboxes_are_checked(self):
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
         )
         TestUtils.authorize_current_user_as_operator_user(self, operator_baker())
         response = TestUtils.mock_patch_with_auth_role(
@@ -47,7 +47,7 @@ class TestOperationRegistrationSubmissionEndpoint(CommonTestSetup):
         assert response.json()['message'] == "All checkboxes must be checked to submit the registration."
 
     def test_submission_endpoint_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         operation = set_up_valid_mock_operation(Operation.Purposes.POTENTIAL_REPORTING_OPERATION)
         operation.operator = approved_user_operator.operator
         operation.save()
@@ -69,8 +69,8 @@ class TestOperationRegistrationSubmissionEndpoint(CommonTestSetup):
         assert response_operation.status == Operation.Statuses.REGISTERED
 
     def test_submission_endpoint_malformed_data(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         response = TestUtils.mock_patch_with_auth_role(
             self,
             "industry_user",

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/test_bcghg_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/test_bcghg_id.py
@@ -6,7 +6,7 @@ from model_bakery import baker
 
 class TestOperationBcghgIdEndpoint(CommonTestSetup):
     def test_authorized_role_can_issue_id(self):
-        operation = baker.make_recipe('utils.operation')
+        operation = baker.make_recipe('registration.tests.utils.operation')
 
         response = TestUtils.mock_patch_with_auth_role(
             self,

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/test_boro_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/test_boro_id.py
@@ -14,7 +14,11 @@ class TestOperationBoroIdEndpoint(CommonTestSetup):
             {},
             custom_reverse_lazy(
                 "operation_boro_id",
-                kwargs={'operation_id': baker.make_recipe('utils.operation', status=Operation.Statuses.REGISTERED).id},
+                kwargs={
+                    'operation_id': baker.make_recipe(
+                        'registration.tests.utils.operation', status=Operation.Statuses.REGISTERED
+                    ).id
+                },
             ),
         )
         assert response.status_code == 200

--- a/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/test_facilities.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/_operation_id/test_facilities.py
@@ -14,7 +14,7 @@ class TestFacilitiesEndpoint(CommonTestSetup):
     # GET
     def test_facilities_endpoint_list_facilities_paginated(self):
 
-        timeline = baker.make_recipe('utils.facility_designated_operation_timeline', _quantity=45)
+        timeline = baker.make_recipe('registration.tests.utils.facility_designated_operation_timeline', _quantity=45)
 
         facilities_url = custom_reverse_lazy(
             'list_facilities_by_operation_id', kwargs={'operation_id': timeline[0].operation.id}
@@ -77,10 +77,14 @@ class TestFacilitiesEndpoint(CommonTestSetup):
         assert page_2_first_facility.id > page_2_first_facility_reverse.id
 
     def test_facilities_endpoint_list_facilities_with_filter(self):
-        timeline = baker.make_recipe('utils.facility_designated_operation_timeline', _quantity=15)
-        named_facility = baker.make_recipe('utils.facility', name='Mynameis', type=Facility.Types.MEDIUM_FACILITY)
+        timeline = baker.make_recipe('registration.tests.utils.facility_designated_operation_timeline', _quantity=15)
+        named_facility = baker.make_recipe(
+            'registration.tests.utils.facility', name='Mynameis', type=Facility.Types.MEDIUM_FACILITY
+        )
         baker.make_recipe(
-            'utils.facility_designated_operation_timeline', facility=named_facility, operation=timeline[0].operation
+            'registration.tests.utils.facility_designated_operation_timeline',
+            facility=named_facility,
+            operation=timeline[0].operation,
         )
 
         facilities_url = custom_reverse_lazy(
@@ -149,7 +153,7 @@ class TestFacilitiesEndpoint(CommonTestSetup):
         owning_operator = operator_baker()
         TestUtils.authorize_current_user_as_operator_user(self, owning_operator)
         owning_operation = operation_baker(owning_operator.id)
-        facility_instance = baker.make_recipe('utils.facility')
+        facility_instance = baker.make_recipe('registration.tests.utils.facility')
         mock_facility = {
             'name': facility_instance.name,
             'type': 'Large Facility',

--- a/bc_obps/registration/tests/endpoints/v2/_operations/test_current.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/test_current.py
@@ -5,11 +5,11 @@ from registration.utils import custom_reverse_lazy
 
 class TestOperationsCurrentEndpoint(CommonTestSetup):
     def test_get_current_users_operations(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
 
         # operation for a different user_operator
-        baker.make_recipe('utils.operation')
+        baker.make_recipe('registration.tests.utils.operation')
 
         response = TestUtils.mock_get_with_auth_role(
             self, 'industry_user', custom_reverse_lazy("list_current_users_operations")

--- a/bc_obps/registration/tests/endpoints/v2/_operations/test_operation_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operations/test_operation_id.py
@@ -79,9 +79,9 @@ class TestOperationIdEndpoint(CommonTestSetup):
         assert response_2.status_code == 401
 
     def test_operations_endpoint_get_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             registration_purpose='Potential Reporting Operation',
         )
@@ -94,8 +94,8 @@ class TestOperationIdEndpoint(CommonTestSetup):
         assert response_data.get("registration_purpose") == 'Potential Reporting Operation'
 
     def test_operations_with_documents_endpoint_get_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         response = TestUtils.mock_get_with_auth_role(
             self,
             "cas_admin",
@@ -106,11 +106,13 @@ class TestOperationIdEndpoint(CommonTestSetup):
         assert response_data.get("id") == str(operation.id)
 
     def test_operations_endpoint_put_success(self):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         operation = baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator, status=Operation.Statuses.REGISTERED
+            'registration.tests.utils.operation',
+            operator=approved_user_operator.operator,
+            status=Operation.Statuses.REGISTERED,
         )
-        contact = baker.make_recipe('utils.contact')
+        contact = baker.make_recipe('registration.tests.utils.contact')
         self.test_payload["operation_representatives"] = [contact.id]
         response = TestUtils.mock_put_with_auth_role(
             self,

--- a/bc_obps/registration/tests/endpoints/v2/_operators/_operator_id/test_confirm.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operators/_operator_id/test_confirm.py
@@ -14,7 +14,7 @@ class TestOperatorIdConfirmEndpoint(CommonTestSetup):
         Testing that the API endpoint fetches the operator for the given ID.
         """
 
-        operator = baker.make_recipe('utils.operator')
+        operator = baker.make_recipe('registration.tests.utils.operator')
         mock_get_operator_confirm.return_value = operator
         response = TestUtils.mock_get_with_auth_role(
             self,

--- a/bc_obps/registration/tests/endpoints/v2/_operators/test_operator_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_operators/test_operator_id.py
@@ -14,7 +14,7 @@ class TestOperatorIdEndpoint(CommonTestSetup):
         Testing that the API endpoint fetches the operator for the given ID.
         """
 
-        operator = baker.make_recipe('utils.operator')
+        operator = baker.make_recipe('registration.tests.utils.operator')
         mock_get_operator.return_value = operator
         # Act: Mock the authorization and perform the request
         TestUtils.authorize_current_user_as_operator_user(self, operator=operator)

--- a/bc_obps/registration/tests/endpoints/v2/_transfer_events/test_transfer_id.py
+++ b/bc_obps/registration/tests/endpoints/v2/_transfer_events/test_transfer_id.py
@@ -12,7 +12,9 @@ from datetime import datetime
 class TestTransferIdEndpoint(CommonTestSetup):
     @patch("service.transfer_event_service.TransferEventService.get_if_authorized")
     def test_authorized_users_can_get_transfer_event(self, mock_get_if_authorized: MagicMock):
-        transfer_event = baker.make_recipe('utils.transfer_event', operation=baker.make_recipe('utils.operation'))
+        transfer_event = baker.make_recipe(
+            'registration.tests.utils.transfer_event', operation=baker.make_recipe('registration.tests.utils.operation')
+        )
         mock_get_if_authorized.return_value = transfer_event
         for role in AppRole.get_authorized_irc_roles():
             response = TestUtils.mock_get_with_auth_role(
@@ -73,7 +75,9 @@ class TestTransferIdEndpoint(CommonTestSetup):
     @patch("service.transfer_event_service.TransferEventService.update_transfer_event")
     @pytest.mark.parametrize("entity", ["Operation", "Facility"])
     def test_cas_analyst_can_update_transfer_event(self, mock_update_transfer_event: MagicMock, entity):
-        transfer_event = baker.make_recipe('utils.transfer_event', operation=baker.make_recipe('utils.operation'))
+        transfer_event = baker.make_recipe(
+            'registration.tests.utils.transfer_event', operation=baker.make_recipe('registration.tests.utils.operation')
+        )
         mock_update_transfer_event.return_value = transfer_event
         mock_payload = {
             "transfer_entity": entity,

--- a/bc_obps/registration/tests/endpoints/v2/_user_operators/_user_operator_id/test_user_operator_update_status.py
+++ b/bc_obps/registration/tests/endpoints/v2/_user_operators/_user_operator_id/test_user_operator_update_status.py
@@ -73,9 +73,11 @@ class TestUpdateUserOperatorStatusEndpoint(CommonTestSetup):
     def test_cas_analyst_approves_access_request_with_existing_operator(self, mocker):
 
         approved_admin_user_operator = baker.make_recipe(
-            'utils.approved_user_operator', role=UserOperator.Roles.ADMIN, user=self.user
+            'registration.tests.utils.approved_user_operator', role=UserOperator.Roles.ADMIN, user=self.user
         )
-        pending_user_operator = baker.make_recipe('utils.user_operator', operator=approved_admin_user_operator.operator)
+        pending_user_operator = baker.make_recipe(
+            'registration.tests.utils.user_operator', operator=approved_admin_user_operator.operator
+        )
 
         pending_user_operator.user.business_guid = approved_admin_user_operator.user.business_guid
 

--- a/bc_obps/registration/tests/endpoints/v2/test_operations.py
+++ b/bc_obps/registration/tests/endpoints/v2/test_operations.py
@@ -21,11 +21,13 @@ class TestOperationsEndpoint(CommonTestSetup):
         """
 
         # Arrange: Mock facilities returned by the service
-        timeline = make_recipe('utils.operation_designated_operator_timeline', _quantity=2)
+        timeline = make_recipe('registration.tests.utils.operation_designated_operator_timeline', _quantity=2)
         mock_list_operations_timeline.return_value = timeline
 
         # Act: Mock the authorization and perform the request
-        TestUtils.authorize_current_user_as_operator_user(self, operator=make_recipe('utils.operator'))
+        TestUtils.authorize_current_user_as_operator_user(
+            self, operator=make_recipe('registration.tests.utils.operator')
+        )
         response = TestUtils.mock_get_with_auth_role(
             self,
             "industry_user",
@@ -73,7 +75,7 @@ class TestPostOperationsEndpoint(CommonTestSetup):
 
     # GET
     def test_user_can_post_operation_success(self):
-        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         response = TestUtils.mock_post_with_auth_role(
             self,
             "industry_user",

--- a/bc_obps/registration/tests/endpoints/v2/test_registration_purpose_endpoint.py
+++ b/bc_obps/registration/tests/endpoints/v2/test_registration_purpose_endpoint.py
@@ -6,7 +6,7 @@ from model_bakery import baker
 
 class TestRegistrationPurposesEndpoint(CommonTestSetup):
     def test_users_can_get_registration_purposes(self):
-        baker.make_recipe('utils.approved_user_operator', user=self.user)
+        baker.make_recipe('registration.tests.utils.approved_user_operator', user=self.user)
         response = TestUtils.mock_get_with_auth_role(
             self, "industry_user", custom_reverse_lazy('get_registration_purposes')
         )

--- a/bc_obps/registration/tests/endpoints/v2/test_transfer_events.py
+++ b/bc_obps/registration/tests/endpoints/v2/test_transfer_events.py
@@ -12,12 +12,18 @@ from registration.utils import custom_reverse_lazy
 
 class TestTransferEventEndpoint(CommonTestSetup):
     url = custom_reverse_lazy('list_transfer_events')
+
     # GET
     def test_list_transfer_events_unpaginated(self):
         # transfer of an operation
-        baker.make_recipe('utils.transfer_event', operation=baker.make_recipe('utils.operation'))
+        baker.make_recipe(
+            'registration.tests.utils.transfer_event', operation=baker.make_recipe('registration.tests.utils.operation')
+        )
         # transfer of 50 facilities
-        baker.make_recipe('utils.transfer_event', facilities=baker.make_recipe('utils.facility', _quantity=50))
+        baker.make_recipe(
+            'registration.tests.utils.transfer_event',
+            facilities=baker.make_recipe('registration.tests.utils.facility', _quantity=50),
+        )
         for role in ['cas_admin', 'cas_analyst']:
             response = TestUtils.mock_get_with_auth_role(self, role, self.url + "?paginate_result=False")
             assert response.status_code == 200
@@ -41,9 +47,15 @@ class TestTransferEventEndpoint(CommonTestSetup):
 
         for _ in range(20):
             # transfer of an operation
-            baker.make_recipe('utils.transfer_event', operation=baker.make_recipe('utils.operation'))
+            baker.make_recipe(
+                'registration.tests.utils.transfer_event',
+                operation=baker.make_recipe('registration.tests.utils.operation'),
+            )
             # transfer of 50 facilities
-            baker.make_recipe('utils.transfer_event', facilities=baker.make_recipe('utils.facility', _quantity=2))
+            baker.make_recipe(
+                'registration.tests.utils.transfer_event',
+                facilities=baker.make_recipe('registration.tests.utils.facility', _quantity=2),
+            )
         # Get the default page 1 response
         response = TestUtils.mock_get_with_auth_role(self, "cas_admin", custom_reverse_lazy("list_transfer_events"))
         assert response.status_code == 200
@@ -87,12 +99,16 @@ class TestTransferEventEndpoint(CommonTestSetup):
         today = timezone.make_aware(datetime.now())
         yesterday = today - timedelta(days=1)
         # transfer of an operation
-        baker.make_recipe('utils.transfer_event', operation=baker.make_recipe('utils.operation'), effective_date=today)
+        baker.make_recipe(
+            'registration.tests.utils.transfer_event',
+            operation=baker.make_recipe('registration.tests.utils.operation'),
+            effective_date=today,
+        )
         # transfer of 50 facilities
         baker.make_recipe(
-            'utils.transfer_event',
+            'registration.tests.utils.transfer_event',
             effective_date=yesterday,
-            facilities=baker.make_recipe('utils.facility', _quantity=50),
+            facilities=baker.make_recipe('registration.tests.utils.facility', _quantity=50),
         )
 
         response_ascending = TestUtils.mock_get_with_auth_role(
@@ -110,9 +126,15 @@ class TestTransferEventEndpoint(CommonTestSetup):
 
     def test_transfer_events_endpoint_list_transfer_events_with_filter(self):
         # transfer of an operation
-        baker.make_recipe('utils.transfer_event', operation=baker.make_recipe('utils.operation', name='Test Operation'))
+        baker.make_recipe(
+            'registration.tests.utils.transfer_event',
+            operation=baker.make_recipe('registration.tests.utils.operation', name='Test Operation'),
+        )
         # transfer of 50 facilities
-        baker.make_recipe('utils.transfer_event', facilities=baker.make_recipe('utils.facility', _quantity=50))
+        baker.make_recipe(
+            'registration.tests.utils.transfer_event',
+            facilities=baker.make_recipe('registration.tests.utils.facility', _quantity=50),
+        )
 
         # Get the default page 1 response
         response = TestUtils.mock_get_with_auth_role(
@@ -154,8 +176,8 @@ class TestTransferEventEndpoint(CommonTestSetup):
         }
 
         mock_transfer_event = baker.make_recipe(
-            'utils.transfer_event',
-            operation=baker.make_recipe('utils.operation'),
+            'registration.tests.utils.transfer_event',
+            operation=baker.make_recipe('registration.tests.utils.operation'),
             status=TransferEvent.Statuses.TRANSFERRED,
         )
         mock_create_transfer_event.return_value = mock_transfer_event

--- a/bc_obps/registration/tests/endpoints/v2/test_user_operators.py
+++ b/bc_obps/registration/tests/endpoints/v2/test_user_operators.py
@@ -274,7 +274,9 @@ class TestListUserOperators(CommonTestSetup):
     def test_list_user_operators_v2_paginated(self):
         for _ in range(50):
             baker.make_recipe(
-                'utils.user_operator', role=UserOperator.Roles.ADMIN, status=UserOperator.Statuses.APPROVED
+                'registration.tests.utils.user_operator',
+                role=UserOperator.Roles.ADMIN,
+                status=UserOperator.Statuses.APPROVED,
             )
         # Get the default page 1 response
         response = TestUtils.mock_get_with_auth_role(self, "cas_admin", self.url)
@@ -322,28 +324,36 @@ class TestListUserOperators(CommonTestSetup):
 
     def test_list_user_operators_v2_with_filter(self):
         baker.make_recipe(
-            'utils.user_operator',
+            'registration.tests.utils.user_operator',
             role=UserOperator.Roles.ADMIN,
             status=UserOperator.Statuses.APPROVED,
-            user=baker.make_recipe('utils.industry_operator_user', first_name="Jane", last_name="Doe"),
+            user=baker.make_recipe(
+                'registration.tests.utils.industry_operator_user', first_name="Jane", last_name="Doe"
+            ),
         )
         baker.make_recipe(
-            'utils.user_operator',
+            'registration.tests.utils.user_operator',
             role=UserOperator.Roles.ADMIN,
             status=UserOperator.Statuses.APPROVED,
-            user=baker.make_recipe('utils.industry_operator_user', first_name="Bob", last_name="Smith"),
+            user=baker.make_recipe(
+                'registration.tests.utils.industry_operator_user', first_name="Bob", last_name="Smith"
+            ),
         )
         baker.make_recipe(
-            'utils.user_operator',
+            'registration.tests.utils.user_operator',
             role=UserOperator.Roles.ADMIN,
             status=UserOperator.Statuses.DECLINED,
-            user=baker.make_recipe('utils.industry_operator_user', first_name="John", last_name="Doe"),
+            user=baker.make_recipe(
+                'registration.tests.utils.industry_operator_user', first_name="John", last_name="Doe"
+            ),
         )
         baker.make_recipe(
-            'utils.user_operator',
+            'registration.tests.utils.user_operator',
             role=UserOperator.Roles.ADMIN,
             status=UserOperator.Statuses.DECLINED,
-            user=baker.make_recipe('utils.industry_operator_user', first_name="Henry", last_name="Ives"),
+            user=baker.make_recipe(
+                'registration.tests.utils.industry_operator_user', first_name="Henry", last_name="Ives"
+            ),
         )
 
         # Get the default page 1 response
@@ -381,7 +391,9 @@ class TestListUserOperators(CommonTestSetup):
             # add 2 approved admin user operators to test the endpoint
             approved_admin_user_operators.append(
                 baker.make_recipe(
-                    'utils.user_operator', role=UserOperator.Roles.ADMIN, status=UserOperator.Statuses.APPROVED
+                    'registration.tests.utils.user_operator',
+                    role=UserOperator.Roles.ADMIN,
+                    status=UserOperator.Statuses.APPROVED,
                 )
             )
         response = TestUtils.mock_get_with_auth_role(self, "cas_admin", self.url)

--- a/bc_obps/registration/tests/integration/test_changing_registration_purpose.py
+++ b/bc_obps/registration/tests/integration/test_changing_registration_purpose.py
@@ -25,10 +25,12 @@ class TestChangingRegistrationPurpose(CommonTestSetup):
         return {"date_of_first_shipment": "On or after April 1, 2024", "new_entrant_application": MOCK_DATA_URL}
 
     def _prepare_test_data(self, registration_purpose):
-        self.approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        contact = baker.make_recipe('utils.contact')
+        self.approved_user_operator = baker.make_recipe(
+            'registration.tests.utils.approved_user_operator', user=self.user
+        )
+        contact = baker.make_recipe('registration.tests.utils.contact')
         self.operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             created_by=self.user,
             operator=self.approved_user_operator.operator,
             registration_purpose=registration_purpose,

--- a/bc_obps/registration/tests/integration/test_operation_registration.py
+++ b/bc_obps/registration/tests/integration/test_operation_registration.py
@@ -11,13 +11,15 @@ from registration.utils import custom_reverse_lazy
 
 class TestOperationRegistration(CommonTestSetup):
     def _prepare_test_data(self, operation_type: OperationTypes):
-        self.approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=self.user)
-        self.bcghg_id = baker.make_recipe('utils.bcghg_id')
-        self.boro_id = baker.make_recipe('utils.boro_id')
+        self.approved_user_operator = baker.make_recipe(
+            'registration.tests.utils.approved_user_operator', user=self.user
+        )
+        self.bcghg_id = baker.make_recipe('registration.tests.utils.bcghg_id')
+        self.boro_id = baker.make_recipe('registration.tests.utils.boro_id')
         # add some random contacts and facilities so we can test that they are not overridden
-        random_contacts = baker.make_recipe('utils.contact', _quantity=5)
+        random_contacts = baker.make_recipe('registration.tests.utils.contact', _quantity=5)
         self.operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             created_by=self.user,
             operator=self.approved_user_operator.operator,
             bcghg_id=self.bcghg_id,
@@ -28,7 +30,7 @@ class TestOperationRegistration(CommonTestSetup):
         # add some facilities so we can test that they are not overridden
         if operation_type == OperationTypes.LFO:
             baker.make_recipe(
-                'utils.facility_designated_operation_timeline',
+                'registration.tests.utils.facility_designated_operation_timeline',
                 operation=self.operation,
                 status=FacilityDesignatedOperationTimeline.Statuses.ACTIVE,
                 _quantity=5,

--- a/bc_obps/registration/tests/models/event/event_base_model_mixin.py
+++ b/bc_obps/registration/tests/models/event/event_base_model_mixin.py
@@ -9,9 +9,9 @@ from zoneinfo import ZoneInfo
 class EventBaseModelMixin(BaseTestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.operation: Operation = baker.make_recipe('utils.operation')
-        cls.facility1: Facility = baker.make_recipe('utils.facility')
-        cls.facility2: Facility = baker.make_recipe('utils.facility')
+        cls.operation: Operation = baker.make_recipe('registration.tests.utils.operation')
+        cls.facility1: Facility = baker.make_recipe('registration.tests.utils.facility')
+        cls.facility2: Facility = baker.make_recipe('registration.tests.utils.facility')
 
     def create_event_with_operation_only(self, *args, **kwargs):
         event = self.model.objects.create(

--- a/bc_obps/registration/tests/models/event/test_transfer.py
+++ b/bc_obps/registration/tests/models/event/test_transfer.py
@@ -45,10 +45,10 @@ class TransferEventModelTest(EventBaseModelMixin):
             ("from_operation", "from operation", None, None),
             ("to_operation", "to operation", None, None),
         ]
-        cls.from_operator: Operator = baker.make_recipe('utils.operator')
-        cls.to_operator: Operator = baker.make_recipe('utils.operator')
-        cls.from_operation: Operation = baker.make_recipe('utils.operation')
-        cls.to_operation: Operation = baker.make_recipe('utils.operation')
+        cls.from_operator: Operator = baker.make_recipe('registration.tests.utils.operator')
+        cls.to_operator: Operator = baker.make_recipe('registration.tests.utils.operator')
+        cls.from_operation: Operation = baker.make_recipe('registration.tests.utils.operation')
+        cls.to_operation: Operation = baker.make_recipe('registration.tests.utils.operation')
         super().setUpTestData()
 
     def test_event_with_operation_only(self):

--- a/bc_obps/registration/tests/models/test_facility.py
+++ b/bc_obps/registration/tests/models/test_facility.py
@@ -59,9 +59,11 @@ class FacilityModelTest(BaseTestCase):
     def test_generate_unique_bcghg_id_multiple_existing_ids_facility(self):
         existing_ids = ['13221210001', '13221210002', '13221210003', '23221210001', '23221210002', '14862100001']
         for existing_id in existing_ids:
-            baker.make_recipe('utils.operation', bcghg_id=baker.make(BcGreenhouseGasId, id=existing_id))
+            baker.make_recipe(
+                'registration.tests.utils.operation', bcghg_id=baker.make(BcGreenhouseGasId, id=existing_id)
+            )
         facility_designated_operation_timeline = baker.make_recipe(
-            'utils.facility_designated_operation_timeline', facility=self.test_object, end_date=None
+            'registration.tests.utils.facility_designated_operation_timeline', facility=self.test_object, end_date=None
         )
         facility_designated_operation_timeline.operation.type = 'Single Facility Operation'
         facility_designated_operation_timeline.operation.naics_code = baker.make(NaicsCode, naics_code='322121')

--- a/bc_obps/registration/tests/models/test_operation.py
+++ b/bc_obps/registration/tests/models/test_operation.py
@@ -42,7 +42,7 @@ class OperationModelTest(BaseTestCase):
     @classmethod
     def setUpTestData(cls):
         cls.test_object = baker.make_recipe(
-            'utils.operation', swrs_facility_id=6565, status=Operation.Statuses.REGISTERED
+            'registration.tests.utils.operation', swrs_facility_id=6565, status=Operation.Statuses.REGISTERED
         )
         Operation.objects.filter(swrs_facility_id__isnull=False).first()
 
@@ -196,7 +196,9 @@ class OperationModelTest(BaseTestCase):
     def test_generate_unique_bcghg_id_multiple_existing_ids(self):
         existing_ids = ['13221210001', '13221210002', '13221210003', '23221210001', '23221210002', '14862100001']
         for existing_id in existing_ids:
-            baker.make_recipe('utils.operation', bcghg_id=baker.make(BcGreenhouseGasId, id=existing_id))
+            baker.make_recipe(
+                'registration.tests.utils.operation', bcghg_id=baker.make(BcGreenhouseGasId, id=existing_id)
+            )
 
         self.test_object.bcghg_id = None
         self.test_object.type = 'Single Facility Operation'
@@ -206,13 +208,15 @@ class OperationModelTest(BaseTestCase):
         assert self.test_object.bcghg_id.pk == expected_id
 
     def test_user_has_access_to_operation(self):
-        random_user_operator = baker.make_recipe('utils.user_operator')
+        random_user_operator = baker.make_recipe('registration.tests.utils.user_operator')
         operation_for_random_user_operator = baker.make_recipe(
-            'utils.operation', operator=random_user_operator.operator
+            'registration.tests.utils.operation', operator=random_user_operator.operator
         )
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator', user=User.objects.first())
+        approved_user_operator = baker.make_recipe(
+            'registration.tests.utils.approved_user_operator', user=User.objects.first()
+        )
         operation_for_approved_user_operator = baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator
+            'registration.tests.utils.operation', operator=approved_user_operator.operator
         )
         self.assertFalse(
             operation_for_random_user_operator.user_has_access(approved_user_operator.user.user_guid),

--- a/bc_obps/registration/tests/models/test_operation_designated_operator_timeline.py
+++ b/bc_obps/registration/tests/models/test_operation_designated_operator_timeline.py
@@ -8,7 +8,7 @@ from registration.tests.constants import (
 class OperationDesignatedOperatorTimelineModelTest(BaseTestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.test_object = baker.make_recipe('utils.operation_designated_operator_timeline')
+        cls.test_object = baker.make_recipe('registration.tests.utils.operation_designated_operator_timeline')
         cls.field_data = [
             *TIMESTAMP_COMMON_FIELDS,
             ("id", "ID", None, None),

--- a/bc_obps/registration/tests/models/test_timestamped_model.py
+++ b/bc_obps/registration/tests/models/test_timestamped_model.py
@@ -11,7 +11,7 @@ class TestTimeStampedModel:
     def test_create_update_audit_fields():
         # Create a timestamped table (operator)
         operator = baker.make_recipe(
-            'utils.operator',
+            'registration.tests.utils.operator',
         )
 
         # Update a timestamped table (operator)

--- a/bc_obps/registration/tests/test_utils.py
+++ b/bc_obps/registration/tests/test_utils.py
@@ -328,33 +328,33 @@ class TestFileHashComparison(TestCase):
 class TestGenerateUniqueBcghgIdForOperationOrFacility(TestCase):
     def test_cannot_create_operation_with_duplicate_bcghg_id(self):
         bcghg_id_instance = baker.make(BcGreenhouseGasId, id='14121100001')
-        operation_instance: Operation = baker.make_recipe('utils.operation')
+        operation_instance: Operation = baker.make_recipe('registration.tests.utils.operation')
         operation_instance.bcghg_id = bcghg_id_instance
         operation_instance.save(update_fields=['bcghg_id'])
         with pytest.raises(ValidationError, match='Operation with this Bcghg id already exists.'):
-            baker.make_recipe('utils.operation', bcghg_id=bcghg_id_instance)
+            baker.make_recipe('registration.tests.utils.operation', bcghg_id=bcghg_id_instance)
 
     def test_cannot_create_facility_with_duplicate_bcghg_id(self):
         bcghg_id_instance = baker.make(BcGreenhouseGasId, id='14121100001')
-        facility_instance: Facility = baker.make_recipe('utils.facility')
+        facility_instance: Facility = baker.make_recipe('registration.tests.utils.facility')
         facility_instance.bcghg_id = bcghg_id_instance
         facility_instance.save(update_fields=['bcghg_id'])
         with pytest.raises(ValidationError, match='Facility with this Bcghg id already exists.'):
-            baker.make_recipe('utils.facility', bcghg_id=bcghg_id_instance)
+            baker.make_recipe('registration.tests.utils.facility', bcghg_id=bcghg_id_instance)
 
     def test_does_not_generate_if_record_has_existing_bcghg_id(self):
         existing_id = baker.make(BcGreenhouseGasId, id='14121100001')
-        operation: Operation = baker.make_recipe('utils.operation', bcghg_id=existing_id)
+        operation: Operation = baker.make_recipe('registration.tests.utils.operation', bcghg_id=existing_id)
         operation.generate_unique_bcghg_id()
         assert operation.bcghg_id == existing_id
 
     def test_does_not_generate_for_operation_if_type_is_invalid(self):
-        operation: Operation = baker.make_recipe('utils.operation', type='Not my type')
+        operation: Operation = baker.make_recipe('registration.tests.utils.operation', type='Not my type')
         with pytest.raises(ValueError, match='Invalid operation type: Not my type'):
             operation.generate_unique_bcghg_id()
 
     def test_does_not_generate_for_facility_if_type_is_invalid(self):
-        timeline = baker.make_recipe('utils.facility_designated_operation_timeline')
+        timeline = baker.make_recipe('registration.tests.utils.facility_designated_operation_timeline')
         timeline.end_date = None
         timeline.save()
         timeline.operation.type = 'Not my type'
@@ -363,13 +363,13 @@ class TestGenerateUniqueBcghgIdForOperationOrFacility(TestCase):
             timeline.facility.generate_unique_bcghg_id()
 
     def test_generate_unique_bcghg_id_for_operation(self):
-        operation: Operation = baker.make_recipe('utils.operation', type='Linear Facility Operation')
+        operation: Operation = baker.make_recipe('registration.tests.utils.operation', type='Linear Facility Operation')
         operation.generate_unique_bcghg_id()
         expected_id = f'2{operation.naics_code.naics_code}0001'
         assert operation.bcghg_id.pk == expected_id
 
     def test_generate_unique_bcghg_id_for_facility(self):
-        timeline = baker.make_recipe('utils.facility_designated_operation_timeline')
+        timeline = baker.make_recipe('registration.tests.utils.facility_designated_operation_timeline')
         timeline.end_date = None
         timeline.save()
         timeline.operation.type = 'Linear Facility Operation'

--- a/bc_obps/registration/tests/utils/helpers.py
+++ b/bc_obps/registration/tests/utils/helpers.py
@@ -91,10 +91,10 @@ class TestUtils:
             - `owning_operation`: The created operation instance associated with the operator.
         """
         # Create an operator instance
-        operator = baker.make_recipe('utils.operator')
+        operator = baker.make_recipe('registration.tests.utils.operator')
 
         # Create an operation instance associated with the operator
-        owning_operation = baker.make_recipe('utils.operation', operator=operator)
+        owning_operation = baker.make_recipe('registration.tests.utils.operation', operator=operator)
 
         # Return the created operator and operation instances
         return operator, owning_operation
@@ -132,9 +132,9 @@ class TestUtils:
 
         # Create a facility, optionally with an address
         facility = baker.make_recipe(
-            'utils.facility',
+            'registration.tests.utils.facility',
             operation=owning_operation,
-            address=baker.make_recipe('utils.address') if with_address else None,
+            address=baker.make_recipe('registration.tests.utils.address') if with_address else None,
         )
 
         # Link the created facility with the operation
@@ -227,7 +227,7 @@ class TestUtils:
     @staticmethod
     def mock_update_operation_payload():
         naics_code = baker.make(NaicsCode, naics_code=123456, naics_description='desc')
-        point_of_contact = baker.make_recipe('utils.contact')
+        point_of_contact = baker.make_recipe('registration.tests.utils.contact')
         product = baker.make(RegulatedProduct)
         operation = operation_baker()
         operation.regulated_products.set([product.id])

--- a/bc_obps/reporting/tests/models/test_facility_report.py
+++ b/bc_obps/reporting/tests/models/test_facility_report.py
@@ -12,7 +12,7 @@ from reporting.tests.utils.immutable_report_version import (
 class FacilityReportModelTest(BaseTestCase):
     @classmethod
     def setUpTestData(cls):
-        f = baker.make_recipe("utils.facility")
+        f = baker.make_recipe('registration.tests.utils.facility')
 
         cls.test_object = FacilityReport.objects.create(
             facility=f,

--- a/bc_obps/reporting/tests/utils/report_data_bakers.py
+++ b/bc_obps/reporting/tests/utils/report_data_bakers.py
@@ -20,7 +20,7 @@ from reporting.tests.utils.bakers import report_version_baker, activity_baker, s
 def facility_report_baker(**props):
     report_version = props.get('report_version') or report_version_baker()
     default_props = {
-        "facility": baker.make_recipe('utils.facility'),
+        "facility": baker.make_recipe('registration.tests.utils.facility'),
         "report_version": report_version,
     }
     return baker.make(FacilityReport, **(default_props | props))

--- a/bc_obps/service/tests/data_access_service/test_data_access_contact_service.py
+++ b/bc_obps/service/tests/data_access_service/test_data_access_contact_service.py
@@ -18,8 +18,8 @@ pytestmark = pytest.mark.django_db
 class TestDataAccessContactService:
     @staticmethod
     def test_list_contacts_for_irc_user():
-        baker.make_recipe('utils.contact', _quantity=10)
-        user = baker.make_recipe('utils.cas_admin')
+        baker.make_recipe('registration.tests.utils.contact', _quantity=10)
+        user = baker.make_recipe('registration.tests.utils.cas_admin')
         assert ContactDataAccessService.get_all_contacts_for_user(user).count() == 10
 
     @staticmethod

--- a/bc_obps/service/tests/data_access_service/test_data_access_operation_designated_operator_timeline.py
+++ b/bc_obps/service/tests/data_access_service/test_data_access_operation_designated_operator_timeline.py
@@ -15,23 +15,23 @@ class TestDataAccessOperationDesignatedOperatorTimelineService:
     def test_unapproved_user_exception():
         with pytest.raises(Exception, match=UNAUTHORIZED_MESSAGE):
             OperationDesignatedOperatorTimelineDataAccessService.get_operation_timeline_for_user(
-                baker.make_recipe('utils.industry_operator_user')
+                baker.make_recipe('registration.tests.utils.industry_operator_user')
             )
 
     @staticmethod
     def test_get_operations_for_industry_user():
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
 
         # transferred operation - should not be returned
         baker.make_recipe(
-            'utils.operation_designated_operator_timeline',
+            'registration.tests.utils.operation_designated_operator_timeline',
             status=OperationDesignatedOperatorTimeline.Statuses.TRANSFERRED,
             operator=approved_user_operator.operator,
         )
 
         # closed operations
         baker.make_recipe(
-            'utils.operation_designated_operator_timeline',
+            'registration.tests.utils.operation_designated_operator_timeline',
             status=OperationDesignatedOperatorTimeline.Statuses.CLOSED,
             operator=approved_user_operator.operator,
             _quantity=20,
@@ -39,7 +39,7 @@ class TestDataAccessOperationDesignatedOperatorTimelineService:
 
         # someone else's operations - should not be returned
         baker.make_recipe(
-            'utils.operation_designated_operator_timeline',
+            'registration.tests.utils.operation_designated_operator_timeline',
             status=OperationDesignatedOperatorTimeline.Statuses.CLOSED,
             _quantity=5,
         )
@@ -55,27 +55,27 @@ class TestDataAccessOperationDesignatedOperatorTimelineService:
 
         # non-registered operation - should not be returned
         baker.make_recipe(
-            'utils.operation_designated_operator_timeline',
-            operation=baker.make_recipe('utils.operation', status=Operation.Statuses.DRAFT),
+            'registration.tests.utils.operation_designated_operator_timeline',
+            operation=baker.make_recipe('registration.tests.utils.operation', status=Operation.Statuses.DRAFT),
         )
 
         # transferred operation
         baker.make_recipe(
-            'utils.operation_designated_operator_timeline',
-            operation=baker.make_recipe('utils.operation', status=Operation.Statuses.REGISTERED),
+            'registration.tests.utils.operation_designated_operator_timeline',
+            operation=baker.make_recipe('registration.tests.utils.operation', status=Operation.Statuses.REGISTERED),
             status=OperationDesignatedOperatorTimeline.Statuses.TRANSFERRED,
         )
 
         # closed operations
         baker.make_recipe(
-            'utils.operation_designated_operator_timeline',
-            operation=baker.make_recipe('utils.operation', status=Operation.Statuses.REGISTERED),
+            'registration.tests.utils.operation_designated_operator_timeline',
+            operation=baker.make_recipe('registration.tests.utils.operation', status=Operation.Statuses.REGISTERED),
             status=OperationDesignatedOperatorTimeline.Statuses.CLOSED,
             _quantity=20,
         )
 
         timeline = OperationDesignatedOperatorTimelineDataAccessService.get_operation_timeline_for_user(
-            baker.make_recipe('utils.cas_admin')
+            baker.make_recipe('registration.tests.utils.cas_admin')
         )
 
         assert timeline.count() == 21

--- a/bc_obps/service/tests/data_access_service/test_data_access_user_operator_service.py
+++ b/bc_obps/service/tests/data_access_service/test_data_access_user_operator_service.py
@@ -13,8 +13,8 @@ class TestDataAccessUserOperatorService:
     @staticmethod
     def test_get_admin_user_operator_requests_for_irc_users():
         # Prepare operators
-        declined_operator = baker.make_recipe('utils.operator', status=Operator.Statuses.DECLINED)
-        approved_operator = baker.make_recipe('utils.operator', status=Operator.Statuses.APPROVED)
+        declined_operator = baker.make_recipe('registration.tests.utils.operator', status=Operator.Statuses.DECLINED)
+        approved_operator = baker.make_recipe('registration.tests.utils.operator', status=Operator.Statuses.APPROVED)
 
         user_operators_with_declined_operator = []
         approved_admin_user_operators = []
@@ -27,8 +27,8 @@ class TestDataAccessUserOperatorService:
         # Declined operator with user operators (should be excluded in final result)
         user_operators_with_declined_operator.extend(
             baker.make_recipe(
-                'utils.user_operator',
-                user=cycle(baker.make_recipe('utils.industry_operator_user', _quantity=5)),
+                'registration.tests.utils.user_operator',
+                user=cycle(baker.make_recipe('registration.tests.utils.industry_operator_user', _quantity=5)),
                 role=UserOperator.Roles.ADMIN,
                 status=UserOperator.Statuses.PENDING,
                 operator=declined_operator,
@@ -39,8 +39,8 @@ class TestDataAccessUserOperatorService:
         # Approved admin user operators (should be included in final result)
         approved_admin_user_operators.extend(
             baker.make_recipe(
-                'utils.user_operator',
-                user=cycle(baker.make_recipe('utils.industry_operator_user', _quantity=5)),
+                'registration.tests.utils.user_operator',
+                user=cycle(baker.make_recipe('registration.tests.utils.industry_operator_user', _quantity=5)),
                 role=UserOperator.Roles.ADMIN,
                 status=UserOperator.Statuses.APPROVED,
                 _quantity=5,
@@ -50,8 +50,8 @@ class TestDataAccessUserOperatorService:
         # Pending(status) admin user operators for approved operator (should be included in final result)
         pending_admin_user_operators_for_approved_operator.extend(
             baker.make_recipe(
-                'utils.user_operator',
-                user=cycle(baker.make_recipe('utils.industry_operator_user', _quantity=5)),
+                'registration.tests.utils.user_operator',
+                user=cycle(baker.make_recipe('registration.tests.utils.industry_operator_user', _quantity=5)),
                 operator=approved_operator,
                 role=UserOperator.Roles.ADMIN,
                 status=UserOperator.Statuses.PENDING,
@@ -62,8 +62,8 @@ class TestDataAccessUserOperatorService:
         # Declined admin user operators (should be included in final result)
         declined_admin_user_operators.extend(
             baker.make_recipe(
-                'utils.user_operator',
-                user=cycle(baker.make_recipe('utils.industry_operator_user', _quantity=5)),
+                'registration.tests.utils.user_operator',
+                user=cycle(baker.make_recipe('registration.tests.utils.industry_operator_user', _quantity=5)),
                 role=UserOperator.Roles.ADMIN,
                 status=UserOperator.Statuses.DECLINED,
                 _quantity=5,
@@ -73,8 +73,8 @@ class TestDataAccessUserOperatorService:
         # Declined pending (role) user operators (should be included in final result only if no approved admin exists)
         declined_pending_user_operators.extend(
             baker.make_recipe(
-                'utils.user_operator',
-                user=cycle(baker.make_recipe('utils.industry_operator_user', _quantity=5)),
+                'registration.tests.utils.user_operator',
+                user=cycle(baker.make_recipe('registration.tests.utils.industry_operator_user', _quantity=5)),
                 role=UserOperator.Roles.PENDING,
                 status=UserOperator.Statuses.DECLINED,
                 _quantity=5,
@@ -84,8 +84,8 @@ class TestDataAccessUserOperatorService:
         # Pending (role/status) user operators for the approved operator(should be excluded due to approved admin user)
         pending_user_operators_with_pending_status.extend(
             baker.make_recipe(
-                'utils.user_operator',
-                user=cycle(baker.make_recipe('utils.industry_operator_user', _quantity=5)),
+                'registration.tests.utils.user_operator',
+                user=cycle(baker.make_recipe('registration.tests.utils.industry_operator_user', _quantity=5)),
                 role=UserOperator.Roles.PENDING,
                 status=UserOperator.Statuses.PENDING,
                 operator=approved_operator,
@@ -95,7 +95,7 @@ class TestDataAccessUserOperatorService:
 
         # Add approved admin user for the approved operator (to prevent showing pending(status) user operators for this operator)
         approved_user_operator_for_approved_operator = baker.make_recipe(
-            'utils.user_operator',
+            'registration.tests.utils.user_operator',
             role=UserOperator.Roles.ADMIN,
             status=UserOperator.Statuses.APPROVED,
             operator=approved_operator,

--- a/bc_obps/service/tests/test_contact_service.py
+++ b/bc_obps/service/tests/test_contact_service.py
@@ -123,10 +123,10 @@ class TestContactService:
 
     @staticmethod
     def test_update_contact_without_address():
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
 
         contact = baker.make_recipe(
-            'utils.contact', operator=approved_user_operator.operator, address=None
+            'registration.tests.utils.contact', operator=approved_user_operator.operator, address=None
         )  # Contact with no address
 
         contact_payload = ContactIn(
@@ -253,13 +253,14 @@ class TestContactService:
     @staticmethod
     def test_get_with_places_assigned_with_contacts():
         contact = baker.make_recipe(
-            'utils.contact', business_role=BusinessRole.objects.get(role_name='Operation Representative')
+            'registration.tests.utils.contact',
+            business_role=BusinessRole.objects.get(role_name='Operation Representative'),
         )
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         # add contact to operator (they have to be associated with the operator or will throw unauthorized)
         approved_user_operator.operator.contacts.set([contact])
         # add contact to operation
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         operation.contacts.set([contact])
 
         result = ContactService.get_with_places_assigned(approved_user_operator.user.user_guid, contact.id)
@@ -270,9 +271,10 @@ class TestContactService:
     @staticmethod
     def test_get_with_places_assigned_with_no_contacts():
         contact = baker.make_recipe(
-            'utils.contact', business_role=BusinessRole.objects.get(role_name='Operation Representative')
+            'registration.tests.utils.contact',
+            business_role=BusinessRole.objects.get(role_name='Operation Representative'),
         )
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         # add contact to operator (they have to be associated with the operator or will throw unauthorized)
         approved_user_operator.operator.contacts.set([contact])
 

--- a/bc_obps/service/tests/test_contact_service_v2.py
+++ b/bc_obps/service/tests/test_contact_service_v2.py
@@ -11,12 +11,14 @@ class TestListContactService:
     @staticmethod
     def test_list_contacts():
 
-        user = baker.make_recipe('utils.cas_admin')
+        user = baker.make_recipe('registration.tests.utils.cas_admin')
 
-        operators = baker.make_recipe('utils.operator', _quantity=2)
+        operators = baker.make_recipe('registration.tests.utils.operator', _quantity=2)
 
-        baker.make_recipe('utils.contact', operator=operators[0])
-        baker.make_recipe('utils.contact', operator=operators[1], _quantity=2)  # one operator has two contacts
+        baker.make_recipe('registration.tests.utils.contact', operator=operators[0])
+        baker.make_recipe(
+            'registration.tests.utils.contact', operator=operators[1], _quantity=2
+        )  # one operator has two contacts
 
         assert (
             ContactServiceV2.list_contacts_v2(
@@ -30,13 +32,14 @@ class TestContactService:
     @staticmethod
     def test_get_with_places_assigned_with_contacts():
         contact = baker.make_recipe(
-            'utils.contact', business_role=BusinessRole.objects.get(role_name='Operation Representative')
+            'registration.tests.utils.contact',
+            business_role=BusinessRole.objects.get(role_name='Operation Representative'),
         )
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         # add contact to operator (they have to be associated with the operator or will throw unauthorized)
         approved_user_operator.operator.contacts.set([contact])
         # add contact to operation
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         operation.contacts.set([contact])
 
         result = ContactServiceV2.get_with_places_assigned_v2(contact.id)
@@ -49,9 +52,10 @@ class TestContactService:
     @staticmethod
     def test_get_with_places_assigned_with_no_contacts():
         contact = baker.make_recipe(
-            'utils.contact', business_role=BusinessRole.objects.get(role_name='Operation Representative')
+            'registration.tests.utils.contact',
+            business_role=BusinessRole.objects.get(role_name='Operation Representative'),
         )
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         # add contact to operator (they have to be associated with the operator or will throw unauthorized)
         approved_user_operator.operator.contacts.set([contact])
 
@@ -60,7 +64,7 @@ class TestContactService:
 
     @staticmethod
     def test_raises_exception_if_contact_missing_address():
-        contact = baker.make_recipe('utils.contact', address=None)
+        contact = baker.make_recipe('registration.tests.utils.contact', address=None)
 
         with pytest.raises(
             Exception,
@@ -71,7 +75,9 @@ class TestContactService:
     @staticmethod
     def test_raises_exception_if_operation_rep_missing_required_fields():
         contacts = baker.make_recipe(
-            'utils.contact', business_role=BusinessRole.objects.get(role_name='Operation Representative'), _quantity=5
+            'registration.tests.utils.contact',
+            business_role=BusinessRole.objects.get(role_name='Operation Representative'),
+            _quantity=5,
         )
         contacts[0].address = None
         contacts[0].save()

--- a/bc_obps/service/tests/test_document_service.py
+++ b/bc_obps/service/tests/test_document_service.py
@@ -16,8 +16,8 @@ class TestDocumentService:
     def test_create_operation_document():
         # the value received by the service is a File (transformed into this in the django ninja schema)
         file = data_url_to_file(MOCK_DATA_URL)
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         document, created = DocumentService.create_or_replace_operation_document(
             approved_user_operator.user_id, operation.id, file, 'boundary_map'
         )
@@ -28,8 +28,8 @@ class TestDocumentService:
 
     @staticmethod
     def test_do_not_update_duplicate_operation_document():
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         existing_document = DocumentDataAccessService.create_document(
             approved_user_operator.user_id, data_url_to_file(MOCK_DATA_URL), 'boundary_map'
         )
@@ -50,8 +50,8 @@ class TestDocumentService:
 
     @staticmethod
     def test_update_operation_document():
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         existing_document = DocumentDataAccessService.create_document(
             approved_user_operator.user_id, data_url_to_file(MOCK_DATA_URL), 'boundary_map'
         )
@@ -70,9 +70,9 @@ class TestDocumentService:
 
     @pytest.mark.parametrize("registration_status", [Operation.Statuses.REGISTERED, Operation.Statuses.DRAFT])
     def test_archive_or_delete_operation_document(self, registration_status):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         operation = baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator, status=registration_status
+            'registration.tests.utils.operation', operator=approved_user_operator.operator, status=registration_status
         )
         b_map = DocumentDataAccessService.create_document(
             approved_user_operator.user_id, data_url_to_file(MOCK_DATA_URL), 'boundary_map'

--- a/bc_obps/service/tests/test_document_service_v2.py
+++ b/bc_obps/service/tests/test_document_service_v2.py
@@ -15,9 +15,9 @@ pytestmark = pytest.mark.django_db
 class TestDocumentServiceV2:
     @staticmethod
     def test_get_operation_document_by_type_if_authorized():
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
-        document = baker.make_recipe('utils.document', operation=operation)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
+        document = baker.make_recipe('registration.tests.utils.document', operation=operation)
         retrieved_document = DocumentServiceV2.get_operation_document_by_type_if_authorized(
             approved_user_operator.user.user_guid, operation.id, 'boundary_map'
         )
@@ -25,9 +25,9 @@ class TestDocumentServiceV2:
 
     @staticmethod
     def test_cannot_get_operation_document_by_type_if_unauthorized():
-        user = baker.make_recipe('utils.industry_operator_user')
-        operation = baker.make_recipe('utils.operation')
-        baker.make_recipe('utils.document')
+        user = baker.make_recipe('registration.tests.utils.industry_operator_user')
+        operation = baker.make_recipe('registration.tests.utils.operation')
+        baker.make_recipe('registration.tests.utils.document')
         with pytest.raises(Exception, match='Unauthorized.'):
             DocumentServiceV2.get_operation_document_by_type_if_authorized(user.user_guid, operation.id, 'boundary_map')
 
@@ -35,8 +35,8 @@ class TestDocumentServiceV2:
     def test_create_operation_document():
         # the value received by the service is a File (transformed into this in the django ninja schema)
         file = data_url_to_file(MOCK_DATA_URL)
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         document, created = DocumentServiceV2.create_or_replace_operation_document(
             approved_user_operator.user_id, operation.id, file, 'boundary_map'
         )
@@ -47,8 +47,8 @@ class TestDocumentServiceV2:
 
     @staticmethod
     def test_do_not_update_duplicate_operation_document():
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         DocumentDataAccessServiceV2.create_document(
             approved_user_operator.user_id, data_url_to_file(MOCK_DATA_URL), 'boundary_map', operation.id
         )
@@ -68,8 +68,8 @@ class TestDocumentServiceV2:
 
     @staticmethod
     def test_update_operation_document():
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         DocumentDataAccessServiceV2.create_document(
             approved_user_operator.user_id, data_url_to_file(MOCK_DATA_URL), 'boundary_map', operation.id
         )
@@ -87,9 +87,9 @@ class TestDocumentServiceV2:
 
     @pytest.mark.parametrize("registration_status", [Operation.Statuses.REGISTERED, Operation.Statuses.DRAFT])
     def test_archive_or_delete_operation_document(self, registration_status):
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         operation = baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator, status=registration_status
+            'registration.tests.utils.operation', operator=approved_user_operator.operator, status=registration_status
         )
         # boundary map
         b_map = DocumentDataAccessServiceV2.create_document(

--- a/bc_obps/service/tests/test_operation_designated_operator_timeline_service.py
+++ b/bc_obps/service/tests/test_operation_designated_operator_timeline_service.py
@@ -12,15 +12,20 @@ pytestmark = pytest.mark.django_db
 class TestOperationDesignatedOperatorTimelineService:
     @staticmethod
     def test_get_current_timeline():
-        timeline_with_no_end_date = baker.make_recipe('utils.operation_designated_operator_timeline', end_date=None)
+        timeline_with_no_end_date = baker.make_recipe(
+            'registration.tests.utils.operation_designated_operator_timeline', end_date=None
+        )
         # another timeline for the same operation to make sure it is not returned
-        baker.make_recipe('utils.operation_designated_operator_timeline', operation=timeline_with_no_end_date.operation)
+        baker.make_recipe(
+            'registration.tests.utils.operation_designated_operator_timeline',
+            operation=timeline_with_no_end_date.operation,
+        )
         result_found = OperationDesignatedOperatorTimelineService.get_current_timeline(
             timeline_with_no_end_date.operator_id, timeline_with_no_end_date.operation_id
         )
         assert result_found == timeline_with_no_end_date
 
-        timeline_with_end_date = baker.make_recipe('utils.operation_designated_operator_timeline')
+        timeline_with_end_date = baker.make_recipe('registration.tests.utils.operation_designated_operator_timeline')
         result_not_found = OperationDesignatedOperatorTimelineService.get_current_timeline(
             timeline_with_end_date.operator_id, timeline_with_end_date.operation_id
         )
@@ -29,7 +34,8 @@ class TestOperationDesignatedOperatorTimelineService:
     @staticmethod
     def test_set_timeline_status_and_end_date():
         timeline = baker.make_recipe(
-            'utils.operation_designated_operator_timeline', status=OperationDesignatedOperatorTimeline.Statuses.ACTIVE
+            'registration.tests.utils.operation_designated_operator_timeline',
+            status=OperationDesignatedOperatorTimeline.Statuses.ACTIVE,
         )
         new_status = OperationDesignatedOperatorTimeline.Statuses.TRANSFERRED
         end_date = datetime.now(ZoneInfo("UTC"))

--- a/bc_obps/service/tests/test_operation_service_v2.py
+++ b/bc_obps/service/tests/test_operation_service_v2.py
@@ -39,7 +39,9 @@ pytestmark = pytest.mark.django_db
 
 def set_up_valid_mock_operation(purpose: Operation.Purposes):
     # create operation and purpose
-    operation = baker.make_recipe('utils.operation', status=Operation.Statuses.DRAFT, registration_purpose=purpose)
+    operation = baker.make_recipe(
+        'registration.tests.utils.operation', status=Operation.Statuses.DRAFT, registration_purpose=purpose
+    )
 
     # create mock valid operation rep
     address = baker.make_recipe('registration.tests.utils.address')
@@ -115,7 +117,7 @@ class TestOperationServiceV2:
     def test_assigns_single_selected_purpose():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             registration_purpose='Potential Reporting Operation',
         )
@@ -139,7 +141,7 @@ class TestOperationServiceV2:
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         opted_in_operation_detail = baker.make_recipe('registration.tests.utils.opted_in_operation_detail')
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             registration_purpose=Operation.Purposes.OPTED_IN_OPERATION,
             opt_in=True,
@@ -163,7 +165,7 @@ class TestOperationServiceV2:
     def test_assigning_opted_in_operation_will_create_and_opted_in_operation_detail():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             registration_purpose=Operation.Purposes.OPTED_IN_OPERATION,
         )
@@ -186,14 +188,18 @@ class TestOperationServiceV2:
     def test_list_current_users_unregistered_operations():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         users_unregistered_operation = baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator, status=Operation.Statuses.PENDING
+            'registration.tests.utils.operation',
+            operator=approved_user_operator.operator,
+            status=Operation.Statuses.PENDING,
         )
         # operation with a registered status
         baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator, status=Operation.Statuses.REGISTERED
+            'registration.tests.utils.operation',
+            operator=approved_user_operator.operator,
+            status=Operation.Statuses.REGISTERED,
         )
         # operation for a different user_operator
-        baker.make_recipe('utils.operation', status=Operation.Statuses.PENDING)
+        baker.make_recipe('registration.tests.utils.operation', status=Operation.Statuses.PENDING)
 
         result = OperationServiceV2.list_current_users_unregistered_operations(approved_user_operator.user.user_guid)
         assert Operation.objects.count() == 3
@@ -223,7 +229,9 @@ class TestOperationServiceV2:
     def test_update_operation_status_fail():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         users_operation = baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator, created_by=approved_user_operator.user
+            'registration.tests.utils.operation',
+            operator=approved_user_operator.operator,
+            created_by=approved_user_operator.user,
         )
         users_operation.contacts.set([])
 
@@ -240,9 +248,11 @@ class TestOperationServiceV2:
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=user)
 
         random_operator = baker.make_recipe(
-            'utils.operator', cra_business_number=123456789, bc_corporate_registry_number='abc1234567'
+            'registration.tests.utils.operator',
+            cra_business_number=123456789,
+            bc_corporate_registry_number='abc1234567',
         )
-        operation = baker.make_recipe('utils.operation', operator=random_operator)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=random_operator)
         with pytest.raises(Exception, match=UNAUTHORIZED_MESSAGE):
             OperationServiceV2.update_status(
                 approved_user_operator.user.user_guid, operation.id, Operation.Statuses.REGISTERED
@@ -251,7 +261,7 @@ class TestOperationServiceV2:
     @staticmethod
     def test_assign_new_contacts_to_operation_and_operator():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         payload = OperationRepresentativeIn(
             first_name="John",
             last_name="Doe",
@@ -282,7 +292,7 @@ class TestOperationServiceV2:
         contacts = baker.make_recipe(
             'registration.tests.utils.contact', operator=approved_user_operator.operator, _quantity=5
         )
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
 
         contact_to_update = contacts[0]
 
@@ -332,9 +342,11 @@ class TestOperationServiceV2:
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', user=user)
 
         random_operator = baker.make_recipe(
-            'utils.operator', cra_business_number=123456789, bc_corporate_registry_number='abc1234567'
+            'registration.tests.utils.operator',
+            cra_business_number=123456789,
+            bc_corporate_registry_number='abc1234567',
         )
-        operation = baker.make_recipe('utils.operation', operator=random_operator)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=random_operator)
         with pytest.raises(Exception, match=UNAUTHORIZED_MESSAGE):
             OperationServiceV2.update_opted_in_operation_detail(approved_user_operator.user.user_guid, operation.id, {})
 
@@ -342,7 +354,9 @@ class TestOperationServiceV2:
     def test_create_or_replace_new_entrant_application():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         users_operation = baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator, created_by=approved_user_operator.user
+            'registration.tests.utils.operation',
+            operator=approved_user_operator.operator,
+            created_by=approved_user_operator.user,
         )
         payload = OperationNewEntrantApplicationIn(
             new_entrant_application=MOCK_DATA_URL,
@@ -384,9 +398,9 @@ class TestRegisterOperationInformation:
 
     @staticmethod
     def test_register_operation_information_existing_eio():
-        approved_user_operator = baker.make_recipe('utils.approved_user_operator')
+        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         users_operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             created_by=approved_user_operator.user,
             type="Electricity Import Operation",
@@ -442,7 +456,9 @@ class TestRegisterOperationInformation:
     def test_register_operation_information_existing_operation():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         users_operation = baker.make_recipe(
-            'utils.operation', operator=approved_user_operator.operator, created_by=approved_user_operator.user
+            'registration.tests.utils.operation',
+            operator=approved_user_operator.operator,
+            created_by=approved_user_operator.user,
         )
         payload = OperationInformationIn(
             registration_purpose='Potential Reporting Operation',
@@ -472,7 +488,7 @@ class TestRegisterOperationInformation:
     def test_is_operation_new_entrant_information_complete_true():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         users_operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             registration_purpose=Operation.Purposes.NEW_ENTRANT_OPERATION,
             date_of_first_shipment=Operation.DateOfFirstShipmentChoices.ON_OR_AFTER_APRIL_1_2024,
@@ -488,7 +504,7 @@ class TestRegisterOperationInformation:
     def test_is_operation_new_entrant_information_complete_no_date():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         users_operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             registration_purpose=Operation.Purposes.NEW_ENTRANT_OPERATION,
         )
@@ -503,7 +519,7 @@ class TestRegisterOperationInformation:
     def test_is_operation_new_entrant_information_complete_no_application():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         users_operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             registration_purpose=Operation.Purposes.NEW_ENTRANT_OPERATION,
             date_of_first_shipment=Operation.DateOfFirstShipmentChoices.ON_OR_BEFORE_MARCH_31_2024,
@@ -595,7 +611,9 @@ class TestOperationServiceV2CreateOrUpdateOperation:
     @staticmethod
     def test_update_operation_with_multiple_operators():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
-        existing_operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        existing_operation = baker.make_recipe(
+            'registration.tests.utils.operation', operator=approved_user_operator.operator
+        )
         multiple_operators = baker.make_recipe(
             'registration.tests.utils.multiple_operator', operation=existing_operation, _quantity=3
         )
@@ -655,7 +673,9 @@ class TestOperationServiceV2CreateOrUpdateOperation:
     @staticmethod
     def test_update_operation_archive_multiple_operators():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
-        existing_operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        existing_operation = baker.make_recipe(
+            'registration.tests.utils.operation', operator=approved_user_operator.operator
+        )
         multiple_operators = baker.make_recipe(
             'registration.tests.utils.multiple_operator', operation=existing_operation, _quantity=3
         )
@@ -687,7 +707,9 @@ class TestOperationServiceV2CreateOrUpdateOperation:
     @staticmethod
     def test_update_operation_with_operation_representatives_with_address():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
-        existing_operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        existing_operation = baker.make_recipe(
+            'registration.tests.utils.operation', operator=approved_user_operator.operator
+        )
         contacts = baker.make_recipe(
             'registration.tests.utils.contact',
             business_role=BusinessRole.objects.get(role_name='Operation Representative'),
@@ -723,7 +745,7 @@ class TestOperationServiceV2UpdateOperation:
     def test_update_operation_fails_if_operation_not_registered(self):
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         existing_operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             created_by=approved_user_operator.user,
             status=Operation.Statuses.DRAFT,
@@ -746,7 +768,7 @@ class TestOperationServiceV2UpdateOperation:
     def test_update_operation(self):
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         existing_operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             created_by=approved_user_operator.user,
             status=Operation.Statuses.REGISTERED,
@@ -776,7 +798,7 @@ class TestOperationServiceV2UpdateOperation:
     def test_update_operation_with_no_regulated_products(self):
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         existing_operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             created_by=approved_user_operator.user,
             status=Operation.Statuses.REGISTERED,
@@ -807,7 +829,7 @@ class TestOperationServiceV2UpdateOperation:
     def test_update_operation_with_new_entrant_application_data(self):
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         existing_operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             created_by=approved_user_operator.user,
             date_of_first_shipment=Operation.DateOfFirstShipmentChoices.ON_OR_AFTER_APRIL_1_2024,
@@ -847,7 +869,7 @@ class TestOperationServiceV2CheckCurrentUsersRegisteredOperation:
 
         # Create an operation with status 'Registered'
         baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             created_by=approved_user_operator.user,
             status="Registered",
@@ -862,7 +884,7 @@ class TestOperationServiceV2CheckCurrentUsersRegisteredOperation:
 
         # Create an operation with a different status
         baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             created_by=approved_user_operator.user,
             status="Draft",
@@ -881,7 +903,7 @@ class TestOperationServiceV2CheckCurrentUsersRegisteredOperation:
 
         # Create an operation with a non-registered status
         baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             created_by=approved_user_operator.user,
             status="Draft",
@@ -898,7 +920,7 @@ class TestOperationServiceV2CheckCurrentUsersRegisteredOperation:
 class TestRaiseExceptionIfOperationRegistrationDataIncomplete:
     @staticmethod
     def test_raises_exception_if_no_purpose():
-        operation = baker.make_recipe('utils.operation', status=Operation.Statuses.DRAFT)
+        operation = baker.make_recipe('registration.tests.utils.operation', status=Operation.Statuses.DRAFT)
         # the only way to not have a registration purpose on an operation is to first set one when creating the operation,
         # then manually remove it
         operation.registration_purpose = None
@@ -1001,7 +1023,7 @@ class TestHandleChangeOfRegistrationPurpose:
     def test_old_purpose_opted_in():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             registration_purpose=Operation.Purposes.OPTED_IN_OPERATION,
             opt_in=True,
@@ -1033,7 +1055,7 @@ class TestHandleChangeOfRegistrationPurpose:
     def test_old_purpose_new_entrant():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             registration_purpose=Operation.Purposes.NEW_ENTRANT_OPERATION,
             date_of_first_shipment=Operation.DateOfFirstShipmentChoices.ON_OR_BEFORE_MARCH_31_2024,
@@ -1074,7 +1096,7 @@ class TestHandleChangeOfRegistrationPurpose:
     def test_new_purpose_eio():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             registration_purpose=Operation.Purposes.REPORTING_OPERATION,
         )
@@ -1106,11 +1128,11 @@ class TestHandleChangeOfRegistrationPurpose:
     @staticmethod
     def test_new_purpose_reporting():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
-        products = baker.make_recipe('utils.regulated_product', _quantity=3)
+        products = baker.make_recipe('registration.tests.utils.regulated_product', _quantity=3)
         activities = baker.make(Activity, _quantity=3)
         activity_pks = [activity.id for activity in activities]
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             regulated_products=products,
         )
@@ -1137,7 +1159,7 @@ class TestGenerateBoroId:
     def test_generates_boro_id():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             status=Operation.Statuses.REGISTERED,
         )
@@ -1150,7 +1172,7 @@ class TestGenerateBoroId:
     def test_raises_exception_if_operation_is_non_regulated():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             status=Operation.Statuses.REGISTERED,
             registration_purpose=Operation.Purposes.ELECTRICITY_IMPORT_OPERATION,
@@ -1163,7 +1185,7 @@ class TestGenerateBoroId:
     def test_raises_exception_if_operation_is_not_registered():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
             operator=approved_user_operator.operator,
             status=Operation.Statuses.DRAFT,
             registration_purpose=Operation.Purposes.NEW_ENTRANT_OPERATION,
@@ -1178,7 +1200,7 @@ class TestRemoveOperationRepresentative:
     def test_cannot_remove_anything_from_other_users_operations():
         user = baker.make_recipe('registration.tests.utils.industry_operator_user')
         operation = baker.make_recipe(
-            'utils.operation',
+            'registration.tests.utils.operation',
         )
         contact1 = baker.make_recipe('registration.tests.utils.contact', id=1)
         contact2 = baker.make_recipe('registration.tests.utils.contact', id=2)
@@ -1190,7 +1212,7 @@ class TestRemoveOperationRepresentative:
     @staticmethod
     def test_removes_operation_representative():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
-        operation = baker.make_recipe('utils.operation', operator=approved_user_operator.operator)
+        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
         contact1 = baker.make_recipe('registration.tests.utils.contact', id=1)
         contact2 = baker.make_recipe('registration.tests.utils.contact', id=2)
         operation.contacts.add(contact1, contact2)
@@ -1223,8 +1245,8 @@ class TestUpdateOperationsOperator:
     def test_update_operations_operator_success(mock_get_by_guid):
         cas_analyst = baker.make_recipe('registration.tests.utils.cas_analyst')
         mock_get_by_guid.return_value = cas_analyst
-        operation = baker.make_recipe('utils.operation')
-        operator = baker.make_recipe('utils.operator')
+        operation = baker.make_recipe('registration.tests.utils.operation')
+        operator = baker.make_recipe('registration.tests.utils.operator')
         OperationServiceV2.update_operator(cas_analyst.user_guid, operation, operator.id)
         assert operation.operator == operator
 
@@ -1281,17 +1303,23 @@ class TestListOperationTimeline:
         baker.make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
             operator=approved_user_operator.operator,
-            operation=baker.make_recipe('utils.operation', bcghg_id=(baker.make(BcGreenhouseGasId, id='11111111111'))),
+            operation=baker.make_recipe(
+                'registration.tests.utils.operation', bcghg_id=(baker.make(BcGreenhouseGasId, id='11111111111'))
+            ),
         )
         baker.make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
             operator=approved_user_operator.operator,
-            operation=baker.make_recipe('utils.operation', bcghg_id=(baker.make(BcGreenhouseGasId, id='15555555555'))),
+            operation=baker.make_recipe(
+                'registration.tests.utils.operation', bcghg_id=(baker.make(BcGreenhouseGasId, id='15555555555'))
+            ),
         )
         baker.make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
             operator=approved_user_operator.operator,
-            operation=baker.make_recipe('utils.operation', bcghg_id=(baker.make(BcGreenhouseGasId, id='29999999999'))),
+            operation=baker.make_recipe(
+                'registration.tests.utils.operation', bcghg_id=(baker.make(BcGreenhouseGasId, id='29999999999'))
+            ),
         )
 
         timeline = OperationServiceV2.list_operations_timeline(

--- a/bc_obps/service/tests/test_operator_service_v2.py
+++ b/bc_obps/service/tests/test_operator_service_v2.py
@@ -20,7 +20,7 @@ class TestUpdateOperatorV2:
     def test_update_operator_no_address_change():
         user = baker.make(User, app_role=AppRole.objects.get(role_name="industry_user"))
         operator = baker.make_recipe(
-            'utils.operator',
+            'registration.tests.utils.operator',
         )
         baker.make(
             UserOperator,
@@ -53,7 +53,7 @@ class TestUpdateOperatorV2:
     def test_update_operator_address_change():
         user = baker.make(User, app_role=AppRole.objects.get(role_name="industry_user"))
         operator = baker.make_recipe(
-            'utils.operator',
+            'registration.tests.utils.operator',
         )
         baker.make(
             UserOperator,
@@ -87,9 +87,9 @@ class TestUpdateOperatorV2:
     def test_update_operator_with_partner_operators():
         user = baker.make(User, app_role=AppRole.objects.get(role_name="industry_user"))
         operator = baker.make_recipe(
-            'utils.operator',
+            'registration.tests.utils.operator',
         )
-        baker.make_recipe('utils.partner_operator', bc_obps_operator=operator, _quantity=3)
+        baker.make_recipe('registration.tests.utils.partner_operator', bc_obps_operator=operator, _quantity=3)
         assert PartnerOperator.objects.count() == 3
         baker.make(
             UserOperator,
@@ -139,9 +139,9 @@ class TestUpdateOperatorV2:
     def test_update_operator_archive_all_partner_operators():
         user = baker.make(User, app_role=AppRole.objects.get(role_name="industry_user"))
         operator = baker.make_recipe(
-            'utils.operator',
+            'registration.tests.utils.operator',
         )
-        baker.make_recipe('utils.partner_operator', bc_obps_operator=operator, _quantity=3)
+        baker.make_recipe('registration.tests.utils.partner_operator', bc_obps_operator=operator, _quantity=3)
         baker.make(
             UserOperator,
             user_id=user.user_guid,
@@ -172,11 +172,11 @@ class TestUpdateOperatorV2:
     def test_update_operator_with_parent_operators():
         user = baker.make(User, app_role=AppRole.objects.get(role_name="industry_user"))
         operator = baker.make_recipe(
-            'utils.operator',
+            'registration.tests.utils.operator',
         )
-        baker.make_recipe('utils.canadian_parent_operator', child_operator=operator, _quantity=2)
+        baker.make_recipe('registration.tests.utils.canadian_parent_operator', child_operator=operator, _quantity=2)
 
-        baker.make_recipe('utils.foreign_parent_operator', child_operator=operator, _quantity=2)
+        baker.make_recipe('registration.tests.utils.foreign_parent_operator', child_operator=operator, _quantity=2)
 
         assert ParentOperator.objects.count() == 4
         baker.make(
@@ -237,10 +237,10 @@ class TestUpdateOperatorV2:
     def test_update_operator_delete_parent_operator_address():
         user = baker.make(User, app_role=AppRole.objects.get(role_name="industry_user"))
         operator = baker.make_recipe(
-            'utils.operator',
+            'registration.tests.utils.operator',
         )
         baker.make_recipe(
-            'utils.canadian_parent_operator',
+            'registration.tests.utils.canadian_parent_operator',
             child_operator=operator,
         )
 
@@ -280,11 +280,11 @@ class TestUpdateOperatorV2:
     def test_update_operator_archive_all_parent_operators():
         user = baker.make(User, app_role=AppRole.objects.get(role_name="industry_user"))
         operator = baker.make_recipe(
-            'utils.operator',
+            'registration.tests.utils.operator',
         )
-        baker.make_recipe('utils.canadian_parent_operator', child_operator=operator, _quantity=2)
+        baker.make_recipe('registration.tests.utils.canadian_parent_operator', child_operator=operator, _quantity=2)
 
-        baker.make_recipe('utils.foreign_parent_operator', child_operator=operator, _quantity=2)
+        baker.make_recipe('registration.tests.utils.foreign_parent_operator', child_operator=operator, _quantity=2)
 
         baker.make(
             UserOperator,
@@ -316,11 +316,13 @@ class TestUpdateOperatorV2:
 class TestOperatorHasRequiredFields:
     @staticmethod
     def test_operator_has_all_required_fields():
-        operator = baker.make_recipe('utils.operator')
+        operator = baker.make_recipe('registration.tests.utils.operator')
         assert OperatorServiceV2.has_required_fields(operator) is True
 
     @staticmethod
     def test_operator_does_not_have_all_required_fields():
         # Create an operator with the required fields, but set legal_name to an empty string
-        operator = baker.make_recipe('utils.operator', legal_name=' ')  # Set legal_name to an empty string
+        operator = baker.make_recipe(
+            'registration.tests.utils.operator', legal_name=' '
+        )  # Set legal_name to an empty string
         assert OperatorServiceV2.has_required_fields(operator) is False

--- a/bc_obps/service/tests/test_report_service.py
+++ b/bc_obps/service/tests/test_report_service.py
@@ -58,7 +58,7 @@ class TestReportService(TestCase):
                 "service.data_access_service.facility_service.FacilityDataAccessService.get_current_facilities_by_operation"
             ) as mock_facility_data_access_service_get_current_facilities_by_operation,
         ):
-            mock_facilities = baker.make_recipe('utils.facility', _quantity=3)
+            mock_facilities = baker.make_recipe('registration.tests.utils.facility', _quantity=3)
 
             mock_report_data_access_service_report_exists.return_value = False
             mock_facility_data_access_service_get_current_facilities_by_operation.return_value = mock_facilities
@@ -159,15 +159,13 @@ class TestReportService(TestCase):
             operation_report_type="New Report Type",
         )
 
-        with mock.patch('service.report_service.ReportOperation.objects.get') as mock_get, mock.patch(
-            'service.report_service.ReportOperationRepresentative.objects.filter'
-        ) as mock_filter, mock.patch(
-            'service.report_service.FacilityReport.objects.filter'
-        ) as mock_facility_filter, mock.patch(
-            'service.report_service.Activity.objects.filter'
-        ) as mock_activity_filter, mock.patch(
-            'service.report_service.RegulatedProduct.objects.filter'
-        ) as mock_regulated_product_filter:
+        with (
+            mock.patch('service.report_service.ReportOperation.objects.get') as mock_get,
+            mock.patch('service.report_service.ReportOperationRepresentative.objects.filter') as mock_filter,
+            mock.patch('service.report_service.FacilityReport.objects.filter') as mock_facility_filter,
+            mock.patch('service.report_service.Activity.objects.filter') as mock_activity_filter,
+            mock.patch('service.report_service.RegulatedProduct.objects.filter') as mock_regulated_product_filter,
+        ):
             mock_report_operation = mock.MagicMock(spec=ReportOperation)
             mock_get.return_value = mock_report_operation
 


### PR DESCRIPTION
No card. Tests have started erroring if only a partial baker recipe path is given ("utils.facility" vs. "registration.tests.utils.facility") and this PR adds the full path to everything. Fixing this has been creating noise in other PRs