### PR TITLE
fix: malware scanning file status cronjob errors

### DIFF
--- a/bc_obps/service/data_access_service/document_service.py
+++ b/bc_obps/service/data_access_service/document_service.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from registration.models import Document, DocumentType
 from django.core.files.base import ContentFile
 from django.core.files.storage import storages
+import pgtrigger
 
 
 class DocumentDataAccessService:
@@ -45,5 +46,7 @@ class DocumentDataAccessService:
             # The file is not in any of the quarantined or clean buckets
             return Document.FileStatus.UNSCANNED
 
-        document.save()
+        # Ignore the audit columns triggers, we're not changing anything about the document itself
+        with pgtrigger.ignore("registration.Document:set_updated_audit_columns"):
+            document.save()
         return document.status

--- a/helm/cas-bciers/templates/cronJobs/check-file-status.yaml
+++ b/helm/cas-bciers/templates/cronJobs/check-file-status.yaml
@@ -26,6 +26,8 @@ spec:
             imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
             env:
               {{- include "cas-bciers.backendEnvVars" . | nindent 14 }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/attachment-credentials/attachment-credentials.json"
             command:
               - /usr/bin/env
               - bash
@@ -37,7 +39,16 @@ spec:
             volumeMounts:
               - name: check-document-file-status-lock
                 mountPath: /data/locks
+              - mountPath: "/attachment-credentials"
+                name: gcs-attachment-credentials
+                readOnly: true
           volumes:
             - name: check-document-file-status-lock
               persistentVolumeClaim:
                 claimName: check-document-file-status-lock-pvc
+            - name: gcs-attachment-credentials
+              secret:
+                secretName: gcp-{{ .Release.Namespace }}-bciers-attach-service-account-key
+                items:
+                - key: credentials.json
+                  path: attachment-credentials.json


### PR DESCRIPTION
The cronjob function to check the status of documents as they move through malware scanning is failing in OpenShift for two reasons: 
- Missing GCP application credentials.
- No 'user' being identified when updating the file status (and therefore the location to target) in the DB, so no update record could be added. 

This PR addresses both of those issues. 