### PR TITLE
378 refactor valid date away from created_at

### DIFF
--- a/bc_obps/reporting/service/report_activity_save_service.py
+++ b/bc_obps/reporting/service/report_activity_save_service.py
@@ -1,6 +1,6 @@
 import uuid
 from django.db import transaction
-from service.utils.get_report_valid_year_from_version_id import get_report_valid_year_from_version_id
+from service.utils.get_report_valid_date_from_version_id import get_report_valid_date_from_version_id
 from registration.models.activity import Activity
 from reporting.models.activity_json_schema import ActivityJsonSchema
 from reporting.models.activity_source_type_json_schema import (
@@ -63,7 +63,7 @@ class ReportActivitySaveService:
         # Save raw json data
         self.save_raw_data(data)
         # Get the valid date for the activity configurations
-        valid_date = get_report_valid_year_from_version_id(self.facility_report.report_version.id)
+        valid_date = get_report_valid_date_from_version_id(self.facility_report.report_version.id)
         # Only one ReportActivity record per report_version/faciltiy/activity should ever exist
         report_activity, _ = ReportActivity.objects.update_or_create(
             id=data.get("id"),
@@ -99,7 +99,7 @@ class ReportActivitySaveService:
     ) -> ReportSourceType:
         source_type = SourceType.objects.get(json_key=source_type_slug)
         json_data = exclude_keys(source_type_data, ["units", "fuels", "emissions", "id"])
-        valid_date = get_report_valid_year_from_version_id(self.facility_report.report_version.id)
+        valid_date = get_report_valid_date_from_version_id(self.facility_report.report_version.id)
         json_base_schema = ActivitySourceTypeJsonSchema.objects.get(
             activity=report_activity.activity,
             source_type=source_type,

--- a/bc_obps/reporting/tests/api/test_activity_data.py
+++ b/bc_obps/reporting/tests/api/test_activity_data.py
@@ -9,7 +9,11 @@ from registration.utils import custom_reverse_lazy
 class TestActivityData(CommonTestSetup):
     def test_authorized_users_can_get_activity_data(self):
         operator = baker.make_recipe("registration.tests.utils.operator")
-        facility_report = baker.make_recipe('reporting.tests.utils.facility_report')
+        valid_year = baker.make_recipe('reporting.tests.utils.reporting_year', reporting_year=2025)
+        facility_report = baker.make_recipe(
+            'reporting.tests.utils.facility_report',
+            report_version__report__reporting_year_id=valid_year.reporting_year,
+        )
         TestUtils.authorize_current_user_as_operator_user(self, operator=operator)
 
         response = TestUtils.mock_get_with_auth_role(
@@ -21,7 +25,7 @@ class TestActivityData(CommonTestSetup):
             )
             + "?activity_id=1",
         )
-
+        print(response.json())
         assert response.status_code == 200
         response_object = json.loads(response.json())
         assert response_object['activityId'] == 1

--- a/bc_obps/reporting/tests/api/test_activity_data.py
+++ b/bc_obps/reporting/tests/api/test_activity_data.py
@@ -25,7 +25,6 @@ class TestActivityData(CommonTestSetup):
             )
             + "?activity_id=1",
         )
-        print(response.json())
         assert response.status_code == 200
         response_object = json.loads(response.json())
         assert response_object['activityId'] == 1

--- a/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
@@ -15,7 +15,11 @@ class TestReportActivityEndpoint(CommonTestSetup):
         super().setup_method()
 
         # Create basic test data
-        self.facility_report = make_recipe('reporting.tests.utils.facility_report')
+        valid_year = make_recipe('reporting.tests.utils.reporting_year', reporting_year=2025)
+        self.facility_report = make_recipe(
+            'reporting.tests.utils.facility_report',
+            report_version__report__reporting_year_id=valid_year.reporting_year,
+        )
         self.activity = make_recipe('reporting.tests.utils.activity')
 
         # Create endpoint

--- a/bc_obps/reporting/tests/service/test_report_activity_save_service/infrastructure.py
+++ b/bc_obps/reporting/tests/service/test_report_activity_save_service/infrastructure.py
@@ -9,7 +9,7 @@ from reporting.models.report_fuel import ReportFuel
 from reporting.models.report_unit import ReportUnit
 from model_bakery.baker import make_recipe, make
 from reporting.models.report_version import ReportVersion
