### PR TITLE
Chore: 560 emissions fuel unit value

### DIFF
--- a/bc_obps/reporting/migrations/0008_prod_data.py
+++ b/bc_obps/reporting/migrations/0008_prod_data.py
@@ -663,45 +663,17 @@ def init_reporting_field_data(apps, schema_monitor):
         [
             ReportingField(field_name='Fuel Default High Heating Value', field_type='number', field_units=None),
             ReportingField(
-                field_name='Unit-Fuel-CO2 Default Emission Factor', field_type='number', field_units='kg/GJ'
-            ),
-            ReportingField(
-                field_name='Unit-Fuel-CO2 Default Emission Factor', field_type='number', field_units='kg/fuel units'
-            ),
-            ReportingField(
                 field_name='Fuel Annual Weighted Average High Heating Value', field_type='number', field_units=None
             ),
             ReportingField(field_name='Unit-Fuel Annual Steam Generated', field_type='number', field_units=None),
             ReportingField(field_name='Boiler Ratio', field_type='number', field_units=None),
-            ReportingField(field_name='Unit-Fuel-CO2 Emission Factor', field_type='number', field_units='kg/GJ'),
             ReportingField(
                 field_name='Fuel Annual Weighted Average Carbon Content (weight fraction)',
                 field_type='number',
                 field_units=None,
             ),
-            ReportingField(
-                field_name='Unit-Fuel-CO2 Measured Emission Factor', field_type='number', field_units='kg/fuel units'
-            ),
             ReportingField(field_name='Description', field_type='string', field_units=None),
-            ReportingField(
-                field_name='Unit-Fuel-CH4 Default Emission Factor', field_type='number', field_units='kg/GJ'
-            ),
-            ReportingField(
-                field_name='Unit-Fuel-CH4 Default Emission Factor', field_type='number', field_units='kg/fuel units'
-            ),
-            ReportingField(
-                field_name='Unit-Fuel-CH4 Measured Emission Factor', field_type='number', field_units='kg/fuel units'
-            ),
             ReportingField(field_name='Unit-Fuel Heat Input', field_type='number', field_units=None),
-            ReportingField(
-                field_name='Unit-Fuel-N2O Default Emission Factor', field_type='number', field_units='kg/GJ'
-            ),
-            ReportingField(
-                field_name='Unit-Fuel-N2O Default Emission Factor', field_type='number', field_units='kg/fuel units'
-            ),
-            ReportingField(
-                field_name='Unit-Fuel-N2O Measured Emission Factor', field_type='number', field_units='kg/fuel units'
-            ),
             ReportingField(
                 field_name='Average of Quarterly chemical oxygen demand', field_type='number', field_units='kg/m3'
             ),
@@ -769,6 +741,46 @@ def init_reporting_field_data(apps, schema_monitor):
                 field_type='number',
                 field_units=None,
             ),
+            ReportingField(field_name='Unit-Fuel-CO2 Default EF', field_type='number', field_units='kg/fuel units'),
+            ReportingField(field_name='Unit-Fuel-CO2 Default HHV-Default EF', field_type='number', field_units='kg/GJ'),
+            ReportingField(
+                field_name='Unit-Fuel-CO2 Measured HHV-Default EF', field_type='number', field_units='kg/GJ'
+            ),
+            ReportingField(
+                field_name='Unit-Fuel-CO2 Measured Steam-Default EF', field_type='number', field_units='kg/GJ'
+            ),
+            ReportingField(
+                field_name='Unit-Fuel-CO2 Measured Steam-Measured EF', field_type='number', field_units='kg/fuel units'
+            ),
+            ReportingField(
+                field_name='Unit-Fuel-CO2 Site-specific EF', field_type='number', field_units='kg/fuel units'
+            ),
+            ReportingField(field_name='Unit-Fuel-CH4 Default EF', field_type='number', field_units='kg/fuel units'),
+            ReportingField(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_type='number', field_units='kg/GJ'),
+            ReportingField(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_type='number', field_units='kg/GJ'),
+            ReportingField(field_name='Unit-Fuel-CH4 Measured EF', field_type='number', field_units='kg/fuel units'),
+            ReportingField(
+                field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_type='number', field_units='kg/GJ'
+            ),
+            ReportingField(
+                field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_type='number', field_units='kg/GJ'
+            ),
+            ReportingField(
+                field_name='Unit-Fuel-CH4 Site-specific EF', field_type='number', field_units='kg/fuel units'
+            ),
+            ReportingField(field_name='Unit-Fuel-N2O Default EF', field_type='number', field_units='kg/fuel units'),
+            ReportingField(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_type='number', field_units='kg/GJ'),
+            ReportingField(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_type='number', field_units='kg/GJ'),
+            ReportingField(field_name='Unit-Fuel-N2O Measured EF', field_type='number', field_units='kg/fuel units'),
+            ReportingField(
+                field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_type='number', field_units='kg/GJ'
+            ),
+            ReportingField(
+                field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_type='number', field_units='kg/GJ'
+            ),
+            ReportingField(
+                field_name='Unit-Fuel-N2O Site-specific EF', field_type='number', field_units='kg/fuel units'
+            ),
         ]
     )
 
