### PR TITLE
fix: report flows

### DIFF
--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -384,7 +384,7 @@
       "status": "Registered",
       "bc_obps_regulated_operation": "24-0017",
       "registration_purpose": "Reporting Operation",
-      "activities": [1, 5],
+      "activities": [1],
       "contacts": [3]
     }
   },

--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -98,10 +98,10 @@
       "opt_in": false,
       "bcghg_id": "23219990001",
       "regulated_products": [1, 2],
-      "registration_purpose": "OBPS Regulated Operation",
+      "registration_purpose": "Reporting Operation",
       "status": "Registered",
       "bc_obps_regulated_operation": "24-0003",
-      "activities": [1, 5],
+      "activities": [1],
       "operation_has_multiple_operators": true,
       "contacts": [3]
     }
@@ -296,7 +296,7 @@
       "opt_in": false,
       "bcghg_id": "23219990015",
       "status": "Draft",
-      "activities": [1, 5],
+      "activities": [1],
       "registration_purpose": "Potential Reporting Operation"
     }
   },

--- a/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataPage.tsx
+++ b/bciers/apps/reporting/src/app/components/additionalInformation/additionalReportingData/AdditionalReportingDataPage.tsx
@@ -4,8 +4,12 @@ import { getReportAdditionalData } from "@reporting/src/app/utils/getReportAddit
 import { HasReportVersion } from "@reporting/src/app/utils/defaultPageFactoryTypes";
 import { REGULATED_OPERATION_REGISTRATION_PURPOSE } from "@reporting/src/app/utils/constants";
 import { getFacilityReport } from "@reporting/src/app/utils/getFacilityReport";
