### PR TITLE
chore: validate report verification on submit

### DIFF
--- a/bciers/apps/reporting/src/app/components/signOff/reportValidationMessages.ts
+++ b/bciers/apps/reporting/src/app/components/signOff/reportValidationMessages.ts
@@ -1,4 +1,6 @@
 const reportValidationMessagesMap: { [key: string]: string } = {
+  missing_report_verification:
+    "Verification information must be completed with this report.  Please complete the Verification page.",
   verification_statement:
     "A verification statement must be uploaded with this report. Please upload a verification statement on the Attachments page.",
 };


### PR DESCRIPTION
Addresses:  [601](https://github.com/bcgov/cas-reporting/issues/601)

### 🚀 Impact:

- Added submission verification of report verification record when report needs verification

## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button  

---

### **Test: Sign-off `Submit` when verification is needed**  

#### **Steps:**  
1. Click Start/Continue for an Operation with where Verification is needed, ex `Bugle SFO - Registered`
2. Navigate to `/sign-off` for operation where Verification is needed, ex: http://localhost:3000/reporting/reports/1/sign-off
3. Click `Submit`
#### **Expected Result**  
✅  Error displays: "Verification information must be completed with this report.  Please complete the Verification page."

4. Navigate to `/verification`, ex:  http://localhost:3000/reporting/reports/1/verification
5. Complete required fields
6. Click `Save & Continue`
7.  Navigate to `/sign-off`, ex: http://localhost:3000/reporting/reports/1/sign-off
8. Click `Submit`

#### **Expected Result**  
✅  Error displays: "A verification statement must be uploaded with this report. Please upload a verification statement on the Attachments page."

9. Navigate to `/attachments`, ex:  http://localhost:3000/reporting/reports/1/attachment
5. Complete required fields
6. Click `Save & Continue`
7.  Navigate to `/sign-off`, ex: http://localhost:3000/reporting/reports/1/sign-off
8. Click `Submit`

✅  Report is submitted

---

### **Test: Sign-off `Submit` when verification is not needed**  

#### **Steps:**  
1. Click Start/Continue for an Operation with where Verification is not needed, ex: `Bat LFO - Registered`
2. Navigate to `/sign-off`
3. Click `Submit`

#### **Expected Result**  

✅  Report is submitted