@@ -780,20 +792,17 @@ def reverse_init_reporting_field_data(apps, schema_monitor):
     ReportingField = apps.get_model('reporting', 'ReportingField')
     ReportingField.objects.filter(
         field_name__in=[
-            'Unit-Fuel-CO2 Measured Emission Factor',
-            'Unit-Fuel Heat Input',
-            'Unit-Fuel-CO2 Default Emission Factor',
-            'Unit-Fuel-CH4 Measured Emission Factor',
-            'Unit-Fuel Annual Steam Generated',
-            'Description',
-            'Unit-Fuel-CO2 Emission Factor',
-            'Boiler Ratio',
-            'Unit-Fuel-N2O Default Emission Factor',
-            'Unit-Fuel-CH4 Default Emission Factor',
-            'Fuel Annual Weighted Average High Heating Value',
-            'Unit-Fuel-N2O Measured Emission Factor',
             'Fuel Default High Heating Value',
+            'Fuel Annual Weighted Average High Heating Value',
+            'Unit-Fuel Annual Steam Generated',
+            'Boiler Ratio',
             'Fuel Annual Weighted Average Carbon Content (weight fraction)',
+            'Description',
+            'Unit-Fuel Heat Input',
+            'Average of Quarterly chemical oxygen demand',
+            'Average of Quarterly five-day biochemical oxygen demand',
+            'Average of Quarterly Nitrogen in effluent',
+            'Measured conversion factor',
             'Annual Weighted Average Carbon Content',
             'Annual Weighted Average Molecular Weight',
             'Molar Volume Conversion Factor',
@@ -833,12 +842,28 @@ def reverse_init_reporting_field_data(apps, schema_monitor):
             'Overvoltage Methodology',
             'Overvoltage Emission Factor',
             'Last Date of Overvoltage Emission Factor Measurement',
-            'Average of Quarterly chemical oxygen demand'
-            'Average of Quarterly five-day biochemical oxygen demand'
-            'Average of Quarterly Nitrogen in effluent'
-            'Measured conversion factor',
             'Amount of raw material consumed (t)',
             'Raw material organic carbon content (weight fraction)',
+            'Unit-Fuel-CO2 Default EF',
+            'Unit-Fuel-CO2 Default HHV-Default EF',
+            'Unit-Fuel-CO2 Measured HHV-Default EF',
+            'Unit-Fuel-CO2 Measured Steam-Default EF',
+            'Unit-Fuel-CO2 Measured Steam-Measured EF',
+            'Unit-Fuel-CO2 Site-specific EF',
+            'Unit-Fuel-CH4 Default EF',
+            'Unit-Fuel-CH4 Default HHV-Default EF',
+            'Unit-Fuel-CH4 Heat Input-Default EF',
+            'Unit-Fuel-CH4 Measured EF',
+            'Unit-Fuel-CH4 Measured HHV-Default EF',
+            'Unit-Fuel-CH4 Measured Steam-Default EF',
+            'Unit-Fuel-CH4 Site-specific EF',
+            'Unit-Fuel-N2O Default EF',
+            'Unit-Fuel-N2O Default HHV-Default EF',
+            'Unit-Fuel-N2O Heat Input-Default EF',
+            'Unit-Fuel-N2O Measured EF',
+            'Unit-Fuel-N2O Measured HHV-Default EF',
+            'Unit-Fuel-N2O Measured Steam-Default EF',
+            'Unit-Fuel-N2O Site-specific EF',
         ]
     ).delete()
 

--- a/bc_obps/reporting/migrations/0008_prod_data.py
+++ b/bc_obps/reporting/migrations/0008_prod_data.py
@@ -755,31 +755,27 @@ def init_reporting_field_data(apps, schema_monitor):
             ReportingField(
                 field_name='Unit-Fuel-CO2 Site-specific EF', field_type='number', field_units='kg/fuel units'
             ),
