### PR TITLE
feat: add woody biomass emission exception for pulp and paper

### DIFF
--- a/bc_obps/reporting/migrations/0018_pulp_and_paper_production.py
+++ b/bc_obps/reporting/migrations/0018_pulp_and_paper_production.py
@@ -192,6 +192,7 @@ def init_reporting_field_data(apps, schema_monitor):
                 field_type='number',
                 field_units=None,
             ),
+            ReportingField(field_name='Is Woody Biomass', field_type='boolean', field_units=None),
         ]
     )
 
@@ -328,6 +329,16 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
     ).reporting_fields.add(
         ReportingField.objects.get(field_name='Description', field_units__isnull=True),
     )
+    ConfigurationElement.objects.get(
+        activity_id=Activity.objects.get(name='Pulp and paper production').id,
+        source_type_id=SourceType.objects.get(name='Pulping and chemical recovery').id,
+        gas_type_id=GasType.objects.get(chemical_formula='CO2').id,
+        methodology_id=Methodology.objects.get(name='Alternative Parameter Measurement Methodology').id,
+        valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
+        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Is Woody Biomass', field_units__isnull=True),
+    )
     # CO2 - Replacement Methodology
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(name='Pulp and paper production').id,
@@ -338,6 +349,16 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
         ReportingField.objects.get(field_name='Description', field_units__isnull=True),
+    )
+    ConfigurationElement.objects.get(
+        activity_id=Activity.objects.get(name='Pulp and paper production').id,
+        source_type_id=SourceType.objects.get(name='Pulping and chemical recovery').id,
+        gas_type_id=GasType.objects.get(chemical_formula='CO2').id,
+        methodology_id=Methodology.objects.get(name='Replacement Methodology').id,
+        valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
+        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Is Woody Biomass', field_units__isnull=True),
     )
 
     # CH4
@@ -385,6 +406,16 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
     ).reporting_fields.add(
         ReportingField.objects.get(field_name='Description', field_units__isnull=True),
     )
+    ConfigurationElement.objects.get(
+        activity_id=Activity.objects.get(name='Pulp and paper production').id,
+        source_type_id=SourceType.objects.get(name='Pulping and chemical recovery').id,
+        gas_type_id=GasType.objects.get(chemical_formula='CH4').id,
+        methodology_id=Methodology.objects.get(name='Alternative Parameter Measurement Methodology').id,
+        valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
+        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Is Woody Biomass', field_units__isnull=True),
+    )
     # CH4 - Replacement Methodology
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(name='Pulp and paper production').id,
@@ -395,6 +426,16 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
         ReportingField.objects.get(field_name='Description', field_units__isnull=True),
+    )
+    ConfigurationElement.objects.get(
+        activity_id=Activity.objects.get(name='Pulp and paper production').id,
+        source_type_id=SourceType.objects.get(name='Pulping and chemical recovery').id,
+        gas_type_id=GasType.objects.get(chemical_formula='CH4').id,
+        methodology_id=Methodology.objects.get(name='Replacement Methodology').id,
+        valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
+        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Is Woody Biomass', field_units__isnull=True),
     )
 
     # N2O
@@ -442,6 +483,16 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
     ).reporting_fields.add(
         ReportingField.objects.get(field_name='Description', field_units__isnull=True),
     )
+    ConfigurationElement.objects.get(
+        activity_id=Activity.objects.get(name='Pulp and paper production').id,
+        source_type_id=SourceType.objects.get(name='Pulping and chemical recovery').id,
+        gas_type_id=GasType.objects.get(chemical_formula='N2O').id,
+        methodology_id=Methodology.objects.get(name='Alternative Parameter Measurement Methodology').id,
+        valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
+        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Is Woody Biomass', field_units__isnull=True),
+    )
     # N2O - Replacement Methodology
     ConfigurationElement.objects.get(
         activity_id=Activity.objects.get(name='Pulp and paper production').id,
@@ -452,6 +503,16 @@ def init_configuration_element_reporting_fields_data(apps, schema_monitor):
         valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
     ).reporting_fields.add(
         ReportingField.objects.get(field_name='Description', field_units__isnull=True),
+    )
+    ConfigurationElement.objects.get(
+        activity_id=Activity.objects.get(name='Pulp and paper production').id,
+        source_type_id=SourceType.objects.get(name='Pulping and chemical recovery').id,
+        gas_type_id=GasType.objects.get(chemical_formula='N2O').id,
+        methodology_id=Methodology.objects.get(name='Replacement Methodology').id,
+        valid_from_id=Configuration.objects.get(valid_from='2023-01-01').id,
+        valid_to_id=Configuration.objects.get(valid_to='2099-12-31').id,
+    ).reporting_fields.add(
+        ReportingField.objects.get(field_name='Is Woody Biomass', field_units__isnull=True),
     )
 
 

--- a/bc_obps/reporting/service/emission_category_mapping_service.py
+++ b/bc_obps/reporting/service/emission_category_mapping_service.py
@@ -1,3 +1,4 @@
+from registration.models.activity import Activity
 from reporting.models.report_emission import ReportEmission
 from reporting.models.report_fuel import ReportFuel
 from reporting.models.report_source_type import ReportSourceType
@@ -14,6 +15,7 @@ class EmissionCategoryMappingService:
         report_source_type: ReportSourceType,
         report_fuel: ReportFuel | None,
         report_emission: ReportEmission,
