### PR TITLE
chore: fixed the tasklist for additional Information

### DIFF
--- a/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
@@ -11,17 +11,14 @@ import {
 import { actionHandler } from "@bciers/actions";
 import { useSearchParams } from "next/navigation";
 import { multiStepHeaderSteps } from "@reporting/src/app/components/taskList/multiStepHeaderConfig";
-import {
-  ActivePage,
-  getAdditionalInformationTaskList,
-} from "@reporting/src/app/components/taskList/3_additionalInformation";
+import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 
 interface AdditionalReportingDataProps {
   versionId: number;
   includeElectricityGenerated: boolean;
   initialFormData: any;
   isNewEntrant: boolean;
-  operationType?: string;
+  taskListElements: TaskListElement[];
 }
 
 interface FormData {
@@ -43,7 +40,7 @@ export default function AdditionalReportingDataForm({
   includeElectricityGenerated,
   initialFormData,
   isNewEntrant,
-  operationType,
+  taskListElements,
 }: AdditionalReportingDataProps) {
   const [formData, setFormData] = useState<FormData>(initialFormData);
   const [errors, setErrors] = useState<string[]>();
@@ -86,12 +83,7 @@ export default function AdditionalReportingDataForm({
     <MultiStepFormWithTaskList
       initialStep={2}
       steps={multiStepHeaderSteps}
-      taskListElements={getAdditionalInformationTaskList(
-        versionId,
-        ActivePage.AdditionalReportingData,
-        isNewEntrant,
-        operationType,
-      )}
+      taskListElements={taskListElements}
       schema={schema}
       uiSchema={additionalReportingDataUiSchema}
       formData={formData}

--- a/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataForm.tsx
@@ -21,6 +21,7 @@ interface AdditionalReportingDataProps {
   includeElectricityGenerated: boolean;
   initialFormData: any;
   isNewEntrant: boolean;
+  operationType?: string;
 }
 
 interface FormData {
@@ -42,6 +43,7 @@ export default function AdditionalReportingDataForm({
   includeElectricityGenerated,
   initialFormData,
   isNewEntrant,
+  operationType,
 }: AdditionalReportingDataProps) {
   const [formData, setFormData] = useState<FormData>(initialFormData);
   const [errors, setErrors] = useState<string[]>();
@@ -88,6 +90,7 @@ export default function AdditionalReportingDataForm({
         versionId,
         ActivePage.AdditionalReportingData,
         isNewEntrant,
+        operationType,
       )}
       schema={schema}
       uiSchema={additionalReportingDataUiSchema}

--- a/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataPage.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataPage.tsx
@@ -6,6 +6,7 @@ import {
   REGULATED_OPERATION_REGISTRATION_PURPOSE,
   NEW_ENTRANT_REGISTRATION_PURPOSE,
 } from "@reporting/src/app/utils/constants";
+import { getFacilityReport } from "@reporting/src/app/utils/getFacilityReport";
 
 export function transformReportAdditionalData(reportAdditionalData: any) {
   const captureType = [];
@@ -43,6 +44,7 @@ export default async function AdditionalReportingDataPage({
   const reportAdditionalData = await getReportAdditionalData(version_id);
 
   const transformedData = transformReportAdditionalData(reportAdditionalData);
+  const operationType = await getFacilityReport(version_id);
 
   return (
     <AdditionalReportingDataForm
@@ -52,6 +54,7 @@ export default async function AdditionalReportingDataPage({
       }
       isNewEntrant={registrationPurpose === NEW_ENTRANT_REGISTRATION_PURPOSE}
       initialFormData={transformedData}
+      operationType={operationType?.operation_type}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataPage.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataPage.tsx
@@ -7,6 +7,10 @@ import {
   NEW_ENTRANT_REGISTRATION_PURPOSE,
 } from "@reporting/src/app/utils/constants";
 import { getFacilityReport } from "@reporting/src/app/utils/getFacilityReport";
+import {
+  ActivePage,
+  getAdditionalInformationTaskList,
+} from "@reporting/src/app/components/taskList/3_additionalInformation";
 
 export function transformReportAdditionalData(reportAdditionalData: any) {
   const captureType = [];
@@ -45,16 +49,22 @@ export default async function AdditionalReportingDataPage({
 
   const transformedData = transformReportAdditionalData(reportAdditionalData);
   const operationType = await getFacilityReport(version_id);
-
+  const isNewEntrant = registrationPurpose === NEW_ENTRANT_REGISTRATION_PURPOSE;
+  const taskListElements = getAdditionalInformationTaskList(
+    version_id,
+    ActivePage.AdditionalReportingData,
+    isNewEntrant,
+    operationType?.operation_type,
+  );
   return (
     <AdditionalReportingDataForm
       versionId={version_id}
       includeElectricityGenerated={
         registrationPurpose === REGULATED_OPERATION_REGISTRATION_PURPOSE
       }
-      isNewEntrant={registrationPurpose === NEW_ENTRANT_REGISTRATION_PURPOSE}
+      isNewEntrant={isNewEntrant}
       initialFormData={transformedData}
-      operationType={operationType?.operation_type}
+      taskListElements={taskListElements}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/additionalInformation/newEntrantInformation/NewEntrantInformationPage.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/newEntrantInformation/NewEntrantInformationPage.tsx
@@ -3,6 +3,7 @@ import { getNewEntrantData } from "@reporting/src/app/utils/getNewEntrantData";
 import { getAdditionalInformationTaskList } from "@reporting/src/app/components/taskList/3_additionalInformation";
 import { ActivePage } from "@reporting/src/app/components/taskList/3_additionalInformation";
 import { HasReportVersion } from "@reporting/src/app/utils/defaultPageFactoryTypes";
+import { getFacilityReport } from "@reporting/src/app/utils/getFacilityReport";
 
 export default async function NewEntrantInformationPage({
   version_id,
@@ -62,10 +63,12 @@ export default async function NewEntrantInformationPage({
     ),
   };
 
+  const operationType = await getFacilityReport(version_id);
   const taskListElements = getAdditionalInformationTaskList(
     version_id,
     ActivePage.NewEntrantInformation,
     true,
+    operationType?.operation_type,
   );
 
   return (

--- a/bciers/apps/reporting/src/app/components/additionalInformation/operationEmissionSummary/OperationEmissionSummaryPage.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/operationEmissionSummary/OperationEmissionSummaryPage.tsx
@@ -26,13 +26,6 @@ const OperationEmissionSummaryPage = async ({ version_id }: Props) => {
     isNewEntrant,
     operationType?.operation_type,
   );
-
-  const emissionSummaryTaskListElement = taskListData.find(
-    (e) => e.title == "Operation emission summary",
-  );
-  if (emissionSummaryTaskListElement)
-    emissionSummaryTaskListElement.isActive = true;
-
   return (
     <OperationEmissionSummaryForm
       versionId={version_id}

--- a/bciers/apps/reporting/src/app/components/additionalInformation/operationEmissionSummary/OperationEmissionSummaryPage.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/operationEmissionSummary/OperationEmissionSummaryPage.tsx
@@ -1,9 +1,13 @@
 import React from "react";
 import OperationEmissionSummaryForm from "./OperationEmissionSummaryForm";
-import { getAdditionalInformationTaskList } from "@reporting/src/app/components/taskList/3_additionalInformation";
+import {
+  ActivePage,
+  getAdditionalInformationTaskList,
+} from "@reporting/src/app/components/taskList/3_additionalInformation";
 import { NEW_ENTRANT_REGISTRATION_PURPOSE } from "@reporting/src/app/utils/constants";
 import { getOperationEmissionSummaryData } from "@bciers/actions/api/getOperationEmissionSummaryData";
 import { getRegistrationPurpose } from "@reporting/src/app/utils/getRegistrationPurpose";
+import { getFacilityReport } from "@reporting/src/app/utils/getFacilityReport";
 
 interface Props {
   version_id: number;
@@ -11,17 +15,23 @@ interface Props {
 
 const OperationEmissionSummaryPage = async ({ version_id }: Props) => {
   const summaryData = await getOperationEmissionSummaryData(version_id);
-  const taskListData = getAdditionalInformationTaskList(version_id);
+  const isNewEntrant =
+    (await getRegistrationPurpose(version_id))?.registration_purpose ===
+    NEW_ENTRANT_REGISTRATION_PURPOSE;
+  const operationType = await getFacilityReport(version_id);
+
+  const taskListData = getAdditionalInformationTaskList(
+    version_id,
+    ActivePage.OperationEmissionSummary,
+    isNewEntrant,
+    operationType?.operation_type,
+  );
 
   const emissionSummaryTaskListElement = taskListData.find(
     (e) => e.title == "Operation emission summary",
   );
   if (emissionSummaryTaskListElement)
     emissionSummaryTaskListElement.isActive = true;
-
-  const isNewEntrant =
-    (await getRegistrationPurpose(version_id)) ===
-    NEW_ENTRANT_REGISTRATION_PURPOSE;
 
   return (
     <OperationEmissionSummaryForm

--- a/bciers/apps/reporting/src/app/components/taskList/3_additionalInformation.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/3_additionalInformation.ts
@@ -10,11 +10,16 @@ export const getAdditionalInformationTaskList: (
   versionId: number,
   activeIndex?: ActivePage | number,
   isNewEntrant?: boolean,
-) => TaskListElement[] = (versionId, activeIndex, isNewEntrant) => {
+  operationType?: string,
+) => TaskListElement[] = (
+  versionId,
+  activeIndex,
+  isNewEntrant,
+  operationType,
+) => {
   const additionalReportingDataItem: TaskListElement = {
     type: "Page",
     title: "Additional reporting data",
-    isChecked: true,
     link: `/reports/${versionId}/additional-reporting-data`,
     isActive: activeIndex === ActivePage.AdditionalReportingData,
   };
@@ -33,11 +38,17 @@ export const getAdditionalInformationTaskList: (
     link: `/reports/${versionId}/emission-summary`,
   };
 
-  return isNewEntrant
-    ? [
-        additionalReportingDataItem,
-        newEntrantItem,
-        operationEmissionSummaryItem,
-      ]
-    : [additionalReportingDataItem, operationEmissionSummaryItem];
+  const taskList: TaskListElement[] = [additionalReportingDataItem];
+
+  // Add new entrant item if applicable
+  if (isNewEntrant) {
+    taskList.push(newEntrantItem);
+  }
+
+  // Add operation emission summary item only if operationType is "Linear Facility Operation"
+  if (operationType === "Linear Facility Operation") {
+    taskList.push(operationEmissionSummaryItem);
+  }
+
+  return taskList;
 };

--- a/bciers/apps/reporting/src/tests/components/additionalInformation/AdditionalReportingData.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/additionalInformation/AdditionalReportingData.test.tsx
@@ -51,6 +51,7 @@ describe("AdditionalReportingData Component", () => {
         includeElectricityGenerated={false}
         initialFormData={{}}
         isNewEntrant={true}
+        operationType={"Linear Facility Operation"}
       />,
     );
     const capturedEmissionsText = await screen.findByText(
@@ -66,6 +67,7 @@ describe("AdditionalReportingData Component", () => {
         includeElectricityGenerated={false}
         initialFormData={{}}
         isNewEntrant={true}
+        operationType={"Linear Facility Operation"}
       />,
     );
 
@@ -88,6 +90,7 @@ describe("AdditionalReportingData Component", () => {
         includeElectricityGenerated={true}
         initialFormData={{}}
         isNewEntrant={false}
+        operationType={"Linear Facility Operation"}
       />,
     );
 
@@ -102,6 +105,7 @@ describe("AdditionalReportingData Component", () => {
         includeElectricityGenerated={false}
         initialFormData={{}}
         isNewEntrant={true}
+        operationType={"Linear Facility Operation"}
       />,
     );
 

--- a/bciers/apps/reporting/src/tests/components/additionalInformation/AdditionalReportingData.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/additionalInformation/AdditionalReportingData.test.tsx
@@ -51,7 +51,7 @@ describe("AdditionalReportingData Component", () => {
         includeElectricityGenerated={false}
         initialFormData={{}}
         isNewEntrant={true}
-        operationType={"Linear Facility Operation"}
+        taskListElements={[]}
       />,
     );
     const capturedEmissionsText = await screen.findByText(
@@ -67,7 +67,7 @@ describe("AdditionalReportingData Component", () => {
         includeElectricityGenerated={false}
         initialFormData={{}}
         isNewEntrant={true}
-        operationType={"Linear Facility Operation"}
+        taskListElements={[]}
       />,
     );
 
@@ -90,7 +90,7 @@ describe("AdditionalReportingData Component", () => {
         includeElectricityGenerated={true}
         initialFormData={{}}
         isNewEntrant={false}
-        operationType={"Linear Facility Operation"}
+        taskListElements={[]}
       />,
     );
 
@@ -105,7 +105,7 @@ describe("AdditionalReportingData Component", () => {
         includeElectricityGenerated={false}
         initialFormData={{}}
         isNewEntrant={true}
-        operationType={"Linear Facility Operation"}
+        taskListElements={[]}
       />,
     );
 


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/563
Changes: 

1. Added operation type to additional Information tasklist, so that if the operation type is LFO, then only it should show operation emission summary page.
2. Passed operation type from New Entrant, Additional Reporting Data and operation emission summary page.
3. Fixed the test for Additional Reporting Data Form