### PR TITLE
Chore/512 pulp paper compliance exception

### DIFF
--- a/bc_obps/common/tests/endpoints/auth/constants.py
+++ b/bc_obps/common/tests/endpoints/auth/constants.py
@@ -422,6 +422,11 @@ ENDPOINTS = {
             "endpoint_name": "get_operation_emission_summary_totals",
             "kwargs": {"version_id": MOCK_INT},
         },
+        {
+            "method": "get",
+            "endpoint_name": "get_overlapping_industrial_process_emissions",
+            "kwargs": {"version_id": MOCK_INT, "facility_id": MOCK_UUID},
+        },
     ],
     "authorized_irc_user_and_industry_admin_user": [],
     "cas_director": [

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -208,7 +208,11 @@ export default function FacilityEmissionAllocationForm({
         );
     }
     // Validate the updated form data and set an error message if validation fails
-    const newErrors = validateFormData(updatedFormData);
+    const newErrors = validateFormData(
+      updatedFormData,
+      isPulpAndPaper,
+      overlappingIndustrialProcessEmissions,
+    );
     setErrors(newErrors);
     setSubmitButtonDisabled(newErrors.length > 0);
 

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -102,7 +102,9 @@ const validateFormData = (
         (p) => p.product_name === "Pulp and paper: chemical pulp",
       );
     if (!chemicalPulpAllocation)
-      newErrors.push("Missing Product: 'Pulp and paper: chemical pulp'");
+      newErrors.push(
+        "Missing Product: 'Pulp and paper: chemical pulp'. Please add the product on the operation review page",
+      );
     else if (
       chemicalPulpAllocation.allocated_quantity -
         overlappingIndustrialProcessEmissions <

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationPage.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationPage.tsx
@@ -5,6 +5,7 @@ import { HasFacilityId } from "@reporting/src/app/utils/defaultPageFactoryTypes"
 import { getReportInformationTasklist } from "@reporting/src/app/utils/getReportInformationTaskListData";
 import { getNavigationInformation } from "../taskList/navigationInformation";
 import { HeaderStep, ReportingPage } from "../taskList/types";
+import { getOverlappingIndustrialProcessEmissions } from "../../utils/getOverlappingIndProcessEmissions";
 
 export default async function FacilityEmissionAllocationPage({
   version_id,
@@ -16,6 +17,20 @@ export default async function FacilityEmissionAllocationPage({
   );
   const orderedActivities = await getOrderedActivities(version_id, facility_id);
   const initialData = await getEmissionAllocations(version_id, facility_id);
+
+  // These values are used when reporting the pulp & paper activity
+  let isPulpAndPaper = false;
+  let overlappingIndustrialProcessEmissions = 0; // emissions that are categorized as both industrial_process and excluded (ie: woody biomass)
+  if (
+    orderedActivities.find(
+      (activity: { id: Number; name: String; slug: String }) =>
+        (activity.slug = "pulp_and_paper"),
+    )
+  ) {
+    isPulpAndPaper = true;
+    overlappingIndustrialProcessEmissions =
+      await getOverlappingIndustrialProcessEmissions(version_id, facility_id);
+  }
 
   const navInfo = await getNavigationInformation(
     HeaderStep.ReportInformation,
@@ -35,6 +50,10 @@ export default async function FacilityEmissionAllocationPage({
       orderedActivities={orderedActivities}
       initialData={initialData}
       navigationInformation={navInfo}
+      isPulpAndPaper={isPulpAndPaper}
+      overlappingIndustrialProcessEmissions={
+        overlappingIndustrialProcessEmissions
+      }
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/facility/types.ts
+++ b/bciers/apps/reporting/src/app/components/facility/types.ts
@@ -5,7 +5,7 @@ export interface Product {
 }
 
 export interface EmissionAllocationData {
-  emission_category: string;
+  emission_category_name: string;
   emission_total: number;
   category_type: string;
   products: Product[];

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -14,6 +14,8 @@ interface Props {
   initialData: ProductData[];
   schema: RJSFSchema;
   navigationInformation: NavigationInformation;
+  isPulpAndPaper: boolean;
+  overlappingIndustrialProcessEmissions: number;
 }
 
 const ProductionDataForm: React.FC<Props> = ({
@@ -23,6 +25,8 @@ const ProductionDataForm: React.FC<Props> = ({
   allowedProducts,
   initialData,
   navigationInformation,
+  isPulpAndPaper,
+  overlappingIndustrialProcessEmissions,
 }) => {
   const initialFormData = {
     product_selection: initialData.map((i) => i.product_name),
@@ -50,6 +54,17 @@ const ProductionDataForm: React.FC<Props> = ({
   };
 
   const onSubmit = async (data: any) => {
+    /*
+      Handle pulp & paper overlapping industrial process exception:
+      If pulp & paper is reported and there are industrial process emissions that are also categorized as excluded (ie: woody biomass)
+      Then the 'Pulp and paper: chemical pulp' product must be reported
+    */
+    if (isPulpAndPaper && overlappingIndustrialProcessEmissions > 0) {
+      if (!data.product_selection.includes("Pulp and paper: chemical pulp")) {
+        setErrors(["Missing Product: 'Pulp and paper: chemical pulp'"]);
+        return false;
+      }
+    }
     const response = await postProductionData(
       report_version_id,
       facility_id,

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -61,7 +61,9 @@ const ProductionDataForm: React.FC<Props> = ({
     */
     if (isPulpAndPaper && overlappingIndustrialProcessEmissions > 0) {
       if (!data.product_selection.includes("Pulp and paper: chemical pulp")) {
-        setErrors(["Missing Product: 'Pulp and paper: chemical pulp'"]);
+        setErrors([
+          "Missing Product: 'Pulp and paper: chemical pulp'. Please add the product on the operation review page",
+        ]);
         return false;
       }
     }

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataPage.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataPage.tsx
@@ -6,6 +6,7 @@ import { HasFacilityId } from "@reporting/src/app/utils/defaultPageFactoryTypes"
 import { getReportInformationTasklist } from "@reporting/src/app/utils/getReportInformationTaskListData";
 import { getNavigationInformation } from "../taskList/navigationInformation";
 import { HeaderStep, ReportingPage } from "../taskList/types";
+import { getOverlappingIndustrialProcessEmissions } from "@reporting/src/app/utils/getOverlappingIndProcessEmissions";
 
 export default async function ProductionDataPage({
   version_id,
@@ -32,6 +33,20 @@ export default async function ProductionDataPage({
 
   const orderedActivities = await getOrderedActivities(version_id, facility_id);
 
+  // These values are used when reporting the pulp & paper activity
+  let isPulpAndPaper = false;
+  let overlappingIndustrialProcessEmissions = 0; // emissions that are categorized as both industrial_process and excluded (ie: woody biomass)
+  if (
+    orderedActivities.find(
+      (activity: { id: Number; name: String; slug: String }) =>
+        (activity.slug = "pulp_and_paper"),
+    )
+  ) {
+    isPulpAndPaper = true;
+    overlappingIndustrialProcessEmissions =
+      await getOverlappingIndustrialProcessEmissions(version_id, facility_id);
+  }
+
   const navInfo = await getNavigationInformation(
     HeaderStep.ReportInformation,
     ReportingPage.ProductionData,
@@ -51,6 +66,10 @@ export default async function ProductionDataPage({
       initialData={response.report_products}
       schema={schema}
       navigationInformation={navInfo}
+      isPulpAndPaper={isPulpAndPaper}
+      overlappingIndustrialProcessEmissions={
+        overlappingIndustrialProcessEmissions
+      }
     />
   );
 }

--- a/bciers/apps/reporting/src/app/utils/getOverlappingIndProcessEmissions.ts
+++ b/bciers/apps/reporting/src/app/utils/getOverlappingIndProcessEmissions.ts
@@ -1,0 +1,15 @@
+import { actionHandler } from "@bciers/actions";
+
+export async function getOverlappingIndustrialProcessEmissions(
+  reportVersionId: number,
+  facilityId: string,
+) {
+  const endpoint = `reporting/report-version/${reportVersionId}/facility-report/${facilityId}/overlapping_industrial_process_emissions`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch overlapping industrial process emissions for report version ${reportVersionId}, facility ${facilityId}.`,
+    );
+  }
+  return response;
+}

--- a/bciers/apps/reporting/src/tests/components/facility/FacilityEmissionAllocationPage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/facility/FacilityEmissionAllocationPage.test.tsx
@@ -6,6 +6,7 @@ import { getEmissionAllocations } from "@reporting/src/app/utils/getEmissionAllo
 import { getNavigationInformation } from "@reporting/src/app/components/taskList/navigationInformation";
 import { dummyNavigationInformation } from "../taskList/utils";
 import { useRouter } from "@bciers/testConfig/mocks";
+import { getOverlappingIndustrialProcessEmissions } from "@reporting/src/app/utils/getOverlappingIndProcessEmissions";
 
 // ✨ Mocks
 vi.mock("@reporting/src/app/utils/getReportInformationTaskListData", () => ({
@@ -20,6 +21,9 @@ vi.mock("@reporting/src/app/utils/getEmissionAllocations", () => ({
 }));
 vi.mock("@reporting/src/app/components/taskList/navigationInformation", () => ({
   getNavigationInformation: vi.fn(),
+}));
+vi.mock("@reporting/src/app/utils/getOverlappingIndProcessEmissions", () => ({
+  getOverlappingIndustrialProcessEmissions: vi.fn(),
 }));
 
 // 🏷 Constants
@@ -194,6 +198,9 @@ describe("The FacilityEmissionAllocationPage component", () => {
     (getNavigationInformation as ReturnType<typeof vi.fn>).mockReturnValueOnce(
       dummyNavigationInformation,
     );
+    (
+      getOverlappingIndustrialProcessEmissions as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(0.0);
     // Render the page with the `versionId` prop
     render(
       await FacilityEmissionAllocationPage({


### PR DESCRIPTION
This PR implements handling an exception for Pulp & Paper. [Issue 512](https://github.com/bcgov/cas-reporting/issues/512)

On the Frontend it should:
- throw a validation error on the Production page if: 
  - the activity Pulp & paper is reported,
  - there are emissions reported that are categorized as both industrial process & excluded 
  - and the chemical pulp product is not reported
- throw a validation error on the Emission allocation page if:
  - the activity Pulp & paper is reported,
  - there are emissions reported that are categorized as both industrial process & excluded
  - and chemical pulp product is not reported OR if the amount allocated to chemical pulp - sum of emissions categorized as both industrial process & excluded is less than 0.

On the Backend it should:
- Subtract the total of emissions categorized as both industrial process & excluded from the total industrial process emissions allocated to the chemical pulp product