-            ReportingField(field_name='Unit-Fuel-CH4 Default EF', field_type='number', field_units='kg/fuel units'),
-            ReportingField(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_type='number', field_units='kg/GJ'),
-            ReportingField(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_type='number', field_units='kg/GJ'),
-            ReportingField(field_name='Unit-Fuel-CH4 Measured EF', field_type='number', field_units='kg/fuel units'),
+            ReportingField(field_name='Unit-Fuel-CH4 Default EF', field_type='number', field_units='g/fuel units'),
+            ReportingField(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_type='number', field_units='g/GJ'),
+            ReportingField(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_type='number', field_units='g/GJ'),
+            ReportingField(field_name='Unit-Fuel-CH4 Measured EF', field_type='number', field_units='g/fuel units'),
+            ReportingField(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_type='number', field_units='g/GJ'),
             ReportingField(
-                field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_type='number', field_units='kg/GJ'
+                field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_type='number', field_units='g/GJ'
             ),
             ReportingField(
-                field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_type='number', field_units='kg/GJ'
+                field_name='Unit-Fuel-CH4 Site-specific EF', field_type='number', field_units='g/fuel units'
+            ),
+            ReportingField(field_name='Unit-Fuel-N2O Default EF', field_type='number', field_units='g/fuel units'),
+            ReportingField(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_type='number', field_units='g/GJ'),
+            ReportingField(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_type='number', field_units='g/GJ'),
+            ReportingField(field_name='Unit-Fuel-N2O Measured EF', field_type='number', field_units='g/fuel units'),
+            ReportingField(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_type='number', field_units='g/GJ'),
+            ReportingField(
+                field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_type='number', field_units='g/GJ'
             ),
             ReportingField(
-                field_name='Unit-Fuel-CH4 Site-specific EF', field_type='number', field_units='kg/fuel units'
-            ),
-            ReportingField(field_name='Unit-Fuel-N2O Default EF', field_type='number', field_units='kg/fuel units'),
-            ReportingField(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_type='number', field_units='kg/GJ'),
-            ReportingField(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_type='number', field_units='kg/GJ'),
-            ReportingField(field_name='Unit-Fuel-N2O Measured EF', field_type='number', field_units='kg/fuel units'),
-            ReportingField(
-                field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_type='number', field_units='kg/GJ'
-            ),
-            ReportingField(
-                field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_type='number', field_units='kg/GJ'
-            ),
-            ReportingField(
-                field_name='Unit-Fuel-N2O Site-specific EF', field_type='number', field_units='kg/fuel units'
+                field_name='Unit-Fuel-N2O Site-specific EF', field_type='number', field_units='g/fuel units'
             ),
         ]
     )

--- a/bc_obps/reporting/migrations/0009_general_stationary_combustion_data.py
+++ b/bc_obps/reporting/migrations/0009_general_stationary_combustion_data.py
@@ -567,7 +567,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Default EF - Unit-Fuel-CO2 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -580,7 +580,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default EF', field_units='kg/fuel units')
     )
     # CO2 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -608,7 +608,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -644,7 +644,9 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         methodology_id=Methodology.objects.get(name='Measured Steam/Default EF').id,
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(ReportingField.objects.get(field_name='Unit-Fuel-CO2 Emission Factor', field_units='kg/GJ'))
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Default EF', field_units='kg/GJ')
+    )
     # CO2 - Measured CC - Fuel Annual Weighted Average Carbon Content (weight fraction)
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(name='General stationary combustion excluding line tracing').id,
@@ -684,7 +686,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Measured EF', field_units='kg/fuel units')
     )
     # CO2 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -733,7 +735,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -746,7 +748,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -774,7 +776,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -787,7 +789,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -824,7 +826,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -848,7 +850,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -897,7 +899,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -910,7 +912,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -938,7 +940,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -951,7 +953,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -988,7 +990,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1012,7 +1014,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1062,7 +1064,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Default EF - Unit-Fuel-CO2 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1075,7 +1077,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default EF', field_units='kg/fuel units')
     )
     # CO2 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1103,7 +1105,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1139,7 +1141,9 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         methodology_id=Methodology.objects.get(name='Measured Steam/Default EF').id,
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(ReportingField.objects.get(field_name='Unit-Fuel-CO2 Emission Factor', field_units='kg/GJ'))
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Default EF', field_units='kg/GJ')
+    )
     # CO2 - Measured CC - Fuel Annual Weighted Average Carbon Content (weight fraction)
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(name='General stationary combustion excluding line tracing').id,
@@ -1179,7 +1183,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Measured EF', field_units='kg/fuel units')
     )
     # CO2 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1228,7 +1232,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1241,7 +1245,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1269,7 +1273,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1282,7 +1286,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1319,7 +1323,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1343,7 +1347,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1392,7 +1396,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1405,7 +1409,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1433,7 +1437,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1446,7 +1450,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1483,7 +1487,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1507,7 +1511,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0009_general_stationary_combustion_data.py
+++ b/bc_obps/reporting/migrations/0009_general_stationary_combustion_data.py
@@ -735,7 +735,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -748,7 +748,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='g/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -776,7 +776,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -789,7 +789,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='g/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -826,7 +826,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='g/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -850,7 +850,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='g/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -899,7 +899,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -912,7 +912,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='g/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -940,7 +940,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -953,7 +953,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='g/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -990,7 +990,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='g/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1014,7 +1014,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='g/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1232,7 +1232,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1245,7 +1245,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='g/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1273,7 +1273,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1286,7 +1286,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='g/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1323,7 +1323,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='g/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1347,7 +1347,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='g/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1396,7 +1396,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1409,7 +1409,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='g/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1437,7 +1437,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1450,7 +1450,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='g/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1487,7 +1487,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='g/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1511,7 +1511,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='g/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0010_combustion_for_line_tracing_data.py
+++ b/bc_obps/reporting/migrations/0010_combustion_for_line_tracing_data.py
@@ -365,7 +365,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Default EF - Unit-Fuel-CO2 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -380,7 +380,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default EF', field_units='kg/fuel units')
     )
     # CO2 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -412,7 +412,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -454,7 +454,9 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         methodology_id=Methodology.objects.get(name='Measured Steam/Default EF').id,
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(ReportingField.objects.get(field_name='Unit-Fuel-CO2 Emission Factor', field_units='kg/GJ'))
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Default EF', field_units='kg/GJ')
+    )
     # CO2 - Measured CC - Fuel Annual Weighted Average Carbon Content (weight fraction)
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(
@@ -500,7 +502,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Measured EF', field_units='kg/fuel units')
     )
     # CO2 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -557,7 +559,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -572,7 +574,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -604,7 +606,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -619,7 +621,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -662,7 +664,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -690,7 +692,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -747,7 +749,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -762,7 +764,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -794,7 +796,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -809,7 +811,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -852,7 +854,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -880,7 +882,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0010_combustion_for_line_tracing_data.py
