### PR TITLE
Chore/2980 prod resources and routes

### DIFF
--- a/helm/cas-bciers/templates/administration/hpa.yaml
+++ b/helm/cas-bciers/templates/administration/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.administrationFrontend.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-administration-frontend-hpa
+  labels:
+    {{- include "cas-bciers.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cas-bciers.fullname" . }}-administration-frontend
+  minReplicas: {{ .Values.administrationFrontend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.administrationFrontend.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.administrationFrontend.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.administrationFrontend.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.administrationFrontend.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.administrationFrontend.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/cas-bciers/templates/administration/route.yaml
+++ b/helm/cas-bciers/templates/administration/route.yaml
@@ -1,3 +1,14 @@
+{{- $keySecret := "Secret not found" }}
+{{- $certSecret := "Secret not found" }}
+{{- $CACertSecret := "Secret not found" }}
+
+{{- $existingSSLSecret := (lookup "v1" "Secret" .Release.Namespace "ssl-cert-bciers" ) }}
+{{- if $existingSSLSecret }}
+{{- $keySecret = index $existingSSLSecret.data "private-key" | b64dec | quote}}
+{{- $certSecret = index $existingSSLSecret.data "certificate" | b64dec | quote}}
+{{- $CACertSecret = index $existingSSLSecret.data "CACert" | b64dec | quote}}
+{{- end -}}
+
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -16,6 +27,11 @@ spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
+{{- if hasSuffix "-prod" .Release.Namespace }}
+    key: {{ $keySecret }}
+    certificate: {{ $certSecret }}
+    caCertificate: {{ $CACertSecret }}
+{{- end }}
   to:
     kind: Service
     name: {{ template "cas-bciers.fullname" . }}-administration-frontend

--- a/helm/cas-bciers/templates/compliance/route.yaml
+++ b/helm/cas-bciers/templates/compliance/route.yaml
@@ -1,3 +1,14 @@
+{{- $keySecret := "Secret not found" }}
+{{- $certSecret := "Secret not found" }}
+{{- $CACertSecret := "Secret not found" }}
+
+{{- $existingSSLSecret := (lookup "v1" "Secret" .Release.Namespace "ssl-cert-bciers" ) }}
+{{- if $existingSSLSecret }}
+{{- $keySecret = index $existingSSLSecret.data "private-key" | b64dec | quote}}
+{{- $certSecret = index $existingSSLSecret.data "certificate" | b64dec | quote}}
+{{- $CACertSecret = index $existingSSLSecret.data "CACert" | b64dec | quote}}
+{{- end -}}
+
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -16,6 +27,11 @@ spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
+{{- if hasSuffix "-prod" .Release.Namespace }}
+    key: {{ $keySecret }}
+    certificate: {{ $certSecret }}
+    caCertificate: {{ $CACertSecret }}
+{{- end }}
   to:
     kind: Service
     name: {{ template "cas-bciers.fullname" . }}-compliance-frontend

--- a/helm/cas-bciers/templates/dashboard/hpa.yaml
+++ b/helm/cas-bciers/templates/dashboard/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.dashboardFrontend.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-dashboard-frontend-hpa
+  labels:
+    {{- include "cas-bciers.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cas-bciers.fullname" . }}-dashboard-frontend
+  minReplicas: {{ .Values.dashboardFrontend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.dashboardFrontend.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.dashboardFrontend.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.dashboardFrontend.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.dashboardFrontend.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.dashboardFrontend.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/cas-bciers/templates/dashboard/route.yaml
+++ b/helm/cas-bciers/templates/dashboard/route.yaml
@@ -1,3 +1,14 @@
+{{- $keySecret := "Secret not found" }}
+{{- $certSecret := "Secret not found" }}
+{{- $CACertSecret := "Secret not found" }}
+
+{{- $existingSSLSecret := (lookup "v1" "Secret" .Release.Namespace "ssl-cert-bciers" ) }}
+{{- if $existingSSLSecret }}
+{{- $keySecret = index $existingSSLSecret.data "private-key" | b64dec | quote}}
+{{- $certSecret = index $existingSSLSecret.data "certificate" | b64dec | quote}}
+{{- $CACertSecret = index $existingSSLSecret.data "CACert" | b64dec | quote}}
+{{- end -}}
+
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -16,6 +27,11 @@ spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
+{{- if hasSuffix "-prod" .Release.Namespace }}
+    key: {{ $keySecret }}
+    certificate: {{ $certSecret }}
+    caCertificate: {{ $CACertSecret }}
+{{- end }}
   to:
     kind: Service
     name: {{ template "cas-bciers.fullname" . }}-dashboard-frontend

--- a/helm/cas-bciers/templates/registration/hpa.yaml
+++ b/helm/cas-bciers/templates/registration/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.registrationFrontend.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-registration-frontend-hpa
+  labels:
+    {{- include "cas-bciers.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cas-bciers.fullname" . }}-registration-frontend
+  minReplicas: {{ .Values.registrationFrontend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.registrationFrontend.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.registrationFrontend.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.registrationFrontend.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.registrationFrontend.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.registrationFrontend.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/cas-bciers/templates/registration/route.yaml
+++ b/helm/cas-bciers/templates/registration/route.yaml
@@ -1,3 +1,14 @@
+{{- $keySecret := "Secret not found" }}
+{{- $certSecret := "Secret not found" }}
+{{- $CACertSecret := "Secret not found" }}
+
+{{- $existingSSLSecret := (lookup "v1" "Secret" .Release.Namespace "ssl-cert-bciers" ) }}
+{{- if $existingSSLSecret }}
+{{- $keySecret = index $existingSSLSecret.data "private-key" | b64dec | quote}}
+{{- $certSecret = index $existingSSLSecret.data "certificate" | b64dec | quote}}
+{{- $CACertSecret = index $existingSSLSecret.data "CACert" | b64dec | quote}}
+{{- end -}}
+
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -16,6 +27,11 @@ spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
+{{- if hasSuffix "-prod" .Release.Namespace }}
+    key: {{ $keySecret }}
+    certificate: {{ $certSecret }}
+    caCertificate: {{ $CACertSecret }}
+{{- end }}
   to:
     kind: Service
     name: {{ template "cas-bciers.fullname" . }}-registration-frontend

--- a/helm/cas-bciers/templates/reporting/hpa.yaml
+++ b/helm/cas-bciers/templates/reporting/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.reportingFrontend.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-reporting-frontend-hpa
+  labels:
+    {{- include "cas-bciers.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cas-bciers.fullname" . }}-reporting-frontend
+  minReplicas: {{ .Values.reportingFrontend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.reportingFrontend.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.reportingFrontend.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.reportingFrontend.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.reportingFrontend.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.reportingFrontend.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/cas-bciers/templates/reporting/route.yaml
+++ b/helm/cas-bciers/templates/reporting/route.yaml
@@ -1,3 +1,14 @@
+{{- $keySecret := "Secret not found" }}
+{{- $certSecret := "Secret not found" }}
+{{- $CACertSecret := "Secret not found" }}
+
+{{- $existingSSLSecret := (lookup "v1" "Secret" .Release.Namespace "ssl-cert-bciers" ) }}
+{{- if $existingSSLSecret }}
+{{- $keySecret = index $existingSSLSecret.data "private-key" | b64dec | quote}}
+{{- $certSecret = index $existingSSLSecret.data "certificate" | b64dec | quote}}
+{{- $CACertSecret = index $existingSSLSecret.data "CACert" | b64dec | quote}}
+{{- end -}}
+
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -16,6 +27,11 @@ spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
+{{- if hasSuffix "-prod" .Release.Namespace }}
+    key: {{ $keySecret }}
+    certificate: {{ $certSecret }}
+    caCertificate: {{ $CACertSecret }}
+{{- end }}
   to:
     kind: Service
     name: {{ template "cas-bciers.fullname" . }}-reporting-frontend

--- a/helm/cas-bciers/values-prod.yaml
+++ b/helm/cas-bciers/values-prod.yaml
@@ -14,6 +14,12 @@ backend:
       cpu: 250m
       memory: 550Mi
 
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 80
+
 administrationFrontend:
   replicaCount: 2
 
@@ -32,6 +38,12 @@ administrationFrontend:
     requests:
       cpu: 60m
       memory: 128Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 80
 
 registrationFrontend:
   replicaCount: 2
@@ -52,6 +64,12 @@ registrationFrontend:
       cpu: 60m
       memory: 128Mi
 
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 80
+
 reportingFrontend:
   replicaCount: 2
 
@@ -70,6 +88,12 @@ reportingFrontend:
     requests:
       cpu: 60m
       memory: 128Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 80
 
 complianceFrontend:
   replicaCount: 0
@@ -112,6 +136,12 @@ dashboardFrontend:
     requests:
       cpu: 60m
       memory: 128Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 80
 
 growthbook:
   clientKey: sdk-9Vyna67jpIYdjMa

--- a/helm/cas-bciers/values-prod.yaml
+++ b/helm/cas-bciers/values-prod.yaml
@@ -11,8 +11,8 @@ backend:
     limits:
       memory: 1024Mi
     requests:
-      cpu: 150m
-      memory: 512Mi
+      cpu: 250m
+      memory: 550Mi
 
 administrationFrontend:
   replicaCount: 2
@@ -72,7 +72,7 @@ reportingFrontend:
       memory: 128Mi
 
 complianceFrontend:
-  replicaCount: 1
+  replicaCount: 0
 
   image:
     tag: "latest"


### PR DESCRIPTION
Part of [#2980](https://github.com/orgs/bcgov/projects/123/views/19?pane=issue&itemId=101178888&issue=bcgov%7Ccas-registration%7C2980). Tunes the frontend/backend pods and adds SSL to routes.

## Changes 🚧

- Added HPA to backend pod and Dashboard/Admin/Reporting/Registration frontend pods
- Added SSL to routes for Dashboard/Admin/Reporting/Registration frontend pods
- Tuned resources on frontend/backend pods
- Set Compliance pod to 0