+        methodology_data: dict,
     ) -> None:
         categories_set = []
         activity_id = report_source_type.report_activity.activity.id
@@ -53,4 +55,27 @@ class EmissionCategoryMappingService:
 
         if other:
             categories_set.append(other.emission_category.id)
+        if EmissionCategoryMappingService.is_pulp_and_paper_woody_biomass(activity_id, methodology_data):
+            categories_set.append(
+                EmissionCategoryMapping.objects.get(
+                    activity_id=activity_id,
+                    source_type_id=source_type_id,
+                    emission_category__category_name='CO2 emissions from excluded woody biomass',
+                ).emission_category.id
+            )
+
         report_emission.emission_categories.set(categories_set)
+
+    @staticmethod
+    def is_pulp_and_paper_woody_biomass(activity_id: int, methodology_data: dict) -> bool:
+        activity = Activity.objects.filter(id=activity_id).first()
+        if activity and activity.slug == 'pulp_and_paper':
+            if methodology_data['methodology'] in ['Solids-HHV', 'Solids-CC']:
+                return True
+            elif methodology_data['methodology'] in [
+                'Alternative Parameter Measurement Methodology',
+                'Replacement Methodology',
+            ]:
+                if methodology_data.get('isWoodyBiomass', False):
+                    return True
+        return False

--- a/bc_obps/reporting/service/report_activity_save_service.py
+++ b/bc_obps/reporting/service/report_activity_save_service.py
@@ -259,7 +259,9 @@ class ReportActivitySaveService:
             },
             defaults={"json_data": json_data, "gas_type": gas_type},
         )
-        EmissionCategoryMappingService.apply_emission_categories(report_source_type, report_fuel, report_emission)
+        EmissionCategoryMappingService.apply_emission_categories(
+            report_source_type, report_fuel, report_emission, emission_data["methodology"]
+        )
 
         self.save_methodology(report_emission, emission_data["methodology"])
 

--- a/bc_obps/reporting/tests/models/program_configuration_tests/test_pulp_and_paper_production_2024.py
+++ b/bc_obps/reporting/tests/models/program_configuration_tests/test_pulp_and_paper_production_2024.py
@@ -20,18 +20,18 @@ class PulpAndPaperProduction2024TestCase(TestCase):
                 'Solids-HHV': 3,
                 'Solids-CC': 3,
                 'Make-up Chemical Use Methodology': 2,
-                'Alternative Parameter Measurement Methodology': 1,
-                'Replacement Methodology': 1,
+                'Alternative Parameter Measurement Methodology': 2,
+                'Replacement Methodology': 2,
             },
             'CH4': {
                 'Solids-HHV': 3,
-                'Alternative Parameter Measurement Methodology': 1,
-                'Replacement Methodology': 1,
+                'Alternative Parameter Measurement Methodology': 2,
+                'Replacement Methodology': 2,
             },
             'N2O': {
                 'Solids-HHV': 3,
-                'Alternative Parameter Measurement Methodology': 1,
-                'Replacement Methodology': 1,
+                'Alternative Parameter Measurement Methodology': 2,
+                'Replacement Methodology': 2,
             },
         }
 

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/pulpAndPaperUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/pulpAndPaperUiSchema.ts
@@ -49,6 +49,12 @@ const uiSchema = {
             methodology: {
               "ui:FieldTemplate": InlineFieldTemplate,
             },
+            isWoodyBiomass: {
+              "ui:options": {
+                label: true,
+                title: "This emission is categorized as 'Woody biomass'",
+              },
+            },
           },
         },
       },


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/402

### Changes
 - added is_pulp_and_paper_woody_biomass function instead of handle_exception (as in the dev checklist). This function returns a bool rather than applying the category itself
 - added a checkmark to activity page. The field and configurations for this were added to the original pulp_and_paper migration
 - added a test for the expected outcome

### To Test locally
 1. Reset database, run migrations, run frontend and backends, log in.
 2. Navigate to http://localhost:3000/reporting/reports/1/review-operator-data
 3. add 'Pulp and Paper' to the Reporting activities field and click 'Save & Continue'
 4. select a Person responsible and click 'Save & Continue'
 5. Click 'Pulp and Paper production' on the task list
 
###### Conditions for emissions to be categorized as Woody biomass:
 a. Methodology is either 'Solids-HHV' or 'Solids-CC'
 b. Methodology is either 'Alternative Parameter Measurement Methodology' or 'Replacement Methodology' and the "This emission is categorized as 'Woody biomass'" checkbox is selected

6. Fill out and save at least one emission that matches these conditions and have at least one match conditions b.
7. Click on 'Emissions Summary' in the task list
   - Expect to see the emissions (in tCO2e) you have submitted in the 'Industrial Process Emissions' and the 'CO2 emissions from excluded woody biomass' fields
 8. Navigate back to the Pulp and Paper activity form
 9. Uncheck the 'is woody biomass' checkbox on at least one emission and save. Change nothing else.
 10. Navigate back to the 'Emissions Summary' page
   - Expect to the total of emissions in 'CO2 emissions from excluded woody biomass' field has decreased by the amount of emissions that were unchecked. 
   - Expect to see the total of emissions in 'Industrial Process Emissions' is unchanged
