### PR TITLE
fix: set status checking cronjob to once per 5 minutes

### DIFF
--- a/helm/cas-bciers/templates/cronJobs/check-file-status.yaml
+++ b/helm/cas-bciers/templates/cronJobs/check-file-status.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   suspend: false
-  schedule: "*/1  * * * *"
+  schedule: "*/5 * * * *"
   jobTemplate:
     spec:
       backoffLimit: 0


### PR DESCRIPTION
A quick fix to cause the Malware scanning bucket cronjob to trigger once every 5 minutes (per minimum defined by OpenShift). 

Will be working on a permanent solution.