### PR TITLE
Bug: Errors on attachments

### DIFF
--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -388,7 +388,7 @@
       "status": "Registered",
       "bc_obps_regulated_operation": "24-0016",
       "registration_purpose": "Reporting Operation",
-      "activities": [1, 5],
+      "activities": [1],
       "contacts": [3]
     }
   },

--- a/bciers/apps/reporting/src/app/components/attachments/AttachmentsForm.tsx
+++ b/bciers/apps/reporting/src/app/components/attachments/AttachmentsForm.tsx
@@ -32,7 +32,7 @@ const AttachmentsForm: React.FC<Props> = ({
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [isRedirecting, setIsRedirecting] = useState<boolean>(false);
 
-  const [error, setError] = useState<string>();
+  const [errors, setErrors] = useState<string[]>();
   const [validationErrors, setValidationErrors] = useState<{
     [fileType: string]: string;
   }>({});
@@ -73,7 +73,7 @@ const AttachmentsForm: React.FC<Props> = ({
 
     if (Object.keys(pendingUploadFiles).length === 0) {
       // Nothing to submit
-      if (canContinue) router.push(saveAndContinueUrl);
+      if (canContinue) return router.push(saveAndContinueUrl);
       else return;
     }
 
@@ -88,13 +88,14 @@ const AttachmentsForm: React.FC<Props> = ({
     const response = await postAttachments(version_id, formData);
 
     if (response.error) {
-      setError(response.error);
+      setErrors([response.error]);
+    } else {
+      if (canContinue) {
+        setIsRedirecting(true);
+        router.push(saveAndContinueUrl);
+      }
     }
 
-    if (canContinue) {
-      setIsRedirecting(true);
-      router.push(saveAndContinueUrl);
-    }
     setIsSaving(false);
   };
 
@@ -137,7 +138,7 @@ const AttachmentsForm: React.FC<Props> = ({
         cancelUrl="#"
         backUrl={backUrl}
         continueUrl={saveAndContinueUrl}
-        error={error}
+        errors={errors}
         isSaving={isSaving}
         isRedirecting={isRedirecting}
         noFormSave={() => handleSubmit(false)}

--- a/bciers/apps/reporting/src/tests/components/attachments/AttachmentsForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/attachments/AttachmentsForm.test.tsx
@@ -163,7 +163,7 @@ describe("The attachments form", () => {
       fireEvent.click(screen.getByText("Save & Continue"));
     });
 
-    expect(mockPostAttachments).toHaveBeenCalled();
+    expect(mockPostAttachments).not.toHaveBeenCalled();
     expect(screen.queryByText("Must be present")).not.toBeInTheDocument();
   });
 

--- a/bciers/libs/components/src/form/FormAlerts.tsx
+++ b/bciers/libs/components/src/form/FormAlerts.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Alert } from "@mui/material";
+
+interface FormAlertsProps {
+  errors: string[] | undefined;
+}
+
+const FormAlerts: React.FC<FormAlertsProps> = ({ errors }) => {
+  if (!errors || errors.length === 0) {
+    return null; // Don't render anything if there are no errors
+  }
+
+  return (
+    <div className="min-h-[48px] box-border mt-4">
+      {errors.map((e, index) => (
+        <Alert key={index} severity="error">
+          {e}
+        </Alert>
+      ))}
+    </div>
+  );
+};
+
+export default FormAlerts;

--- a/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
+++ b/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
@@ -3,13 +3,13 @@
 import React from "react";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/ReportingTaskList";
-import { Alert, Box } from "@mui/material";
+import { Box } from "@mui/material";
 import MultiStepHeader from "@bciers/components/form/components/MultiStepHeader";
-import ReportingStepButtons from "./components/ReportingStepButtons";
-
+import ReportingStepButtons from "@bciers/components/form/components/ReportingStepButtons";
+import FormAlerts from "@bciers/components/form/FormAlerts";
 /**
  * Similar to the MultiStepFormWithTaskList,
- * except doesn't display a for, but can be used as a wrapper for any other page for a consistent look.
+ * except doesn't display a form, but can be used as a wrapper for any other page for a consistent look.
  */
 
 interface Props {
@@ -23,7 +23,7 @@ interface Props {
   continueUrl: string;
   saveButtonText?: string;
   submittingButtonText?: string;
-  error?: string;
+  errors?: string[];
   isSaving?: boolean;
   isRedirecting?: boolean;
   noFormSave?: () => void;
@@ -39,7 +39,7 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
   backUrl,
   continueUrl,
   submittingButtonText,
-  error,
+  errors,
   isSaving,
   isRedirecting,
   noFormSave,
@@ -50,11 +50,6 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
       <div className="container mx-auto p-4" data-testid="facility-review">
         <MultiStepHeader stepIndex={initialStep} steps={steps} />
       </div>
-      {error && (
-        <div className="min-h-6">
-          <Alert severity="error">{error}</Alert>
-        </div>
-      )}
       <div className="w-full flex">
         {/* Make the task list hidden on small screens and visible on medium and up */}
         <div className="hidden md:block">
@@ -72,6 +67,9 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
             isSaving={isSaving}
             noSaveButton={noSaveButton}
           />
+
+          {/* Render form alerts */}
+          <FormAlerts errors={errors} />
         </div>
       </div>
     </Box>

--- a/bciers/libs/components/src/form/NavigationForm.tsx
+++ b/bciers/libs/components/src/form/NavigationForm.tsx
@@ -5,7 +5,7 @@ import FormBase, { FormPropsWithTheme } from "./FormBase";
 import Form from "@rjsf/core";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import ReportingStepButtons from "./components/ReportingStepButtons";
-import { Alert } from "@mui/material";
+import FormAlerts from "@bciers/components/form/FormAlerts";
 import { useRouter } from "next/navigation";
 
 export interface NavigationFormProps
@@ -20,7 +20,7 @@ export interface NavigationFormProps
   onSubmit?: (data: any, navigateAfterSubmit: boolean) => Promise<boolean>;
   buttonText?: string;
   onChange?: (data: any) => void;
-  errors?: any[];
+  errors?: string[];
   saveButtonDisabled?: boolean;
   submitButtonDisabled?: boolean;
   noSaveButton?: boolean;
@@ -126,15 +126,8 @@ const NavigationForm: React.FC<NavigationFormProps> = (props) => {
         buttonText={buttonText}
         noSaveButton={noSaveButton}
       />
-      {errors && errors.length > 0 && (
-        <div key="form-alerts" className="min-h-[48px] box-border mt-4">
-          {errors.map((e, index) => (
-            <Alert key={index} severity="error">
-              {e}
-            </Alert>
-          ))}
-        </div>
-      )}
+      {/* Render form alerts */}
+      <FormAlerts errors={errors} />
     </FormBase>
   );
 };


### PR DESCRIPTION
Addresses: 
[508](https://github.com/bcgov/cas-reporting/issues/508)
[611](https://github.com/bcgov/cas-reporting/issues/611)

### ⚠️ Issue:
Attachments form was submitted even if there were no pending files; such as, when there was no need for verification attachment or there was already a verification attachment, resulting in a "flashing" error at the top of the page before router navigation to sign-off page (see 508 screen-cast) 


### 🚀 Impact:
- Updated `AttachmentsForm.tsx` to return on router navigation when no pending attachment; therefore, preventing form submit
- Updated `MultiStepWrapperWithTaskList.tsx` to display errors at the bottom of the page, similar to `MultiStepFormWithTaskList.tsx`

## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button  

---

### **Test: Attachments `Save & Continue` when verification is not needed**  

#### **Steps:**  
1. Click `Start/Continue` for an Operation with where Verification is not needed, ex: `Bat LFO - Registered`
2. Navigate to `/attachments`, ex: http://localhost:3000/reporting/reports/3/attachments
3. Click `Save & Continue`

#### **Expected Result**  

✅  
- Form is NOT submitted
- There is no API error
- There is no  error flash on top of page
- `Sign-off` page is displayed


---

### **Test: Attachments `Save & Continue` when verification is needed**  

#### **Steps:**  
1. Navigate to a report attachments where Verification is needed, ex: http://localhost:3000/reporting/reports/1/attachments
2. Click `Save & Continue`
#### **Expected Result**  
✅  
- The `Verification Statement*` is required
4. Add an attachment for Verification Statement*
5. Click `Save & Continue`
#### **Expected Result** 
✅   
- Form is submitted
- Page routes to `Sign-Off` 

---

### **Test: Attachments `Save & Continue` when verification is already attached**  

#### **Steps:**  
6. After step 5 above, navigate to attachments, ex: http://localhost:3000/reporting/reports/1/attachments
#### **Expected Result**  
✅  
- The `Verification Statement*` attachment has been saved
7. Click `Save & Continue`
#### **Expected Result**  
✅  
- Form is NOT submitted
- There is no API error
- There is no  error flash on top of page
- Page routes to `Sign-Off` 

---

### **Test: `MultiStepWrapperWithTaskList.tsx`  error message** 

#### **Steps:**  
1. Mock an error display in  `MultiStepWrapperWithTaskList.tsx` by remming out code for pendingUploadFiles in  `AttachmentsForm.tsx` , ex: 
```
 // if (Object.keys(pendingUploadFiles).length === 0) {
    //   // Nothing to submit
    //   if (canContinue) return router.push(saveAndContinueUrl);
    //   else return;
    // }
```
2. Navigate to a record with an attachment, ex: http://localhost:3000/reporting/reports/1/attachments
3. Click `Save & Continue`
#### **Expected Result**  
✅  
- Error displays on the page footer
![image](https://github.com/user-attachments/assets/a862d469-85bc-4a79-86cc-e5eddf58e077)

---

### **Test: `MultiStepFormWithTaskList.tsx`  error message**

#### **Steps:**  
1. Navigate to sign-off for a record which requires verification but has not saved the verification page, ex: http://localhost:3000/reporting/reports/1/sign-off
2. Complete required fields
3. Click `Save & Continue`
#### **Expected Result**  
✅  
- Error displays on the page footer
![image](https://github.com/user-attachments/assets/b0747ee4-e1e8-451c-9673-c05872d6f975)
