### PR TITLE
chore: add created_at values to mock report fixtures

### DIFF
--- a/bc_obps/reporting/fixtures/mock/report.json
+++ b/bc_obps/reporting/fixtures/mock/report.json
@@ -5,6 +5,7 @@
       "id": 1,
       "operation_id": "3b5b95ea-2a1a-450d-8e2e-2e15feed96c9",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
+      "created_at": "2025-02-18 20:09:05.41476+00",
       "reporting_year_id": 2024
     }
   },
@@ -14,6 +15,7 @@
       "id": 2,
       "operation_id": "002d5a9e-32a6-4191-938c-2c02bfec592d",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
+      "created_at": "2025-02-18 20:09:05.41476+00",
       "reporting_year_id": 2024
     }
   }


### PR DESCRIPTION
Stopgap until this ticket gets picked up: https://github.com/bcgov/cas-reporting/issues/378
Fixes our dev data by including a created_at value for the mock reports in the dev fixtures.