### PR TITLE
507 part2 allocation of emissions alterations

### DIFF
--- a/bc_obps/reporting/migrations/0039_reportproductemissionallocation_and_more.py
+++ b/bc_obps/reporting/migrations/0039_reportproductemissionallocation_and_more.py
@@ -30,8 +30,12 @@ class Migration(migrations.Migration):
                 (
                     'allocation_methodology',
                     models.CharField(
-                        choices=[('Calculator', 'Calculator'), ('Other', 'Other')],
-                        default='Calculator',
+                        choices=[
+                            ('Not Applicable', 'Not Applicable'),
+                            ('OBPS Allocation Calculator', 'Calculator'),
+                            ('Other', 'Other'),
+                        ],
+                        default='OBPS Allocation Calculator',
                         db_comment='The methodology used to calculate the allocated emissions',
                         max_length=255,
                     ),

--- a/bc_obps/reporting/models/report_product_emission_allocation.py
+++ b/bc_obps/reporting/models/report_product_emission_allocation.py
@@ -14,7 +14,8 @@ class ReportProductEmissionAllocation(TimeStampedModel):
     """
 
     class AllocationMethodologyChoices(models.TextChoices):
-        CALCULATOR = ("Calculator",)
+        NOT_APPLICABLE = "Not Applicable"
+        CALCULATOR = ("OBPS Allocation Calculator",)
         OTHER = "Other"
 
     report_version = models.ForeignKey(

--- a/bciers/apps/reporting/src/app/components/facility/calculateEmissionsData.ts
+++ b/bciers/apps/reporting/src/app/components/facility/calculateEmissionsData.ts
@@ -22,9 +22,14 @@ export const calculateEmissionData = (category: EmissionAllocationData) => {
     0,
   );
 
-  const emissionTotal = Number(category.emission_total) || 1;
+  const emissionTotal = Number(category.emission_total);
+  let percentage;
 
-  const percentage = handlePercentageNearHundred((sum / emissionTotal) * 100);
+  if (emissionTotal) {
+    percentage = handlePercentageNearHundred((sum / emissionTotal) * 100);
+  } else {
+    percentage = sum ? -99.99 : 100;
+  }
 
   return {
     ...category,

--- a/bciers/apps/reporting/src/app/components/facility/calculateEmissionsData.ts
+++ b/bciers/apps/reporting/src/app/components/facility/calculateEmissionsData.ts
@@ -28,12 +28,15 @@ export const calculateEmissionData = (category: EmissionAllocationData) => {
   if (emissionTotal) {
     percentage = handlePercentageNearHundred((sum / emissionTotal) * 100);
   } else {
-    percentage = sum ? -99.99 : 100;
+    percentage = sum ? -1 : 100;
   }
 
   return {
     ...category,
-    products_emission_allocation_sum: `${percentage.toFixed(2)}%`,
+    products_emission_allocation_sum:
+      percentage < 0 || percentage > 100
+        ? `This category is over-allocated by ${sum - emissionTotal}`
+        : `${percentage.toFixed(2)}%`,
     emission_total: category.emission_total.toString(),
   };
 };

--- a/bciers/apps/reporting/src/data/jsonSchema/facility/facilityEmissionAllocation.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/facility/facilityEmissionAllocation.tsx
@@ -170,7 +170,7 @@ export const emissionAllocationSchema: RJSFSchema = {
     allocation_methodology: {
       type: "string",
       title: "Methodology",
-      enum: ["Calculator", "Other"],
+      enum: ["Not Applicable", "OBPS Allocation Calculator", "Other"],
     },
     basic_emission_allocation_data_title: {
       title:


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/507 (only the changes under "EDITED TO ADD". Other changes in this ticket have already been implemented)

### Changes to Emission Allocation page
 - Added "Not Applicable" as an option to the Methodology dropdown menu
 - Updated the "Calculator" option in the dropdown menu to be "OBPS Allocation Calculator"
 - Changed how percentage allocated is displayed when the **_total emissions of a category are 0._**
    - When 0 emissions are allocated: shows 100% (Changed from 0%). This makes it so that the good state is always 100%. When moving through each emission category, if it says 100% then it is good.
    - When *ANY* emissions are allocated, shows '-99.99%'. This is (i hope) clearly an ERROR amount and, coupled with the error message ('all emissions must be allocated to 100%'), should allow the users to clearly see where the problem exists.  
