### PR TITLE
3043 make timestamps uniform

### DIFF
--- a/bciers/apps/reporting/src/app/components/signOff/Success.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/Success.tsx
@@ -1,9 +1,10 @@
 import Check from "@bciers/components/icons/Check";
 import Link from "next/link";
 import { getTodaysDateWithTime } from "@reporting/src/app/utils/formatDate";
+import formatTimestamp from "@bciers/utils/src/formatTimestamp";
 
 const ReportSubmission = () => {
-  const currentDate = getTodaysDateWithTime();
+  const currentDate = formatTimestamp(getTodaysDateWithTime());
 
   return (
     <div className="flex items-center justify-center">


### PR DESCRIPTION
Fixes #3043: Updates the format of timestamp at the end of reporting the same way Transfer page is formatted