-import { getNavigationInformation } from "../../taskList/navigationInformation";
-import { HeaderStep, ReportingPage } from "../../taskList/types";
+import { getNavigationInformation } from "@reporting/src/app/components/taskList/navigationInformation";
+import {
+  HeaderStep,
+  ReportingPage,
+} from "@reporting/src/app/components/taskList/types";
+import { OperationTypes } from "@bciers/utils/src/enums";
 
 export function transformReportAdditionalData(reportAdditionalData: any) {
   const captureType = [];
@@ -44,12 +48,15 @@ export default async function AdditionalReportingDataPage({
 
   const transformedData = transformReportAdditionalData(reportAdditionalData);
   const facilityReport = await getFacilityReport(version_id);
-
   const navInfo = await getNavigationInformation(
     HeaderStep.AdditionalInformation,
     ReportingPage.AdditionalReportingData,
     version_id,
     facilityReport?.facility_id,
+    {
+      returnToFacilitiesTable:
+        facilityReport.operation_type === OperationTypes.LFO,
+    },
   );
 
   return (

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewPage.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewPage.tsx
@@ -25,7 +25,7 @@ export default async function FacilityReviewPage({
     version_id,
     facility_id,
     {
-      facilityName: facilityData?.facilityName,
+      facilityName: facilityData?.facility_name,
       orderedActivities: orderedActivities,
     },
   );

--- a/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
@@ -35,7 +35,7 @@ const FinalReviewForm: React.FC<Props> = ({ navigationInformation, data }) => {
       submittingButtonText="Continue"
       noSaveButton
     >
-      <FinalReviewForms data={data} />;
+      <FinalReviewForms data={data} />
     </MultiStepWrapperWithTaskList>
   );
 };

--- a/bciers/apps/reporting/src/app/components/taskList/navigationInformation.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/navigationInformation.ts
@@ -92,12 +92,22 @@ export async function getNavigationInformation(
   const taskListHeaders = taskListHeaderPages.map((tlp) => tlp.element);
   const taskList = taskListNonHeaderPages.map((tlp) => tlp.element);
 
-  const pageIndex = pages.indexOf(page);
-  if (pageIndex === -1)
-    // The current page wasn't found in the flow's step
-    throw new Error(
-      `Page ${page} was not found in this reporting flow, unable to generate the appropriate tasklist and navigation.`,
-    );
+  // Determine the index of the current page from the filtered tasklistPages array.
+  // First, try to find the active page (assuming each factory sets an isActive flag).
+  let pageIndex = tasklistPages.findIndex((task) => task.element.isActive);
+
+  // If no tasklist page is marked active, fall back to finding the index
+  // in the original pages array.
+  if (pageIndex === -1) {
+    pageIndex = pages.indexOf(page);
+    if (pageIndex === -1) {
+      // The current page wasn't found in either the filtered list or the original flow,
+      // so throw an error.
+      throw new Error(
+        `Page ${page} was not found in this reporting flow, unable to generate the appropriate tasklist and navigation.`,
+      );
+    }
+  }
 
   // find forward and back links
   // - either from the current page factory itself

--- a/bciers/apps/reporting/src/app/components/taskList/reportingFlows/sfoReportingOnlyFlow.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/reportingFlows/sfoReportingOnlyFlow.ts
@@ -4,18 +4,13 @@ export const sfoReportingOnlyFlow: ReportingFlowDescription = {
   [HeaderStep.OperationInformation]: [
     ReportingPage.ReviewOperationInfo,
     ReportingPage.PersonResponsible,
-    ReportingPage.ReviewFacilities,
   ],
   [HeaderStep.ReportInformation]: [
     ReportingPage.Activities,
     ReportingPage.NonAttributableEmission,
     ReportingPage.EmissionSummary,
-    ReportingPage.EndOfReport,
   ],
-  [HeaderStep.AdditionalInformation]: [
-    ReportingPage.AdditionalReportingData,
-    ReportingPage.OperationEmissionSummary,
-  ],
+  [HeaderStep.AdditionalInformation]: [ReportingPage.AdditionalReportingData],
   [HeaderStep.SignOffSubmit]: [
     ReportingPage.FinalReview,
     ReportingPage.Verification,

--- a/bciers/apps/reporting/src/app/components/taskList/taskListPages/3_additionalInformation.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/taskListPages/3_additionalInformation.ts
@@ -1,16 +1,31 @@
 import { ReportingPage, TaskListPageFactory } from "../types";
+import { getReportingOperation } from "@reporting/src/app/utils/getReportingOperation";
+import { OperationTypes } from "@bciers/utils/src/enums";
 
 export const additionalInformationPageFactories: {
   [Page in ReportingPage]?: TaskListPageFactory;
 } = {
-  [ReportingPage.AdditionalReportingData]: (activePage, reportVersionId) => ({
-    element: {
-      type: "Page",
-      title: "Additional reporting data",
-      link: `/reports/${reportVersionId}/additional-reporting-data`,
-      isActive: activePage === ReportingPage.AdditionalReportingData,
-    },
-  }),
+  [ReportingPage.AdditionalReportingData]: async (
+    activePage,
+    reportVersionId,
+  ) => {
+    const reportOperation = await getReportingOperation(reportVersionId);
+    const operationType = reportOperation?.operation_type;
+    const backUrl =
+      operationType === OperationTypes.LFO
+        ? `/reports/${reportVersionId}/facilities/report-information`
+        : undefined;
+
+    return {
+      element: {
+        type: "Page",
+        title: "Additional reporting data",
+        link: `/reports/${reportVersionId}/additional-reporting-data`,
+        isActive: activePage === ReportingPage.AdditionalReportingData,
+      },
+      backUrl,
+    };
+  },
   [ReportingPage.NewEntrantInformation]: (activePage, reportVersionId) => ({
     element: {
       type: "Page",

--- a/bciers/apps/reporting/src/app/components/taskList/taskListPages/3_additionalInformation.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/taskListPages/3_additionalInformation.ts
@@ -1,31 +1,24 @@
 import { ReportingPage, TaskListPageFactory } from "../types";
-import { getReportingOperation } from "@reporting/src/app/utils/getReportingOperation";
-import { OperationTypes } from "@bciers/utils/src/enums";
 
 export const additionalInformationPageFactories: {
   [Page in ReportingPage]?: TaskListPageFactory;
 } = {
-  [ReportingPage.AdditionalReportingData]: async (
+  [ReportingPage.AdditionalReportingData]: (
     activePage,
     reportVersionId,
-  ) => {
-    const reportOperation = await getReportingOperation(reportVersionId);
-    const operationType = reportOperation?.operation_type;
-    const backUrl =
-      operationType === OperationTypes.LFO
-        ? `/reports/${reportVersionId}/facilities/report-information`
-        : undefined;
-
-    return {
-      element: {
-        type: "Page",
-        title: "Additional reporting data",
-        link: `/reports/${reportVersionId}/additional-reporting-data`,
-        isActive: activePage === ReportingPage.AdditionalReportingData,
-      },
-      backUrl,
-    };
-  },
+    _,
+    context,
+  ) => ({
+    element: {
+      type: "Page",
+      title: "Additional reporting data",
+      link: `/reports/${reportVersionId}/additional-reporting-data`,
+      isActive: activePage === ReportingPage.AdditionalReportingData,
+    },
+    backUrl: context?.returnToFacilitiesTable
+      ? `/reports/${reportVersionId}/facilities/report-information`
+      : undefined,
+  }),
   [ReportingPage.NewEntrantInformation]: (activePage, reportVersionId) => ({
     element: {
       type: "Page",

--- a/bciers/apps/reporting/src/app/components/taskList/taskListPages/5_signOffSubmit.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/taskListPages/5_signOffSubmit.ts
@@ -1,4 +1,3 @@
-import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import { ReportingPage, TaskListPageFactory } from "../types";
 
 export const signOffSubmitPageFactories: {
@@ -41,63 +40,4 @@ export const signOffSubmitPageFactories: {
       isActive: activePage === ReportingPage.SignOff,
     },
   }),
-};
-
-export enum ActivePage {
-  "Verification" = 0,
-  "Attachments",
-  "FinalReview",
-  "SignOff",
-}
-export const getSignOffAndSubmitSteps: (
-  versionId: number,
-  activeIndex?: ActivePage | number,
-  needsVerification?: boolean,
-) => Promise<TaskListElement[]> = async (
-  versionId,
-  activeIndex = undefined,
-  needsVerification = false,
-) => {
-  // Build the TaskListElement array
-  const elements: TaskListElement[] = [
-    {
-      type: "Page", // Set the type to "Page"
-      title: "Final review",
-      link: `/reports/${versionId}/final-review`,
-      isActive: activeIndex === ActivePage.FinalReview,
-    },
-    {
-      type: "Page", // Set the type to "Page"
-      title: "Verification",
-      link: `/reports/${versionId}/verification`,
-      isActive: activeIndex === ActivePage.Verification,
-    },
-    {
-      type: "Page", // Set the type to "Page"
-      title: "Attachments",
-      link: `/reports/${versionId}/attachments`,
-      isActive: activeIndex === ActivePage.Attachments,
-    },
-    {
-      type: "Page", // Set the type to "Page"
-      title: "Sign-off",
-      link: `/reports/${versionId}/sign-off`,
-      isActive: activeIndex === ActivePage.SignOff,
-    },
-  ];
-  // Conditionally filter out "Verification" based on needsVerification is false
-  const filteredElements: TaskListElement[] = elements.filter((element) => {
-    if (!needsVerification) {
-      return element.title !== "Verification";
-    }
-    return true; // If needsVerification is true, keep all elements
-  });
-  return [
-    {
-      type: "Section",
-      title: "Sign-off & submit",
-      isExpanded: true,
-      elements: filteredElements,
-    },
-  ];
 };

--- a/bciers/apps/reporting/src/app/components/taskList/types.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/types.ts
@@ -86,6 +86,7 @@ export interface TaskListPageFactoryContext {
   orderedActivities?: ActivityData[];
   currentActivity?: ActivityData;
   skipVerification?: boolean;
+  returnToFacilitiesTable?: boolean;
 }
 
 type SyncTaskListPageFactory = (

--- a/bciers/apps/reporting/src/tests/components/attachments/AttachmentPage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/attachments/AttachmentPage.test.tsx
@@ -17,13 +17,6 @@ vi.mock("@reporting/src/app/utils/getReportNeedsVerification", () => ({
   getReportNeedsVerification: vi.fn(),
 }));
 
-vi.mock("@reporting/src/app/components/taskList/5_signOffSubmit", () => ({
-  getSignOffAndSubmitSteps: vi.fn().mockReturnValue("test task list"),
-  ActivePage: {
-    Attachments: "Attachments",
-  },
-}));
-
 vi.mock("@reporting/src/app/components/taskList/navigationInformation", () => ({
   getNavigationInformation: vi.fn(),
 }));


### PR DESCRIPTION
Addresses: 
[645](https://github.com/bcgov/cas-reporting/issues/645)
[600](https://github.com/bcgov/cas-reporting/issues/600)
[598](https://github.com/bcgov/cas-reporting/issues/598)
[640](https://github.com/bcgov/cas-reporting/issues/640)
[644](https://github.com/bcgov/cas-reporting/issues/644)

###  ⚠️ Issues:
- `SFO` flow has `LFO` pages
-  `navigationInformation.ts`  computed the page index based on the flow pages array, which included hidden (skipped) tasklist elements, resulting in a mismatch between the calculated page index and the actual visible task list and error on `Sign-off & Submit`

### 🚀 Impact:

- Updated pages definitions in `sfoReportingOnlyFlow`
- Updated `navigationInformation.ts` to find page index from the filtered tasklistPages array rather than in the flowData pages. This way, if a page like "Verification" is hidden in the task list, the current page index will be computed correctly.


## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button
5. Log in using `bc-cas-dev`


### Test: SFO `Reporting Operation` Flow
#### Fix: Bug - SFO Reporting Operation shows LFO workflow [645](https://github.com/bcgov/cas-reporting/issues/645)

#### **Steps**  
1. Navigate to http://localhost:3000/reporting/reports/
2. Select operation `Bangles SFO - Registered - has Multiple Operators` 
3. Click `Start`

#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/1aaf1ac8-37f6-47aa-94de-113199bc2630)
- Operation Type is `Single Facility Operation`
- Operation Purpose is `Reporting Operation`
- Breadcrumbs display as expected
- Step is `Operation Information`
- Tasklist links include:
  -  `Review operation information`
  -  `Person responsible`
- Tasklist links work as expected
- Navigation buttons work as expected

4. Complete forms until `Activities`

#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/7a250318-b116-4e65-8423-c44cbf728a05)
- Breadcrumbs display as expected
- Step is `Report Information`
- Tasklist links include:
  -  `Activities`
  -  `Non-attributable emissions`
  -  `Emissions summary`
- Navigation buttons work as expected


5. Complete forms until `Additional Reporting Data`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/4fcf7831-fadf-4963-aee1-42d64d103da3)
- Breadcrumbs display as expected
- Step is `Additional Information`
- Tasklist links include:
  -  `Additional reporting data`
- Tasklist links work as expected
- Navigation buttons work as expected

❗ **Note**  `Additional reporting data` "Back" returns to  `Emissions summary `


6. Complete forms until `Compliance Summary`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/e0b6f5d6-87ff-4d9c-9616-d875d62b8c31)
- Breadcrumbs display as expected
- Step is `Compliance Summary`
- Tasklist links include:
  -  `Compliance summary`
- Tasklist links work as expected
- Navigation buttons work as expected


7. Complete forms until `Final Review`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/d9676002-bc04-445a-bed6-0d044b660bb8)
- Breadcrumbs display as expected
- Step is `Sign-off & Submit`
- Tasklist links include:
  -  `Final review`
  - `Attachments`
  - `Sign-off`
- Tasklist links work as expected
- Navigation buttons work as expected



8. Complete forms until `Sign-off`
9. Click `Submit Report`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/1d71dc1b-4d8d-4d4e-af79-97429b0c1100)
Report is submitted

---


### **Test: LFO `Reporting Operation` Flow**  
####  Fix: Bug: LFO missing facility name in the task list [640](https://github.com/bcgov/cas-reporting/issues/640)
#### Fix: Bug: LFO navigation from Additional Reporting page [598](https://github.com/bcgov/cas-reporting/issues/598)
#### Fix: Bug: Cannot view Final Review page - Reporting Operation [600](https://github.com/bcgov/cas-reporting/issues/600)

#### **Steps**  
1. Navigate to http://localhost:3000/reporting/reports/
2. Select `Bin LFO - Registered`
3. Click button `Start`

#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/38227c59-dc73-4ad2-9d1e-8188933560cf)
- Operation Type is `Linear Facility Operation`
- Operation Purpose is `Reporting Operation`
- Breadcrumbs display as expected
- Step is `Operation Information`
- Tasklist links include:
  -  `Review operation information`
  -  `Person responsible`
  -  `Review Facilities`
- Tasklist links work as expected
- Navigation buttons work as expected

4. Complete forms until `Report Information`

#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/1eb12032-e591-4015-8f9c-e2896e143bbb)
- Breadcrumbs display as expected
- Step is `Report Information`
- No Tasklist is displayed
- Navigation buttons work as expected


5. Click `Continue` on a facility record
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/e4583922-0c74-4fac-85fa-d3c25142f44c)
- `Review Facility Information` form is displayed
- Tasklist links include:
  -  `Review facility information`
  -  `Activities`
  -  `Non-attributable emissions`
  - `Emissions summary`
  - `Facility Report Completed`
❗ **Note**  Tasklist header displays the facility name


6. Complete forms until `Additional Reporting Data`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/34e21bfd-1d41-4576-8fc5-b3c76d55d06f)
- Breadcrumbs display as expected
- Step is `Additional Information`
- Tasklist links include:
  -  `Additional reporting data`
  - `Operation emission summary`
- Tasklist links work as expected
- Navigation buttons work as expected
❗ **Note**  `Additional reporting data` "Back" returns to  `Report Information` not `End of Facility Report`

7. Complete forms until `Final Review`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/c06d3061-95d2-4e8d-9a87-aa51d21146af)
- Breadcrumbs display as expected
- Step is `Sign-off & Submit`
- Tasklist links include:
  -  `Final review`
  - `Attachments`
  - `Sign-off`
- Tasklist links work as expected
- Navigation buttons work as expected

8. Complete forms until `Sign-off`
9. Click `Submit Report`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/9440171c-96fd-4880-8e50-bd4c79baa4ce)
Report is submitted

---

### **Test: LFO `Potential Reporting Operation` Final Review**  

#### Fix: Bugs in Potential Reporting Operation [644](https://github.com/bcgov/cas-reporting/issues/644)

#### **Steps**  
1. Navigate to http://localhost:3000/administration/operations
2. Register an `LFO` with registration purpose `Potential Reporting Operation`, ex: `Bling LFO - Draft`
3. Navigate to http://localhost:3000/reporting/reports/
4. Select `Bling LFO - Draft`
5. Click button `Start`
6. Navigate to `atttachments`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/40ee0eba-c2c5-4cc3-a697-e7e097e6e440)
- Attachment page displays

7. Click `Save and Continue`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/a2281262-e241-4649-b8d4-7727b499b331)
- Sign-off page displays
8. Click `Submit Report`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/9440171c-96fd-4880-8e50-bd4c79baa4ce)
Report is submitted
---

**Regression Tests:**
✅ SFO NON `Reporting Operation` Flow
✅ LFO NON `Reporting Operation` Flow