### PR TITLE
fix: only add source types from the formData to the query string

### DIFF
--- a/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
@@ -27,7 +27,7 @@ const activityFactoryItem: ReviewDataFactoryItem = async (
       activity.id,
     );
 
-    const sourceTypeQueryString = formData?.soureTypes
+    const sourceTypeQueryString = formData?.sourceTypes
       ? Object.entries(initData.sourceTypeMap)
           .filter(([, v]) => String(v) in formData.sourceTypes)
           .map(([k]) => `&source_types[]=${k}`)

--- a/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
@@ -28,7 +28,7 @@ const activityFactoryItem: ReviewDataFactoryItem = async (
     );
 
     const sourceTypeQueryString = Object.entries(initData.sourceTypeMap)
-      .filter(([, v]) => String(v) in formData)
+      .filter(([, v]) => String(v) in formData.sourceTypes)
       .map(([k]) => `&source_types[]=${k}`)
       .join("");
 

--- a/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
@@ -27,10 +27,12 @@ const activityFactoryItem: ReviewDataFactoryItem = async (
       activity.id,
     );
 
-    const sourceTypeQueryString = Object.entries(initData.sourceTypeMap)
-      .filter(([, v]) => String(v) in formData.sourceTypes)
-      .map(([k]) => `&source_types[]=${k}`)
-      .join("");
+    const sourceTypeQueryString = formData?.soureTypes
+      ? Object.entries(initData.sourceTypeMap)
+          .filter(([, v]) => String(v) in formData.sourceTypes)
+          .map(([k]) => `&source_types[]=${k}`)
+          .join("")
+      : "";
 
     const schema = safeJsonParse(
       await getActivitySchema(versionId, activity.id, sourceTypeQueryString),


### PR DESCRIPTION
Details on the bug & how to reproduce the path are in the [issue ticket](https://github.com/bcgov/cas-reporting/issues/591)