### PR TITLE
Add django querycount package

### DIFF
--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -105,6 +105,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     'simple_history.middleware.HistoryRequestMiddleware',
+    # django-querycount is hard coded to work only in DEBUG mode set to true
+    'querycount.middleware.QueryCountMiddleware',
 ]
 
 if DEBUG:  # DEV only apps
@@ -213,3 +215,12 @@ if not DEBUG and ENVIRONMENT == "dev":
 
 
 RLS_FLAG = False
+
+# DJANGO-QUERYCOUNT SETTINGS
+# Repo: https://github.com/bradmontgomery/django-querycount
+QUERYCOUNT = {
+    # define a list of regexp patterns that get applied to each request's path. If there is a match, the middleware will not be applied to that request
+    'IGNORE_REQUEST_PATTERNS': [r'^/admin/', r'^/static/', r'^/silk/'],
+    # define a list of regexp patterns that ignored to statistic sql query count
+    'IGNORE_SQL_PATTERNS': [r'silk_'],
+}

--- a/bc_obps/poetry.lock
+++ b/bc_obps/poetry.lock
@@ -488,6 +488,16 @@ files = [
 phonenumbers = "*"
 
 [[package]]
+name = "django-querycount"
+version = "0.8.3"
+description = "Middleware that Prints the number of DB queries to the runserver console."
+optional = false
+python-versions = "*"
+files = [
+    {file = "django-querycount-0.8.3.tar.gz", hash = "sha256:0782484e8a1bd29498fa0195a67106e47cdcc98fafe80cebb1991964077cb694"},
+]
+
+[[package]]
 name = "django-silk"
 version = "5.1.0"
 description = "Silky smooth profiling for the Django Framework"
@@ -1691,6 +1701,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -2063,4 +2074,4 @@ brotli = ["Brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "d12a116f9e2f5860e9d5f5890d3ce0ac103c565c97a4534ce48bd35aa774a7c4"
+content-hash = "faeface28ffbee2fbd2e6a343cdd9565e8b9755069b1b23febdc644818caf749"

--- a/bc_obps/pyproject.toml
+++ b/bc_obps/pyproject.toml
@@ -23,6 +23,7 @@ gunicorn = "^22.0.0"
 sentry-sdk = {extras = ["django"], version = "^2.8.0"}
 dj-database-url = "^2.1.0"
 django-pgtrigger = "^4.13.3"
+django-querycount = "^0.8.3"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.3.0"

--- a/docs/backend/django-querycount.md
+++ b/docs/backend/django-querycount.md
@@ -1,0 +1,62 @@
+# django-querycount
+
+## Overview
+
+`django-querycount` is a Django middleware that helps developers track the number of database queries executed per request. This package is particularly useful for optimizing database performance and identifying inefficient query patterns.
+
+## Features
+
+- Logs the total number of database queries for each request.
+- Provides detailed query information in the Django console.
+- Helps identify N+1 query issues and excessive database calls.
+
+## Usage
+
+To enable `django-querycount`, add it to the `MIDDLEWARE` setting in your Django project's settings file:
+
+```python
+MIDDLEWARE = [
+    ...
+    'querycount.middleware.QueryCountMiddleware',
+    ...
+]
+```
+
+> **Note:** This package is hardcoded to be used only when `DEBUG = True`. It will not function in production environments where `DEBUG` is `None`.
+
+## Configuration
+
+You can customize `django-querycount` behavior by adding the following configuration to your Django settings:
+
+```python
+QUERYCOUNT = {
+    'THRESHOLDS': {
+        'MEDIUM': 50,  # Number of queries considered a medium load
+        'HIGH': 200,  # Number of queries considered a high load
+        'MIN_TIME_TO_LOG': 0,  # Minimum execution time (in ms) before a query is logged
+        'MIN_QUERY_COUNT_TO_LOG': 0  # Minimum number of queries before logging starts
+    },
+    'IGNORE_REQUEST_PATTERNS': [],  # List of request paths to exclude from logging
+    'IGNORE_SQL_PATTERNS': [],  # List of SQL queries to ignore from logging
+    'DISPLAY_DUPLICATES': None,  # If set, controls how duplicate queries are displayed
+    'RESPONSE_HEADER': 'X-DjangoQueryCount-Count'  # Custom header to display query count in responses
+}
+```
+
+### Explanation of Configuration Options
+
+- **`THRESHOLDS`**: Defines the limits for medium and high query loads.
+  - `MEDIUM`: The number of queries at which a request is considered to have a medium query load.
+  - `HIGH`: The number of queries at which a request is considered to have a high query load.
+  - `MIN_TIME_TO_LOG`: Only logs queries that take longer than this threshold (in milliseconds).
+  - `MIN_QUERY_COUNT_TO_LOG`: Logs queries only if the total number reaches this threshold.
+- **`IGNORE_REQUEST_PATTERNS`**: A list of URL patterns for which query counting should be ignored.
+- **`IGNORE_SQL_PATTERNS`**: A list of SQL query patterns that should be excluded from logs.
+- **`DISPLAY_DUPLICATES`**: Determines how duplicate queries should be displayed. If set, duplicate queries will be grouped accordingly.
+- **`RESPONSE_HEADER`**: Allows setting a custom HTTP response header that includes the query count.
+
+## More Information
+
+For more details and configuration options, refer to the official GitHub repository:
+
+[django-querycount on GitHub](https://github.com/bradmontgomery/django-querycount)


### PR DESCRIPTION
This package helps developers track the number of database queries executed per request. This package is particularly useful for optimizing database performance and identifying inefficient query patterns.

To test, just run the app and navigate to different parts of it. You will see a table in your backend terminal indicating the number of queries for each request.