+++ b/bc_obps/reporting/migrations/0010_combustion_for_line_tracing_data.py
@@ -559,7 +559,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -574,7 +574,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='g/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -606,7 +606,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -621,7 +621,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='g/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -664,7 +664,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='g/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -692,7 +692,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='g/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -749,7 +749,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -764,7 +764,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='g/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -796,7 +796,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -811,7 +811,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='g/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -854,7 +854,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='g/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -882,7 +882,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='g/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0011_mobile_combustion_data.py
+++ b/bc_obps/reporting/migrations/0011_mobile_combustion_data.py
@@ -183,7 +183,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default EF', field_units='kg/fuel units')
     )
     # CO2 - Site-specific EF - Unit-Fuel-CO2 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -196,7 +196,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Site-specific EF', field_units='kg/fuel units')
     )
     # CO2 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -232,7 +232,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
     )
     # CH4 - Site-specific EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -245,7 +245,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Site-specific EF', field_units='kg/fuel units')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -280,7 +280,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
     )
     # N2O - Site-specific EF - Unit-Fuel-CO2 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -293,7 +293,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Site-specific EF', field_units='kg/fuel units')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0011_mobile_combustion_data.py
+++ b/bc_obps/reporting/migrations/0011_mobile_combustion_data.py
@@ -232,7 +232,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='g/fuel units')
     )
     # CH4 - Site-specific EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -245,7 +245,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Site-specific EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Site-specific EF', field_units='g/fuel units')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -280,7 +280,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='g/fuel units')
     )
     # N2O - Site-specific EF - Unit-Fuel-CO2 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -293,7 +293,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Site-specific EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Site-specific EF', field_units='g/fuel units')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0012_gsc_other_than_non_compression.py
+++ b/bc_obps/reporting/migrations/0012_gsc_other_than_non_compression.py
@@ -965,7 +965,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Default EF - Unit-Fuel-CO2 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -980,7 +980,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default EF', field_units='kg/fuel units')
     )
     # CO2 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1012,7 +1012,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1054,7 +1054,9 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         methodology_id=Methodology.objects.get(name='Measured Steam/Default EF').id,
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(ReportingField.objects.get(field_name='Unit-Fuel-CO2 Emission Factor', field_units='kg/GJ'))
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Default EF', field_units='kg/GJ')
+    )
     # CO2 - Measured CC - Fuel Annual Weighted Average Carbon Content (weight fraction)
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(
@@ -1100,7 +1102,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Measured EF', field_units='kg/fuel units')
     )
     # CO2 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1157,7 +1159,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1172,7 +1174,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1204,7 +1206,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1219,7 +1221,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1262,7 +1264,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1290,7 +1292,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1347,7 +1349,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1362,7 +1364,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1394,7 +1396,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1409,7 +1411,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1452,7 +1454,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1480,7 +1482,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1538,7 +1540,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Default EF - Unit-Fuel-CO2 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1553,7 +1555,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default EF', field_units='kg/fuel units')
     )
     # CO2 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1585,7 +1587,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1627,7 +1629,9 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         methodology_id=Methodology.objects.get(name='Measured Steam/Default EF').id,
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(ReportingField.objects.get(field_name='Unit-Fuel-CO2 Emission Factor', field_units='kg/GJ'))
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Default EF', field_units='kg/GJ')
+    )
     # CO2 - Measured CC - Fuel Annual Weighted Average Carbon Content (weight fraction)
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(
@@ -1673,7 +1677,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Measured EF', field_units='kg/fuel units')
     )
     # CO2 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1730,7 +1734,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1745,7 +1749,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1777,7 +1781,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1792,7 +1796,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1835,7 +1839,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1863,7 +1867,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1920,7 +1924,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1935,7 +1939,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1967,7 +1971,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1982,7 +1986,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2025,7 +2029,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -2053,7 +2057,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -2111,7 +2115,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Default EF - Unit-Fuel-CO2 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -2126,7 +2130,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default EF', field_units='kg/fuel units')
     )
     # CO2 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -2158,7 +2162,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2200,7 +2204,9 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         methodology_id=Methodology.objects.get(name='Measured Steam/Default EF').id,
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(ReportingField.objects.get(field_name='Unit-Fuel-CO2 Emission Factor', field_units='kg/GJ'))
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Default EF', field_units='kg/GJ')
+    )
     # CO2 - Measured CC - Fuel Annual Weighted Average Carbon Content (weight fraction)
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(
@@ -2246,7 +2252,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Measured EF', field_units='kg/fuel units')
     )
     # CO2 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -2303,7 +2309,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -2318,7 +2324,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -2350,7 +2356,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -2365,7 +2371,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2408,7 +2414,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -2436,7 +2442,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -2493,7 +2499,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -2508,7 +2514,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -2540,7 +2546,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -2555,7 +2561,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2598,7 +2604,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -2626,7 +2632,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0012_gsc_other_than_non_compression.py
