### PR TITLE
464 uat part2

### DIFF
--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/field_gas_process_vent_gas_at_lfo.json
@@ -52,6 +52,11 @@
                     }
                   }
                 },
+                "fuelDescription": {
+                  "title": "Fuel Description",
+                  "maxLength": 500,
+                  "type": "string"
+                },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",
                   "type": "number",

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/with_useful_energy.json
@@ -52,6 +52,11 @@
                     }
                   }
                 },
+                "fuelDescription": {
+                  "title": "Fuel Description",
+                  "maxLength": 500,
+                  "type": "string"
+                },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",
                   "type": "number"

--- a/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
+++ b/bc_obps/reporting/json_schemas/2024/gsc_other_than_non_compression/without_useful_energy.json
@@ -52,6 +52,11 @@
                     }
                   }
                 },
+                "fuelDescription": {
+                  "title": "Fuel Description",
+                  "maxLength": 500,
+                  "type": "string"
+                },
                 "annualFuelAmount": {
                   "title": "Annual Fuel Amount",
                   "type": "number"

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscOtherThanNonCompression.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscOtherThanNonCompression.ts
@@ -66,7 +66,12 @@ const uiSchema = {
               title: "Fuel",
             },
             items: {
-              "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
+              "ui:order": [
+                "fuelType",
+                "fuelDescription",
+                "annualFuelAmount",
+                "emissions",
+              ],
               fuelType: {
                 "ui:field": "fuelType",
                 "ui:FieldTemplate": FieldTemplate,
@@ -82,6 +87,9 @@ const uiSchema = {
                 fuelClassification: {
                   "ui:FieldTemplate": InlineFieldTemplate,
                 },
+              },
+              fuelDescription: {
+                "ui:FieldTemplate": InlineFieldTemplate,
               },
               annualFuelAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,
@@ -145,7 +153,12 @@ const uiSchema = {
               title: "Fuel",
             },
             items: {
-              "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
+              "ui:order": [
+                "fuelType",
+                "fuelDescription",
+                "annualFuelAmount",
+                "emissions",
+              ],
               fuelType: {
                 "ui:field": "fuelType",
                 "ui:FieldTemplate": FieldTemplate,
@@ -161,6 +174,9 @@ const uiSchema = {
                 fuelClassification: {
                   "ui:FieldTemplate": InlineFieldTemplate,
                 },
+              },
+              fuelDescription: {
+                "ui:FieldTemplate": InlineFieldTemplate,
               },
               annualFuelAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,
@@ -225,7 +241,12 @@ const uiSchema = {
               title: "Fuel",
             },
             items: {
-              "ui:order": ["fuelType", "annualFuelAmount", "emissions"],
+              "ui:order": [
+                "fuelType",
+                "fuelDescription",
+                "annualFuelAmount",
+                "emissions",
+              ],
               fuelType: {
                 "ui:field": "fuelType",
                 "ui:FieldTemplate": FieldTemplate,
@@ -241,6 +262,9 @@ const uiSchema = {
                 fuelClassification: {
                   "ui:FieldTemplate": InlineFieldTemplate,
                 },
+              },
+              fuelDescription: {
+                "ui:FieldTemplate": InlineFieldTemplate,
               },
               annualFuelAmount: {
                 "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/libs/utils/src/customReportingActivityFormCalculations.test.ts
+++ b/bciers/libs/utils/src/customReportingActivityFormCalculations.test.ts
@@ -25,7 +25,7 @@ describe("customReportingActivityFormCalculations", () => {
     expect(fuel.annualFuelAmount).toBe(10);
   });
 
-  it("does not calculate the annual fuel amount in mobile combustion form without all quarters", () => {
+  it("calculates the annual fuel amount in mobile combustion form with filled quarters", () => {
     const jsonForm = {
       sourceTypes: {
         mobileFuelCombustionPartOfFacility: {
@@ -42,6 +42,6 @@ describe("customReportingActivityFormCalculations", () => {
     calculateMobileAnnualAmount(jsonForm);
     const fuel =
       jsonForm.sourceTypes.mobileFuelCombustionPartOfFacility.fuels[0];
-    expect(fuel.annualFuelAmount).toBe(undefined);
+    expect(fuel.annualFuelAmount).toBe(1);
   });
 });

--- a/bciers/libs/utils/src/customReportingActivityFormCalculations.ts
+++ b/bciers/libs/utils/src/customReportingActivityFormCalculations.ts
@@ -2,20 +2,13 @@ export const calculateMobileAnnualAmount = (formData: any) => {
   const mobileUnit = formData?.sourceTypes?.mobileFuelCombustionPartOfFacility;
   if (!mobileUnit || !mobileUnit.fuels) return;
 
-  // For each fuel, calculate annual amount if all quarters are present
+  //  For each fuel, for each quarter amount, add to calculated annual fuel amount
   for (const fuel of mobileUnit.fuels) {
-    if (
-      !fuel?.q1FuelAmount ||
-      !fuel?.q2FuelAmount ||
-      !fuel?.q3FuelAmount ||
-      !fuel?.q4FuelAmount
-    )
-      return;
-    const total =
-      fuel.q1FuelAmount +
-      fuel.q2FuelAmount +
-      fuel.q3FuelAmount +
-      fuel.q4FuelAmount;
+    let total = 0;
+    if (fuel?.q1FuelAmount !== null && fuel?.q1FuelAmount !== undefined) total += fuel.q1FuelAmount;
+    if (fuel?.q2FuelAmount !== null && fuel?.q2FuelAmount !== undefined) total += fuel.q2FuelAmount;
+    if (fuel?.q3FuelAmount !== null && fuel?.q3FuelAmount !== undefined) total += fuel.q3FuelAmount;
+    if (fuel?.q4FuelAmount !== null && fuel?.q4FuelAmount !== undefined) total += fuel.q4FuelAmount;
     fuel["annualFuelAmount"] = total; // Apply total
   }
 };

--- a/bciers/libs/utils/src/customReportingActivityFormCalculations.ts
+++ b/bciers/libs/utils/src/customReportingActivityFormCalculations.ts
@@ -5,10 +5,14 @@ export const calculateMobileAnnualAmount = (formData: any) => {
   //  For each fuel, for each quarter amount, add to calculated annual fuel amount
   for (const fuel of mobileUnit.fuels) {
     let total = 0;
-    if (fuel?.q1FuelAmount !== null && fuel?.q1FuelAmount !== undefined) total += fuel.q1FuelAmount;
-    if (fuel?.q2FuelAmount !== null && fuel?.q2FuelAmount !== undefined) total += fuel.q2FuelAmount;
-    if (fuel?.q3FuelAmount !== null && fuel?.q3FuelAmount !== undefined) total += fuel.q3FuelAmount;
-    if (fuel?.q4FuelAmount !== null && fuel?.q4FuelAmount !== undefined) total += fuel.q4FuelAmount;
+    if (fuel?.q1FuelAmount !== null && fuel?.q1FuelAmount !== undefined)
+      total += fuel.q1FuelAmount;
+    if (fuel?.q2FuelAmount !== null && fuel?.q2FuelAmount !== undefined)
+      total += fuel.q2FuelAmount;
+    if (fuel?.q3FuelAmount !== null && fuel?.q3FuelAmount !== undefined)
+      total += fuel.q3FuelAmount;
+    if (fuel?.q4FuelAmount !== null && fuel?.q4FuelAmount !== undefined)
+      total += fuel.q4FuelAmount;
     fuel["annualFuelAmount"] = total; // Apply total
   }
 };


### PR DESCRIPTION
This PR addresses the latest comment in [464](https://github.com/bcgov/cas-reporting/issues/464):

- [ ] In General stationary combustion, other than non-compression and non-processing combustion activity, the Fuel Description field is visible
- [ ] In Fuel combustion by mobile equipment activity, when there is already a saved data and you go back to change one quarter to 0, the Annual Fuel Amount field's value shows the correct computation

- **fix: improve mobile fuel annual amount calculator to fix reporting form 0 issues**
- **chore: add fuel description to gsc other than non activity form for dev site test feedback**