-from service.utils.get_report_valid_year_from_version_id import get_report_valid_year_from_version_id
+from service.utils.get_report_valid_date_from_version_id import get_report_valid_date_from_version_id
 
 
 def get_report_unit_by_index(
@@ -51,7 +51,7 @@ class TestInfrastructure:
         t.facility_report.refresh_from_db()
         t.report_version = t.facility_report.report_version
         t.user = make_recipe('registration.tests.utils.industry_operator_user')
-        valid_date = get_report_valid_year_from_version_id(t.report_version.id)
+        valid_date = get_report_valid_date_from_version_id(t.report_version.id)
         t.configuration = Configuration.objects.get(valid_from__lte=valid_date, valid_to__gte=valid_date)
         t.activity = make_recipe("reporting.tests.utils.activity")
         t.activity_json_schema = make_recipe(
@@ -80,7 +80,7 @@ class TestInfrastructure:
         t.facility_report.refresh_from_db()
         t.report_version = t.facility_report.report_version
         t.user = make_recipe('registration.tests.utils.industry_operator_user')
-        valid_date = get_report_valid_year_from_version_id(t.report_version.id)
+        valid_date = get_report_valid_date_from_version_id(t.report_version.id)
         t.configuration = Configuration.objects.get(valid_from__lte=valid_date, valid_to__gte=valid_date)
         t.activity = Activity.objects.get(slug=activity_slug)
         t.activity_json_schema = ActivityJsonSchema.objects.get(
@@ -101,7 +101,7 @@ class TestInfrastructure:
         t.facility_report.refresh_from_db()
         t.report_version = report_version
         t.user = make_recipe('registration.tests.utils.industry_operator_user')
-        valid_date = get_report_valid_year_from_version_id(t.report_version.id)
+        valid_date = get_report_valid_date_from_version_id(t.report_version.id)
         t.configuration = Configuration.objects.get(valid_from__lte=valid_date, valid_to__gte=valid_date)
         t.activity = Activity.objects.get(slug="gsc_non_compression")
         t.activity_json_schema = ActivityJsonSchema.objects.get(

--- a/bc_obps/service/activity_service.py
+++ b/bc_obps/service/activity_service.py
@@ -3,14 +3,14 @@ from reporting.models import Configuration, ConfigurationElement
 from typing import List, Dict, Any
 from registration.models import Activity
 from uuid import UUID
-from service.facility_report_service import FacilityReportService
+from service.utils.get_report_valid_year_from_version_id import get_report_valid_year_from_version_id
 
 
 class ActivityService:
     @classmethod
     def get_initial_activity_data(cls, version_id: int, facility_id: UUID, activity_id: int) -> str:
         source_type_map: dict[int, str] = {}
-        report_date = FacilityReportService.get_facility_report_by_version_and_id(version_id, facility_id).created_at
+        report_date = get_report_valid_year_from_version_id(version_id)
         config = Configuration.objects.get(valid_from__lte=report_date, valid_to__gte=report_date)
         source_type_data = (
             ConfigurationElement.objects.select_related('source_type')

--- a/bc_obps/service/activity_service.py
+++ b/bc_obps/service/activity_service.py
@@ -3,14 +3,14 @@ from reporting.models import Configuration, ConfigurationElement
 from typing import List, Dict, Any
 from registration.models import Activity
 from uuid import UUID
-from service.utils.get_report_valid_year_from_version_id import get_report_valid_year_from_version_id
+from service.utils.get_report_valid_date_from_version_id import get_report_valid_date_from_version_id
 
 
 class ActivityService:
     @classmethod
     def get_initial_activity_data(cls, version_id: int, facility_id: UUID, activity_id: int) -> str:
         source_type_map: dict[int, str] = {}
-        report_date = get_report_valid_year_from_version_id(version_id)
+        report_date = get_report_valid_date_from_version_id(version_id)
         config = Configuration.objects.get(valid_from__lte=report_date, valid_to__gte=report_date)
         source_type_data = (
             ConfigurationElement.objects.select_related('source_type')

--- a/bc_obps/service/form_builder_service.py
+++ b/bc_obps/service/form_builder_service.py
@@ -1,6 +1,6 @@
 import json
-from service.utils.get_report_valid_year_from_version_id import (
-    get_report_valid_year_from_version_id,
+from service.utils.get_report_valid_date_from_version_id import (
+    get_report_valid_date_from_version_id,
 )
 from reporting.models import (
     Configuration,
@@ -377,7 +377,7 @@ class FormBuilderService:
 
         Description:
             - First, it verifies that the `activity` parameter is valid. If `activity` is None, it raises an exception.
-            - Then, it determines the report date by using `get_report_valid_year_from_version_id()`,
+            - Then, it determines the report date by using `get_report_valid_date_from_version_id()`,
               which extracts the valid reporting year based on the report version.
             - It retrieves a `Configuration` object that matches the report date by checking if the date
               falls between the `valid_from` and `valid_to` fields.
@@ -387,7 +387,7 @@ class FormBuilderService:
         if activity is None:
             raise Exception("Cannot build a schema without Activity data")
 
-        report_date = get_report_valid_year_from_version_id(report_version_id)
+        report_date = get_report_valid_date_from_version_id(report_version_id)
         # Get config objects
         config = Configuration.objects.only("id").get(valid_from__lte=report_date, valid_to__gte=report_date)
         schema = build_schema(config.id, activity, source_types)

--- a/bc_obps/service/tests/test_service_utils.py
+++ b/bc_obps/service/tests/test_service_utils.py
@@ -1,14 +1,14 @@
 import datetime
 from django.test import TestCase
 from reporting.tests.utils.bakers import baker
-from service.utils.get_report_valid_year_from_version_id import get_report_valid_year_from_version_id
+from service.utils.get_report_valid_date_from_version_id import get_report_valid_date_from_version_id
 
 
 class TestServiceUtils(TestCase):
-    def test_get_report_valid_year_from_version_id(self):
+    def test_get_report_valid_date_from_version_id(self):
         TEST_YEAR = 2024
         DEFAULT_MONTH = 5
         DEFAULT_DAY = 31
         TEST_DATE = datetime.date(TEST_YEAR, DEFAULT_MONTH, DEFAULT_DAY)
         report_version = baker.make_recipe("reporting.tests.utils.report_version", report__reporting_year_id=TEST_YEAR)
-        assert get_report_valid_year_from_version_id(report_version.id) == TEST_DATE
+        assert get_report_valid_date_from_version_id(report_version.id) == TEST_DATE

--- a/bc_obps/service/utils/constants.py
+++ b/bc_obps/service/utils/constants.py
@@ -1,4 +1,4 @@
-# May 31st. Month and Day appended to reporting_year_id(calendar year as an int) in get_report_valid_year_from_version_id
+# May 31st. Month and Day appended to reporting_year_id(calendar year as an int) in get_report_valid_date_from_version_id
 # to form a date string used to find the valid configuration for a report version
 REPORT_VERSION_DEFAULT_MONTH = 5
 REPORT_VERSION_DEFAULT_DAY = 31

--- a/bc_obps/service/utils/get_report_valid_date_from_version_id.py
+++ b/bc_obps/service/utils/get_report_valid_date_from_version_id.py
@@ -3,6 +3,6 @@ from reporting.models.report_version import ReportVersion
 from .constants import REPORT_VERSION_DEFAULT_MONTH, REPORT_VERSION_DEFAULT_DAY
 
 
-def get_report_valid_year_from_version_id(report_version_id: int) -> date:
+def get_report_valid_date_from_version_id(report_version_id: int) -> date:
     report_version = ReportVersion.objects.get(id=report_version_id)
     return date(report_version.report.reporting_year_id, REPORT_VERSION_DEFAULT_MONTH, REPORT_VERSION_DEFAULT_DAY)


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/378

### Changes
 - Activity service: GET changed to use reporting_year_id instead of created_at
 - activity_save_service: POST changed to use  reporting_year_id instead of created_at
 - updated relevant tests to use reporting_year_id and hardcoded in a valid reporting_year, otherwise the model bakery try using the year -7643453423 (because the reporting_year is an int field, and not a date field)
 - Updated name of supporting function (get_report_valid\_**year**\_from_version_id -> get_report_valid\_**date**\_...) to more accurately reflect the functions purpose.
 
 #### Note:
The ticket included removing facility_id after the refactor since it would no longer be used. Work in (this)[https://github.com/bcgov/cas-reporting/issues/522] ticket likely mean it is still needed.