### PR TITLE
Update Activity UI Schema: Add `id` to `ui:order` property

### DIFF
--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/aluminumUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/aluminumUiSchema.ts
@@ -12,6 +12,7 @@ const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
   "ui:classNames": "form-heading-label",
   "ui:order": [
+    "id",
     "smelterTechType",
     "annualEmissions",
     "anodeCathodeBackingGreenCokeCalcination",

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/cementProductionUISchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/cementProductionUISchema.ts
@@ -26,7 +26,7 @@ const definitionSchema = {
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
   "ui:classNames": "form-heading-label",
-  "ui:order": ["coverGasFromElectrolysisCells", "sourceTypes"],
+  "ui:order": ["id", "coverGasFromElectrolysisCells", "sourceTypes"],
   id: {
     "ui:widget": "hidden",
   },


### PR DESCRIPTION
Addresses bug:
![image](https://github.com/user-attachments/assets/f08c87cc-3259-4c95-ad61-69bd0b31456d)



### 🚀 Impact:

- Added JSON property `id` to activity uischemas that have an  `ui:order` property


## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button  

---

### **Test: Activities  `Aluminum or alumina production`; `Cement production`**  

#### **Steps:**  
1. Navigate to http://localhost:3000/reporting/reports/
2. Click `Continue` on a report `Bugle SFO - Registered`
3. Select `Reporting activities`: `Aluminum or alumina production`; `Cement production`
4. Click `Save & Close`
5. Navigate to activities, ex http://localhost:3000/reporting/reports/1/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/activities
6. Click `Aluminum or alumina production`
#### **Expected Result**  
✅  No "id" error
![image](https://github.com/user-attachments/assets/63be2f6a-c692-4a4a-b553-24e8c1a85c58)

7. Click `Cement production`
#### **Expected Result**  
✅  No "id" error
![image](https://github.com/user-attachments/assets/300dc73c-909b-473f-8869-97929bbd28d7)



---

### **Optional Test: All Activities**  

#### **Steps:**  
1. Navigate to http://localhost:3000/reporting/reports/
2. Click `Continue` on a report `Bugle SFO - Registered`
3. Select `Reporting activities`: all options
4. Click `Save & Close`
5. Navigate to each activity, ex:
 http://localhost:3000/reporting/reports/1/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/activities?activity_id=1
 http://localhost:3000/reporting/reports/1/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/activities?activity_id=2
 http://localhost:3000/reporting/reports/1/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/activities?activity_id=3
 http://localhost:3000/reporting/reports/1/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/activities?activity_id=4

#### **Expected Result**  
✅  If schema is defined, no "id" error