### PR TITLE
chore: fixed report table

### DIFF
--- a/bciers/apps/reporting/src/app/components/datagrid/models/facilities/getFacilityColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/facilities/getFacilityColumns.tsx
@@ -14,7 +14,7 @@ const ActionCell = ({
   const router = useRouter();
 
   const handleRedirect = () => {
-    const url = `/reporting/reports/${version_id}/facilities/${id}/review-facility-information`;
+    const url = `/reports/${version_id}/facilities/${id}/review-facility-information`;
     router.push(url);
   };
 

--- a/bciers/apps/reporting/src/app/components/datagrid/models/operations/operationColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/operations/operationColumns.tsx
@@ -1,121 +1,10 @@
 "use client";
-import { GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
-import Button from "@mui/material/Button";
-import Menu from "@mui/material/Menu";
-import MenuItem from "@mui/material/MenuItem";
-import * as React from "react";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
-import { useRouter } from "next/navigation";
-import { getReportingYear } from "@reporting/src/app/utils/getReportingYear";
+import { GridColDef } from "@mui/x-data-grid";
 import ReportingOperationStatusCell from "@reporting/src/app/components/operations/cells/ReportingOperationStatusCell";
-import { createReport } from "@reporting/src/app/utils/createReport";
+import ActionCell from "@reporting/src/app/components/operations/cells/ActionCell";
+import MoreCell from "@reporting/src/app/components/operations/cells/MoreActions";
 
 export const OPERATOR_COLUMN_INDEX = 1;
-
-const MoreCell: React.FC = () => {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
-
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
-  return (
-    <div>
-      <Button
-        id="basic-button"
-        aria-controls={open ? "basic-menu" : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? "true" : undefined}
-        onClick={handleClick}
-      >
-        <MoreVertIcon />
-      </Button>
-      <Menu
-        id="basic-menu"
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
-        MenuListProps={{
-          "aria-labelledby": "basic-button",
-        }}
-      >
-        <MenuItem onClick={handleClose}>Edit Report</MenuItem>
-        <MenuItem onClick={handleClose}>Report History</MenuItem>
-        <MenuItem onClick={handleClose}>Download LFO</MenuItem>
-        <MenuItem onClick={handleClose}>Download .csv</MenuItem>
-      </Menu>
-    </div>
-  );
-};
-
-const ActionCell = (params: GridRenderCellParams) => {
-  const reportVersionId = params?.row?.report_version_id;
-  const router = useRouter();
-  const OperationId = params.row.id;
-  const [responseError, setResponseError] = React.useState<string | null>(null);
-  const [hasClicked, setHasClicked] = React.useState<boolean>(false);
-
-  const handleStartReport = async (
-    operationId: string,
-    reportingYear: number,
-  ): Promise<string> => {
-    try {
-      const response = await createReport(operationId, reportingYear);
-      if (response?.error)
-        setResponseError(
-          `We couldn't create a report for operation ID '${operationId}' and reporting year '${reportingYear}': ${response?.error}.`,
-        );
-      return response;
-    } catch (error) {
-      throw error;
-    }
-  };
-
-  if (responseError) {
-    throw new Error(responseError); // Use the error message in the error boundary in case operation not found
-  }
-
-  const handleStartClick = async () => {
-    const reportingYearObj = await getReportingYear();
-    const newReportId = await handleStartReport(
-      OperationId,
-      reportingYearObj.reporting_year,
-    );
-    if (typeof newReportId === "number")
-      router.push(`reports/${newReportId}/review-operator-data`);
-  };
-
-  if (reportVersionId) {
-    return (
-      <Button
-        color="primary"
-        onClick={() =>
-          router.push(`reports/${reportVersionId}/review-operator-data`)
-        }
-      >
-        Continue
-      </Button>
-    );
-  }
-
-  return (
-    <Button
-      color="primary"
-      disabled={hasClicked}
-      onClick={() => {
-        setHasClicked(true);
-        handleStartClick();
-      }}
-    >
-      Start
-    </Button>
-  );
-};
 
 const operationColumns = (): GridColDef[] => {
   const columns: GridColDef[] = [
@@ -126,24 +15,25 @@ const operationColumns = (): GridColDef[] => {
       width: 560,
     },
     {
-      field: "report_id",
-      headerName: "Actions",
-      renderCell: ActionCell,
-      sortable: false,
-      width: 120,
-    },
-    {
       field: "report_status",
       headerName: "Status",
       renderCell: ReportingOperationStatusCell,
       align: "center",
       headerAlign: "center",
-      width: 160,
+      width: 200,
     },
     {
+      field: "report_id",
+      headerName: "Actions",
+      renderCell: ActionCell,
+      sortable: false,
+      width: 200,
+    },
+
+    {
       field: "more",
-      headerName: "More",
-      renderCell: () => <MoreCell />,
+      headerName: "More Actions",
+      renderCell: MoreCell,
       sortable: false,
       width: 120,
       flex: 1,

--- a/bciers/apps/reporting/src/app/components/operations/cells/ActionCell.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/cells/ActionCell.tsx
@@ -1,0 +1,87 @@
+import { GridRenderCellParams } from "@mui/x-data-grid";
+import { useRouter } from "next/navigation";
+import * as React from "react";
+import { createReport } from "@reporting/src/app/utils/createReport";
+import { getReportingYear } from "@reporting/src/app/utils/getReportingYear";
+import Button from "@mui/material/Button";
+import { BC_GOV_LINKS_COLOR } from "@bciers/styles";
+import { ReportOperationStatus } from "@bciers/utils/src/enums";
+
+const ActionCell = (params: GridRenderCellParams) => {
+  const reportVersionId = params?.row?.report_version_id;
+  const reportStatus = params?.row?.report_status;
+  const router = useRouter();
+  const OperationId = params.row.id;
+  const [responseError, setResponseError] = React.useState<string | null>(null);
+  const [hasClicked, setHasClicked] = React.useState<boolean>(false);
+
+  const handleStartReport = async (
+    operationId: string,
+    reportingYear: number,
+  ): Promise<string> => {
+    try {
+      const response = await createReport(operationId, reportingYear);
+      if (response?.error)
+        setResponseError(
+          `We couldn't create a report for operation ID '${operationId}' and reporting year '${reportingYear}': ${response?.error}.`,
+        );
+      return response;
+    } catch (error) {
+      throw error;
+    }
+  };
+
+  if (responseError) {
+    throw new Error(responseError);
+  }
+
+  const handleStartClick = async () => {
+    const reportingYearObj = await getReportingYear();
+    const newReportId = await handleStartReport(
+      OperationId,
+      reportingYearObj.reporting_year,
+    );
+    if (typeof newReportId === "number")
+      router.push(`reports/${newReportId}/review-operator-data`);
+  };
+
+  let buttonText = "Start";
+  let buttonAction: () => Promise<void> = async () => handleStartClick();
+  let buttonDisabled = hasClicked;
+
+  if (reportVersionId) {
+    if (reportStatus === ReportOperationStatus.DRAFT) {
+      buttonText = "Continue";
+      buttonAction = async () =>
+        router.push(`reports/${reportVersionId}/review-operator-data`);
+      buttonDisabled = false;
+    } else if (reportStatus === ReportOperationStatus.SUBMITTED) {
+      buttonText = "View Details";
+      buttonAction = async () =>
+        router.push(`reports/${reportVersionId}/review-operator-data`);
+      buttonDisabled = false;
+    }
+  }
+
+  return (
+    <Button
+      sx={{
+        width: 120,
+        height: 40,
+        borderRadius: "5px",
+        border: `1px solid ${BC_GOV_LINKS_COLOR}`,
+        cursor: buttonDisabled ? "not-allowed" : "pointer",
+      }}
+      color="primary"
+      disabled={buttonDisabled}
+      onClick={async () => {
+        setHasClicked(true);
+        await buttonAction();
+      }}
+    >
+      {buttonText}
+    </Button>
+  );
+};
+
+export default ActionCell;

--- a/bciers/apps/reporting/src/app/components/operations/cells/MoreActions.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/cells/MoreActions.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import Button from "@mui/material/Button";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import { useRouter } from "next/navigation";
+import { GridRenderCellParams } from "@mui/x-data-grid";
+import { ReportOperationStatus } from "@bciers/utils/src/enums";
+
+const MoreCell = (params: GridRenderCellParams) => {
+  const reportId = params?.row?.report_id;
+  const reportStatus = params?.row?.report_status;
+
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const router = useRouter();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <Button
+        id="basic-button"
+        aria-controls={open ? "basic-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleClick}
+      >
+        <MoreVertIcon />
+      </Button>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          "aria-labelledby": "basic-button",
+        }}
+      >
+        {reportStatus && reportStatus === ReportOperationStatus.SUBMITTED && (
+          <MenuItem onClick={handleClose}>Create Supplementary Report</MenuItem>
+        )}
+        <MenuItem
+          onClick={async () =>
+            router.push(`reports/${reportId}/report-history`)
+          }
+        >
+          Report History
+        </MenuItem>
+      </Menu>
+    </div>
+  );
+};
+
+export default MoreCell;

--- a/bciers/apps/reporting/src/app/components/operations/cells/ReportingOperationStatusCell.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/cells/ReportingOperationStatusCell.tsx
@@ -1,36 +1,31 @@
 "use client";
 
 import { ReportOperationStatus } from "@bciers/utils/src/enums";
-import { Chip, ChipOwnProps } from "@mui/material";
 import { GridRenderCellParams } from "@mui/x-data-grid";
+import {
+  BC_GOV_PRIMARY_BRAND_COLOR_BLUE,
+  BC_GOV_SEMANTICS_GREEN,
+} from "@bciers/styles";
 
 export default function ReportingOperationStatusCell(
   params: GridRenderCellParams,
 ) {
-  const colorMap = new Map<string, ChipOwnProps["color"]>([
-    [ReportOperationStatus.NOT_STARTED, "primary"],
-    [ReportOperationStatus.DRAFT, "primary"],
-    [ReportOperationStatus.SUBMITTED, "success"],
+  const colorMap = new Map<string, string>([
+    [ReportOperationStatus.NOT_STARTED, BC_GOV_PRIMARY_BRAND_COLOR_BLUE],
+    [ReportOperationStatus.DRAFT, BC_GOV_PRIMARY_BRAND_COLOR_BLUE],
+    [ReportOperationStatus.SUBMITTED, BC_GOV_SEMANTICS_GREEN],
   ]);
   const status = params.value || ReportOperationStatus.NOT_STARTED;
   const statusColor = colorMap.get(status) || "primary";
-  const isMultiLineStatus = status === ReportOperationStatus.NOT_STARTED;
-
-  const fontSize = isMultiLineStatus ? "14px" : "16px";
   return (
-    <Chip
-      label={
-        <div style={{ whiteSpace: "normal", color: statusColor, fontSize }}>
-          {status}
-        </div>
-      }
-      variant="outlined"
-      color={statusColor}
-      sx={{
-        width: 100,
-        height: 40,
-        borderRadius: "20px",
+    <div
+      style={{
+        whiteSpace: "normal",
+        fontSize: "16px",
+        color: statusColor,
       }}
-    />
+    >
+      {status}
+    </div>
   );
 }

--- a/bciers/apps/reporting/src/tests/components/dataGrid/model/operations/operationColumns.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/dataGrid/model/operations/operationColumns.test.tsx
@@ -1,7 +1,7 @@
-import { describe } from "vitest";
+import { describe, vi } from "vitest";
 import operationColumns from "@reporting/src/app/components/datagrid/models/operations/operationColumns";
 import { GridColDef } from "@mui/x-data-grid";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useRouter } from "@bciers/testConfig/mocks";
 
@@ -18,6 +18,7 @@ describe("operationColumns function", () => {
   vi.mock("@reporting/src/app/utils/getReportingYear", () => ({
     getReportingYear: vi.fn().mockResolvedValue({ reporting_year: 2023 }),
   }));
+
   vi.mock("@reporting/src/app/utils/createReport", () => ({
     createReport: vi.fn().mockResolvedValue(1),
   }));
@@ -45,32 +46,33 @@ describe("operationColumns function", () => {
     assert(columns[1].width === 560, "Column 2 width should be 560");
 
     assert(
-      columns[2].field === "report_id",
-      'Column 3 field should be "report_id"',
+      columns[2].field === "report_status",
+      'Column 3 field should be "report_status"',
     );
-    assert(
-      columns[2].headerName === "Actions",
-      'Column 3 headerName should be "Actions"',
-    );
-    assert(columns[2].width === 120, "Column 3 width should be 120");
+    assert(columns[2].width === 200, "Column 3 width should be 200");
 
     assert(
-      columns[3].field === "report_status",
-      'Column 4 field should be "report_status"',
+      columns[3].field === "report_id",
+      'Column 4 field should be "report_id"',
     );
-    assert(columns[3].width === 160, "Column 4 width should be 160");
-
-    assert(columns[4].field === "more", 'Column 5 field should be "action"');
     assert(
-      columns[4].headerName === "More",
-      'Column 5 headerName should be "More"',
+      columns[3].headerName === "Actions",
+      'Column 4 headerName should be "Actions"',
     );
-    assert(columns[4].sortable === false, "Column 4 sortable should be false");
-    assert(columns[4].width === 120, "Column 4 width should be 120");
-    assert(columns[4].flex === 1, "Column 4 flex should be 1");
+    assert(columns[3].sortable === false, "Column 4 sortable should be false");
+    assert(columns[3].width === 200, "Column 4 width should be 200");
+
+    assert(columns[4].field === "more", 'Column 5 field should be "more"');
+    assert(
+      columns[4].headerName === "More Actions",
+      'Column 5 headerName should be "More Actions"',
+    );
+    assert(columns[4].sortable === false, "Column 5 sortable should be false");
+    assert(columns[4].width === 120, "Column 5 width should be 120");
+    assert(columns[4].flex === 1, "Column 5 flex should be 1");
   });
 
-  it("has a 'start' button in the 'Actions' column when report_id is null", () => {
+  it("has a 'start' button in the 'Actions' column when report_version_id is null", () => {
     const columns: GridColDef[] = operationColumns();
 
     const row = {
@@ -84,53 +86,18 @@ describe("operationColumns function", () => {
 
     const params = {
       row,
-      value: row.report_id,
+      value: row.report_version_id,
     };
 
     function WrapperComponent() {
-      // in order for hook to work
-      const cell = columns[2].renderCell;
+      const cell = columns[3].renderCell;
 
       return <div>{cell(params)}</div>;
     }
 
     render(<WrapperComponent />);
-    expect(screen.getByText("Start")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start" })).toBeInTheDocument();
   });
-
-  it("navigates to the new report when clicking the 'Start' button", async () => {
-    const user = userEvent.setup();
-
-    const columns = operationColumns();
-
-    const row = {
-      id: "1",
-      bcghg_id: "12111130002",
-      name: "Operation with report",
-      report_id: null,
-      report_version_id: null,
-      report_status: null,
-    };
-
-    const params = {
-      row,
-      value: row.report_id,
-    };
-
-    function WrapperComponent() {
-      const cell = columns[2].renderCell;
-
-      return <div>{cell(params)}</div>;
-    }
-
-    render(<WrapperComponent />);
-    await user.click(screen.getByText("Start"));
-
-    await waitFor(() => {
-      expect(useRouter().push).toHaveBeenCalled();
-    });
-  });
-
   it("has a 'continue' button in the 'Actions' column when report_id exists", () => {
     const columns: GridColDef[] = operationColumns();
 
@@ -149,7 +116,7 @@ describe("operationColumns function", () => {
     };
 
     function WrapperComponent() {
-      const cell = columns[2].renderCell;
+      const cell = columns[3].renderCell;
 
       return <div>{cell(params)}</div>;
     }
@@ -178,7 +145,7 @@ describe("operationColumns function", () => {
     };
 
     function WrapperComponent() {
-      const cell = columns[2].renderCell;
+      const cell = columns[3].renderCell;
 
       return <div>{cell(params)}</div>;
     }
@@ -186,8 +153,6 @@ describe("operationColumns function", () => {
     render(<WrapperComponent />);
     await user.click(screen.getByText("Continue"));
 
-    expect(useRouter().push).toHaveBeenCalledWith(
-      `reports/15/review-operator-data`,
-    );
+    expect(mockPush).toHaveBeenCalledWith(`reports/15/review-operator-data`);
   });
 });


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/519
Changes:

1. Modifed Action cells
2. Change heading from More to More Actions
3. Fixed the text colours
4. added button outline for actions cells
5. Modified the menu items in more actions

To test:

1. Go to http://localhost:3000/reporting/reports
2. manually change status of any report in report_version table to Submitted, and you will see submitted in status with green colour , in action the button text will be View Details and in more actions two options - Create Supplementary Report and Report History.(As of now we do not have functionality for view detail, but that will be capture in separate tickt)
3. For all the other status, in more action only Report History will be visible

