### PR TITLE
chore: remove files_have_the_same_hash

### DIFF
--- a/bc_obps/registration/tests/test_utils.py
+++ b/bc_obps/registration/tests/test_utils.py
@@ -9,14 +9,12 @@ from registration.models import User, UserOperator, AppRole
 from registration.utils import (
     file_to_data_url,
     data_url_to_file,
-    files_have_same_hash,
     update_model_instance,
     generate_useful_error,
 )
 from django.core.exceptions import ValidationError
 from ninja.errors import HttpError
 from django.test import RequestFactory, TestCase
-from django.core.files.base import ContentFile
 from registration.tests.utils.bakers import document_baker, user_operator_baker
 import requests
 
@@ -283,46 +281,6 @@ class TestDataUrlToFile:
 
         with pytest.raises(base64.binascii.Error):
             data_url_to_file(data_url)
-
-
-class TestFileHashComparison(TestCase):
-    def test_same_content(self):
-        """Tests if the function returns True for files with identical content."""
-        content = b"This is some sample content."
-        file1 = ContentFile(content, "test_file1.txt")
-        file2 = ContentFile(content, "test_file2.txt")
-
-        self.assertTrue(files_have_same_hash(file1, file2))
-
-    def test_different_content(self):
-        """Tests if the function returns False for files with different content."""
-        content1 = b"This is some content."
-        content2 = b"This is different content."
-        file1 = ContentFile(content1, "test_file1.txt")
-        file2 = ContentFile(content2, "test_file2.txt")
-
-        self.assertFalse(files_have_same_hash(file1, file2))
-
-    def test_empty_file(self):
-        """Tests if the function handles empty files."""
-        empty_content = b""
-        file1 = ContentFile(empty_content, "empty_file.txt")
-        file2 = ContentFile(empty_content, "empty_file2.txt")
-
-        self.assertTrue(files_have_same_hash(file1, file2))
-
-    def test_none_values(self):
-        """Tests if the function raises a ValueError when None is passed as a file."""
-        content = b"This is some sample content."
-        file1 = ContentFile(content, "test_file.txt")
-        file2 = ContentFile(content, "test_file2.txt")
-        with self.assertRaises(ValueError) as context:
-            files_have_same_hash(None, file2)
-        self.assertEqual(str(context.exception), "Both files must be provided to compare hashes.")
-
-        with self.assertRaises(ValueError) as context:
-            files_have_same_hash(file1, None)
-        self.assertEqual(str(context.exception), "Both files must be provided to compare hashes.")
 
 
 class TestGenerateUniqueBcghgIdForOperationOrFacility(TestCase):

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -8,7 +8,6 @@ from registration.constants import DEFAULT_API_NAMESPACE
 import requests
 import base64
 import re
-import hashlib
 from django.core.files.base import ContentFile
 from registration.models import (
     Document,
@@ -124,42 +123,6 @@ def custom_reverse_lazy(view_name: str, *args: Any, **kwargs: DictStrAny) -> Uni
 def set_verification_columns(record: Union[UserOperator, Operator, Operation], user_guid: UUID) -> None:
     record.verified_at = datetime.now(ZoneInfo("UTC"))
     record.verified_by_id = user_guid
-
-
-def files_have_same_hash(file1: Optional[ContentFile], file2: Optional[ContentFile]) -> bool:
-    """
-    Compare the hash of two files to determine if they are the same.
-    this might miss formatting changes.
-    """
-
-    # If either file is None, raise an error
-    if not file1 or not file2:
-        raise ValueError("Both files must be provided to compare hashes.")
-
-    hash1 = hashlib.sha256()
-    hash2 = hashlib.sha256()
-
-    try:
-        # Handle ContentFile
-        if isinstance(file1, ContentFile):
-            hash1.update(file1.read())
-        else:
-            # Handle FileField
-            with file1.open(mode='rb') as f1:
-                for chunk in iter(lambda: f1.read(4096), b''):
-                    hash1.update(chunk)
-
-        # Repeat for the second file
-        if isinstance(file2, ContentFile):
-            hash2.update(file2.read())
-        else:
-            with file2.open(mode='rb') as f2:
-                for chunk in iter(lambda: f2.read(4096), b''):
-                    hash2.update(chunk)
-
-        return hash1.hexdigest() == hash2.hexdigest()
-    except Exception as e:
-        raise ValueError(f"Error comparing files: {e}")
 
 
 class CustomPagination(PageNumberPagination):

--- a/bc_obps/service/document_service.py
+++ b/bc_obps/service/document_service.py
@@ -2,7 +2,6 @@ from typing import Tuple
 from uuid import UUID
 from service.data_access_service.document_service import DocumentDataAccessService
 from registration.models import Document, Operation
-from registration.utils import files_have_same_hash
 from django.core.files.base import ContentFile
 from service.data_access_service.operation_service import OperationDataAccessService
 
@@ -28,14 +27,10 @@ class DocumentService:
         :returns: Tuple[Document, bool] where the bool is True if a new document was created, False if an existing document was updated
         """
         existing_document = cls.get_operation_document_by_type_if_authorized(user_guid, operation_id, document_type)
-        # if there is an existing  document, check if the new one is different
+        # if there is an existing document, delete it
         if existing_document:
-            # We need to check if the file has changed, if it has, we need to delete the old one and create a new one
-            if not files_have_same_hash(file_data, existing_document.file):
-                existing_document.delete()
-            else:
-                return existing_document, False
-        # if there is no existing document, create a new one
+            existing_document.delete()
+
         document = DocumentDataAccessService.create_document(user_guid, file_data, document_type, operation_id)
         return document, True
 

--- a/bc_obps/service/tests/test_document_service.py
+++ b/bc_obps/service/tests/test_document_service.py
@@ -45,27 +45,6 @@ class TestDocumentService:
         assert created is True
 
     @staticmethod
-    def test_do_not_update_duplicate_operation_document():
-        approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
-        operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)
-        DocumentDataAccessService.create_document(
-            approved_user_operator.user_id, data_url_to_file(MOCK_DATA_URL), 'boundary_map', operation.id
-        )
-        created_at = operation.documents.first().created_at
-
-        updated_file = data_url_to_file(MOCK_DATA_URL)
-        document, created = DocumentService.create_or_replace_operation_document(
-            approved_user_operator.user_id, operation.id, updated_file, 'boundary_map'
-        )
-
-        assert Document.objects.count() == 1
-        assert document.type.name == 'boundary_map'
-        # MOCK_DATA_URL's filename is mock.pdf. When adding files to django, the name is appended, so we just check that 'mock' in the name
-        assert document.file.name.find("mock") != -1
-        assert document.created_at == created_at
-        assert created is False
-
-    @staticmethod
     def test_update_operation_document():
         approved_user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator')
         operation = baker.make_recipe('registration.tests.utils.operation', operator=approved_user_operator.operator)


### PR DESCRIPTION
Part of https://github.com/bcgov/cas-registration/issues/2123 and fixes: https://github.com/orgs/bcgov/projects/123/views/16?filterQuery=repo%3Abcgov%2Fcas-registration+-status%3Adone+uat&pane=issue&itemId=99417803&issue=bcgov%7Ccas-registration%7C2915

This PR:
- removes the files_have_the_same_hash function to improve performance
- I was unable to reproduce the UAT bug (check out https://github.com/bcgov/cas-registration/pull/3009 if you want to use the same data as the test env). However, this PR should fix it as I'm removing the function the error was coming from