+++ b/bc_obps/reporting/migrations/0012_gsc_other_than_non_compression.py
@@ -1159,7 +1159,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1174,7 +1174,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='g/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1206,7 +1206,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1221,7 +1221,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='g/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1264,7 +1264,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='g/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1292,7 +1292,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='g/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1349,7 +1349,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1364,7 +1364,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='g/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1396,7 +1396,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1411,7 +1411,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='g/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1454,7 +1454,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='g/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1482,7 +1482,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='g/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1734,7 +1734,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1749,7 +1749,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='g/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1781,7 +1781,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1796,7 +1796,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='g/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1839,7 +1839,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='g/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1867,7 +1867,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='g/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1924,7 +1924,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1939,7 +1939,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='g/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1971,7 +1971,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1986,7 +1986,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='g/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2029,7 +2029,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='g/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -2057,7 +2057,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='g/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -2309,7 +2309,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -2324,7 +2324,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='g/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -2356,7 +2356,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -2371,7 +2371,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='g/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2414,7 +2414,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='g/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -2442,7 +2442,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='g/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -2499,7 +2499,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -2514,7 +2514,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='g/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -2546,7 +2546,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -2561,7 +2561,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='g/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2604,7 +2604,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='g/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -2632,7 +2632,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='g/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0013_refinery_fuel_gas_data.py
+++ b/bc_obps/reporting/migrations/0013_refinery_fuel_gas_data.py
@@ -338,7 +338,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -351,7 +351,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='g/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -379,7 +379,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -392,7 +392,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='g/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -429,7 +429,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='g/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -453,7 +453,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='g/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -502,7 +502,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -515,7 +515,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='g/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -543,7 +543,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -556,7 +556,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='g/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -593,7 +593,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='g/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -617,7 +617,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='g/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0013_refinery_fuel_gas_data.py
+++ b/bc_obps/reporting/migrations/0013_refinery_fuel_gas_data.py
@@ -338,7 +338,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -351,7 +351,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -379,7 +379,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -392,7 +392,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -429,7 +429,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -453,7 +453,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -502,7 +502,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -515,7 +515,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -543,7 +543,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -556,7 +556,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -593,7 +593,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -617,7 +617,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0015_gsc_non_compression_non_processing.py
+++ b/bc_obps/reporting/migrations/0015_gsc_non_compression_non_processing.py
@@ -1128,7 +1128,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1141,7 +1141,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='g/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1169,7 +1169,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1182,7 +1182,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='g/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1219,7 +1219,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='g/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1243,7 +1243,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='g/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1292,7 +1292,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1305,7 +1305,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='g/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1333,7 +1333,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1346,7 +1346,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='g/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1383,7 +1383,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='g/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1407,7 +1407,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='g/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1625,7 +1625,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1638,7 +1638,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='g/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1666,7 +1666,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1679,7 +1679,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='g/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1716,7 +1716,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='g/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1740,7 +1740,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='g/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1789,7 +1789,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1802,7 +1802,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='g/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1830,7 +1830,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1843,7 +1843,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='g/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1880,7 +1880,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='g/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1904,7 +1904,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='g/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -2122,7 +2122,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -2135,7 +2135,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='g/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -2163,7 +2163,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='g/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -2176,7 +2176,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='g/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2213,7 +2213,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='g/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -2237,7 +2237,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='g/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -2286,7 +2286,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -2299,7 +2299,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='g/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -2327,7 +2327,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='g/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -2340,7 +2340,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='g/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2377,7 +2377,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='g/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -2401,7 +2401,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='g/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0015_gsc_non_compression_non_processing.py
+++ b/bc_obps/reporting/migrations/0015_gsc_non_compression_non_processing.py
@@ -960,7 +960,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Default EF - Unit-Fuel-CO2 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -973,7 +973,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default EF', field_units='kg/fuel units')
     )
     # CO2 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1001,7 +1001,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1037,7 +1037,9 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         methodology_id=Methodology.objects.get(name='Measured Steam/Default EF').id,
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(ReportingField.objects.get(field_name='Unit-Fuel-CO2 Emission Factor', field_units='kg/GJ'))
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Default EF', field_units='kg/GJ')
+    )
     # CO2 - Measured CC - Fuel Annual Weighted Average Carbon Content (weight fraction)
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(name='General stationary non-compression and non-processing combustion').id,
@@ -1077,7 +1079,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Measured EF', field_units='kg/fuel units')
     )
     # CO2 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1126,7 +1128,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1139,7 +1141,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1167,7 +1169,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1180,7 +1182,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1217,7 +1219,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1241,7 +1243,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1290,7 +1292,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1303,7 +1305,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1331,7 +1333,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1344,7 +1346,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1381,7 +1383,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1405,7 +1407,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1455,7 +1457,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Default EF - Unit-Fuel-CO2 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1468,7 +1470,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default EF', field_units='kg/fuel units')
     )
     # CO2 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1496,7 +1498,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1532,7 +1534,9 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         methodology_id=Methodology.objects.get(name='Measured Steam/Default EF').id,
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(ReportingField.objects.get(field_name='Unit-Fuel-CO2 Emission Factor', field_units='kg/GJ'))
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Default EF', field_units='kg/GJ')
+    )
     # CO2 - Measured CC - Fuel Annual Weighted Average Carbon Content (weight fraction)
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(name='General stationary non-compression and non-processing combustion').id,
@@ -1572,7 +1576,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Measured EF', field_units='kg/fuel units')
     )
     # CO2 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1621,7 +1625,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1634,7 +1638,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1662,7 +1666,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1675,7 +1679,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1712,7 +1716,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1736,7 +1740,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1785,7 +1789,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1798,7 +1802,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1826,7 +1830,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -1839,7 +1843,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -1876,7 +1880,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -1900,7 +1904,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -1950,7 +1954,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Default EF - Unit-Fuel-CO2 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -1963,7 +1967,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default EF', field_units='kg/fuel units')
     )
     # CO2 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -1991,7 +1995,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CO2 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2027,7 +2031,9 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         methodology_id=Methodology.objects.get(name='Measured Steam/Default EF').id,
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
-    ).reporting_fields.add(ReportingField.objects.get(field_name='Unit-Fuel-CO2 Emission Factor', field_units='kg/GJ'))
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Default EF', field_units='kg/GJ')
+    )
     # CO2 - Measured CC - Fuel Annual Weighted Average Carbon Content (weight fraction)
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(name='General stationary non-compression and non-processing combustion').id,
@@ -2067,7 +2073,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CO2 Measured Steam-Measured EF', field_units='kg/fuel units')
     )
     # CO2 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -2116,7 +2122,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Default EF - Unit-Fuel-CH4 Default Emission Factor
     ConfigurationElement.objects.get(
@@ -2129,7 +2135,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default EF', field_units='kg/fuel units')
     )
     # CH4 - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -2157,7 +2163,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured HHV-Default EF', field_units='kg/GJ')
     )
     # CH4 - Measured EF - Unit-Fuel-CH4 Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -2170,7 +2176,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured EF', field_units='kg/fuel units')
     )
     # CH4 - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2207,7 +2213,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Measured Steam-Default EF', field_units='kg/GJ')
     )
     # CH4 - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -2231,7 +2237,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-CH4 Heat Input-Default EF', field_units='kg/GJ')
     )
     # CH4 - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(
