### PR TITLE
fix: resolve multiple operators in ninja schema

### DIFF
--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -43,9 +43,7 @@ class OperationRegistrationOut(ModelSchema):
 
     @staticmethod
     def resolve_operation_has_multiple_operators(obj: Operation) -> bool:
-        if obj.multiple_operators.exists():
-            return True
-        return False
+        return obj.multiple_operators.exists()
 
     @staticmethod
     def resolve_multiple_operators_array(obj: Operation) -> Optional[List[MultipleOperator]]:

--- a/bc_obps/registration/schema/operation.py
+++ b/bc_obps/registration/schema/operation.py
@@ -42,6 +42,12 @@ class OperationRegistrationOut(ModelSchema):
         return None
 
     @staticmethod
+    def resolve_operation_has_multiple_operators(obj: Operation) -> bool:
+        if obj.multiple_operators.exists():
+            return True
+        return False
+
+    @staticmethod
     def resolve_multiple_operators_array(obj: Operation) -> Optional[List[MultipleOperator]]:
         if obj.multiple_operators.exists():
             return [

--- a/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
@@ -68,6 +68,34 @@ describe("the OperationInformationForm component", () => {
       id: "b974a7fc-ff63-41aa-9d57-509ebe2553a4",
       name: "Operation 1",
       registration_purpose: "Electricity Import Operation",
+      operation_has_multiple_operators: true,
+      multiple_operators_array: [
+        {
+          mo_is_extraprovincial_company: false,
+          mo_legal_name: "mops 1",
+          mo_trade_name: "ads",
+          mo_cra_business_number: 555555555,
+          mo_bc_corporate_registry_number: "aaa5555555",
+          mo_business_structure: "Sole Proprietorship",
+          mo_attorney_street_address: "ads",
+          mo_municipality: "ad",
+          mo_province: "NS",
+          mo_postal_code: "H0H0H0",
+          id: 2,
+        },
+        {
+          mo_is_extraprovincial_company: true,
+          mo_legal_name: "mops 2",
+          mo_trade_name: "ads",
+          mo_cra_business_number: 666666666,
+          mo_business_structure: "General Partnership",
+          mo_attorney_street_address: "ad",
+          mo_municipality: "ad",
+          mo_province: "NS",
+          mo_postal_code: "H0H0H0",
+          id: 3,
+        },
+      ],
     }); // mock the GET from selecting an operation
     render(
       <OperationInformationForm
@@ -92,14 +120,26 @@ describe("the OperationInformationForm component", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText(/Operation name+/i)).toHaveValue(
-        "Operation 1",
-      );
+      // spot check section 1
       expect(
         screen.getByLabelText(
           /The purpose of this registration is to register as a:+/i,
         ),
       ).toHaveValue("Electricity Import Operation");
+
+      // spot check section 2
+      expect(screen.getByLabelText(/Operation name+/i)).toHaveValue(
+        "Operation 1",
+      );
+
+      // spot check section 3
+      const multipleOperatorLegalNames =
+        screen.getAllByLabelText(/legal name+/i);
+
+      expect(multipleOperatorLegalNames).toHaveLength(2);
+
+      expect(multipleOperatorLegalNames[0]).toHaveValue("mops 1");
+      expect(multipleOperatorLegalNames[1]).toHaveValue("mops 2");
     });
   });
 


### PR DESCRIPTION
card: https://github.com/bcgov/cas-registration/issues/2968

This PR:
- fixes multiple operators not being retrieved in the Operation Registration Form
- vitest for ^