### PR TITLE
Remove and replace fixtures for reporting_year in prod_data migration

### DIFF
--- a/bc_obps/reporting/migrations/0008_prod_data.py
+++ b/bc_obps/reporting/migrations/0008_prod_data.py
@@ -634,15 +634,35 @@ def init_reporting_years(apps, schema_editor):
     '''
     Add initial year data to erc.reporting_year
     '''
-    from django.core.management import call_command
-
-    fixture_files = [
-        'reporting/fixtures/mock/reporting_year.json',
-    ]
-
-    # Load the fixtures
-    for fixture in fixture_files:
-        call_command('loaddata', fixture)
+    ReportingYear = apps.get_model('reporting', 'ReportingYear')
+    ReportingYear.objects.bulk_create(
+        [
+            ReportingYear(
+                reporting_year=2023,
+                reporting_window_start="2024-01-01 00:00:00.000 -08:00",
+                reporting_window_end="2024-12-31 23:59:59.999 -08:00",
+                report_due_date="2024-05-31 23:59:59.999 -07:00",
+            ),
+            ReportingYear(
+                reporting_year=2024,
+                reporting_window_start="2025-01-01 00:00:00.000 -08:00",
+                reporting_window_end="2025-12-31 23:59:59.999 -08:00",
+                report_due_date="2025-05-31 23:59:59.999 -07:00",
+            ),
+            ReportingYear(
+                reporting_year=2025,
+                reporting_window_start="2026-01-01 00:00:00.000 -08:00",
+                reporting_window_end="2026-12-31 23:59:59.999 -08:00",
+                report_due_date="2026-05-31 23:59:59.999 -07:00",
+            ),
+            ReportingYear(
+                reporting_year=2026,
+                reporting_window_start="2027-01-01 00:00:00.000 -08:00",
+                reporting_window_end="2027-12-31 23:59:59.999 -08:00",
+                report_due_date="2027-05-31 23:59:59.999 -07:00",
+            ),
+        ]
+    )
 
 
 def reverse_init_reporting_years(apps, schema_editor):
@@ -650,7 +670,7 @@ def reverse_init_reporting_years(apps, schema_editor):
     Remove initial year data from erc.reporting_year
     '''
     ReportingYears = apps.get_model('reporting', 'ReportingYear')
-    ReportingYears.objects.filter(reporting_year__in=[2023, 2024]).delete()
+    ReportingYears.objects.filter(reporting_year__in=[2023, 2024, 2025, 2026]).delete()
 
 
 def init_reporting_field_data(apps, schema_monitor):

--- a/bc_obps/reporting/tests/api/test_activity_data.py
+++ b/bc_obps/reporting/tests/api/test_activity_data.py
@@ -9,10 +9,9 @@ from registration.utils import custom_reverse_lazy
 class TestActivityData(CommonTestSetup):
     def test_authorized_users_can_get_activity_data(self):
         operator = baker.make_recipe("registration.tests.utils.operator")
-        valid_year = baker.make_recipe('reporting.tests.utils.reporting_year', reporting_year=2025)
         facility_report = baker.make_recipe(
             'reporting.tests.utils.facility_report',
-            report_version__report__reporting_year_id=valid_year.reporting_year,
+            report_version__report__reporting_year_id=2025,
         )
         TestUtils.authorize_current_user_as_operator_user(self, operator=operator)
 

--- a/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
@@ -15,10 +15,9 @@ class TestReportActivityEndpoint(CommonTestSetup):
         super().setup_method()
 
         # Create basic test data
-        valid_year = make_recipe('reporting.tests.utils.reporting_year', reporting_year=2025)
         self.facility_report = make_recipe(
             'reporting.tests.utils.facility_report',
-            report_version__report__reporting_year_id=valid_year.reporting_year,
+            report_version__report__reporting_year_id=2025,
         )
         self.activity = make_recipe('reporting.tests.utils.activity')
 

--- a/bc_obps/reporting/tests/service/test_compliance_service/infrastructure.py
+++ b/bc_obps/reporting/tests/service/test_compliance_service/infrastructure.py
@@ -167,14 +167,7 @@ class ComplianceTestInfrastructure:
     @classmethod
     def reporting_year_2025(cls):
         t = cls.build()
-        reporting_year = make_recipe(
-            "reporting.tests.utils.reporting_year",
-            reporting_year=2025,
-            reporting_window_start='2025-12-31 16:00:00-08',
-            reporting_window_end='2026-12-31 16:00:00-08',
-            report_due_date='2025-05-31 16:59:59.999-07',
-        )
-        Report.objects.filter(pk=t.report_1.id).update(reporting_year=reporting_year)
+        Report.objects.filter(pk=t.report_1.id).update(reporting_year=2025)
         return t
 
     @classmethod

--- a/bc_obps/reporting/tests/service/test_report_activity_save_service/infrastructure.py
+++ b/bc_obps/reporting/tests/service/test_report_activity_save_service/infrastructure.py
@@ -43,10 +43,9 @@ class TestInfrastructure:
     @classmethod
     def build(cls):
         t = TestInfrastructure()
-        valid_year = make_recipe('reporting.tests.utils.reporting_year', reporting_year=2025)
         t.facility_report = make_recipe(
             'reporting.tests.utils.facility_report',
-            report_version__report__reporting_year_id=valid_year.reporting_year,
+            report_version__report__reporting_year_id=2025,
         )
         t.facility_report.refresh_from_db()
         t.report_version = t.facility_report.report_version
@@ -72,10 +71,9 @@ class TestInfrastructure:
     @classmethod
     def build_from_real_config(cls, activity_slug="gsc_non_compression"):
         t = TestInfrastructure()
-        valid_year = make_recipe('reporting.tests.utils.reporting_year', reporting_year=2025)
         t.facility_report = make_recipe(
             'reporting.tests.utils.facility_report',
-            report_version__report__reporting_year_id=valid_year.reporting_year,
+            report_version__report__reporting_year_id=2025,
         )
         t.facility_report.refresh_from_db()
         t.report_version = t.facility_report.report_version


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/578

In the prod_data migration, changed how the ReportingYear entries are created:
 - Removed the load from fixtures
 - Used the fixture values to generate entries based on the model

Also updated tests that were using the model bakery to create 2025 reporting_year

**** Notes
 - All the datetime values are the same as the fixtures, except they have been made local time (PST/PDT) instead of UTC.
 - 2025 and 2026 were added
 - 2023 was kept in because (despite the fact that it will never be a reporting_year) a compliance migration creating compliance_periods uses 2023 as a fk, and I didn't want to mess with it.