### PR TITLE
2169 2 changing reg purpose

### DIFF
--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -22,16 +22,19 @@ import { useSessionRole } from "@bciers/utils/src/sessionUtils";
 import Note from "@bciers/components/layout/Note";
 import Link from "next/link";
 import ConfirmChangeOfRegistrationPurposeModal from "@/registration/app/components/operations/registration/ConfirmChangeOfRegistrationPurposeModal";
-import { eioOperationInformationSchema } from "../../data/jsonSchema/operationInformation/operationInformation";
 
 const OperationInformationForm = ({
   formData,
   operationId,
   schema: initialSchema,
+  eioSchema,
+  generalSchema,
 }: {
   formData: OperationInformationPartialFormData;
   operationId: UUID;
   schema: RJSFSchema;
+  eioSchema: RJSFSchema;
+  generalSchema: RJSFSchema;
 }) => {
   const [error, setError] = useState(undefined);
   const [schema, setSchema] = useState(initialSchema);
@@ -55,18 +58,11 @@ const OperationInformationForm = ({
       formData.registration_purpose = selectedPurpose;
     }
     if (selectedPurpose === RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION) {
-      // EIOs only require basic information, so if a user selects EIO we remove some of the form fields
-      setSchema({
-        ...initialSchema,
-        properties: {
-          ...initialSchema.properties,
-          section1: eioOperationInformationSchema,
-        },
-      });
+      setSchema(eioSchema);
     } else {
-      setSchema(initialSchema);
+      setSchema(generalSchema);
     }
-  }, [selectedPurpose]);
+  }, [selectedPurpose, eioSchema, generalSchema]);
 
   const handleSubmit = async (data: {
     formData?: OperationInformationFormData;

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -3,6 +3,7 @@ import { getOperationWithDocuments } from "@bciers/actions/api";
 import { createAdministrationOperationInformationSchema } from "../../data/jsonSchema/operationInformation/administrationOperationInformation";
 import { UUID } from "crypto";
 import { validate as isValidUUID } from "uuid";
+import { RegistrationPurposes } from "@/registration/app/components/operations/registration/enums";
 
 const OperationInformationPage = async ({
   operationId,
@@ -17,7 +18,7 @@ const OperationInformationPage = async ({
   if (operation?.error) throw new Error("Error fetching operation information");
 
   const formSchema = await createAdministrationOperationInformationSchema(
-    operation?.registration_purpose,
+    undefined, // we do know the registration purpose at this point, but we don't want to consider it when generating the schema
     operation.status,
   );
 

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -18,7 +18,15 @@ const OperationInformationPage = async ({
   if (operation?.error) throw new Error("Error fetching operation information");
 
   const formSchema = await createAdministrationOperationInformationSchema(
-    undefined, // we do know the registration purpose at this point, but we don't want to consider it when generating the schema
+    operation.registration_purpose,
+    operation.status,
+  );
+  const eioSchema = await createAdministrationOperationInformationSchema(
+    RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION,
+    operation.status,
+  );
+  const generalSchema = await createAdministrationOperationInformationSchema(
+    undefined,
     operation.status,
   );
 
@@ -29,7 +37,11 @@ const OperationInformationPage = async ({
         registration_purpose: operation?.registration_purpose,
       }}
       operationId={operationId}
+      // this is the schema needed for the operation's existing registration purpose
       schema={formSchema}
+      // these schemas are used to support changing the registration purpose
+      eioSchema={eioSchema}
+      generalSchema={generalSchema}
     />
   );
 };

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationOperationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/administrationOperationInformation.ts
@@ -17,7 +17,7 @@ import { Apps, OperationStatus } from "@bciers/utils/src/enums";
 import { optedInOperationDetailsUiSchema } from "./optedInOperation";
 import { RegistrationPurposes } from "@/registration/app/components/operations/registration/enums";
 export const createAdministrationOperationInformationSchema = async (
-  registrationPurposeValue: RegistrationPurposes,
+  registrationPurposeValue: RegistrationPurposes | undefined,
   status: OperationStatus,
 ): Promise<RJSFSchema> => {
   const administrationOperationInformationSchema: RJSFSchema = {

--- a/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
@@ -179,6 +179,8 @@ describe("the OperationInformationForm component", () => {
         formData={{}}
         schema={testSchema}
         operationId={operationId}
+        eioSchema={testSchema}
+        generalSchema={testSchema}
       />,
     );
 
@@ -201,6 +203,8 @@ describe("the OperationInformationForm component", () => {
         formData={formData}
         schema={createdFormSchema}
         operationId={operationId}
+        eioSchema={testSchema}
+        generalSchema={createdFormSchema}
       />,
     );
     //name
@@ -253,15 +257,23 @@ describe("the OperationInformationForm component", () => {
       );
     render(
       <OperationInformationForm
-        formData={{ name: "Operation 3", type: "Electricity Import Operation" }}
+        formData={{
+          name: "Operation 3",
+          type: "Electricity Import Operation",
+          registration_purpose: "Electricity Import Operation",
+        }}
         schema={createdFormSchema}
         operationId={operationId}
+        eioSchema={createdFormSchema}
+        generalSchema={testSchema}
       />,
     );
     //name
     expect(screen.getByText(/Operation 3/i)).toBeVisible();
-    // type
-    expect(screen.getByText(/Electricity Import Operation/i)).toBeVisible();
+    // type and purpose
+    expect(screen.getAllByText(/Electricity Import Operation/i)).toHaveLength(
+      2,
+    );
     // primary naics code
     expect(screen.queryByText(/naics/i)).not.toBeInTheDocument();
 
@@ -271,7 +283,6 @@ describe("the OperationInformationForm component", () => {
         /The purpose of this registration is to register as a\:/i,
       ),
     ).toBeVisible();
-    expect(screen.getByText(/Electricity Import Operation/i)).toBeVisible();
   });
 
   it("should enable editing when the Edit button is clicked", async () => {
@@ -280,6 +291,8 @@ describe("the OperationInformationForm component", () => {
         formData={formData}
         schema={testSchema}
         operationId={operationId}
+        eioSchema={testSchema}
+        generalSchema={testSchema}
       />,
     );
 
@@ -300,6 +313,8 @@ describe("the OperationInformationForm component", () => {
         formData={formData}
         schema={testSchema}
         operationId={operationId}
+        eioSchema={testSchema}
+        generalSchema={testSchema}
       />,
     );
 
@@ -345,6 +360,8 @@ describe("the OperationInformationForm component", () => {
         formData={optInFormData}
         schema={testSchemaWithOpt}
         operationId={operationId}
+        eioSchema={testSchema}
+        generalSchema={testSchemaWithOpt}
       />,
     );
 
@@ -416,6 +433,8 @@ describe("the OperationInformationForm component", () => {
         formData={formData}
         schema={testSchema}
         operationId={operationId}
+        eioSchema={testSchema}
+        generalSchema={testSchema}
       />,
     );
 
@@ -440,6 +459,8 @@ describe("the OperationInformationForm component", () => {
         formData={optInFormData}
         schema={testSchemaWithOpt}
         operationId={operationId}
+        eioSchema={testSchema}
+        generalSchema={testSchemaWithOpt}
       />,
     );
 
@@ -587,6 +608,26 @@ describe("the OperationInformationForm component", () => {
           },
         }}
         operationId={operationId}
+        eioSchema={testSchema}
+        generalSchema={{
+          type: "object",
+          properties: {
+            section1: {
+              title: "Section 1",
+              type: "object",
+              properties: {
+                bc_obps_regulated_operation: {
+                  type: "string",
+                  title: "BORO ID",
+                },
+                bcghg_id: {
+                  type: "string",
+                  title: "BCGHGID",
+                },
+              },
+            },
+          },
+        }}
       />,
     );
 
@@ -610,6 +651,26 @@ describe("the OperationInformationForm component", () => {
 
       render(
         <OperationInformationForm
+          eioSchema={testSchema}
+          generalSchema={{
+            type: "object",
+            properties: {
+              section1: {
+                title: "Section 1",
+                type: "object",
+                properties: {
+                  bc_obps_regulated_operation: {
+                    type: "string",
+                    title: "BORO ID",
+                  },
+                  bcghg_id: {
+                    type: "string",
+                    title: "BCGHGID",
+                  },
+                },
+              },
+            },
+          }}
           formData={{ ...formData, status: OperationStatus.REGISTERED }}
           schema={{
             type: "object",
@@ -653,6 +714,8 @@ describe("the OperationInformationForm component", () => {
 
     const { container } = render(
       <OperationInformationForm
+        eioSchema={testSchema}
+        generalSchema={modifiedSchema}
         formData={newEntrantFormData}
         schema={modifiedSchema}
         operationId={operationId}
@@ -752,6 +815,8 @@ describe("the OperationInformationForm component", () => {
 
     render(
       <OperationInformationForm
+        eioSchema={testSchema}
+        generalSchema={testSchemaWithNewEntrant}
         formData={newEntrantFormData}
         schema={testSchemaWithNewEntrant}
         operationId={operationId}
@@ -812,6 +877,8 @@ describe("the OperationInformationForm component", () => {
 
     render(
       <OperationInformationForm
+        eioSchema={testSchema}
+        generalSchema={createdFormSchema}
         formData={formData}
         schema={createdFormSchema}
         operationId={operationId}
@@ -865,6 +932,8 @@ describe("the OperationInformationForm component", () => {
 
       render(
         <OperationInformationForm
+          eioSchema={testSchema}
+          generalSchema={createdFormSchema}
           formData={testFormData}
           schema={createdFormSchema}
           operationId={operationId}
@@ -937,6 +1006,8 @@ describe("the OperationInformationForm component", () => {
 
     render(
       <OperationInformationForm
+        eioSchema={testSchema}
+        generalSchema={createdFormSchema}
         formData={{}}
         schema={createdFormSchema}
         operationId={operationId}

--- a/bciers/apps/registration/app/components/operations/registration/ConfirmChangeOfRegistrationPurposeModal.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/ConfirmChangeOfRegistrationPurposeModal.tsx
@@ -22,7 +22,7 @@ export default function ConfirmChangeOfRegistrationPurposeModal({
       confirmText="Change registration purpose"
     >
       Are you sure you want to change your registration purpose? If you proceed,
-      all of the form data you have entered will be lost.
+      some of the form data you have entered will be lost.
     </SimpleModal>
   );
 }


### PR DESCRIPTION
card: #2169 

This is a second PR for the same card to fix some issues @fviduya found in QA. See the card's comments for more details, but TLDR the issues are:
- modal text said ALL of the data will be deleted when changing purpose, but fields that are still relevant to the new purpose stayed filled
- on the admin OperationForm, when switching from an EIO to another purpose, the form stayed stuck on the EIO fields and dropdown options

This PR:
- update the modal text to say SOME instead of ALL (desired behaviour is to keep stuff that's still relevant)
- fix the stuck EIO form. Did this by: When we first generate the rjsf schema (`formSchema`), we do that based on the existing registration purpose. However, if a user switches the purpose, we need the new purpose's schema, and we can't generate that in the form because it has to be done in a server component. To deal with this, I'm creating all the schemas (`formSchema`, `eioSchema`, `generalSchema`) in the parent and passing them all to the form so that we can swap between schemas using state/useEffect. One day I would like to refactor this more cleanly, but today is not that day