### PR TITLE
chore: fixed field error on review operation page

### DIFF
--- a/bc_obps/reporting/schema/report_operation.py
+++ b/bc_obps/reporting/schema/report_operation.py
@@ -4,7 +4,7 @@ from reporting.models import ReportOperationRepresentative
 from reporting.models.report_operation import ReportOperation
 from pydantic import alias_generators
 
-from typing import List
+from typing import List, Optional
 
 
 def to_camel(string: str) -> str:
@@ -57,7 +57,7 @@ class ReportOperationIn(Schema):
     """
 
     operator_legal_name: str
-    operator_trade_name: str
+    operator_trade_name: Optional[str] = None
     operation_name: str
     operation_type: str
     operation_bcghgid: str
@@ -66,18 +66,3 @@ class ReportOperationIn(Schema):
     regulated_products: List[str]
     operation_report_type: str
     operation_representative_name: List[int]
-
-    class Meta:
-        alias_generator = to_snake
-        fields = [
-            'operator_legal_name',
-            'operator_trade_name',
-            'operation_name',
-            'operation_type',
-            'operation_bcghgid',
-            'bc_obps_regulated_operation_id',
-            'activities',
-            'regulated_products',
-            'operation_representative_name',
-            'operation_report_type',
-        ]

--- a/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/operationReviewFactoryItem.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/operationReviewFactoryItem.ts
@@ -10,6 +10,11 @@ import { formatDate } from "@reporting/src/app/utils/formatDate";
 import { getRegistrationPurpose } from "@reporting/src/app/utils/getRegistrationPurpose";
 import { getAllActivities } from "@reporting/src/app/utils/getAllReportingActivities";
 import { getRegulatedProducts } from "@bciers/actions/api";
+import {
+  ELECTRICITY_IMPORT_OPERATION,
+  POTENTIAL_REPORTING_OPERATION,
+  REPORTING_OPERATION,
+} from "@reporting/src/app/utils/constants";
 
 const operationReviewFactoryItem: ReviewDataFactoryItem = async (versionId) => {
   const reportingOperationData = await getReportingOperation(versionId);
@@ -25,6 +30,11 @@ const operationReviewFactoryItem: ReviewDataFactoryItem = async (versionId) => {
 
   const allActivities = await getAllActivities();
   const allRegulatedProducts = await getRegulatedProducts();
+  const showRegulatedProducts = ![
+    ELECTRICITY_IMPORT_OPERATION,
+    REPORTING_OPERATION,
+    POTENTIAL_REPORTING_OPERATION,
+  ].includes(registrationPurpose);
 
   const schema: any = updateSchema(
     operationReviewSchema,
@@ -34,6 +44,7 @@ const operationReviewFactoryItem: ReviewDataFactoryItem = async (versionId) => {
     allActivities,
     allRegulatedProducts,
     reportingOperationData.report_operation_representatives,
+    showRegulatedProducts,
   );
 
   // Purpose note doesn't show up on the final review page

--- a/bciers/apps/reporting/src/app/components/operations/OperationReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReviewForm.tsx
@@ -43,6 +43,7 @@ interface Props {
     id: number;
     representative_name: string;
   }[];
+  showRegulatedProducts?: boolean;
 }
 
 export default function OperationReviewForm({
@@ -55,6 +56,7 @@ export default function OperationReviewForm({
   registrationPurpose,
   facilityReport,
   allRepresentatives,
+  showRegulatedProducts,
 }: Props) {
   const [pendingChangeReportType, setPendingChangeReportType] =
     useState<string>();
@@ -94,7 +96,8 @@ export default function OperationReviewForm({
               return activity.name;
             }),
       regulated_products:
-        formDataState.operation_report_type === "Simple Report"
+        formDataState.operation_report_type === "Simple Report" ||
+        !showRegulatedProducts
           ? []
           : formDataObject.regulated_products?.map((productId: any) => {
               const product = allRegulatedProducts.find(
@@ -133,6 +136,7 @@ export default function OperationReviewForm({
           allActivities,
           allRegulatedProducts,
           allRepresentatives,
+          showRegulatedProducts,
         ),
       );
     }

--- a/bciers/apps/reporting/src/app/components/operations/OperationReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReviewForm.tsx
@@ -43,7 +43,7 @@ interface Props {
     id: number;
     representative_name: string;
   }[];
-  showRegulatedProducts?: boolean;
+  showRegulatedProducts: boolean;
 }
 
 export default function OperationReviewForm({

--- a/bciers/apps/reporting/src/app/components/operations/OperationReviewPage.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReviewPage.tsx
@@ -37,8 +37,6 @@ export default async function OperationReviewPage({
     POTENTIAL_REPORTING_OPERATION,
   ].includes(registrationPurposeString);
 
-  console.log("showRegulatedProducts", showRegulatedProducts);
-
   return (
     <OperationReviewForm
       formData={transformedOperation}

--- a/bciers/apps/reporting/src/app/components/operations/OperationReviewPage.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReviewPage.tsx
@@ -7,6 +7,11 @@ import { getRegistrationPurpose } from "@reporting/src/app/utils/getRegistration
 import { getFacilityReport } from "@reporting/src/app/utils/getFacilityReport";
 import { HasReportVersion } from "@reporting/src/app/utils/defaultPageFactoryTypes";
 import OperationReviewForm from "./OperationReviewForm";
+import {
+  ELECTRICITY_IMPORT_OPERATION,
+  POTENTIAL_REPORTING_OPERATION,
+  REPORTING_OPERATION,
+} from "@reporting/src/app/utils/constants";
 
 export default async function OperationReviewPage({
   version_id,
@@ -26,6 +31,13 @@ export default async function OperationReviewPage({
       reportOperation.report_operation_representatives,
   };
   const allRepresentatives = reportOperation.report_operation_representatives;
+  const showRegulatedProducts = ![
+    ELECTRICITY_IMPORT_OPERATION,
+    REPORTING_OPERATION,
+    POTENTIAL_REPORTING_OPERATION,
+  ].includes(registrationPurposeString);
+
+  console.log("showRegulatedProducts", showRegulatedProducts);
 
   return (
     <OperationReviewForm
@@ -38,6 +50,7 @@ export default async function OperationReviewPage({
       registrationPurpose={registrationPurposeString}
       facilityReport={facilityReport}
       allRepresentatives={allRepresentatives}
+      showRegulatedProducts={showRegulatedProducts}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/utils/constants.ts
+++ b/bciers/apps/reporting/src/app/utils/constants.ts
@@ -3,3 +3,6 @@ export const cancelUrlReports = "/reports";
 export const REGULATED_OPERATION_REGISTRATION_PURPOSE =
   "OBPS Regulated Operation";
 export const NEW_ENTRANT_REGISTRATION_PURPOSE = "New Entrant Operation";
+export const ELECTRICITY_IMPORT_OPERATION = "Electricity Import Operation";
+export const REPORTING_OPERATION = "Reporting Operation";
+export const POTENTIAL_REPORTING_OPERATION = "Potential Reporting Operation";

--- a/bciers/apps/reporting/src/data/jsonSchema/operations.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/operations.ts
@@ -11,8 +11,8 @@ export const operationReviewSchema: RJSFSchema = {
   title: "Review Operation Information",
   required: [
     "operation_representative_name",
-    "operation_bcghgid",
     "operation_name",
+    "operator_legal_name",
   ],
 
   properties: {

--- a/bciers/apps/reporting/src/data/jsonSchema/operations.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/operations.ts
@@ -40,7 +40,7 @@ export const operationReviewSchema: RJSFSchema = {
 
     operator_legal_name: { type: "string", title: "Operator legal name" },
     operator_trade_name: {
-      type: "string" || null,
+      type: ["string", "null"],
       title: "Operator trade name",
     },
     operation_name: { type: "string", title: "Operation name" },

--- a/bciers/apps/reporting/src/data/jsonSchema/operations.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/operations.ts
@@ -39,7 +39,10 @@ export const operationReviewSchema: RJSFSchema = {
     },
 
     operator_legal_name: { type: "string", title: "Operator legal name" },
-    operator_trade_name: { type: "string", title: "Operator trade name" },
+    operator_trade_name: {
+      type: "string" || null,
+      title: "Operator trade name",
+    },
     operation_name: { type: "string", title: "Operation name" },
     operation_type: {
       type: "string",
@@ -185,6 +188,7 @@ export const updateSchema = (
   allActivities: any[],
   allRegulatedProducts: any[],
   allRepresentatives: any[],
+  showRegulatedProducts: boolean,
 ) => {
   return {
     ...prevSchema,
@@ -246,18 +250,21 @@ export const updateSchema = (
                   enumNames: allActivities.map((activity) => activity.name),
                 },
               },
-              regulated_products: {
-                type: "array",
-                title: "Regulated products",
-                minItems: 1,
-                items: {
-                  type: "number",
-                  enum: allRegulatedProducts.map((product) => product.id),
-                  enumNames: allRegulatedProducts.map(
-                    (product) => product.name,
-                  ),
+
+              ...(showRegulatedProducts && {
+                regulated_products: {
+                  type: "array",
+                  title: "Regulated products",
+                  minItems: 1,
+                  items: {
+                    type: "number",
+                    enum: allRegulatedProducts.map((product) => product.id),
+                    enumNames: allRegulatedProducts.map(
+                      (product) => product.name,
+                    ),
+                  },
                 },
-              },
+              }),
             },
           },
         ],

--- a/bciers/apps/reporting/src/tests/components/operations/OperationReviewForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/operations/OperationReviewForm.test.tsx
@@ -116,6 +116,7 @@ describe("OperationReviewForm Component", () => {
               selected_for_report: true,
             },
           ]}
+          showRegulatedProducts={true}
         />,
       );
 
@@ -188,6 +189,7 @@ describe("OperationReviewForm Component", () => {
             selected_for_report: true,
           },
         ]}
+        showRegulatedProducts={true}
       />,
     );
 
@@ -240,6 +242,7 @@ describe("OperationReviewForm Component", () => {
             selected_for_report: true,
           },
         ]}
+        showRegulatedProducts={true}
       />,
     );
 

--- a/bciers/apps/reporting/src/tests/components/operations/OperationReviewForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/operations/OperationReviewForm.test.tsx
@@ -24,6 +24,7 @@ const defaultProps = {
     regulated_products: [1],
     operation_representative_name: [4],
     operation_type: "Test Operation",
+    operator_legal_name: "test operator",
   },
   version_id: 1,
   reportType: { report_type: "Annual Report" },
@@ -94,6 +95,7 @@ describe("OperationReviewForm Component", () => {
             operation_bcghgid: "your-bcghg-id",
             operation_name: "Operation Name",
             operation_type: "Test Operation",
+            operator_legal_name: "test operator",
           }}
           version_id={1}
           reportType={{ report_type: "Annual Report" }}


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/499
Changes:-

1. Added check for registration purpose and conditionally render regulated products
2. Trade to accpet both string or null
3. Fixed test

To test:-

1. Go to http://localhost:3000/reporting/reports
2. Choose any operation with registration purspose as Electricity Import Operation, Reporting Operation or Potential Reporting Operation or manually set registration purpose for any operation to any of these.
3. You will not see regulated products on Review Operation Information