### PR TITLE
Bug: 417 page renders even if the version ID doesn't exist

### DIFF
--- a/bciers/apps/reporting/src/app/utils/getActivityFormData.ts
+++ b/bciers/apps/reporting/src/app/utils/getActivityFormData.ts
@@ -1,17 +1,17 @@
 import { actionHandler } from "@bciers/actions";
 
 export async function getActivityFormData(
-  versionId: number,
+  reportVersionId: number,
   facilityId: string,
   activityId: number,
 ) {
-  const response = await actionHandler(
-    `reporting/report-version/${versionId}/facilities/${facilityId}/activity/${activityId}/report-activity`,
-    "GET",
-    "",
-  );
+  const endpoint = `reporting/report-version/${reportVersionId}/facilities/${facilityId}/activity/${activityId}/report-activity`;
+  const response = await actionHandler(endpoint, "GET");
   if (response.error) {
-    throw new Error("We couldn't find the activity list for this facility.");
+    throw new Error(
+      `Failed to fetch the activity list for report version ${reportVersionId}, facility ${facilityId}, activity ${activityId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
   }
   return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getActivityInitData.ts
+++ b/bciers/apps/reporting/src/app/utils/getActivityInitData.ts
@@ -1,19 +1,16 @@
 import { actionHandler } from "@bciers/actions";
 
 export async function getActivityInitData(
-  versionId: number,
+  reportVersionId: number,
   facilityId: string,
   activityId: number,
 ) {
-  const response = await actionHandler(
-    `reporting/report-version/${versionId}/facility-report/${facilityId}/initial-activity-data?activity_id=${activityId}`,
-    "GET",
-    "",
-  );
-
+  const endpoint = `reporting/report-version/${reportVersionId}/facility-report/${facilityId}/initial-activity-data?activity_id=${activityId}`;
+  const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Error fetching activity init data for version ${versionId}, activity ${activityId}`,
+      `Failed to fetch the activity init data for report version ${reportVersionId}, facility ${facilityId}, activity ${activityId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getActivitySchema.ts
+++ b/bciers/apps/reporting/src/app/utils/getActivitySchema.ts
@@ -1,19 +1,16 @@
 import { actionHandler } from "@bciers/actions";
 
 export async function getActivitySchema(
-  versionId: number,
+  reportVersionId: number,
   activityId: number,
   sourceTypeQueryString: string,
 ) {
-  const response = await actionHandler(
-    `reporting/build-form-schema?activity=${activityId}&report_version_id=${versionId}${sourceTypeQueryString}`,
-    "GET",
-    "",
-  );
-
+  const endpoint = `reporting/build-form-schema?activity=${activityId}&report_version_id=${reportVersionId}${sourceTypeQueryString}`;
+  const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Error fetching schema for version ${versionId}, activity ${activityId}, source types ${sourceTypeQueryString}`,
+      `Failed to fetch the schema for report version ${reportVersionId}, activity ${activityId}, source types ${sourceTypeQueryString}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getAllActivities.ts
+++ b/bciers/apps/reporting/src/app/utils/getAllActivities.ts
@@ -1,5 +1,10 @@
 import { actionHandler } from "@bciers/actions";
 
 export async function getAllActivities() {
-  return actionHandler(`reporting/activities`, "GET", `reporting/activities`);
+  const endpoint = "reporting/activities";
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error("Failed to fetch the activities.");
+  }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getAllEmissionCategories.ts
+++ b/bciers/apps/reporting/src/app/utils/getAllEmissionCategories.ts
@@ -1,9 +1,10 @@
 import { actionHandler } from "@bciers/actions";
 
 export const getAllEmissionCategories = async () => {
-  return actionHandler(
-    `reporting/emission-category`,
-    "GET",
-    `reporting/emission-category`,
-  );
+  const endpoint = "reporting/emission-category";
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error("Failed to fetch the emission category.");
+  }
+  return response;
 };

--- a/bciers/apps/reporting/src/app/utils/getAllGasTypes.ts
+++ b/bciers/apps/reporting/src/app/utils/getAllGasTypes.ts
@@ -1,13 +1,19 @@
 import { actionHandler } from "@bciers/actions";
 
 export const getAllGasTypes = async () => {
-  return actionHandler(`reporting/gas-type`, "GET", `reporting/gas-type`);
+  const endpoint = "reporting/gas-type";
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error("Failed to fetch the gas types.");
+  }
+  return response;
 };
 
 export const getBasicGasTypes = async () => {
-  return actionHandler(
-    `reporting/basic-gas-types`,
-    "GET",
-    `reporting/basic-gas-types`,
-  );
+  const endpoint = "reporting/basic-gas-types";
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error("Failed to fetch the basic gas types.");
+  }
+  return response;
 };

--- a/bciers/apps/reporting/src/app/utils/getAllReportingActivities.ts
+++ b/bciers/apps/reporting/src/app/utils/getAllReportingActivities.ts
@@ -1,5 +1,10 @@
 import { actionHandler } from "@bciers/actions";
 
 export const getAllActivities = async () => {
-  return actionHandler(`reporting/activities`, "GET", `reporting/activities`);
+  const endpoint = "reporting/activities";
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error("Failed to fetch the activities.");
+  }
+  return response;
 };

--- a/bciers/apps/reporting/src/app/utils/getAttachments.ts
+++ b/bciers/apps/reporting/src/app/utils/getAttachments.ts
@@ -1,7 +1,14 @@
 import { actionHandler } from "@bciers/actions";
 
 // 🛠️ Function to fetch a contact by id
-export default async function getAttachments(report_version_id: number) {
-  const endpoint = `reporting/report-version/${report_version_id}/attachments`;
-  return actionHandler(endpoint, "GET", "");
+export default async function getAttachments(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/attachments`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the attachments for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
+  }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getComplianceData.ts
+++ b/bciers/apps/reporting/src/app/utils/getComplianceData.ts
@@ -1,11 +1,12 @@
 import { actionHandler } from "@bciers/actions";
-export async function getComplianceData(versionId: number) {
-  const response = await actionHandler(
-    `reporting/report-version/${versionId}/compliance-data`,
-    "GET",
-  );
+export async function getComplianceData(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/compliance-data`;
+  const response = await actionHandler(endpoint, "GET");
   if (response.error) {
-    throw new Error("We couldn't find the compliance data for this report.");
+    throw new Error(
+      `Failed to fetch the compliance data for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
   }
   return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getEmissionAllocations.ts
+++ b/bciers/apps/reporting/src/app/utils/getEmissionAllocations.ts
@@ -1,9 +1,16 @@
 import { actionHandler } from "@bciers/actions";
 
 export async function getEmissionAllocations(
-  report_version_id: number,
-  facility_id: string,
+  reportVersionId: number,
+  facilityId: string,
 ) {
-  const endpoint = `reporting/report-version/${report_version_id}/facilities/${facility_id}/allocate-emissions`;
-  return actionHandler(endpoint, "GET", "");
+  const endpoint = `reporting/report-version/${reportVersionId}/facilities/${facilityId}/allocate-emissions`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the emission allocations for report version ${reportVersionId}, facility ${facilityId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
+  }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getFacilityReport.ts
+++ b/bciers/apps/reporting/src/app/utils/getFacilityReport.ts
@@ -1,12 +1,13 @@
 import { actionHandler } from "@bciers/actions";
-export async function getFacilityReport(version_id: number) {
-  let response = await actionHandler(
-    `reporting/report-version/${version_id}/facility-report`,
-    "GET",
-    `reporting/report-version/${version_id}/facility-report`,
-  );
 
-  if (response && !response.error) {
-    return response;
+export async function getFacilityReport(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/facility-report`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the facility for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
   }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getFacilityReportDetails.ts
+++ b/bciers/apps/reporting/src/app/utils/getFacilityReportDetails.ts
@@ -1,12 +1,16 @@
 import { actionHandler } from "@bciers/actions";
 
 export async function getFacilityReportDetails(
-  version_id: number,
-  facility_id: string,
+  reportVersionId: number,
+  facilityId: string,
 ) {
-  return actionHandler(
-    `reporting/report-version/${version_id}/facility-report/${facility_id}`,
-    "GET",
-    `reporting/report-version/${version_id}/facility-report/${facility_id}`,
-  );
+  const endpoint = `reporting/report-version/${reportVersionId}/facility-report/${facilityId}`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the facility details for report version ${reportVersionId}, facility ${facilityId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
+  }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getNewEntrantData.ts
+++ b/bciers/apps/reporting/src/app/utils/getNewEntrantData.ts
@@ -1,9 +1,13 @@
 import { actionHandler } from "@bciers/actions";
 
-export async function getNewEntrantData(version_id: number) {
-  return actionHandler(
-    `reporting/report-version/${version_id}/new-entrant-data`,
-    "GET",
-    `reporting/report-version/${version_id}/new-entrant-data`,
-  );
+export async function getNewEntrantData(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/new-entrant-data`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the new entrant data for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
+  }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getNonAttributableEmissionsData.ts
+++ b/bciers/apps/reporting/src/app/utils/getNonAttributableEmissionsData.ts
@@ -1,15 +1,15 @@
 import { actionHandler } from "@bciers/actions";
 export async function getNonAttributableEmissionsData(
-  version_id: number,
+  reportVersionId: number,
   facilityId: string,
 ) {
-  let response = await actionHandler(
-    `reporting/report-version/${version_id}/facilities/${facilityId}/non-attributable`,
-    "GET",
-    `reporting/report-version/${version_id}/facilities/${facilityId}/non-attributable`,
-  );
-
-  if (response && !response.error) {
-    return response;
+  const endpoint = `reporting/report-version/${reportVersionId}/facilities/${facilityId}/non-attributable`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the non attributable emissions data for report version ${reportVersionId}, facility ${facilityId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
   }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getOperationEmissionSummaryData.ts
+++ b/bciers/apps/reporting/src/app/utils/getOperationEmissionSummaryData.ts
@@ -1,0 +1,13 @@
+import { actionHandler } from "@bciers/actions";
+
+export async function getOperationEmissionSummaryData(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/emission-summary`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the operation emissions summary data for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
+  }
+  return response;
+}

--- a/bciers/apps/reporting/src/app/utils/getOperationFacilitiesList.ts
+++ b/bciers/apps/reporting/src/app/utils/getOperationFacilitiesList.ts
@@ -1,11 +1,13 @@
 import { actionHandler } from "@bciers/actions";
-// Fetches the facility list for the operation associated with the given report version ID
-export async function getOperationFacilitiesList(version_id: number) {
-  const response = await actionHandler(
-    `reporting/report-version/${version_id}/review-facilities`,
-    "GET",
-  );
-  if (response && !response.error) {
-    return response;
+
+export async function getOperationFacilitiesList(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/review-facilities`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the facility list for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
   }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getOrderedActivities.ts
+++ b/bciers/apps/reporting/src/app/utils/getOrderedActivities.ts
@@ -1,16 +1,16 @@
 import { actionHandler } from "@bciers/actions";
 
 export async function getOrderedActivities(
-  versionId: number,
+  reportVersionId: number,
   facilityId: string,
 ) {
-  const orderedActivities = await actionHandler(
-    `reporting/report-version/${versionId}/facility-report/${facilityId}/activity-list`,
-    "GET",
-    "",
-  );
-  if (orderedActivities.error) {
-    throw new Error("We couldn't find the activity list for this facility.");
+  const endpoint = `reporting/report-version/${reportVersionId}/facility-report/${facilityId}/activity-list`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the activity list for report version ${reportVersionId}, facility ${facilityId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
   }
-  return orderedActivities;
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getRegistrationPurpose.ts
+++ b/bciers/apps/reporting/src/app/utils/getRegistrationPurpose.ts
@@ -1,12 +1,13 @@
 import { actionHandler } from "@bciers/actions";
 
-export async function getRegistrationPurpose(version_id: number) {
-  const response = await actionHandler(
-    `reporting/report-version/${version_id}/registration_purpose`,
-    "GET",
-  );
-
-  if (response && !response.error) {
-    return response;
+export async function getRegistrationPurpose(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/registration_purpose`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the registration purpose for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
   }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getReportAdditionalData.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportAdditionalData.ts
@@ -1,8 +1,13 @@
 import { actionHandler } from "@bciers/actions";
 
-export async function getReportAdditionalData(version_id: number) {
-  return actionHandler(
-    `reporting/report-version/${version_id}/report-additional-data`,
-    "GET",
-  );
+export async function getReportAdditionalData(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/report-additional-data`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the additional data for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
+  }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getReportFacilityList.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportFacilityList.ts
@@ -1,11 +1,13 @@
 import { actionHandler } from "@bciers/actions";
-// Fetches the facility list for the operation associated with the given report version ID
-export async function getReportFacilityList(version_id: number) {
-  const response = await actionHandler(
-    `reporting/report-version/${version_id}/facility-list`,
-    "GET",
-  );
-  if (response && !response.error) {
-    return response;
+
+export async function getReportFacilityList(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/facility-list`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the facility list for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
   }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getReportInformationTaskListData.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportInformationTaskListData.ts
@@ -2,12 +2,15 @@ import { getFacilityReportDetails } from "@reporting/src/app/utils/getFacilityRe
 import { getFacilityReport } from "@reporting/src/app/utils/getFacilityReport";
 
 export const getReportInformationTasklist = async (
-  versionId: number,
+  reportVersionId: number,
   facilityId: string,
 ) => {
-  const operationType = await getFacilityReport(versionId);
+  const operationType = await getFacilityReport(reportVersionId);
 
-  const facilityData = await getFacilityReportDetails(versionId, facilityId);
+  const facilityData = await getFacilityReportDetails(
+    reportVersionId,
+    facilityId,
+  );
 
   return {
     facilityName: facilityData?.facility_name,

--- a/bciers/apps/reporting/src/app/utils/getReportNeedsVerification.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportNeedsVerification.ts
@@ -1,14 +1,12 @@
 import { actionHandler } from "@bciers/actions";
 
-export async function getReportNeedsVerification(versionId: number) {
-  const response = await actionHandler(
-    `reporting/report-version/${versionId}/report-needs-verification`,
-    "GET",
-    "",
-  );
+export async function getReportNeedsVerification(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/report-needs-verification`;
+  const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      "We couldn't find the verification requirement for this report.",
+      `Failed to fetch the verification requirement for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getReportType.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportType.ts
@@ -1,9 +1,13 @@
 import { actionHandler } from "@bciers/actions";
-export async function getReportType(version_id: number) {
-  let response = await actionHandler(
-    `reporting/report-version/${version_id}/report-type`,
-    "GET",
-    `reporting/report-version/${version_id}/report-type`,
-  );
-  if (!response.error) return response;
+
+export async function getReportType(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/report-type`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the report type for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
+  }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getReportVerification.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportVerification.ts
@@ -1,11 +1,13 @@
 import { actionHandler } from "@bciers/actions";
-// Fetches the report verification data associated with the given report version ID
-export async function getReportVerification(version_id: number) {
-  const response = await actionHandler(
-    `reporting/report-version/${version_id}/report-verification`,
-    "GET",
-  );
-  if (response && !response.error) {
-    return response;
+
+export async function getReportVerification(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/report-verification`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the report verification for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
   }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getReportingOperation.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportingOperation.ts
@@ -1,9 +1,13 @@
 import { actionHandler } from "@bciers/actions";
-export async function getReportingOperation(version_id: number) {
-  let response = await actionHandler(
-    `reporting/report-version/${version_id}/report-operation`,
-    "GET",
-    `reporting/report-version/${version_id}/report-operation`,
-  );
-  if (!response.error) return response;
+
+export async function getReportingOperation(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/report-operation`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the operation for report version ${reportVersionId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
+  }
+  return response;
 }

--- a/bciers/apps/reporting/src/app/utils/getReportingYear.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportingYear.ts
@@ -5,5 +5,13 @@ export const getReportingYear = async (): Promise<{
   report_due_date: string;
   reporting_window_end: string;
 }> => {
-  return actionHandler("reporting/reporting-year", "GET");
+  const endpoint = "reporting/reporting-year";
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the reporting for report year.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
+  }
+  return response;
 };

--- a/bciers/apps/reporting/src/app/utils/getSummaryData.ts
+++ b/bciers/apps/reporting/src/app/utils/getSummaryData.ts
@@ -1,11 +1,16 @@
 import { actionHandler } from "@bciers/actions";
-export async function getSummaryData(versionId: number, facilityId: string) {
-  const response = await actionHandler(
-    `reporting/report-version/${versionId}/facility-report/${facilityId}/emission-summary`,
-    "GET",
-  );
+
+export async function getSummaryData(
+  reportVersionId: number,
+  facilityId: string,
+) {
+  const endpoint = `reporting/report-version/${reportVersionId}/facility-report/${facilityId}/emission-summary`;
+  const response = await actionHandler(endpoint, "GET");
   if (response.error) {
-    throw new Error("We couldn't find the summary data for this report.");
+    throw new Error(
+      `Failed to fetch the emission summary data for report version ${reportVersionId}, facility ${facilityId}.\n` +
+        "Please check if the provided ID(s) are correct and try again.",
+    );
   }
   return response;
 }

--- a/bciers/apps/reporting/src/app/utils/postAttachments.ts
+++ b/bciers/apps/reporting/src/app/utils/postAttachments.ts
@@ -1,16 +1,10 @@
 import { actionHandler } from "@bciers/actions";
 
-async function postAttachments(report_version_id: number, fileData: FormData) {
-  const endpoint = `reporting/report-version/${report_version_id}/attachments`;
-
-  const response = await actionHandler(
-    endpoint,
-    "POST",
-    `/reporting/reports/${report_version_id}/attachments`,
-    {
-      body: fileData,
-    },
-  );
+async function postAttachments(reportVersionId: number, fileData: FormData) {
+  const endpoint = `reporting/report-version/${reportVersionId}/attachments`;
+  const response = await actionHandler(endpoint, "POST", "", {
+    body: fileData,
+  });
 
   return response;
 }

--- a/bciers/apps/reporting/src/tests/components/facility/FacilityEmissionAllocationPage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/facility/FacilityEmissionAllocationPage.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import FacilityEmissionAllocationPage from "@reporting/src/app/components/facility/FacilityEmissionAllocationPage";
+import { getReportInformationTasklist } from "@reporting/src/app/utils/getReportInformationTaskListData";
 import { getOrderedActivities } from "@reporting/src/app/utils/getOrderedActivities";
 import { getEmissionAllocations } from "@reporting/src/app/utils/getEmissionAllocations";
 
 // ✨ Mocks
+vi.mock("@reporting/src/app/utils/getReportInformationTaskListData", () => ({
+  getReportInformationTasklist: vi.fn(),
+}));
+
 vi.mock("@reporting/src/app/utils/getOrderedActivities", () => ({
   getOrderedActivities: vi.fn(),
 }));
@@ -14,6 +19,10 @@ vi.mock("@reporting/src/app/utils/getEmissionAllocations", () => ({
 // 🏷 Constants
 const mockVersionId = 3;
 const mockFacilityId = "abc3";
+const mockReportTaskList = {
+  facilityName: "Test Facility",
+  operationType: "SFO",
+};
 const orderedActivities = [
   {
     id: 1,
@@ -164,10 +173,12 @@ describe("The FacilityEmissionAllocationPage component", () => {
     vi.resetAllMocks();
   });
   it("renders the FacilityEmissionAllocationForm", async () => {
+    (
+      getReportInformationTasklist as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(mockReportTaskList);
     (getOrderedActivities as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       orderedActivities,
     );
-    // Mock the returned value for `getEmissionAllocations`
     (getEmissionAllocations as ReturnType<typeof vi.fn>).mockReturnValueOnce(
       emissionAllocations,
     );

--- a/bciers/apps/reporting/src/tests/components/operations/personResponsible/PersonResponsible.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/operations/personResponsible/PersonResponsible.test.tsx
@@ -3,11 +3,14 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { vi, Mock, it, expect } from "vitest";
 import { actionHandler } from "@bciers/actions";
 import PersonResponsible from "@reporting/src/app/components/operations/personResponsible/PersonResponsible";
+import { getFacilityReport } from "@reporting/src/app/utils/getFacilityReport";
 
 vi.mock("@bciers/actions", () => ({
   actionHandler: vi.fn(),
 }));
-
+vi.mock("@reporting/src/app/utils/getFacilityReport", () => ({
+  getFacilityReport: vi.fn(),
+}));
 const mockPersonResponsibleData = {
   first_name: "John",
   last_name: "Doe",
@@ -19,12 +22,19 @@ const mockContactsData = {
   ],
   count: 2,
 };
+const mockFacilityReport = {
+  facility_id: 1,
+  operation_type: "SFO",
+};
 
 describe("PersonResponsible", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
   it("renders the form correctly after loading", async () => {
+    (getFacilityReport as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockFacilityReport,
+    );
     render(<PersonResponsible version_id={1} />);
     await waitFor(() => {
       expect(
@@ -65,6 +75,7 @@ describe("PersonResponsible", () => {
     (actionHandler as Mock)
       .mockResolvedValueOnce(mockContactsData)
       .mockResolvedValueOnce(mockPersonResponsibleData)
+      .mockResolvedValueOnce(mockFacilityReport)
       .mockResolvedValueOnce({});
 
     render(<PersonResponsible version_id={1} />);

--- a/bciers/apps/reporting/src/tests/components/products/ProductionDataPage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/products/ProductionDataPage.test.tsx
@@ -2,9 +2,13 @@ import { getProductionData } from "@bciers/actions/api";
 import ProductionDataPage from "@reporting/src/app/components/products/ProductionDataPage";
 import { render, screen } from "@testing-library/react";
 import { HasFacilityId } from "@reporting/src/app/utils/defaultPageFactoryTypes";
+import { getReportInformationTasklist } from "@reporting/src/app/utils/getReportInformationTaskListData";
 
 vi.mock("@bciers/actions/api", () => ({
   getProductionData: vi.fn(),
+}));
+vi.mock("@reporting/src/app/utils/getReportInformationTaskListData", () => ({
+  getReportInformationTasklist: vi.fn(),
 }));
 vi.mock("@reporting/src/app/utils/getOrderedActivities", () => ({
   getOrderedActivities: vi.fn().mockReturnValue([]),
@@ -18,12 +22,19 @@ const props: HasFacilityId = {
   facility_id: "abc",
 };
 
+const mockReportTaskList = {
+  facilityName: "Test Facility",
+  operationType: "SFO",
+};
 describe("The Production Data component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("fetches the proper data and passes it to the form", async () => {
+    (
+      getReportInformationTasklist as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(mockReportTaskList);
     getProductionDataMock.mockReturnValue({
       allowed_products: [],
       report_products: [],

--- a/bciers/libs/components/src/error/ErrorBoundary.tsx
+++ b/bciers/libs/components/src/error/ErrorBoundary.tsx
@@ -34,8 +34,12 @@ export default function ErrorBoundary({ error }: Props) {
           marginBottom: "1rem",
         }}
       >
-        <AlertTitle>Error</AlertTitle>
-        <strong>{error.message}</strong>
+        <AlertTitle>
+          <strong>Error</strong>
+        </AlertTitle>
+        <div style={{ whiteSpace: "pre-wrap" }}>
+          <strong>{error.message}</strong>
+        </div>
       </Alert>
     </div>
   );


### PR DESCRIPTION
Addresses [417](https://github.com/bcgov/cas-reporting/issues/417)

### 🚀 Impact:

- Standardizes fetch functions in `bciers/apps/reporting/src/app/utils/*` by:
    - Aligning naming conventions for `reportVersionId`
    - Removing unnecessary `revalidatePath` URL param for `actionHandler`
    - Returning user-friendly error messages for invalid report version IDs

###  📝 Notes:

- Update to `bciers/apps/reporting/src/app/utils/getReportingPersonResponsible.ts` will be handled here:   [429](https://github.com/bcgov/cas-reporting/issues/429)

### 🔬 Local Testing:

###  Tests set-up:
1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd bciers && yarn dev-all
```  
1. Navigate to http://localhost:3000
2. Click button "Log in with Business BCeID"

###  Test: Invalid report version id returns error message

1. Navigate to report urls using an invalid  report version id :
- http://localhost:3000/reporting/reports/999/review-operator-data

- http://localhost:3000/reporting/reports/999/additional-reporting-data
- http://localhost:3000/reporting/reports/999/compliance-summary
- http://localhost:3000/reporting/reports/999/final-review
- http://localhost:3000/reporting/reports/999/verification
- http://localhost:3000/reporting/reports/999/attachments
- http://localhost:3000/reporting/reports/999/sign-off
- http://localhost:3000/reporting/reports/999/facilities/review-facilities-list
**Expected Results**
- User error message displays similar to:
![image](https://github.com/user-attachments/assets/ae8fceb2-4002-4619-b7c8-c8f5c21e7984)