@@ -2280,7 +2286,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Default EF - Unit-Fuel-N2O Default Emission Factor
     ConfigurationElement.objects.get(
@@ -2293,7 +2299,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default EF', field_units='kg/fuel units')
     )
     # N2O - Measured HHV/Default EF - Fuel Annual Weighted Average High Heating Value
     ConfigurationElement.objects.get(
@@ -2321,7 +2327,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured HHV-Default EF', field_units='kg/GJ')
     )
     # N2O - Measured EF - Unit-Fuel-N2O Measured Emission Factor
     ConfigurationElement.objects.get(
@@ -2334,7 +2340,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Emission Factor', field_units='kg/fuel units')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured EF', field_units='kg/fuel units')
     )
     # N2O - Measured Steam/Default EF - Unit-Fuel Annual Steam Generated
     ConfigurationElement.objects.get(
@@ -2371,7 +2377,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Measured Steam-Default EF', field_units='kg/GJ')
     )
     # N2O - Heat Input/Default EF - Unit-Fuel Heat Input
     ConfigurationElement.objects.get(
@@ -2395,7 +2401,7 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
-        ReportingField.objects.get(field_name='Unit-Fuel-N2O Default Emission Factor', field_units='kg/GJ')
+        ReportingField.objects.get(field_name='Unit-Fuel-N2O Heat Input-Default EF', field_units='kg/GJ')
     )
     # N2O - Alternative Parameter Measurement Methodology - Description
     ConfigurationElement.objects.get(

--- a/bc_obps/reporting/migrations/0061_electricity_generation.py
+++ b/bc_obps/reporting/migrations/0061_electricity_generation.py
@@ -107,14 +107,14 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Default HHV/Default EF"],
         "reporting_fields": [
             {"name": "Fuel Default High Heating Value"},
-            {"name": "Unit-Fuel-CH4 Default Emission Factor", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-CH4 Default HHV-Default EF", "units": "kg/GJ"},
         ],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
         "gas_types": ["CH4"],
         "methodologies": ["Default EF"],
-        "reporting_fields": [{"name": "Unit-Fuel-CH4 Default Emission Factor", "units": "kg/fuel units"}],
+        "reporting_fields": [{"name": "Unit-Fuel-CH4 Default EF", "units": "kg/fuel units"}],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
@@ -122,14 +122,14 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Measured HHV/Default EF"],
         "reporting_fields": [
             {"name": "Fuel Annual Weighted Average High Heating Value"},
-            {"name": "Unit-Fuel-CH4 Default Emission Factor", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-CH4 Measured HHV-Default EF", "units": "kg/GJ"},
         ],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
         "gas_types": ["CH4"],
         "methodologies": ["Measured EF"],
-        "reporting_fields": [{"name": "Unit-Fuel-CH4 Measured Emission Factor", "units": "kg/fuel units"}],
+        "reporting_fields": [{"name": "Unit-Fuel-CH4 Measured EF", "units": "kg/fuel units"}],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
@@ -138,7 +138,7 @@ CONFIG_REPORTING_FIELDS = [
         "reporting_fields": [
             {"name": "Unit-Fuel Annual Steam Generated"},
             {"name": "Boiler Ratio"},
-            {"name": "Unit-Fuel-CH4 Default Emission Factor", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-CH4 Measured Steam-Default EF", "units": "kg/GJ"},
         ],
     },
     {
@@ -147,7 +147,7 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Heat Input/Default EF"],
         "reporting_fields": [
             {"name": "Unit-Fuel Heat Input"},
-            {"name": "Unit-Fuel-CH4 Default Emission Factor", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-CH4 Heat Input-Default EF", "units": "kg/GJ"},
         ],
     },
     {
@@ -168,14 +168,14 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Default HHV/Default EF"],
         "reporting_fields": [
             {"name": "Fuel Default High Heating Value"},
-            {"name": "Unit-Fuel-N2O Default Emission Factor", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-N2O Default HHV-Default EF", "units": "kg/GJ"},
         ],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
         "gas_types": ["N2O"],
         "methodologies": ["Default EF"],
-        "reporting_fields": [{"name": "Unit-Fuel-N2O Default Emission Factor", "units": "kg/fuel units"}],
+        "reporting_fields": [{"name": "Unit-Fuel-N2O Default EF", "units": "kg/fuel units"}],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
@@ -183,14 +183,14 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Measured HHV/Default EF"],
         "reporting_fields": [
             {"name": "Fuel Annual Weighted Average High Heating Value"},
-            {"name": "Unit-Fuel-N2O Default Emission Factor", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-N2O Measured HHV-Default EF", "units": "kg/GJ"},
         ],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
         "gas_types": ["N2O"],
         "methodologies": ["Measured EF"],
-        "reporting_fields": [{"name": "Unit-Fuel-N2O Measured Emission Factor", "units": "kg/fuel units"}],
+        "reporting_fields": [{"name": "Unit-Fuel-N2O Measured EF", "units": "kg/fuel units"}],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
@@ -199,7 +199,7 @@ CONFIG_REPORTING_FIELDS = [
         "reporting_fields": [
             {"name": "Unit-Fuel Annual Steam Generated"},
             {"name": "Boiler Ratio"},
-            {"name": "Unit-Fuel-N2O Default Emission Factor", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-N2O Measured Steam-Default EF", "units": "kg/GJ"},
         ],
     },
     {
@@ -208,7 +208,7 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Heat Input/Default EF"],
         "reporting_fields": [
             {"name": "Unit-Fuel Heat Input"},
-            {"name": "Unit-Fuel-N2O Default Emission Factor", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-N2O Heat Input-Default EF", "units": "kg/GJ"},
         ],
     },
     {

--- a/bc_obps/reporting/migrations/0061_electricity_generation.py
+++ b/bc_obps/reporting/migrations/0061_electricity_generation.py
@@ -107,14 +107,14 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Default HHV/Default EF"],
         "reporting_fields": [
             {"name": "Fuel Default High Heating Value"},
-            {"name": "Unit-Fuel-CH4 Default HHV-Default EF", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-CH4 Default HHV-Default EF", "units": "g/GJ"},
         ],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
         "gas_types": ["CH4"],
         "methodologies": ["Default EF"],
-        "reporting_fields": [{"name": "Unit-Fuel-CH4 Default EF", "units": "kg/fuel units"}],
+        "reporting_fields": [{"name": "Unit-Fuel-CH4 Default EF", "units": "g/fuel units"}],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
@@ -122,14 +122,14 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Measured HHV/Default EF"],
         "reporting_fields": [
             {"name": "Fuel Annual Weighted Average High Heating Value"},
-            {"name": "Unit-Fuel-CH4 Measured HHV-Default EF", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-CH4 Measured HHV-Default EF", "units": "g/GJ"},
         ],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
         "gas_types": ["CH4"],
         "methodologies": ["Measured EF"],
-        "reporting_fields": [{"name": "Unit-Fuel-CH4 Measured EF", "units": "kg/fuel units"}],
+        "reporting_fields": [{"name": "Unit-Fuel-CH4 Measured EF", "units": "g/fuel units"}],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
@@ -138,7 +138,7 @@ CONFIG_REPORTING_FIELDS = [
         "reporting_fields": [
             {"name": "Unit-Fuel Annual Steam Generated"},
             {"name": "Boiler Ratio"},
-            {"name": "Unit-Fuel-CH4 Measured Steam-Default EF", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-CH4 Measured Steam-Default EF", "units": "g/GJ"},
         ],
     },
     {
@@ -147,7 +147,7 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Heat Input/Default EF"],
         "reporting_fields": [
             {"name": "Unit-Fuel Heat Input"},
-            {"name": "Unit-Fuel-CH4 Heat Input-Default EF", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-CH4 Heat Input-Default EF", "units": "g/GJ"},
         ],
     },
     {
@@ -168,14 +168,14 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Default HHV/Default EF"],
         "reporting_fields": [
             {"name": "Fuel Default High Heating Value"},
-            {"name": "Unit-Fuel-N2O Default HHV-Default EF", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-N2O Default HHV-Default EF", "units": "g/GJ"},
         ],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
         "gas_types": ["N2O"],
         "methodologies": ["Default EF"],
-        "reporting_fields": [{"name": "Unit-Fuel-N2O Default EF", "units": "kg/fuel units"}],
+        "reporting_fields": [{"name": "Unit-Fuel-N2O Default EF", "units": "g/fuel units"}],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
@@ -183,14 +183,14 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Measured HHV/Default EF"],
         "reporting_fields": [
             {"name": "Fuel Annual Weighted Average High Heating Value"},
-            {"name": "Unit-Fuel-N2O Measured HHV-Default EF", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-N2O Measured HHV-Default EF", "units": "g/GJ"},
         ],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
         "gas_types": ["N2O"],
         "methodologies": ["Measured EF"],
-        "reporting_fields": [{"name": "Unit-Fuel-N2O Measured EF", "units": "kg/fuel units"}],
+        "reporting_fields": [{"name": "Unit-Fuel-N2O Measured EF", "units": "g/fuel units"}],
     },
     {
         "source_type": "Fuel combustion for electricity generation",
@@ -199,7 +199,7 @@ CONFIG_REPORTING_FIELDS = [
         "reporting_fields": [
             {"name": "Unit-Fuel Annual Steam Generated"},
             {"name": "Boiler Ratio"},
-            {"name": "Unit-Fuel-N2O Measured Steam-Default EF", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-N2O Measured Steam-Default EF", "units": "g/GJ"},
         ],
     },
     {
@@ -208,7 +208,7 @@ CONFIG_REPORTING_FIELDS = [
         "methodologies": ["Heat Input/Default EF"],
         "reporting_fields": [
             {"name": "Unit-Fuel Heat Input"},
-            {"name": "Unit-Fuel-N2O Heat Input-Default EF", "units": "kg/GJ"},
+            {"name": "Unit-Fuel-N2O Heat Input-Default EF", "units": "g/GJ"},
         ],
     },
     {


### PR DESCRIPTION
Addresses:
[560](https://github.com/bcgov/cas-reporting/issues/560)

### 🚀 Impact:

- Updated the reporting fuel unit fields names to be unique, based on gas_type and methodology, so fuel units display correctly reflecting the gas type and methodology selected.


### 🔬 Local Testing:

###  Tests set-up:
1. From terminal command, start the api server:
 ```
cd bc_obps
make reset_db
make run
```  
2.  From terminal command, start the app development server:
 ```
cd bciers && yarn dev-all
```  
1. Navigate to http://localhost:3000
2. Click button "Log in with Business BCeID"

### **Test: Emissions Fuel Unit Values **  

#### **Steps**  
1. Navigate to `Activities` route, ex: http://localhost:3000/reporting/reports/1/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/activities
2. Select `General stationary combustion of fuel or waste with production of useful energy`
3. In section `Emission 1` change the gas type and methodology and verify the fuel units displayed: 

#### **Expected Result**  
✅  
| **Gas Type** | **Methodology**                    | **Expected Units**   |
|--------------|-------------------------------------|----------------------|
| CO2          | Default EF                          | kg/fuel units        |
| CO2          | Default HHV-Default EF              | kg/GJ                |
| CO2          | Measured HHV-Default EF             | kg/GJ                |
| CO2          | Measured Steam-Default EF           | kg/GJ                |
| CO2          | Measured Steam-Measured EF          | kg/fuel units        |
| CH4          | Default EF                          | g/fuel units        |
| CH4          | Default HHV-Default EF              | g/GJ                |
| CH4          | Heat Input-Default EF               | g/GJ                |
| CH4          | Measured EF                          | g/fuel units        |
| CH4          | Measured HHV-Default EF             | g/GJ                |
| CH4          | Measured Steam-Default EF           | g/GJ                |
| N2O          | Default EF                          | g/fuel units        |
| N2O          | Default HHV-Default EF              | g/GJ                |
| N2O          | Heat Input-Default EF               | g/GJ                |
| N2O          | Measured EF                          | g/fuel units        |
| N2O          | Measured HHV-Default EF             | g/GJ                |
| N2O          | Measured Steam-Default EF           | g/GJ                |


As per  [BCIERS Reporting Fields](https://bcgov.sharepoint.com/:x:/r/teams/00608-CPRInternal/_layouts/15/doc2.aspx?sourcedoc=%7BB6613650-00EB-422F-A103-41608CD0E2E6%7D&file=BCIERS%20Reporting%20Fields%20v2.xlsx&action=default)
