### PR TITLE
chore: update access to `operation_type`

### DIFF
--- a/bciers/apps/reporting/src/app/components/verification/VerificationPage.tsx
+++ b/bciers/apps/reporting/src/app/components/verification/VerificationPage.tsx
@@ -19,9 +19,7 @@ export default async function VerificationPage({
   // 🚀 Fetch the operation associated with the specified version ID
   const reportOperation = await getReportingOperation(version_id);
   const operationType =
-    reportOperation &&
-    reportOperation.report_operation.operation_type ===
-      "Single Facility Operation"
+    reportOperation?.operation_type === "Single Facility Operation"
       ? "SFO"
       : "LFO";
 

--- a/bciers/apps/reporting/src/middlewares/withRulesAppliedReport.test.ts
+++ b/bciers/apps/reporting/src/middlewares/withRulesAppliedReport.test.ts
@@ -150,9 +150,7 @@ describe("withRulesAppliedReport middleware", () => {
       // Mock API response for getReportingOperation
       fetch.mockResponseOnce(
         JSON.stringify({
-          report_operation: {
-            operation_type: "Single Facility Operation",
-          },
+          operation_type: "Single Facility Operation",
         }),
       );
 

--- a/bciers/apps/reporting/src/middlewares/withRulesAppliedReport.ts
+++ b/bciers/apps/reporting/src/middlewares/withRulesAppliedReport.ts
@@ -89,11 +89,7 @@ const handleIndustryUserRoutes = async (request: NextRequest, token: any) => {
             user_guid: token.user_guid,
           },
         );
-        if (
-          reportOperation &&
-          reportOperation.report_operation.operation_type ===
-            "Single Facility Operation"
-        ) {
+        if (reportOperation?.operation_type === "Single Facility Operation") {
           // 🛸 Redirect to review operator
           return NextResponse.redirect(
             new URL(

--- a/bciers/apps/reporting/src/tests/components/verification/VerificationPage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/verification/VerificationPage.test.tsx
@@ -77,7 +77,7 @@ describe("VerificationPage component", () => {
       { type: "Page", title: "Verification", isActive: true },
     ];
     const mockReportOperation = {
-      report_operation: { operation_type: "Single Facility Operation" },
+      operation_type: "Single Facility Operation",
     };
 
     mockGetReportVerification.mockResolvedValue(mockInitialData);


### PR DESCRIPTION
Addresses changes required access to `operation_type` from the API `def get_report_operation_by_version_id`
[See change](https://github.com/bcgov/cas-registration/commit/10118b1d7d53fe5757a049247145bf432a847f3e)

### 🚀 Impact:

- Updated to `VerificationPage`
- Updated to `withRulesAppliedReport.ts`


## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button  

---

### **Test: `Verification Page`**  

#### **Steps:**  
1. Navigate to: http://localhost:3000/reporting/reports/1/verification

#### **Expected Result**  
✅  
![image](https://github.com/user-attachments/assets/084b6f72-788e-4de6-8790-a55f3f8980cd)

1. Navigate to: http://localhost:3000/reporting/reports/2/verification

#### **Expected Result**  
✅  
![image](https://github.com/user-attachments/assets/8ac1a6d8-5a43-4637-87ec-48f3272afcbb)


---

### **Test: `Facilities Review Page`**  

1. Navigate to: http://localhost:3000/reporting/reports/2/facilities/review-facilities

#### **Expected Result**  
✅  
![image](https://github.com/user-attachments/assets/1177f7e5-2a9c-4e10-9f87-e53c68e44b9c)


1. Navigate to: http://localhost:3000/reporting/reports/1/facilities/review-facilities

#### **Expected Result**  
✅  
![image](https://github.com/user-attachments/assets/df8fcd5a-b45f-4ed9-9b1d-f89082c1efa2)
