### PR TITLE
2971 blank operation form fields

### DIFF
--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -258,12 +258,12 @@
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "submission_date": "2024-01-22T15:27:00.000Z",
-      "name": "Bojangles LFO - Not Started",
+      "name": "Bojangles LFO - Draft",
       "type": "Linear Facilities Operation",
       "naics_code": 21,
       "opt_in": false,
       "bcghg_id": "23219990013",
-      "status": "Not Started",
+      "status": "Draft",
       "registration_purpose": "Electricity Import Operation"
     }
   },
@@ -273,13 +273,13 @@
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "submission_date": "2024-01-23T15:27:00.000Z",
-      "name": "Brine LFO - Not Started",
+      "name": "Brine LFO - Draft",
       "type": "Linear Facilities Operation",
       "naics_code": 21,
       "opt_in": false,
       "bcghg_id": "23219990014",
       "regulated_products": [3],
-      "status": "Not Started",
+      "status": "Draft",
       "activities": [1, 5],
       "registration_purpose": "OBPS Regulated Operation"
     }
@@ -325,12 +325,12 @@
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "submission_date": "2024-01-26T15:27:00.000Z",
-      "name": "Blue LFO - Draft",
+      "name": "Blue LFO - Not Started",
       "type": "Linear Facilities Operation",
       "naics_code": 21,
       "opt_in": false,
       "bcghg_id": "23219990017",
-      "status": "Draft",
+      "status": "Not Started",
       "activities": [1, 5]
     }
   },
@@ -412,6 +412,7 @@
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
       "name": "Blight EIO - Draft",
       "type": "Electricity Import Operation",
+      "registration_purpose": "Electricity Import Operation",
       "status": "Draft"
     }
   },
@@ -420,11 +421,11 @@
     "pk": "0ac72fa9-2636-4f54-b378-af6b1a070787",
     "fields": {
       "operator": "4242ea9d-b917-4129-93c2-db00b7451051",
-      "name": "Brown LFO - Draft -- no facility",
+      "name": "Brown LFO - Not Started -- no facility",
       "type": "Linear Facilities Operation",
       "naics_code": 21,
       "opt_in": false,
-      "status": "Draft",
+      "status": "Not Started",
       "activities": [1, 3]
     }
   },

--- a/bciers/apps/registration/app/components/operations/registration/OperationInformationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/OperationInformationForm.tsx
@@ -162,13 +162,7 @@ const OperationInformationForm = ({
     if (operationData?.error) {
       setError("Failed to fetch operation data!" as any);
     }
-    // combine the entered data with the fetched data
-    const combinedData = {
-      ...data,
-      section1: operationData,
-      section2: operationData,
-    };
-    setConfirmedFormState(combinedData);
+    setConfirmedFormState(createNestedFormData(operationData, schema));
     setKey(Math.random()); // NOSONAR
   };
 

--- a/bciers/apps/registration/app/components/operations/registration/OperationInformationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/OperationInformationForm.tsx
@@ -163,7 +163,11 @@ const OperationInformationForm = ({
       setError("Failed to fetch operation data!" as any);
     }
     // combine the entered data with the fetched data
-    const combinedData = { ...data, section2: operationData };
+    const combinedData = {
+      ...data,
+      section1: operationData,
+      section2: operationData,
+    };
     setConfirmedFormState(combinedData);
     setKey(Math.random()); // NOSONAR
   };


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=100904556&issue=bcgov%7Ccas-registration%7C2971

This PR:
- pulls all the operation data when selecting and operation from the dropdown in the registration form (except multiple operators: https://github.com/bcgov/cas-registration/issues/2968)
- updates mock data to be more accurate (ops that are Not Started wouldn't have a purpose yet, etc.)