### PR TITLE
chore: 597 update error boundary message

### DIFF
--- a/bciers/apps/reporting/src/app/utils/getActivityFormData.ts
+++ b/bciers/apps/reporting/src/app/utils/getActivityFormData.ts
@@ -9,8 +9,7 @@ export async function getActivityFormData(
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the activity list for report version ${reportVersionId}, facility ${facilityId}, activity ${activityId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the activity list for report version ${reportVersionId}, facility ${facilityId}, activity ${activityId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getActivityInitData.ts
+++ b/bciers/apps/reporting/src/app/utils/getActivityInitData.ts
@@ -9,8 +9,7 @@ export async function getActivityInitData(
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the activity init data for report version ${reportVersionId}, facility ${facilityId}, activity ${activityId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the activity init data for report version ${reportVersionId}, facility ${facilityId}, activity ${activityId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getActivitySchema.ts
+++ b/bciers/apps/reporting/src/app/utils/getActivitySchema.ts
@@ -9,8 +9,7 @@ export async function getActivitySchema(
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the schema for report version ${reportVersionId}, activity ${activityId}, source types ${sourceTypeQueryString}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the schema for report version ${reportVersionId}, activity ${activityId}, source types ${sourceTypeQueryString}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getAttachments.ts
+++ b/bciers/apps/reporting/src/app/utils/getAttachments.ts
@@ -6,8 +6,7 @@ export default async function getAttachments(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the attachments for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the attachments for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getComplianceData.ts
+++ b/bciers/apps/reporting/src/app/utils/getComplianceData.ts
@@ -4,8 +4,7 @@ export async function getComplianceData(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the compliance data for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the compliance data for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getEmissionAllocations.ts
+++ b/bciers/apps/reporting/src/app/utils/getEmissionAllocations.ts
@@ -8,8 +8,7 @@ export async function getEmissionAllocations(
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the emission allocations for report version ${reportVersionId}, facility ${facilityId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the emission allocations for report version ${reportVersionId}, facility ${facilityId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getFacilityReport.ts
+++ b/bciers/apps/reporting/src/app/utils/getFacilityReport.ts
@@ -5,8 +5,7 @@ export async function getFacilityReport(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the facility for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the facility for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getFacilityReportDetails.ts
+++ b/bciers/apps/reporting/src/app/utils/getFacilityReportDetails.ts
@@ -8,8 +8,7 @@ export async function getFacilityReportDetails(
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the facility details for report version ${reportVersionId}, facility ${facilityId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the facility details for report version ${reportVersionId}, facility ${facilityId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getNewEntrantData.ts
+++ b/bciers/apps/reporting/src/app/utils/getNewEntrantData.ts
@@ -5,8 +5,7 @@ export async function getNewEntrantData(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the new entrant data for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the new entrant data for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getNonAttributableEmissionsData.ts
+++ b/bciers/apps/reporting/src/app/utils/getNonAttributableEmissionsData.ts
@@ -7,8 +7,7 @@ export async function getNonAttributableEmissionsData(
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the non attributable emissions data for report version ${reportVersionId}, facility ${facilityId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the non attributable emissions data for report version ${reportVersionId}, facility ${facilityId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getOperationEmissionSummaryData.ts
+++ b/bciers/apps/reporting/src/app/utils/getOperationEmissionSummaryData.ts
@@ -5,8 +5,7 @@ export async function getOperationEmissionSummaryData(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the operation emissions summary data for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the operation emissions summary data for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getOperationFacilitiesList.ts
+++ b/bciers/apps/reporting/src/app/utils/getOperationFacilitiesList.ts
@@ -5,8 +5,7 @@ export async function getOperationFacilitiesList(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the facility list for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the facility list for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getOrderedActivities.ts
+++ b/bciers/apps/reporting/src/app/utils/getOrderedActivities.ts
@@ -8,8 +8,7 @@ export async function getOrderedActivities(
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the activity list for report version ${reportVersionId}, facility ${facilityId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the activity list for report version ${reportVersionId}, facility ${facilityId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getRegistrationPurpose.ts
+++ b/bciers/apps/reporting/src/app/utils/getRegistrationPurpose.ts
@@ -5,8 +5,7 @@ export async function getRegistrationPurpose(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the registration purpose for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the registration purpose for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getReportAdditionalData.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportAdditionalData.ts
@@ -5,8 +5,7 @@ export async function getReportAdditionalData(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the additional data for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the additional data for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getReportFacilityList.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportFacilityList.ts
@@ -5,8 +5,7 @@ export async function getReportFacilityList(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the facility list for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the facility list for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getReportNeedsVerification.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportNeedsVerification.ts
@@ -5,8 +5,7 @@ export async function getReportNeedsVerification(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the verification requirement for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the verification requirement for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getReportType.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportType.ts
@@ -5,8 +5,7 @@ export async function getReportType(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the report type for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the report type for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getReportVerification.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportVerification.ts
@@ -5,8 +5,7 @@ export async function getReportVerification(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response && response.error) {
     throw new Error(
-      `Failed to fetch the report verification for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the report verification for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getReportingOperation.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportingOperation.ts
@@ -5,8 +5,7 @@ export async function getReportingOperation(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the operation for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the operation for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getReportingPersonResponsible.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportingPersonResponsible.ts
@@ -5,8 +5,7 @@ export async function getReportingPersonResponsible(reportVersionId: number) {
   const response = await actionHandler(endpoint, "GET");
   if (response && response.error) {
     throw new Error(
-      `Failed to fetch the person responsible for report version ${reportVersionId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the person responsible for report version ${reportVersionId}.`,
     );
   }
   return response;

--- a/bciers/apps/reporting/src/app/utils/getReportingYear.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportingYear.ts
@@ -8,10 +8,7 @@ export const getReportingYear = async (): Promise<{
   const endpoint = "reporting/reporting-year";
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
-    throw new Error(
-      `Failed to fetch the reporting for report year.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
-    );
+    throw new Error(`Failed to fetch the reporting for report year.`);
   }
   return response;
 };

--- a/bciers/apps/reporting/src/app/utils/getSummaryData.ts
+++ b/bciers/apps/reporting/src/app/utils/getSummaryData.ts
@@ -8,8 +8,7 @@ export async function getSummaryData(
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(
-      `Failed to fetch the emission summary data for report version ${reportVersionId}, facility ${facilityId}.\n` +
-        "Please check if the provided ID(s) are correct and try again.",
+      `Failed to fetch the emission summary data for report version ${reportVersionId}, facility ${facilityId}.`,
     );
   }
   return response;

--- a/bciers/libs/components/src/error/ErrorBoundary.tsx
+++ b/bciers/libs/components/src/error/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import * as Sentry from "@sentry/nextjs";
 
 import { Alert, AlertTitle } from "@mui/material";
@@ -7,19 +7,18 @@ interface Props {
   error: Error & { digest?: string };
 }
 export default function ErrorBoundary({ error }: Props) {
+  const [eventId, setEventId] = useState<string | null>(null);
   useEffect(() => {
     if (error) {
       try {
         // Attempt to log the error to Sentry
-        Sentry.captureException(error);
+        const id = Sentry.captureException(error);
+        setEventId(id); // Store Sentry event ID
       } catch (sentryError) {
         // If there's an error logging to Sentry, log it to the console
         // eslint-disable-next-line no-console
         console.error("Error logging to Sentry:", sentryError);
       }
-      // Log the original error to the console
-      // eslint-disable-next-line no-console
-      console.error(error);
     }
   }, [error]);
 
@@ -37,9 +36,17 @@ export default function ErrorBoundary({ error }: Props) {
         <AlertTitle>
           <strong>Error</strong>
         </AlertTitle>
-        <div style={{ whiteSpace: "pre-wrap" }}>
-          <strong>{error.message}</strong>
-        </div>
+        <p>An internal server error has occured.</p>
+        <p>
+          Please try refreshing the page or contact support if the problem
+          persists.
+        </p>
+        <p>If reporting this issue, mention that the error has been logged.</p>
+        {eventId && (
+          <p>
+            Reference Code: <strong>{eventId}</strong>
+          </p>
+        )}
       </Alert>
     </div>
   );

--- a/bciers/libs/components/src/error/ErrorPage.test.tsx
+++ b/bciers/libs/components/src/error/ErrorPage.test.tsx
@@ -24,8 +24,6 @@ describe("ErrorPage", () => {
     render(<ErrorPage error={error} />);
 
     expect(screen.getByText("Something went wrong...")).toBeInTheDocument();
-    expect(screen.getByText("Error")).toBeInTheDocument();
-    expect(screen.getByText("Test error")).toBeInTheDocument();
   });
 });
 
@@ -43,21 +41,6 @@ describe("ErrorBoundary", () => {
     render(<ErrorBoundary error={error} />);
 
     expect(Sentry.captureException).toHaveBeenCalledWith(error);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(error);
-
     consoleErrorSpy.mockRestore();
-  });
-
-  /**
-   * Test to ensure that the error message is displayed correctly within the Alert component
-   * when the ErrorBoundary component mounts with an error prop.
-   */
-  it("displays error message in Alert", () => {
-    const error = new Error("Test error");
-    render(<ErrorBoundary error={error} />);
-
-    expect(screen.getByText("Something went wrong...")).toBeInTheDocument();
-    expect(screen.getByText("Error")).toBeInTheDocument();
-    expect(screen.getByText("Test error")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Addresses: [597](https://github.com/bcgov/cas-reporting/issues/597)

### 🚀 Impact:

- Updated `ErrorBoundary` message to be more user friendly instead of Next.js generic masked error details message
- Included the reference id of the Sentry log in the error message details
- Removed (production masked) error details in `utils` fetch functions

## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button  

---

### **Test: Error Message``**  

#### **Steps:**  
1. Navigate to reporting url using an incorrect report version id, ex:
- http://localhost:3000/reporting/reports/99/review-operation-information
- http://localhost:3000/reporting/reports/99/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/production-data

#### **Expected Result**  
✅  

![image](https://github.com/user-attachments/assets/b43c3597-52ab-42bc-a1f2-3e764b9b0c40)


