### PR TITLE
chore:fix fuel name query string

### DIFF
--- a/bciers/apps/reporting/src/app/components/activities/customFields/FuelFieldComponent.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/customFields/FuelFieldComponent.tsx
@@ -13,8 +13,10 @@ const ObjectField = registry.fields.ObjectField;
 
 export const FuelFields: React.FunctionComponent<FieldProps> = (props) => {
   const handleChange = async (c: FuelDataChangeEvent) => {
+    //encode fuel name to handle `#` in URL as it was being treated as a  fragment identifier, causing data loss when sent in the query string
+    const fuelName = encodeURIComponent(c.fuelName);
     const fuelData = await actionHandler(
-      `reporting/fuel?fuel_name=${c.fuelName}`,
+      `reporting/fuel?fuel_name=${fuelName}`,
       "GET",
       "",
     );


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/540
A vey small PR to encode fuel name to handle `#` in URL as it was being treated as a  fragment identifier, causing data loss when sent in the query string