### PR TITLE
Feat/583 validate report access

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "[python]": {
-    "editor.formatOnSave": false
+    "editor.formatOnSave": true
   },
   "python.formatting.provider": "black",
   "black-formatter.importStrategy": "fromEnvironment",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "[python]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": false
   },
   "python.formatting.provider": "black",
   "black-formatter.importStrategy": "fromEnvironment",

--- a/bc_obps/common/permissions.py
+++ b/bc_obps/common/permissions.py
@@ -150,13 +150,16 @@ def authorize(
         "cas_director_analyst_and_industry_admin_user",
         "authorized_irc_user_and_industry_admin_user",
         "cas_analyst",
-    ]
+    ],
+    *args: Callable[[HttpRequest], bool],
 ) -> Callable[[HttpRequest], bool]:
     """
-    Returns an authentication function that checks if the user has the specified permission.
+    Returns an authentication function that checks if the user has the specified permission, and an arbitrary amount of extra checks.
+    All checks must return True for this one to return True.
 
     Parameters:
       permission (Permissions): The permission to check.
+      *args: an arbitrary number of additional authorization/check functions.
 
     Returns:
       Callable[[HttpRequest], bool]: The authentication function.
@@ -165,6 +168,6 @@ def authorize(
     def check_permission(
         request: HttpRequest,
     ) -> bool:  # This function must return a boolean to work with django-ninja `auth`.
-        return check_permission_for_role(request, permission)
+        return check_permission_for_role(request, permission) and all(validator(request) for validator in args)
 
     return check_permission

--- a/bc_obps/common/permissions.py
+++ b/bc_obps/common/permissions.py
@@ -20,7 +20,7 @@ def raise_401_if_user_not_authorized(
         - have an authorized app_role
         - if the user's app_role is industry_user, then they must additionally have status = 'Approved' in the user_operator table unless industry_user_must_be_approved is set to False (defaults to True)
     """
-    if not hasattr(request, 'current_user'):
+    if not hasattr(request, "current_user"):
         raise HttpError(401, UNAUTHORIZED_MESSAGE)
     user: User = request.current_user
     role_name = getattr(user.app_role, "role_name")
@@ -41,7 +41,7 @@ def raise_401_if_user_not_authorized(
             try:
                 user_operator = (
                     UserOperator.objects.exclude(status=UserOperator.Statuses.DECLINED)
-                    .only('role')
+                    .only("role")
                     .get(user=user.user_guid)
                 )
                 user_operator_role = user_operator.role
@@ -57,7 +57,9 @@ and this is the reason why it is not included in some of the permission configur
 """
 
 
-def get_permission_configs(permission: str) -> Optional[Union[Dict[str, List[str]], Dict[str, bool]]]:
+def get_permission_configs(
+    permission: str,
+) -> Optional[Union[Dict[str, List[str]], Dict[str, bool]]]:
     """
     Returns the permission configurations for the specified permission.
     :param permission: The permission to get the configuration for.
@@ -73,50 +75,50 @@ def get_permission_configs(permission: str) -> Optional[Union[Dict[str, List[str
     all_industry_user_operator_roles = UserOperator.get_all_industry_user_operator_roles()
     permission_configs: Dict[str, Dict] = {
         "all_roles": {
-            'authorized_app_roles': AppRole.get_all_app_roles(),
-            'authorized_user_operator_roles': all_industry_user_operator_roles,
-            'industry_user_must_be_approved': False,
+            "authorized_app_roles": AppRole.get_all_app_roles(),
+            "authorized_user_operator_roles": all_industry_user_operator_roles,
+            "industry_user_must_be_approved": False,
         },
         "authorized_roles": {
-            'authorized_app_roles': all_authorized_app_roles,
-            'authorized_user_operator_roles': all_industry_user_operator_roles,
-            'industry_user_must_be_approved': False,
+            "authorized_app_roles": all_authorized_app_roles,
+            "authorized_user_operator_roles": all_industry_user_operator_roles,
+            "industry_user_must_be_approved": False,
         },
         "approved_authorized_roles": {
-            'authorized_app_roles': all_authorized_app_roles,
-            'authorized_user_operator_roles': all_industry_user_operator_roles,
+            "authorized_app_roles": all_authorized_app_roles,
+            "authorized_user_operator_roles": all_industry_user_operator_roles,
         },
         "industry_user": {
-            'authorized_app_roles': ["industry_user"],
-            'authorized_user_operator_roles': all_industry_user_operator_roles,
-            'industry_user_must_be_approved': False,
+            "authorized_app_roles": ["industry_user"],
+            "authorized_user_operator_roles": all_industry_user_operator_roles,
+            "industry_user_must_be_approved": False,
         },
         "approved_industry_user": {
-            'authorized_app_roles': ["industry_user"],
-            'authorized_user_operator_roles': all_industry_user_operator_roles,
+            "authorized_app_roles": ["industry_user"],
+            "authorized_user_operator_roles": all_industry_user_operator_roles,
         },
         "approved_industry_admin_user": {
-            'authorized_app_roles': ["industry_user"],
-            'authorized_user_operator_roles': ["admin"],
+            "authorized_app_roles": ["industry_user"],
+            "authorized_user_operator_roles": ["admin"],
         },
         "authorized_irc_user_and_industry_admin_user": {
-            'authorized_app_roles': all_authorized_app_roles,
-            'authorized_user_operator_roles': ["admin"],
+            "authorized_app_roles": all_authorized_app_roles,
+            "authorized_user_operator_roles": ["admin"],
         },
         "authorized_irc_user": {
-            'authorized_app_roles': AppRole.get_authorized_irc_roles(),
+            "authorized_app_roles": AppRole.get_authorized_irc_roles(),
         },
         "cas_director": {
-            'authorized_app_roles': list(
+            "authorized_app_roles": list(
                 AppRole.objects.filter(role_name="cas_director").values_list("role_name", flat=True)
             )
         },
         "cas_director_analyst_and_industry_admin_user": {
-            'authorized_app_roles': ["cas_director", "cas_analyst", "industry_user"],
-            'authorized_user_operator_roles': ["admin"],
+            "authorized_app_roles": ["cas_director", "cas_analyst", "industry_user"],
+            "authorized_user_operator_roles": ["admin"],
         },
         "cas_analyst": {
-            'authorized_app_roles': list(
+            "authorized_app_roles": list(
                 AppRole.objects.filter(role_name="cas_analyst").values_list("role_name", flat=True)
             ),
         },
@@ -151,7 +153,6 @@ def authorize(
         "authorized_irc_user_and_industry_admin_user",
         "cas_analyst",
     ],
-    *args: Callable[[HttpRequest], bool],
 ) -> Callable[[HttpRequest], bool]:
     """
     Returns an authentication function that checks if the user has the specified permission, and an arbitrary amount of extra checks.
@@ -168,6 +169,13 @@ def authorize(
     def check_permission(
         request: HttpRequest,
     ) -> bool:  # This function must return a boolean to work with django-ninja `auth`.
-        return check_permission_for_role(request, permission) and all(validator(request) for validator in args)
+        return check_permission_for_role(request, permission)
 
     return check_permission
+
+
+def compose_auth(*args: Callable[[HttpRequest], bool]) -> Callable[[HttpRequest], bool]:
+    def validate_all(request: HttpRequest) -> bool:
+        return all(auth_function(request) for auth_function in args)
+
+    return validate_all

--- a/bc_obps/common/tests/endpoints/auth/constants.py
+++ b/bc_obps/common/tests/endpoints/auth/constants.py
@@ -66,7 +66,7 @@ ENDPOINTS = {
         {
             "method": "get",
             "endpoint_name": "get_report_additional_data_by_version_id",
-            "kwargs": {"report_version_id": MOCK_INT},
+            "kwargs": {"version_id": MOCK_INT},
         },
         {
             "method": "get",
@@ -81,7 +81,7 @@ ENDPOINTS = {
         {
             "method": "get",
             "endpoint_name": "get_report_verification_by_version_id",
-            "kwargs": {"report_version_id": MOCK_INT},
+            "kwargs": {"version_id": MOCK_INT},
         },
         {
             "method": "get",
@@ -93,7 +93,7 @@ ENDPOINTS = {
         {
             "method": "get",
             "endpoint_name": "load_production_data",
-            "kwargs": {"report_version_id": MOCK_INT, "facility_id": MOCK_UUID},
+            "kwargs": {"version_id": MOCK_INT, "facility_id": MOCK_UUID},
         },
         {
             "method": "get",
@@ -104,7 +104,7 @@ ENDPOINTS = {
             "method": "get",
             "endpoint_name": "load_report_activity_data",
             "kwargs": {
-                "report_version_id": MOCK_INT,
+                "version_id": MOCK_INT,
                 "facility_id": MOCK_UUID,
                 "activity_id": MOCK_INT,
             },
@@ -112,7 +112,7 @@ ENDPOINTS = {
         {
             "method": "get",
             "endpoint_name": "get_new_entrant_data",
-            "kwargs": {"report_version_id": MOCK_INT},
+            "kwargs": {"version_id": MOCK_INT},
         },
         {
             "method": "get",
@@ -127,7 +127,7 @@ ENDPOINTS = {
         {
             "method": "get",
             "endpoint_name": "get_selected_facilities",
-            "kwargs": {'report_version_id': MOCK_VERSION},
+            "kwargs": {'version_id': MOCK_VERSION},
         },
         {
             "method": "get",
@@ -137,17 +137,17 @@ ENDPOINTS = {
         {
             "method": "get",
             "endpoint_name": "get_report_attachments",
-            "kwargs": {"report_version_id": MOCK_INT},
+            "kwargs": {"version_id": MOCK_INT},
         },
         {
             "method": "get",
             "endpoint_name": "get_emission_allocations",
-            "kwargs": {"report_version_id": MOCK_INT, "facility_id": MOCK_UUID},
+            "kwargs": {"version_id": MOCK_INT, "facility_id": MOCK_UUID},
         },
         {
             "method": "get",
             "endpoint_name": "get_report_needs_verification",
-            "kwargs": {"report_version_id": MOCK_INT},
+            "kwargs": {"version_id": MOCK_INT},
         },
         {"method": "post", "endpoint_name": "create_facilities"},
         {"method": "post", "endpoint_name": "create_contact"},
@@ -159,7 +159,7 @@ ENDPOINTS = {
         {
             "method": "post",
             "endpoint_name": "save_new_entrant_data",
-            "kwargs": {"report_version_id": MOCK_INT},
+            "kwargs": {"version_id": MOCK_INT},
         },
         {
             "method": "post",
@@ -179,7 +179,7 @@ ENDPOINTS = {
         {
             "method": "post",
             "endpoint_name": "save_selected_facilities",
-            "kwargs": {"report_version_id": MOCK_INT},
+            "kwargs": {"version_id": MOCK_INT},
         },
         {
             "method": "post",
@@ -189,7 +189,7 @@ ENDPOINTS = {
         {
             "method": "post",
             "endpoint_name": "save_report_verification",
-            "kwargs": {"report_version_id": MOCK_INT},
+            "kwargs": {"version_id": MOCK_INT},
         },
         {
             "method": "post",
@@ -200,7 +200,7 @@ ENDPOINTS = {
             "method": "post",
             "endpoint_name": "save_report_activity_data",
             "kwargs": {
-                "report_version_id": MOCK_INT,
+                "version_id": MOCK_INT,
                 "facility_id": MOCK_UUID,
                 "activity_id": MOCK_INT,
             },
@@ -208,17 +208,17 @@ ENDPOINTS = {
         {
             "method": "post",
             "endpoint_name": "save_production_data",
-            "kwargs": {"report_version_id": MOCK_INT, "facility_id": MOCK_UUID},
+            "kwargs": {"version_id": MOCK_INT, "facility_id": MOCK_UUID},
         },
         {
             "method": "post",
             "endpoint_name": "save_emission_allocation_data",
-            "kwargs": {"report_version_id": MOCK_INT, "facility_id": MOCK_UUID},
+            "kwargs": {"version_id": MOCK_INT, "facility_id": MOCK_UUID},
         },
         {
             "method": "post",
             "endpoint_name": "save_report_attachments",
-            "kwargs": {"report_version_id": MOCK_INT},
+            "kwargs": {"version_id": MOCK_INT},
         },
         {
             "method": "put",
@@ -238,7 +238,7 @@ ENDPOINTS = {
         {
             "method": "post",
             "endpoint_name": "create_report_supplementary_version",
-            "kwargs": {"report_version_id": MOCK_INT},
+            "kwargs": {"version_id": MOCK_INT},
         },
         {
             "method": "post",
@@ -287,7 +287,7 @@ ENDPOINTS = {
         {
             "method": "get",
             "endpoint_name": "get_compliance_summary_data",
-            "kwargs": {"report_version_id": MOCK_INT},
+            "kwargs": {"version_id": MOCK_INT},
         },
         {
             "method": "get",

--- a/bc_obps/common/tests/utils/call_endpoint.py
+++ b/bc_obps/common/tests/utils/call_endpoint.py
@@ -1,0 +1,22 @@
+import json
+from model_bakery import baker
+from registration.models.user import User
+
+
+def call_endpoint(client, method, endpoint, app_role=None):
+    client_method = getattr(client, method)
+    kwargs = {
+        'path': endpoint,
+    }
+
+    if app_role:
+        user = baker.make(
+            User, app_role_id=app_role, _fill_optional=True
+        )  # Passing _fill_optional to fill all fields with random data
+        auth_header = {'user_guid': str(user.user_guid)}
+        kwargs['HTTP_AUTHORIZATION'] = json.dumps(auth_header)
+
+    if method.lower() != "get":
+        kwargs.update({'content_type': "application/json", 'data': {}})
+
+    return client_method(**kwargs)

--- a/bc_obps/reporting/api/__init__.py
+++ b/bc_obps/reporting/api/__init__.py
@@ -16,7 +16,7 @@ from .reports import get_registration_purpose_by_version_id
 from .reports import get_regulated_products_by_version_id
 from .reports import get_report_type_by_version
 from .gas_type import get_gas_type
-from .emission_category import get_emission_category, get_operation_emission_summary_totals
+from .report_emission_summary import get_emission_category, get_operation_emission_summary_totals
 from .production_data import save_production_data
 from .report_new_entrant_data import save_new_entrant_data
 from .report_new_entrant_data import get_new_entrant_data

--- a/bc_obps/reporting/api/activity_data.py
+++ b/bc_obps/reporting/api/activity_data.py
@@ -1,4 +1,3 @@
-from reporting.api.permissions import check_version_ownership_in_url
 from service.activity_service import ActivityService
 from common.permissions import authorize
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -7,7 +6,7 @@ from django.http import HttpRequest
 from typing import Tuple
 from uuid import UUID
 from reporting.schema.generic import Message
-
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 ##### GET #####
 
@@ -15,7 +14,7 @@ from reporting.schema.generic import Message
 @router.get(
     "/report-version/{version_id}/facility-report/{facility_id}/initial-activity-data",
     response={200: str, custom_codes_4xx: Message},
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def get_initial_activity_data(
     request: HttpRequest, version_id: int, facility_id: UUID, activity_id: int

--- a/bc_obps/reporting/api/activity_data.py
+++ b/bc_obps/reporting/api/activity_data.py
@@ -1,3 +1,4 @@
+from reporting.api.permissions import check_version_ownership_in_url
 from service.activity_service import ActivityService
 from common.permissions import authorize
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -14,7 +15,7 @@ from reporting.schema.generic import Message
 @router.get(
     "/report-version/{version_id}/facility-report/{facility_id}/initial-activity-data",
     response={200: str, custom_codes_4xx: Message},
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def get_initial_activity_data(
     request: HttpRequest, version_id: int, facility_id: UUID, activity_id: int
@@ -22,6 +23,10 @@ def get_initial_activity_data(
     return 200, ActivityService.get_initial_activity_data(version_id, facility_id, activity_id)
 
 
-@router.get("/activities", response={200: list, custom_codes_4xx: Message})
+@router.get(
+    "/activities",
+    response={200: list, custom_codes_4xx: Message},
+    auth=authorize("approved_authorized_roles"),
+)
 def get_activities(request: HttpRequest) -> Tuple[int, list]:
     return 200, ActivityService.get_all_activities()

--- a/bc_obps/reporting/api/compliance_data.py
+++ b/bc_obps/reporting/api/compliance_data.py
@@ -1,24 +1,23 @@
 from typing import Literal, Tuple
 from django.http import HttpRequest
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from reporting.schema.generic import Message
 from reporting.service.compliance_service import ComplianceService, ComplianceData
 from reporting.schema.compliance_data import ComplianceDataSchemaOut
 from .router import router
-from common.permissions import authorize
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.get(
-    "report-version/{report_version_id}/compliance-data",
+    "report-version/{version_id}/compliance-data",
     response={200: ComplianceDataSchemaOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Retrieves the data for the compliance summary page from multiple data sources.""",
     exclude_none=True,
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
-def get_compliance_summary_data(request: HttpRequest, report_version_id: int) -> Tuple[Literal[200], ComplianceData]:
-    compliance_data = ComplianceService.get_calculated_compliance_data(report_version_id)
+def get_compliance_summary_data(request: HttpRequest, version_id: int) -> Tuple[Literal[200], ComplianceData]:
+    compliance_data = ComplianceService.get_calculated_compliance_data(version_id)
 
     return 200, compliance_data

--- a/bc_obps/reporting/api/compliance_data.py
+++ b/bc_obps/reporting/api/compliance_data.py
@@ -1,5 +1,6 @@
 from typing import Literal, Tuple
 from django.http import HttpRequest
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from reporting.schema.generic import Message
@@ -15,7 +16,7 @@ from common.permissions import authorize
     tags=EMISSIONS_REPORT_TAGS,
     description="""Retrieves the data for the compliance summary page from multiple data sources.""",
     exclude_none=True,
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def get_compliance_summary_data(request: HttpRequest, report_version_id: int) -> Tuple[Literal[200], ComplianceData]:
     compliance_data = ComplianceService.get_calculated_compliance_data(report_version_id)

--- a/bc_obps/reporting/api/facility_report.py
+++ b/bc_obps/reporting/api/facility_report.py
@@ -1,8 +1,6 @@
 from typing import Literal, Tuple, List, Optional
 from uuid import UUID
-from common.permissions import authorize
 from django.http import HttpRequest
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from service.facility_report_service import FacilityReportService
@@ -24,6 +22,10 @@ from ninja import Query
 from django.db.models import QuerySet
 
 from ..utils import ReportingCustomPagination
+from reporting.api.permissions import (
+    approved_industry_user_report_version_composite_auth,
+    approved_authorized_roles_report_version_composite_auth,
+)
 
 
 @router.get(
@@ -32,7 +34,7 @@ from ..utils import ReportingCustomPagination
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes `version_id` (primary key of the ReportVersion model) and `facility_id` to return a single matching `facility_report` object.
     Includes the associated activity IDs if found; otherwise, returns an error message if not found or in case of other issues.""",
-    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
+    auth=approved_authorized_roles_report_version_composite_auth,
 )
 def get_facility_report_form_data(
     request: HttpRequest, version_id: int, facility_id: UUID
@@ -46,7 +48,7 @@ def get_facility_report_form_data(
     response={200: List[FacilityReportActivityDataOut], 404: Message, 400: Message, 500: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes `version_id` (primary key of the ReportVersion model) and `facility_id` to return a list of activities that apply to that facility, ordered by weight""",
-    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
+    auth=approved_authorized_roles_report_version_composite_auth,
 )
 def get_ordered_facility_report_activities(
     request: HttpRequest, version_id: int, facility_id: UUID
@@ -64,7 +66,7 @@ def get_ordered_facility_report_activities(
     description="""Updates the report facility details by version_id and facility_id. The request body should include
     fields to be updated, such as facility name, type, BC GHG ID, activities, and products. Returns the updated report
     facility object or an error message if the update fails.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_facility_report(
     request: HttpRequest, version_id: int, facility_id: UUID, payload: FacilityReportIn
@@ -94,7 +96,7 @@ def save_facility_report(
     response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
-    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
+    auth=approved_authorized_roles_report_version_composite_auth,
 )
 def get_facility_report_by_version_id(request: HttpRequest, version_id: int) -> Tuple[Literal[200], dict]:
     facility_report = FacilityReportService.get_facility_report_by_version_id(version_id)
@@ -118,7 +120,7 @@ def get_facility_report_by_version_id(request: HttpRequest, version_id: int) -> 
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns a list of facilities with their
     details.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 @paginate(ReportingCustomPagination, page_size=10)
 def get_facility_report_list(
@@ -138,7 +140,7 @@ def get_facility_report_list(
     tags=["Emissions Report"],
     description="""Updates facility report details by version_id. The request body should include fields
     to be updated for the respective facility reports.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_facility_report_list(
     request: HttpRequest, version_id: int, payload: List[FacilityReportListInSchema]

--- a/bc_obps/reporting/api/facility_report.py
+++ b/bc_obps/reporting/api/facility_report.py
@@ -2,6 +2,7 @@ from typing import Literal, Tuple, List, Optional
 from uuid import UUID
 from common.permissions import authorize
 from django.http import HttpRequest
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from service.facility_report_service import FacilityReportService
@@ -31,7 +32,7 @@ from ..utils import ReportingCustomPagination
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes `version_id` (primary key of the ReportVersion model) and `facility_id` to return a single matching `facility_report` object.
     Includes the associated activity IDs if found; otherwise, returns an error message if not found or in case of other issues.""",
-    auth=authorize("approved_authorized_roles"),
+    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
 )
 def get_facility_report_form_data(
     request: HttpRequest, version_id: int, facility_id: UUID
@@ -45,7 +46,7 @@ def get_facility_report_form_data(
     response={200: List[FacilityReportActivityDataOut], 404: Message, 400: Message, 500: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes `version_id` (primary key of the ReportVersion model) and `facility_id` to return a list of activities that apply to that facility, ordered by weight""",
-    auth=authorize("approved_authorized_roles"),
+    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
 )
 def get_ordered_facility_report_activities(
     request: HttpRequest, version_id: int, facility_id: UUID
@@ -63,7 +64,7 @@ def get_ordered_facility_report_activities(
     description="""Updates the report facility details by version_id and facility_id. The request body should include
     fields to be updated, such as facility name, type, BC GHG ID, activities, and products. Returns the updated report
     facility object or an error message if the update fails.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def save_facility_report(
     request: HttpRequest, version_id: int, facility_id: UUID, payload: FacilityReportIn
@@ -93,7 +94,7 @@ def save_facility_report(
     response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
-    auth=authorize("approved_authorized_roles"),
+    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
 )
 def get_facility_report_by_version_id(request: HttpRequest, version_id: int) -> Tuple[Literal[200], dict]:
     facility_report = FacilityReportService.get_facility_report_by_version_id(version_id)
@@ -117,7 +118,7 @@ def get_facility_report_by_version_id(request: HttpRequest, version_id: int) -> 
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns a list of facilities with their
     details.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 @paginate(ReportingCustomPagination, page_size=10)
 def get_facility_report_list(
@@ -137,7 +138,7 @@ def get_facility_report_list(
     tags=["Emissions Report"],
     description="""Updates facility report details by version_id. The request body should include fields
     to be updated for the respective facility reports.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def save_facility_report_list(
     request: HttpRequest, version_id: int, payload: List[FacilityReportListInSchema]

--- a/bc_obps/reporting/api/fuel.py
+++ b/bc_obps/reporting/api/fuel.py
@@ -1,3 +1,4 @@
+from common.permissions import authorize
 from service.data_access_service.fuel_service import FuelTypeDataAccessService
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from .router import router
@@ -14,6 +15,7 @@ from registration.schema import Message
 @router.get(
     "/fuel",
     response={200: FuelTypeSchema, custom_codes_4xx: Message},
+    auth=authorize("approved_authorized_roles"),
 )
 def get_fuel_data(
     request: HttpRequest,

--- a/bc_obps/reporting/api/permissions.py
+++ b/bc_obps/reporting/api/permissions.py
@@ -1,0 +1,67 @@
+import json
+import logging
+from typing import Callable
+from django.http import HttpRequest
+from registration.models.operation import Operation
+from registration.models.user_operator import UserOperator
+from reporting.models.report_version import ReportVersion
+
+logger = logging.getLogger(__name__)
+
+
+def is_access_granted(user_operator: UserOperator | None) -> bool:
+    return (
+        user_operator is not None
+        and user_operator.role != UserOperator.Roles.PENDING
+        and user_operator.status == UserOperator.Statuses.APPROVED
+    )
+
+
+def validate_version_ownership_from_url(
+    version_id_param: str,
+) -> Callable[[HttpRequest], bool]:
+    def validate_func(request: HttpRequest) -> bool:
+        if not request.resolver_match:
+            logger.warning("No resolver_match attribute found on request.")
+            return False
+
+        report_version_id = request.resolver_match.kwargs.get(version_id_param)
+        if not report_version_id:
+            logger.warning("No report_version_id found in request.")
+            return False
+
+        report_version = ReportVersion.objects.filter(pk=report_version_id).first()
+        if not report_version:
+            logger.warning("No report version found.")
+            return False
+
+        user_operator = UserOperator.objects.filter(
+            user=request.current_user,  # type: ignore
+            operator=report_version.report.operator,
+        ).first()
+
+        return is_access_granted(user_operator)
+
+    return validate_func
+
+
+def validate_operation_ownership_from_payload() -> Callable[[HttpRequest], bool]:
+    def validate_func(request: HttpRequest) -> bool:
+        operation_id = json.loads(request.body).get("operation_id")
+
+        if not operation_id:
+            logger.warning("Couldn't find operation_id field in payload.")
+            return False
+
+        operation = Operation.objects.filter(pk=operation_id).first()
+        if not operation:
+            logger.warning("Couldn't find operation record.")
+            return False
+
+        user_operator = UserOperator.objects.filter(
+            user=request.current_user, operator=operation.operator  # type: ignore
+        ).first()
+
+        return is_access_granted(user_operator)
+
+    return validate_func

--- a/bc_obps/reporting/api/permissions.py
+++ b/bc_obps/reporting/api/permissions.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from typing import Callable
+from common.permissions import authorize, compose_auth
 from django.http import HttpRequest
 from registration.models.operation import Operation
 from registration.models.user_operator import UserOperator
@@ -74,3 +75,11 @@ def check_operation_ownership() -> Callable[[HttpRequest], bool]:
         return _validate_operation_ownership(request)
 
     return validate_func
+
+
+approved_industry_user_report_version_composite_auth: Callable[[HttpRequest], bool] = compose_auth(
+    authorize("approved_industry_user"), check_version_ownership_in_url("version_id")
+)
+approved_authorized_roles_report_version_composite_auth: Callable[[HttpRequest], bool] = compose_auth(
+    authorize("approved_authorized_roles"), check_version_ownership_in_url("version_id")
+)

--- a/bc_obps/reporting/api/production_data.py
+++ b/bc_obps/reporting/api/production_data.py
@@ -1,9 +1,7 @@
 from typing import List, Literal, Tuple
 from uuid import UUID
-from common.permissions import authorize
 from django.http import HttpRequest
 from common.api.utils import get_current_user_guid
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.models.report_operation import ReportOperation
 from reporting.models.report_product import ReportProduct
@@ -12,18 +10,19 @@ from reporting.service.report_product_service import ReportProductService
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from reporting.schema.generic import Message
 from .router import router
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.post(
-    "report-version/{report_version_id}/facilities/{facility_id}/production-data",
+    "report-version/{version_id}/facilities/{facility_id}/production-data",
     response={200: int, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Saves the data for the production data page into multiple ReportProduct rows""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_production_data(
     request: HttpRequest,
-    report_version_id: int,
+    version_id: int,
     facility_id: UUID,
     payload: List[ReportProductSchemaIn],
 ) -> Literal[200]:
@@ -31,27 +30,27 @@ def save_production_data(
     product_data_dicts = [item.dict() for item in payload]
 
     ReportProductService.save_production_data(
-        report_version_id, facility_id, product_data_dicts, get_current_user_guid(request)
+        version_id, facility_id, product_data_dicts, get_current_user_guid(request)
     )
 
     return 200
 
 
 @router.get(
-    "report-version/{report_version_id}/facilities/{facility_id}/production-data",
+    "report-version/{version_id}/facilities/{facility_id}/production-data",
     response={200: ProductionDataOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Retrieves the data for the production data page from the multiple ReportProduct rows""",
     exclude_none=True,
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
-def load_production_data(request: HttpRequest, report_version_id: int, facility_id: UUID) -> Tuple[Literal[200], dict]:
+def load_production_data(request: HttpRequest, version_id: int, facility_id: UUID) -> Tuple[Literal[200], dict]:
 
     report_products = (
-        ReportProduct.objects.filter(facility_report__facility_id=facility_id, report_version_id=report_version_id)
+        ReportProduct.objects.filter(facility_report__facility_id=facility_id, report_version_id=version_id)
         .order_by("product_id")
         .all()
     )
-    allowed_products = ReportOperation.objects.get(report_version_id=report_version_id).regulated_products.all()
+    allowed_products = ReportOperation.objects.get(report_version_id=version_id).regulated_products.all()
 
     return 200, {"report_products": report_products, "allowed_products": allowed_products}

--- a/bc_obps/reporting/api/production_data.py
+++ b/bc_obps/reporting/api/production_data.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from common.permissions import authorize
 from django.http import HttpRequest
 from common.api.utils import get_current_user_guid
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.models.report_operation import ReportOperation
 from reporting.models.report_product import ReportProduct
@@ -18,7 +19,7 @@ from .router import router
     response={200: int, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Saves the data for the production data page into multiple ReportProduct rows""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def save_production_data(
     request: HttpRequest,
@@ -42,7 +43,7 @@ def save_production_data(
     tags=EMISSIONS_REPORT_TAGS,
     description="""Retrieves the data for the production data page from the multiple ReportProduct rows""",
     exclude_none=True,
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def load_production_data(request: HttpRequest, report_version_id: int, facility_id: UUID) -> Tuple[Literal[200], dict]:
 

--- a/bc_obps/reporting/api/report_activity.py
+++ b/bc_obps/reporting/api/report_activity.py
@@ -1,9 +1,7 @@
 from typing import Literal, Tuple
 from uuid import UUID
-from common.permissions import authorize
 from django.http import HttpRequest
 from common.api.utils import get_current_user_guid
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from reporting.schema.report_activity_data import ReportActivityDataIn
@@ -11,18 +9,19 @@ from reporting.service.report_activity_load_service import ReportActivityLoadSer
 from reporting.service.report_activity_save_service import ReportActivitySaveService
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from .router import router
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.post(
-    "report-version/{report_version_id}/facilities/{facility_id}/activity/{activity_id}/report-activity",
+    "report-version/{version_id}/facilities/{facility_id}/activity/{activity_id}/report-activity",
     response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Saves the data for an activity report form, for a given report version, facility and activity; returns the id of the ReportActivity record on success.""",
-    auth=authorize('approved_industry_user', check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_report_activity_data(
     request: HttpRequest,
-    report_version_id: int,
+    version_id: int,
     facility_id: UUID,
     activity_id: int,
     payload: ReportActivityDataIn,
@@ -30,26 +29,26 @@ def save_report_activity_data(
 
     user_guid = get_current_user_guid(request)
 
-    service = ReportActivitySaveService(report_version_id, facility_id, activity_id, user_guid)
+    service = ReportActivitySaveService(version_id, facility_id, activity_id, user_guid)
     service.save(payload.activity_data)
 
-    return load_report_activity_data(request, report_version_id, facility_id, activity_id)
+    return load_report_activity_data(request, version_id, facility_id, activity_id)
 
 
 @router.get(
-    "report-version/{report_version_id}/facilities/{facility_id}/activity/{activity_id}/report-activity",
+    "report-version/{version_id}/facilities/{facility_id}/activity/{activity_id}/report-activity",
     response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Loads the initial data for an activity report form, for a given report version, facility and activity.""",
-    auth=authorize('approved_industry_user', check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def load_report_activity_data(
     request: HttpRequest,
-    report_version_id: int,
+    version_id: int,
     facility_id: UUID,
     activity_id: int,
 ) -> Tuple[Literal[200], dict]:
 
-    data = ReportActivityLoadService.load(report_version_id, facility_id, activity_id)
+    data = ReportActivityLoadService.load(version_id, facility_id, activity_id)
 
     return 200, data

--- a/bc_obps/reporting/api/report_activity.py
+++ b/bc_obps/reporting/api/report_activity.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from common.permissions import authorize
 from django.http import HttpRequest
 from common.api.utils import get_current_user_guid
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from reporting.schema.report_activity_data import ReportActivityDataIn
@@ -17,7 +18,7 @@ from .router import router
     response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Saves the data for an activity report form, for a given report version, facility and activity; returns the id of the ReportActivity record on success.""",
-    auth=authorize('approved_industry_user'),
+    auth=authorize('approved_industry_user', check_version_ownership_in_url("report_version_id")),
 )
 def save_report_activity_data(
     request: HttpRequest,
@@ -40,7 +41,7 @@ def save_report_activity_data(
     response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Loads the initial data for an activity report form, for a given report version, facility and activity.""",
-    auth=authorize('approved_industry_user'),
+    auth=authorize('approved_industry_user', check_version_ownership_in_url("report_version_id")),
 )
 def load_report_activity_data(
     request: HttpRequest,

--- a/bc_obps/reporting/api/report_additional_data.py
+++ b/bc_obps/reporting/api/report_additional_data.py
@@ -1,8 +1,6 @@
 from typing import Literal, Optional
 from django.http import HttpRequest
 
-from common.permissions import authorize
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -10,6 +8,7 @@ from reporting.service.report_additional_data import ReportAdditionalDataService
 from .router import router
 from ..models import ReportAdditionalData
 from ..schema.report_additional_data import ReportAdditionalDataOut, ReportAdditionalDataIn
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.post(
@@ -17,7 +16,7 @@ from ..schema.report_additional_data import ReportAdditionalDataOut, ReportAddit
     response={201: ReportAdditionalDataOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="Creates or updates additional report data.",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_report_additional_data(
     request: HttpRequest, version_id: int, payload: ReportAdditionalDataIn
@@ -27,14 +26,14 @@ def save_report_additional_data(
 
 
 @router.get(
-    "/report-version/{report_version_id}/report-additional-data",
+    "/report-version/{version_id}/report-additional-data",
     response={200: ReportAdditionalDataOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def get_report_additional_data_by_version_id(
-    request: HttpRequest, report_version_id: int
+    request: HttpRequest, version_id: int
 ) -> tuple[Literal[200], Optional[ReportAdditionalData]]:
-    report_additional_data = ReportAdditionalDataService.get_report_report_additional_data(report_version_id)
+    report_additional_data = ReportAdditionalDataService.get_report_report_additional_data(version_id)
     return 200, report_additional_data

--- a/bc_obps/reporting/api/report_additional_data.py
+++ b/bc_obps/reporting/api/report_additional_data.py
@@ -2,6 +2,7 @@ from typing import Literal, Optional
 from django.http import HttpRequest
 
 from common.permissions import authorize
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -16,7 +17,7 @@ from ..schema.report_additional_data import ReportAdditionalDataOut, ReportAddit
     response={201: ReportAdditionalDataOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="Creates or updates additional report data.",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def save_report_additional_data(
     request: HttpRequest, version_id: int, payload: ReportAdditionalDataIn
@@ -30,7 +31,7 @@ def save_report_additional_data(
     response={200: ReportAdditionalDataOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def get_report_additional_data_by_version_id(
     request: HttpRequest, report_version_id: int

--- a/bc_obps/reporting/api/report_attachments.py
+++ b/bc_obps/reporting/api/report_attachments.py
@@ -4,6 +4,7 @@ from common.permissions import authorize
 from django.db import transaction
 from django.http import HttpRequest
 from ninja import File, Form, UploadedFile
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from reporting.schema.report_attachment import ReportAttachmentOut
@@ -17,7 +18,7 @@ from .router import router
     response={200: List[ReportAttachmentOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Saves the reporting attachments, passed as text in the payload.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 @transaction.atomic()
 def save_report_attachments(
@@ -44,7 +45,7 @@ def save_report_attachments(
     response={200: List[ReportAttachmentOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Returns the list of file attachments for a report version.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def get_report_attachments(
     request: HttpRequest,

--- a/bc_obps/reporting/api/report_emission_allocations.py
+++ b/bc_obps/reporting/api/report_emission_allocations.py
@@ -1,8 +1,6 @@
 from typing import Literal
 from uuid import UUID
 from common.api.utils.current_user_utils import get_current_user_guid
-from common.permissions import authorize
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.schema.report_product_emission_allocation import (
     ReportProductEmissionAllocationsSchemaIn,
     ReportProductEmissionAllocationsSchemaOut,
@@ -13,40 +11,41 @@ from reporting.schema.generic import Message
 from .router import router
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.service.report_emission_allocation_service import ReportEmissionAllocationService
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.get(
-    "report-version/{report_version_id}/facilities/{facility_id}/allocate-emissions",
+    "report-version/{version_id}/facilities/{facility_id}/allocate-emissions",
     response={200: ReportProductEmissionAllocationsSchemaOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Retrieves the data for product emissions allocations that have been saved for a facility""",
     exclude_none=True,
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def get_emission_allocations(
-    request: HttpRequest, report_version_id: int, facility_id: UUID
+    request: HttpRequest, version_id: int, facility_id: UUID
 ) -> tuple[Literal[200], ReportProductEmissionAllocationsSchemaOut]:
     # Delegate the responsibility to the service
-    response_data = ReportEmissionAllocationService.get_emission_allocation_data(report_version_id, facility_id)
+    response_data = ReportEmissionAllocationService.get_emission_allocation_data(version_id, facility_id)
     return 200, response_data
 
 
 @router.post(
-    "report-version/{report_version_id}/facilities/{facility_id}/allocate-emissions",
+    "report-version/{version_id}/facilities/{facility_id}/allocate-emissions",
     response={200: int, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Saves the data for the allocation of emissions page into multiple ReportProductEmissionAllocation rows""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_emission_allocation_data(
     request: HttpRequest,
-    report_version_id: int,
+    version_id: int,
     facility_id: UUID,
     payload: ReportProductEmissionAllocationsSchemaIn,
 ) -> Literal[200]:
 
     ReportEmissionAllocationService.save_emission_allocation_data(
-        report_version_id,
+        version_id,
         facility_id,
         payload,
         get_current_user_guid(request),

--- a/bc_obps/reporting/api/report_emission_allocations.py
+++ b/bc_obps/reporting/api/report_emission_allocations.py
@@ -2,6 +2,7 @@ from typing import Literal
 from uuid import UUID
 from common.api.utils.current_user_utils import get_current_user_guid
 from common.permissions import authorize
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.schema.report_product_emission_allocation import (
     ReportProductEmissionAllocationsSchemaIn,
     ReportProductEmissionAllocationsSchemaOut,
@@ -20,7 +21,7 @@ from reporting.service.report_emission_allocation_service import ReportEmissionA
     tags=EMISSIONS_REPORT_TAGS,
     description="""Retrieves the data for product emissions allocations that have been saved for a facility""",
     exclude_none=True,
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def get_emission_allocations(
     request: HttpRequest, report_version_id: int, facility_id: UUID
@@ -35,7 +36,7 @@ def get_emission_allocations(
     response={200: int, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Saves the data for the allocation of emissions page into multiple ReportProductEmissionAllocation rows""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def save_emission_allocation_data(
     request: HttpRequest,

--- a/bc_obps/reporting/api/report_emission_summary.py
+++ b/bc_obps/reporting/api/report_emission_summary.py
@@ -1,4 +1,5 @@
 from common.permissions import authorize
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.service.emission_category_service import EmissionCategoryService
 from reporting.models import FacilityReport
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -27,7 +28,7 @@ def get_emission_category(request: HttpRequest) -> Tuple[int, List[EmissionCateg
     "/report-version/{version_id}/facility-report/{facility_id}/emission-summary",
     response={200: EmissionSummarySchemaOut, custom_codes_4xx: Message},
     url_name="get_emission_summary_totals",
-    auth=authorize("approved_authorized_roles"),
+    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
 )
 def get_emission_summary_totals(request: HttpRequest, version_id: int, facility_id: UUID) -> Tuple[int, dict]:
     facility_report_id = FacilityReport.objects.get(report_version_id=version_id, facility_id=facility_id).pk
@@ -38,7 +39,7 @@ def get_emission_summary_totals(request: HttpRequest, version_id: int, facility_
     "/report-version/{version_id}/emission-summary",
     response={200: EmissionSummarySchemaOut, custom_codes_4xx: Message},
     url_name="get_operation_emission_summary_totals",
-    auth=authorize("approved_authorized_roles"),
+    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
 )
 def get_operation_emission_summary_totals(request: HttpRequest, version_id: int) -> Tuple[int, dict]:
     return 200, EmissionCategoryService.get_operation_emission_summary_form_data(version_id)

--- a/bc_obps/reporting/api/report_emission_summary.py
+++ b/bc_obps/reporting/api/report_emission_summary.py
@@ -1,5 +1,4 @@
 from common.permissions import authorize
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.service.emission_category_service import EmissionCategoryService
 from reporting.models import FacilityReport
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -10,7 +9,7 @@ from uuid import UUID
 from reporting.schema.generic import Message
 from reporting.models import EmissionCategory
 from reporting.schema.emission_category import EmissionCategorySchema, EmissionSummarySchemaOut
-
+from reporting.api.permissions import approved_authorized_roles_report_version_composite_auth
 
 ##### GET #####
 
@@ -28,7 +27,7 @@ def get_emission_category(request: HttpRequest) -> Tuple[int, List[EmissionCateg
     "/report-version/{version_id}/facility-report/{facility_id}/emission-summary",
     response={200: EmissionSummarySchemaOut, custom_codes_4xx: Message},
     url_name="get_emission_summary_totals",
-    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
+    auth=approved_authorized_roles_report_version_composite_auth,
 )
 def get_emission_summary_totals(request: HttpRequest, version_id: int, facility_id: UUID) -> Tuple[int, dict]:
     facility_report_id = FacilityReport.objects.get(report_version_id=version_id, facility_id=facility_id).pk
@@ -39,7 +38,7 @@ def get_emission_summary_totals(request: HttpRequest, version_id: int, facility_
     "/report-version/{version_id}/emission-summary",
     response={200: EmissionSummarySchemaOut, custom_codes_4xx: Message},
     url_name="get_operation_emission_summary_totals",
-    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
+    auth=approved_authorized_roles_report_version_composite_auth,
 )
 def get_operation_emission_summary_totals(request: HttpRequest, version_id: int) -> Tuple[int, dict]:
     return 200, EmissionCategoryService.get_operation_emission_summary_form_data(version_id)

--- a/bc_obps/reporting/api/report_facilities.py
+++ b/bc_obps/reporting/api/report_facilities.py
@@ -1,12 +1,11 @@
 from typing import Literal, Tuple
-from common.permissions import authorize
 from django.http import HttpRequest
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from .router import router
 from reporting.service.report_facilities_service import ReportFacilitiesService
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.get(
@@ -14,7 +13,7 @@ from reporting.service.report_facilities_service import ReportFacilitiesService
     response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Fetches the facility list for the operation associated with the given report version ID.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def get_report_facility_list_by_version_id(request: HttpRequest, version_id: int) -> Tuple[Literal[200], dict]:
     response_data = ReportFacilitiesService.get_report_facility_list_by_version_id(version_id)

--- a/bc_obps/reporting/api/report_facilities.py
+++ b/bc_obps/reporting/api/report_facilities.py
@@ -1,6 +1,7 @@
 from typing import Literal, Tuple
 from common.permissions import authorize
 from django.http import HttpRequest
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -13,7 +14,7 @@ from reporting.service.report_facilities_service import ReportFacilitiesService
     response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Fetches the facility list for the operation associated with the given report version ID.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def get_report_facility_list_by_version_id(request: HttpRequest, version_id: int) -> Tuple[Literal[200], dict]:
     response_data = ReportFacilitiesService.get_report_facility_list_by_version_id(version_id)

--- a/bc_obps/reporting/api/report_new_entrant_data.py
+++ b/bc_obps/reporting/api/report_new_entrant_data.py
@@ -3,6 +3,7 @@ from typing import Literal, Tuple
 from django.http import HttpRequest
 
 from common.permissions import authorize
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.schema.generic import Message
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from .router import router
@@ -16,7 +17,7 @@ from ..service.report_new_entrant_service import ReportNewEntrantService
     response={200: ReportNewEntrantDataOut, custom_codes_4xx: Message},
     description="""Retrieves the data for the new entrant data page, including selected products and emissions.""",
     exclude_none=True,
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def get_new_entrant_data(request: HttpRequest, report_version_id: int) -> Tuple[int, dict]:
 
@@ -40,7 +41,7 @@ def get_new_entrant_data(request: HttpRequest, report_version_id: int) -> Tuple[
     response={200: int, custom_codes_4xx: Message},
     tags=["Emissions Report"],
     description="Saves the data for the new entrant report",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def save_new_entrant_data(
     request: HttpRequest,

--- a/bc_obps/reporting/api/report_new_entrant_data.py
+++ b/bc_obps/reporting/api/report_new_entrant_data.py
@@ -2,28 +2,27 @@ from typing import Literal, Tuple
 
 from django.http import HttpRequest
 
-from common.permissions import authorize
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.schema.generic import Message
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from .router import router
 from ..schema.report_new_entrant import ReportNewEntrantDataOut, ReportNewEntrantSchemaIn
 
 from ..service.report_new_entrant_service import ReportNewEntrantService
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.get(
-    "report-version/{report_version_id}/new-entrant-data",
+    "report-version/{version_id}/new-entrant-data",
     response={200: ReportNewEntrantDataOut, custom_codes_4xx: Message},
     description="""Retrieves the data for the new entrant data page, including selected products and emissions.""",
     exclude_none=True,
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
-def get_new_entrant_data(request: HttpRequest, report_version_id: int) -> Tuple[int, dict]:
+def get_new_entrant_data(request: HttpRequest, version_id: int) -> Tuple[int, dict]:
 
-    report_new_entrant = ReportNewEntrantService.get_new_entrant_data(report_version_id=report_version_id)
-    emission_category_data = ReportNewEntrantService.get_emissions_data(report_version_id=report_version_id)
-    production_data = ReportNewEntrantService.get_products_data(report_version_id=report_version_id)
+    report_new_entrant = ReportNewEntrantService.get_new_entrant_data(report_version_id=version_id)
+    emission_category_data = ReportNewEntrantService.get_emissions_data(report_version_id=version_id)
+    production_data = ReportNewEntrantService.get_products_data(report_version_id=version_id)
 
     naics_code_data = report_new_entrant.report_version.report.operation.naics_code if report_new_entrant else None
     naics_code = naics_code_data.naics_code if naics_code_data else None
@@ -37,17 +36,17 @@ def get_new_entrant_data(request: HttpRequest, report_version_id: int) -> Tuple[
 
 
 @router.post(
-    "report-version/{report_version_id}/new-entrant-data",
+    "report-version/{version_id}/new-entrant-data",
     response={200: int, custom_codes_4xx: Message},
     tags=["Emissions Report"],
     description="Saves the data for the new entrant report",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_new_entrant_data(
     request: HttpRequest,
-    report_version_id: int,
+    version_id: int,
     payload: ReportNewEntrantSchemaIn,
 ) -> Literal[200]:
-    ReportNewEntrantService.save_new_entrant_data(report_version_id, payload)
+    ReportNewEntrantService.save_new_entrant_data(version_id, payload)
 
     return 200

--- a/bc_obps/reporting/api/report_non_attributable_emissions.py
+++ b/bc_obps/reporting/api/report_non_attributable_emissions.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from django.http import HttpRequest
 
 from common.permissions import authorize
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -22,7 +23,7 @@ from ..service.report_non_attributable_service import ReportNonAttributableServi
     response={200: List[ReportNonAttributableOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns all non-attributable emissions for that report version.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def get_report_non_attributable_by_version_id(
     request: HttpRequest, version_id: int, facility_id: UUID
@@ -41,7 +42,7 @@ def get_report_non_attributable_by_version_id(
     version. If `emissions_exceeded` is `false`, all existing non-attributable emissions data is deleted for the
     specified version and facility. If `emissions_exceeded` is `true`, the provided non-attributable emissions data
     is saved.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def save_report(
     request: HttpRequest, version_id: int, facility_id: UUID, payload: ReportNonAttributableSchema

--- a/bc_obps/reporting/api/report_non_attributable_emissions.py
+++ b/bc_obps/reporting/api/report_non_attributable_emissions.py
@@ -3,8 +3,6 @@ from uuid import UUID
 
 from django.http import HttpRequest
 
-from common.permissions import authorize
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -16,6 +14,7 @@ from ..schema.report_non_attributable_emissions import (
     ReportNonAttributableSchema,
 )
 from ..service.report_non_attributable_service import ReportNonAttributableService
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.get(
@@ -23,7 +22,7 @@ from ..service.report_non_attributable_service import ReportNonAttributableServi
     response={200: List[ReportNonAttributableOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns all non-attributable emissions for that report version.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def get_report_non_attributable_by_version_id(
     request: HttpRequest, version_id: int, facility_id: UUID
@@ -42,7 +41,7 @@ def get_report_non_attributable_by_version_id(
     version. If `emissions_exceeded` is `false`, all existing non-attributable emissions data is deleted for the
     specified version and facility. If `emissions_exceeded` is `true`, the provided non-attributable emissions data
     is saved.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_report(
     request: HttpRequest, version_id: int, facility_id: UUID, payload: ReportNonAttributableSchema

--- a/bc_obps/reporting/api/report_person_responsible.py
+++ b/bc_obps/reporting/api/report_person_responsible.py
@@ -1,7 +1,5 @@
 from typing import Literal, Optional, Tuple
-from common.permissions import authorize
 from django.http import HttpRequest
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from service.report_person_responsible import ReportContactService
@@ -9,6 +7,7 @@ from service.error_service.custom_codes_4xx import custom_codes_4xx
 from .router import router
 from ..models import ReportPersonResponsible
 from ..schema.report_person_responsible import ReportPersonResponsibleIn, ReportPersonResponsibleOut
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.get(
@@ -16,7 +15,7 @@ from ..schema.report_person_responsible import ReportPersonResponsibleIn, Report
     response={200: Optional[ReportPersonResponsibleOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def get_report_person_responsible_by_version_id(
     request: HttpRequest, version_id: int
@@ -33,7 +32,7 @@ def get_report_person_responsible_by_version_id(
         """Creates or updates a contact associated with a report version.
                     Includes fields like legal name, trade name, operation details, and contact information."""
     ),
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_report_contact(
     request: HttpRequest, version_id: int, payload: ReportPersonResponsibleIn

--- a/bc_obps/reporting/api/report_person_responsible.py
+++ b/bc_obps/reporting/api/report_person_responsible.py
@@ -1,6 +1,7 @@
 from typing import Literal, Optional, Tuple
 from common.permissions import authorize
 from django.http import HttpRequest
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from service.report_person_responsible import ReportContactService
@@ -15,7 +16,7 @@ from ..schema.report_person_responsible import ReportPersonResponsibleIn, Report
     response={200: Optional[ReportPersonResponsibleOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def get_report_person_responsible_by_version_id(
     request: HttpRequest, version_id: int
@@ -32,7 +33,7 @@ def get_report_person_responsible_by_version_id(
         """Creates or updates a contact associated with a report version.
                     Includes fields like legal name, trade name, operation details, and contact information."""
     ),
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def save_report_contact(
     request: HttpRequest, version_id: int, payload: ReportPersonResponsibleIn

--- a/bc_obps/reporting/api/report_review_facilties.py
+++ b/bc_obps/reporting/api/report_review_facilties.py
@@ -2,6 +2,7 @@ from typing import Literal
 from uuid import UUID
 
 from common.permissions import authorize
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from django.http import HttpRequest
@@ -17,7 +18,7 @@ from ..service.report_facilities_service import ReportFacilitiesService
     tags=EMISSIONS_REPORT_TAGS,
     description="""Retrieves the list of selected facilities for a report version""",
     exclude_none=True,
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def get_selected_facilities(request: HttpRequest, report_version_id: int) -> tuple[int, dict]:
     response_data = ReportFacilitiesService.get_all_facilities_for_review(report_version_id)
@@ -29,7 +30,7 @@ def get_selected_facilities(request: HttpRequest, report_version_id: int) -> tup
     response={200: int, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Saves the list of selected facilities for a report version""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def save_selected_facilities(
     request: HttpRequest,

--- a/bc_obps/reporting/api/report_review_facilties.py
+++ b/bc_obps/reporting/api/report_review_facilties.py
@@ -1,8 +1,6 @@
 from typing import Literal
 from uuid import UUID
 
-from common.permissions import authorize
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from django.http import HttpRequest
@@ -10,35 +8,36 @@ from reporting.schema.generic import Message
 from .router import router
 from ..schema.report_review_facility import ReportReviewFacilitySchemaOut
 from ..service.report_facilities_service import ReportFacilitiesService
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.get(
-    "report-version/{report_version_id}/review-facilities",
+    "report-version/{version_id}/review-facilities",
     response={200: ReportReviewFacilitySchemaOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Retrieves the list of selected facilities for a report version""",
     exclude_none=True,
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
-def get_selected_facilities(request: HttpRequest, report_version_id: int) -> tuple[int, dict]:
-    response_data = ReportFacilitiesService.get_all_facilities_for_review(report_version_id)
+def get_selected_facilities(request: HttpRequest, version_id: int) -> tuple[int, dict]:
+    response_data = ReportFacilitiesService.get_all_facilities_for_review(version_id)
     return 200, response_data
 
 
 @router.post(
-    "report-version/{report_version_id}/review-facilities",
+    "report-version/{version_id}/review-facilities",
     response={200: int, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Saves the list of selected facilities for a report version""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_selected_facilities(
     request: HttpRequest,
-    report_version_id: int,
+    version_id: int,
     payload: list[UUID],
 ) -> Literal[200]:
     ReportFacilitiesService.save_selected_facilities(
-        report_version_id,
+        version_id,
         payload,
     )
 

--- a/bc_obps/reporting/api/report_supplementary_version.py
+++ b/bc_obps/reporting/api/report_supplementary_version.py
@@ -1,6 +1,7 @@
 from typing import Literal, Tuple
 from common.permissions import authorize
 from django.http import HttpRequest
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from reporting.service.report_supplementary_version_service import ReportSupplementaryVersionService
@@ -14,7 +15,7 @@ from .router import router
     tags=EMISSIONS_REPORT_TAGS,
     description="""Creates a new supplementary report version based on an existing submitted report version.
     This endpoint allows the creation of a new draft version of a previously submitted emissions report.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def create_report_supplementary_version(request: HttpRequest, report_version_id: int) -> Tuple[Literal[201], int]:
     report_version = ReportSupplementaryVersionService.create_report_supplementary_version(report_version_id)

--- a/bc_obps/reporting/api/report_supplementary_version.py
+++ b/bc_obps/reporting/api/report_supplementary_version.py
@@ -1,22 +1,21 @@
 from typing import Literal, Tuple
-from common.permissions import authorize
 from django.http import HttpRequest
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from reporting.service.report_supplementary_version_service import ReportSupplementaryVersionService
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from .router import router
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.post(
-    "/report-version/{report_version_id}/create-report-supplementary-version",
+    "/report-version/{version_id}/create-report-supplementary-version",
     response={201: int, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Creates a new supplementary report version based on an existing submitted report version.
     This endpoint allows the creation of a new draft version of a previously submitted emissions report.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
-def create_report_supplementary_version(request: HttpRequest, report_version_id: int) -> Tuple[Literal[201], int]:
-    report_version = ReportSupplementaryVersionService.create_report_supplementary_version(report_version_id)
+def create_report_supplementary_version(request: HttpRequest, version_id: int) -> Tuple[Literal[201], int]:
+    report_version = ReportSupplementaryVersionService.create_report_supplementary_version(version_id)
     return 201, report_version.id

--- a/bc_obps/reporting/api/report_verification.py
+++ b/bc_obps/reporting/api/report_verification.py
@@ -1,4 +1,5 @@
 from typing import Literal, Optional
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.models.report_verification import ReportVerification
 from common.permissions import authorize
 from django.http import HttpRequest
@@ -15,7 +16,7 @@ from reporting.service.report_verification_service import ReportVerificationServ
     response={200: Optional[ReportVerificationOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Fetches the Verification data associated with the given report version ID.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def get_report_verification_by_version_id(
     request: HttpRequest, report_version_id: int
@@ -28,7 +29,7 @@ def get_report_verification_by_version_id(
     response={200: bool, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Checks if a report needs verification data based on its purpose and attributable emissions.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def get_report_needs_verification(request: HttpRequest, report_version_id: int) -> tuple[Literal[200], bool]:
     return 200, ReportVerificationService.get_report_needs_verification(report_version_id)
@@ -39,7 +40,7 @@ def get_report_needs_verification(request: HttpRequest, report_version_id: int) 
     response={200: ReportVerificationOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Creates or updates the Verification data for the given report version ID.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
 )
 def save_report_verification(
     request: HttpRequest, report_version_id: int, payload: ReportVerificationIn

--- a/bc_obps/reporting/api/report_verification.py
+++ b/bc_obps/reporting/api/report_verification.py
@@ -1,7 +1,5 @@
 from typing import Literal, Optional
-from reporting.api.permissions import check_version_ownership_in_url
 from reporting.models.report_verification import ReportVerification
-from common.permissions import authorize
 from django.http import HttpRequest
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
@@ -9,41 +7,42 @@ from service.error_service.custom_codes_4xx import custom_codes_4xx
 from .router import router
 from reporting.schema.report_verification import ReportVerificationIn, ReportVerificationOut
 from reporting.service.report_verification_service import ReportVerificationService
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 
 
 @router.get(
-    "/report-version/{report_version_id}/report-verification",
+    "/report-version/{version_id}/report-verification",
     response={200: Optional[ReportVerificationOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Fetches the Verification data associated with the given report version ID.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def get_report_verification_by_version_id(
-    request: HttpRequest, report_version_id: int
+    request: HttpRequest, version_id: int
 ) -> tuple[Literal[200], Optional[ReportVerification]]:
-    return 200, ReportVerificationService.get_report_verification_by_version_id(report_version_id)
+    return 200, ReportVerificationService.get_report_verification_by_version_id(version_id)
 
 
 @router.get(
-    "/report-version/{report_version_id}/report-needs-verification",
+    "/report-version/{version_id}/report-needs-verification",
     response={200: bool, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Checks if a report needs verification data based on its purpose and attributable emissions.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
-def get_report_needs_verification(request: HttpRequest, report_version_id: int) -> tuple[Literal[200], bool]:
-    return 200, ReportVerificationService.get_report_needs_verification(report_version_id)
+def get_report_needs_verification(request: HttpRequest, version_id: int) -> tuple[Literal[200], bool]:
+    return 200, ReportVerificationService.get_report_needs_verification(version_id)
 
 
 @router.post(
-    "/report-version/{report_version_id}/report-verification",
+    "/report-version/{version_id}/report-verification",
     response={200: ReportVerificationOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Creates or updates the Verification data for the given report version ID.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("report_version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_report_verification(
-    request: HttpRequest, report_version_id: int, payload: ReportVerificationIn
+    request: HttpRequest, version_id: int, payload: ReportVerificationIn
 ) -> tuple[Literal[200], ReportVerification]:
-    report_verification = ReportVerificationService.save_report_verification(report_version_id, payload)
+    report_verification = ReportVerificationService.save_report_verification(version_id, payload)
     return 200, report_verification

--- a/bc_obps/reporting/api/reports.py
+++ b/bc_obps/reporting/api/reports.py
@@ -5,7 +5,7 @@ from django.db.models import QuerySet
 from common.permissions import authorize
 from django.http import HttpRequest
 from registration.models import RegulatedProduct
-from reporting.api.permissions import validate_operation_ownership_from_payload, validate_version_ownership_from_url
+from reporting.api.permissions import check_operation_ownership, check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from reporting.schema.report import StartReportIn
@@ -28,7 +28,7 @@ from ..schema.report_version import ReportVersionTypeIn, ReportingVersionOut
     description="""Starts a report for a given operation and reporting year, by creating the underlying data structures and
     pre-populating them with facility, operation and operator information. Returns the id of the report that was created.
     This endpoint only allows the creation of a report for an operation / operator to which the current user has access.""",
-    auth=authorize("approved_industry_user", validate_operation_ownership_from_payload()),
+    auth=authorize("approved_industry_user", check_operation_ownership()),
 )
 def start_report(request: HttpRequest, payload: StartReportIn) -> Tuple[Literal[201], int]:
     report_version_id = ReportService.create_report(payload.operation_id, payload.reporting_year)
@@ -40,7 +40,7 @@ def start_report(request: HttpRequest, payload: StartReportIn) -> Tuple[Literal[
     response={200: ReportOperationSchemaOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
-    auth=authorize("approved_authorized_roles", validate_version_ownership_from_url("version_id")),
+    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
 )
 def get_report_operation_by_version_id(request: HttpRequest, version_id: int) -> dict:
     report_service = ReportService.get_report_operation_by_version_id(version_id)
@@ -53,7 +53,7 @@ def get_report_operation_by_version_id(request: HttpRequest, version_id: int) ->
     tags=EMISSIONS_REPORT_TAGS,
     description="""Updates given report operation with fields: Operator Legal Name, Operator Trade Name, Operation Name, Operation Type,
     Operation BC GHG ID, BC OBPS Regulated Operation ID, Operation Representative Name, and Activities.""",
-    auth=authorize("approved_industry_user", validate_version_ownership_from_url("version_id")),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def save_report(
     request: HttpRequest, version_id: int, payload: ReportOperationIn
@@ -68,7 +68,7 @@ def save_report(
     tags=EMISSIONS_REPORT_TAGS,
     description="""Changes the report type of a report version. This operation deletes the report version, including all existing data associated with that report version,
     and returns the id of a newly initialized report version.""",
-    auth=authorize("approved_industry_user", validate_version_ownership_from_url("version_id")),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def change_report_version_type(
     request: HttpRequest, version_id: int, payload: ReportVersionTypeIn
@@ -93,7 +93,7 @@ def get_reporting_year(request: HttpRequest) -> Tuple[Literal[200], ReportingYea
     response={200: List[RegulatedProductOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Retrieves all regulated products associated with a report operation identified by its version ID.""",
-    auth=authorize("approved_industry_user", validate_version_ownership_from_url("version_id")),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def get_regulated_products_by_version_id(
     request: HttpRequest, version_id: int
@@ -107,7 +107,7 @@ def get_regulated_products_by_version_id(
     response={200: ReportingVersionOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="Retrieve the report type for a specific reporting version, including the reporting year and due date.",
-    auth=authorize("approved_industry_user", validate_version_ownership_from_url("version_id")),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def get_report_type_by_version(request: HttpRequest, version_id: int) -> tuple[Literal[200], ReportVersion]:
     report_type = ReportService.get_report_type_by_version_id(version_id)
@@ -119,7 +119,7 @@ def get_report_type_by_version(request: HttpRequest, version_id: int) -> tuple[L
     response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Fetches the registration purpose for the operation associated with the given report version ID.""",
-    auth=authorize("approved_industry_user", validate_version_ownership_from_url("version_id")),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def get_registration_purpose_by_version_id(request: HttpRequest, version_id: int) -> Tuple[Literal[200], dict]:
     response_data = ReportService.get_registration_purpose_by_version_id(version_id)

--- a/bc_obps/reporting/api/reports.py
+++ b/bc_obps/reporting/api/reports.py
@@ -5,6 +5,7 @@ from django.db.models import QuerySet
 from common.permissions import authorize
 from django.http import HttpRequest
 from registration.models import RegulatedProduct
+from reporting.api.permissions import validate_operation_ownership_from_payload, validate_version_ownership_from_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from reporting.schema.report import StartReportIn
@@ -27,7 +28,7 @@ from ..schema.report_version import ReportVersionTypeIn, ReportingVersionOut
     description="""Starts a report for a given operation and reporting year, by creating the underlying data structures and
     pre-populating them with facility, operation and operator information. Returns the id of the report that was created.
     This endpoint only allows the creation of a report for an operation / operator to which the current user has access.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", validate_operation_ownership_from_payload()),
 )
 def start_report(request: HttpRequest, payload: StartReportIn) -> Tuple[Literal[201], int]:
     report_version_id = ReportService.create_report(payload.operation_id, payload.reporting_year)
@@ -39,7 +40,7 @@ def start_report(request: HttpRequest, payload: StartReportIn) -> Tuple[Literal[
     response={200: ReportOperationSchemaOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
-    auth=authorize("approved_authorized_roles"),
+    auth=authorize("approved_authorized_roles", validate_version_ownership_from_url("version_id")),
 )
 def get_report_operation_by_version_id(request: HttpRequest, version_id: int) -> dict:
     report_service = ReportService.get_report_operation_by_version_id(version_id)
@@ -52,7 +53,7 @@ def get_report_operation_by_version_id(request: HttpRequest, version_id: int) ->
     tags=EMISSIONS_REPORT_TAGS,
     description="""Updates given report operation with fields: Operator Legal Name, Operator Trade Name, Operation Name, Operation Type,
     Operation BC GHG ID, BC OBPS Regulated Operation ID, Operation Representative Name, and Activities.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", validate_version_ownership_from_url("version_id")),
 )
 def save_report(
     request: HttpRequest, version_id: int, payload: ReportOperationIn
@@ -67,7 +68,7 @@ def save_report(
     tags=EMISSIONS_REPORT_TAGS,
     description="""Changes the report type of a report version. This operation deletes the report version, including all existing data associated with that report version,
     and returns the id of a newly initialized report version.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", validate_version_ownership_from_url("version_id")),
 )
 def change_report_version_type(
     request: HttpRequest, version_id: int, payload: ReportVersionTypeIn
@@ -92,7 +93,7 @@ def get_reporting_year(request: HttpRequest) -> Tuple[Literal[200], ReportingYea
     response={200: List[RegulatedProductOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Retrieves all regulated products associated with a report operation identified by its version ID.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", validate_version_ownership_from_url("version_id")),
 )
 def get_regulated_products_by_version_id(
     request: HttpRequest, version_id: int
@@ -106,7 +107,7 @@ def get_regulated_products_by_version_id(
     response={200: ReportingVersionOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="Retrieve the report type for a specific reporting version, including the reporting year and due date.",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", validate_version_ownership_from_url("version_id")),
 )
 def get_report_type_by_version(request: HttpRequest, version_id: int) -> tuple[Literal[200], ReportVersion]:
     report_type = ReportService.get_report_type_by_version_id(version_id)
@@ -118,7 +119,7 @@ def get_report_type_by_version(request: HttpRequest, version_id: int) -> tuple[L
     response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Fetches the registration purpose for the operation associated with the given report version ID.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", validate_version_ownership_from_url("version_id")),
 )
 def get_registration_purpose_by_version_id(request: HttpRequest, version_id: int) -> Tuple[Literal[200], dict]:
     response_data = ReportService.get_registration_purpose_by_version_id(version_id)

--- a/bc_obps/reporting/api/reports.py
+++ b/bc_obps/reporting/api/reports.py
@@ -2,10 +2,10 @@ from typing import Literal, Tuple, List
 
 from django.db.models import QuerySet
 
-from common.permissions import authorize
+from common.permissions import authorize, compose_auth
 from django.http import HttpRequest
 from registration.models import RegulatedProduct
-from reporting.api.permissions import check_operation_ownership, check_version_ownership_in_url
+from reporting.api.permissions import check_operation_ownership
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from reporting.schema.report import StartReportIn
@@ -19,6 +19,10 @@ from .router import router
 from ..schema.report_regulated_products import RegulatedProductOut
 from ..models import ReportingYear, ReportVersion
 from ..schema.report_version import ReportVersionTypeIn, ReportingVersionOut
+from reporting.api.permissions import (
+    approved_industry_user_report_version_composite_auth,
+    approved_authorized_roles_report_version_composite_auth,
+)
 
 
 @router.post(
@@ -28,7 +32,7 @@ from ..schema.report_version import ReportVersionTypeIn, ReportingVersionOut
     description="""Starts a report for a given operation and reporting year, by creating the underlying data structures and
     pre-populating them with facility, operation and operator information. Returns the id of the report that was created.
     This endpoint only allows the creation of a report for an operation / operator to which the current user has access.""",
-    auth=authorize("approved_industry_user", check_operation_ownership()),
+    auth=compose_auth(authorize("approved_industry_user"), check_operation_ownership()),
 )
 def start_report(request: HttpRequest, payload: StartReportIn) -> Tuple[Literal[201], int]:
     report_version_id = ReportService.create_report(payload.operation_id, payload.reporting_year)
@@ -40,7 +44,7 @@ def start_report(request: HttpRequest, payload: StartReportIn) -> Tuple[Literal[
     response={200: ReportOperationSchemaOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
-    auth=authorize("approved_authorized_roles", check_version_ownership_in_url("version_id")),
+    auth=approved_authorized_roles_report_version_composite_auth,
 )
 def get_report_operation_by_version_id(request: HttpRequest, version_id: int) -> dict:
     report_service = ReportService.get_report_operation_by_version_id(version_id)
@@ -53,7 +57,7 @@ def get_report_operation_by_version_id(request: HttpRequest, version_id: int) ->
     tags=EMISSIONS_REPORT_TAGS,
     description="""Updates given report operation with fields: Operator Legal Name, Operator Trade Name, Operation Name, Operation Type,
     Operation BC GHG ID, BC OBPS Regulated Operation ID, Operation Representative Name, and Activities.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def save_report(
     request: HttpRequest, version_id: int, payload: ReportOperationIn
@@ -68,7 +72,7 @@ def save_report(
     tags=EMISSIONS_REPORT_TAGS,
     description="""Changes the report type of a report version. This operation deletes the report version, including all existing data associated with that report version,
     and returns the id of a newly initialized report version.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def change_report_version_type(
     request: HttpRequest, version_id: int, payload: ReportVersionTypeIn
@@ -93,7 +97,7 @@ def get_reporting_year(request: HttpRequest) -> Tuple[Literal[200], ReportingYea
     response={200: List[RegulatedProductOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Retrieves all regulated products associated with a report operation identified by its version ID.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def get_regulated_products_by_version_id(
     request: HttpRequest, version_id: int
@@ -107,7 +111,7 @@ def get_regulated_products_by_version_id(
     response={200: ReportingVersionOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="Retrieve the report type for a specific reporting version, including the reporting year and due date.",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def get_report_type_by_version(request: HttpRequest, version_id: int) -> tuple[Literal[200], ReportVersion]:
     report_type = ReportService.get_report_type_by_version_id(version_id)
@@ -119,7 +123,7 @@ def get_report_type_by_version(request: HttpRequest, version_id: int) -> tuple[L
     response={200: dict, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Fetches the registration purpose for the operation associated with the given report version ID.""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def get_registration_purpose_by_version_id(request: HttpRequest, version_id: int) -> Tuple[Literal[200], dict]:
     response_data = ReportService.get_registration_purpose_by_version_id(version_id)

--- a/bc_obps/reporting/api/submit.py
+++ b/bc_obps/reporting/api/submit.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 from reporting.schema.report_sign_off import ReportSignOffIn
 from common.api.utils.current_user_utils import get_current_user_guid
-from common.permissions import authorize
 from django.http import HttpRequest
-from reporting.api.permissions import check_version_ownership_in_url
+from reporting.api.permissions import approved_industry_user_report_version_composite_auth
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from reporting.service.report_submission_service import ReportSubmissionService
@@ -16,7 +15,7 @@ from .router import router
     response={200: int, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Submits a report version""",
-    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
+    auth=approved_industry_user_report_version_composite_auth,
 )
 def submit_report_version(request: HttpRequest, version_id: int, payload: ReportSignOffIn) -> int:
     user_guid: UUID = get_current_user_guid(request)

--- a/bc_obps/reporting/api/submit.py
+++ b/bc_obps/reporting/api/submit.py
@@ -3,6 +3,7 @@ from reporting.schema.report_sign_off import ReportSignOffIn
 from common.api.utils.current_user_utils import get_current_user_guid
 from common.permissions import authorize
 from django.http import HttpRequest
+from reporting.api.permissions import check_version_ownership_in_url
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from reporting.service.report_submission_service import ReportSubmissionService
@@ -15,7 +16,7 @@ from .router import router
     response={200: int, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Submits a report version""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_industry_user", check_version_ownership_in_url("version_id")),
 )
 def submit_report_version(request: HttpRequest, version_id: int, payload: ReportSignOffIn) -> int:
     user_guid: UUID = get_current_user_guid(request)

--- a/bc_obps/reporting/tests/api/test_compliance_data_api.py
+++ b/bc_obps/reporting/tests/api/test_compliance_data_api.py
@@ -1,0 +1,9 @@
+from registration.tests.utils.helpers import CommonTestSetup
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
+
+
+class TestComplianceDataEndpoints(CommonTestSetup):
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated(
+            "get_compliance_summary_data", version_id_param_name="report_version_id"
+        )

--- a/bc_obps/reporting/tests/api/test_compliance_data_api.py
+++ b/bc_obps/reporting/tests/api/test_compliance_data_api.py
@@ -4,6 +4,4 @@ from reporting.tests.utils.report_access_validation import assert_report_version
 
 class TestComplianceDataEndpoints(CommonTestSetup):
     def test_validates_report_version_id(self):
-        assert_report_version_ownership_is_validated(
-            "get_compliance_summary_data", version_id_param_name="report_version_id"
-        )
+        assert_report_version_ownership_is_validated("get_compliance_summary_data")

--- a/bc_obps/reporting/tests/api/test_facility_report_api.py
+++ b/bc_obps/reporting/tests/api/test_facility_report_api.py
@@ -6,6 +6,7 @@ from registration.models import Activity
 from model_bakery import baker
 
 from reporting.schema.facility_report import FacilityReportListInSchema
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestFacilityReportEndpoints(CommonTestSetup):
@@ -17,7 +18,7 @@ class TestFacilityReportEndpoints(CommonTestSetup):
         facility_report = baker.make_recipe('reporting.tests.utils.facility_report')
         TestUtils.authorize_current_user_as_operator_user(self, operator=facility_report.report_version.report.operator)
 
-        endpoint_under_test = '/api/reporting/report-version/9999/facility-report/00000000-0000-0000-0000-000000000000'
+        endpoint_under_test = f'/api/reporting/report-version/{facility_report.report_version.id}/facility-report/00000000-0000-0000-0000-000000000000'
         response = TestUtils.mock_get_with_auth_role(self, 'cas_admin', endpoint_under_test)
 
         assert response.status_code == 404
@@ -108,3 +109,12 @@ class TestFacilityReportEndpoints(CommonTestSetup):
                 FacilityReportListInSchema(facility=facility_id_2, is_completed=False),
             ],
         )
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated("get_facility_report_form_data", facility_id="uuid")
+        assert_report_version_ownership_is_validated("get_ordered_facility_report_activities", facility_id="uuid")
+        assert_report_version_ownership_is_validated("save_facility_report", method="post", facility_id="uuid")
+
+        assert_report_version_ownership_is_validated("get_facility_report_by_version_id")
+        assert_report_version_ownership_is_validated("get_facility_report_list")
+        assert_report_version_ownership_is_validated("save_facility_report_list", method="patch")

--- a/bc_obps/reporting/tests/api/test_fuel.py
+++ b/bc_obps/reporting/tests/api/test_fuel.py
@@ -1,22 +1,23 @@
 from django.test import Client
 import pytest
+from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 
 pytestmark = pytest.mark.django_db
 client = Client()
-pytest.endpoint = "/api/reporting/fuel"
+endpoint = "/api/reporting/fuel"
 
 
-class TestActivityData:
+class TestFuelEndpoint(CommonTestSetup):
     def test_invalid_without_fuel_name(self):
-        response = client.get(f'{pytest.endpoint}')
+        response = TestUtils.mock_get_with_auth_role(self, 'cas_admin', endpoint)
         assert response.status_code == 422
 
     def test_invalid_fuel(self):
-        response = client.get(f'{pytest.endpoint}?fuel_name=non-existent')
+        response = TestUtils.mock_get_with_auth_role(self, 'cas_admin', f'{endpoint}?fuel_name=non-existent')
         assert response.status_code == 404
 
     def test_returns_fuel_data(self):
-        response = client.get('/api/reporting/fuel?fuel_name=Acetylene')
+        response = TestUtils.mock_get_with_auth_role(self, 'cas_admin', '/api/reporting/fuel?fuel_name=Acetylene')
         assert response.status_code == 200
         assert response.json().get('name') == 'Acetylene'
         assert response.json().get('classification') == 'Exempted Non-biomass'

--- a/bc_obps/reporting/tests/api/test_fuel.py
+++ b/bc_obps/reporting/tests/api/test_fuel.py
@@ -1,9 +1,5 @@
-from django.test import Client
-import pytest
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 
-pytestmark = pytest.mark.django_db
-client = Client()
 endpoint = "/api/reporting/fuel"
 
 

--- a/bc_obps/reporting/tests/api/test_permissions.py
+++ b/bc_obps/reporting/tests/api/test_permissions.py
@@ -1,0 +1,135 @@
+from unittest.mock import MagicMock
+from model_bakery.baker import make_recipe
+import pytest
+from reporting.api.permissions import (
+    validate_operation_ownership_from_payload,
+    validate_version_ownership_from_url,
+)
+
+
+pytestmark = pytest.mark.django_db
+
+role_status_access_tuples = [
+    ("pending", "Approved", False),
+    ("pending", "Pending", False),
+    ("pending", "Declined", False),
+    ("admin", "Pending", False),
+    ("admin", "Declined", False),
+    ("reporter", "Pending", False),
+    ("reporter", "Pending", False),
+    ("admin", "Approved", True),
+    ("reporter", "Approved", True),
+]
+
+
+class TestVersionOwnershipFromUrl:
+    @pytest.mark.parametrize("role,status,expected_validity", role_status_access_tuples)
+    def test_version_ownership_from_url(self, role, status, expected_validity):
+        user_operator = make_recipe("registration.tests.utils.user_operator", role=role, status=status)
+        report_version = make_recipe(
+            "reporting.tests.utils.report_version",
+            report__operator=user_operator.operator,
+        )
+
+        validator_under_test = validate_version_ownership_from_url("test_id")
+
+        mock_request = MagicMock()
+        mock_request.resolver_match.kwargs = {"test_id": report_version.id}
+        mock_request.current_user = user_operator.user
+
+        is_valid = validator_under_test(mock_request)
+
+        assert is_valid == expected_validity
+
+    def test_version_ownership_from_url_denies_access_if_no_user_operator_record(self):
+        report_version = make_recipe("reporting.tests.utils.report_version")
+        user = make_recipe("registration.tests.utils.industry_operator_user")
+
+        validator_under_test = validate_version_ownership_from_url("test_id")
+
+        mock_request = MagicMock()
+        mock_request.resolver_match.kwargs = {"test_id": report_version.id}
+        mock_request.current_user = user
+
+        is_valid = validator_under_test(mock_request)
+
+        assert not is_valid
+
+    def test_version_ownership_from_url_denies_access_if_wrong_url_parameter_name(self):
+        user_operator = make_recipe("registration.tests.utils.user_operator", role="admin", status="Approved")
+        report_version = make_recipe(
+            "reporting.tests.utils.report_version",
+            report__operator=user_operator.operator,
+        )
+
+        validator_under_test = validate_version_ownership_from_url("test_id")
+
+        mock_request = MagicMock()
+        mock_request.resolver_match.kwargs = {"another_id": report_version.id}
+        mock_request.current_user = user_operator.user
+
+        is_valid = validator_under_test(mock_request)
+
+        assert not is_valid
+
+    def test_version_ownership_from_url_denies_access_if_no_version_in_url(self):
+        user_operator = make_recipe("registration.tests.utils.user_operator", role="admin", status="Approved")
+        make_recipe(
+            "reporting.tests.utils.report_version",
+            report__operator=user_operator.operator,
+        )
+
+        validator_under_test = validate_version_ownership_from_url("test_id")
+
+        mock_request = MagicMock()
+        mock_request.resolver_match.kwargs = {}
+        mock_request.current_user = user_operator.user
+
+        is_valid = validator_under_test(mock_request)
+
+        assert not is_valid
+
+
+class TestOperationOwnershipFromPayload:
+    @pytest.mark.parametrize("role,status,expected_validity", role_status_access_tuples)
+    def test_operation_ownership_from_payload(self, role, status, expected_validity):
+        user_operator = make_recipe("registration.tests.utils.user_operator", role=role, status=status)
+        operation = make_recipe("registration.tests.utils.operation", operator=user_operator.operator)
+
+        validator_under_test = validate_operation_ownership_from_payload()
+
+        mock_request = MagicMock()
+        mock_request.body = f'{{"operation_id": "{operation.id}"}}'
+        mock_request.current_user = user_operator.user
+
+        is_valid = validator_under_test(mock_request)
+
+        assert is_valid == expected_validity
+
+    def test_operation_ownership_from_payload_denies_if_no_user_operator_record(self):
+        operation = make_recipe("registration.tests.utils.operation")
+        user = make_recipe("registration.tests.utils.industry_operator_user")
+
+        validator_under_test = validate_operation_ownership_from_payload()
+
+        mock_request = MagicMock()
+        mock_request.body = f'{{"operation_id": "{operation.id}"}}'
+        mock_request.current_user = user
+
+        is_valid = validator_under_test(mock_request)
+
+        assert not is_valid
+
+    def test_operation_ownership_from_payload_denies_access_if_missing_field_in_payload(self):
+        user_operator = make_recipe("registration.tests.utils.user_operator", role="admin", status="Approved")
+        operation = make_recipe("registration.tests.utils.operation", operator=user_operator.operator)
+
+        validator_under_test = validate_operation_ownership_from_payload()
+
+        mock_request = MagicMock()
+        mock_request.body = f'{{"some_other_payload": "{operation.id}"}}'
+        mock_request.current_user = user_operator.user
+
+        is_valid = validator_under_test(mock_request)
+
+        assert not is_valid

--- a/bc_obps/reporting/tests/api/test_permissions.py
+++ b/bc_obps/reporting/tests/api/test_permissions.py
@@ -2,8 +2,8 @@ from unittest.mock import MagicMock
 from model_bakery.baker import make_recipe
 import pytest
 from reporting.api.permissions import (
-    validate_operation_ownership_from_payload,
-    validate_version_ownership_from_url,
+    check_operation_ownership,
+    check_version_ownership_in_url,
 )
 
 
@@ -31,7 +31,7 @@ class TestVersionOwnershipFromUrl:
             report__operator=user_operator.operator,
         )
 
-        validator_under_test = validate_version_ownership_from_url("test_id")
+        validator_under_test = check_version_ownership_in_url("test_id")
 
         mock_request = MagicMock()
         mock_request.resolver_match.kwargs = {"test_id": report_version.id}
@@ -45,7 +45,7 @@ class TestVersionOwnershipFromUrl:
         report_version = make_recipe("reporting.tests.utils.report_version")
         user = make_recipe("registration.tests.utils.industry_operator_user")
 
-        validator_under_test = validate_version_ownership_from_url("test_id")
+        validator_under_test = check_version_ownership_in_url("test_id")
 
         mock_request = MagicMock()
         mock_request.resolver_match.kwargs = {"test_id": report_version.id}
@@ -62,7 +62,7 @@ class TestVersionOwnershipFromUrl:
             report__operator=user_operator.operator,
         )
 
-        validator_under_test = validate_version_ownership_from_url("test_id")
+        validator_under_test = check_version_ownership_in_url("test_id")
 
         mock_request = MagicMock()
         mock_request.resolver_match.kwargs = {"another_id": report_version.id}
@@ -79,7 +79,7 @@ class TestVersionOwnershipFromUrl:
             report__operator=user_operator.operator,
         )
 
-        validator_under_test = validate_version_ownership_from_url("test_id")
+        validator_under_test = check_version_ownership_in_url("test_id")
 
         mock_request = MagicMock()
         mock_request.resolver_match.kwargs = {}
@@ -96,7 +96,7 @@ class TestOperationOwnershipFromPayload:
         user_operator = make_recipe("registration.tests.utils.user_operator", role=role, status=status)
         operation = make_recipe("registration.tests.utils.operation", operator=user_operator.operator)
 
-        validator_under_test = validate_operation_ownership_from_payload()
+        validator_under_test = check_operation_ownership()
 
         mock_request = MagicMock()
         mock_request.body = f'{{"operation_id": "{operation.id}"}}'
@@ -110,7 +110,7 @@ class TestOperationOwnershipFromPayload:
         operation = make_recipe("registration.tests.utils.operation")
         user = make_recipe("registration.tests.utils.industry_operator_user")
 
-        validator_under_test = validate_operation_ownership_from_payload()
+        validator_under_test = check_operation_ownership()
 
         mock_request = MagicMock()
         mock_request.body = f'{{"operation_id": "{operation.id}"}}'
@@ -124,7 +124,7 @@ class TestOperationOwnershipFromPayload:
         user_operator = make_recipe("registration.tests.utils.user_operator", role="admin", status="Approved")
         operation = make_recipe("registration.tests.utils.operation", operator=user_operator.operator)
 
-        validator_under_test = validate_operation_ownership_from_payload()
+        validator_under_test = check_operation_ownership()
 
         mock_request = MagicMock()
         mock_request.body = f'{{"some_other_payload": "{operation.id}"}}'

--- a/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
@@ -26,7 +26,7 @@ class TestReportActivityEndpoint(CommonTestSetup):
         self.endpoint = custom_reverse_lazy(
             "save_report_activity_data",
             kwargs={
-                "report_version_id": self.facility_report.report_version.id,
+                "version_id": self.facility_report.report_version.id,
                 "facility_id": self.facility_report.facility.id,
                 "activity_id": self.activity.id,
             },
@@ -177,13 +177,10 @@ class TestReportActivityEndpoint(CommonTestSetup):
         }
 
     def test_validates_report_version_id(self):
-        assert_report_version_ownership_is_validated(
-            "load_report_activity_data", version_id_param_name="report_version_id", facility_id="uuid", activity_id=0
-        )
+        assert_report_version_ownership_is_validated("load_report_activity_data", facility_id="uuid", activity_id=0)
         assert_report_version_ownership_is_validated(
             "save_report_activity_data",
             method="post",
-            version_id_param_name="report_version_id",
             facility_id="uuid",
             activity_id=0,
         )

--- a/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_activity_endpoint.py
@@ -5,6 +5,7 @@ from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from model_bakery.baker import make_recipe
 
 from registration.utils import custom_reverse_lazy
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestReportActivityEndpoint(CommonTestSetup):
@@ -174,3 +175,15 @@ class TestReportActivityEndpoint(CommonTestSetup):
                 }
             },
         }
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated(
+            "load_report_activity_data", version_id_param_name="report_version_id", facility_id="uuid", activity_id=0
+        )
+        assert_report_version_ownership_is_validated(
+            "save_report_activity_data",
+            method="post",
+            version_id_param_name="report_version_id",
+            facility_id="uuid",
+            activity_id=0,
+        )

--- a/bc_obps/reporting/tests/api/test_report_additional_data_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_additional_data_endpoint.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.utils import custom_reverse_lazy
 from reporting.schema.report_additional_data import ReportAdditionalDataIn
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestReportAdditionalDataApi(CommonTestSetup):
@@ -87,3 +88,9 @@ class TestReportAdditionalDataApi(CommonTestSetup):
 
         assert response.status_code == 200
         mock_get_report_additional_data.assert_called_once_with(self.report_version.id)
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated(
+            "get_report_additional_data_by_version_id", version_id_param_name="report_version_id"
+        )
+        assert_report_version_ownership_is_validated("save_report_additional_data", method="post")

--- a/bc_obps/reporting/tests/api/test_report_additional_data_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_additional_data_endpoint.py
@@ -82,7 +82,7 @@ class TestReportAdditionalDataApi(CommonTestSetup):
             "industry_user",
             custom_reverse_lazy(
                 "get_report_additional_data_by_version_id",
-                kwargs={"report_version_id": self.report_version.id},
+                kwargs={"version_id": self.report_version.id},
             ),
         )
 
@@ -90,7 +90,5 @@ class TestReportAdditionalDataApi(CommonTestSetup):
         mock_get_report_additional_data.assert_called_once_with(self.report_version.id)
 
     def test_validates_report_version_id(self):
-        assert_report_version_ownership_is_validated(
-            "get_report_additional_data_by_version_id", version_id_param_name="report_version_id"
-        )
+        assert_report_version_ownership_is_validated("get_report_additional_data_by_version_id")
         assert_report_version_ownership_is_validated("save_report_additional_data", method="post")

--- a/bc_obps/reporting/tests/api/test_report_attachment_api.py
+++ b/bc_obps/reporting/tests/api/test_report_attachment_api.py
@@ -3,6 +3,7 @@ from django.core.files.base import ContentFile
 from model_bakery.baker import make_recipe, prepare
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from reporting.models.report_attachment import ReportAttachment
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestReportAttachmentEndpoints(CommonTestSetup):
@@ -87,3 +88,11 @@ class TestReportAttachmentEndpoints(CommonTestSetup):
         ]
 
         mock_get_attachments.assert_called_once_with(self.report_version.id)
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated(
+            "get_report_attachments", version_id_param_name="report_version_id"
+        )
+        assert_report_version_ownership_is_validated(
+            "save_report_attachments", method="post", version_id_param_name="report_version_id"
+        )

--- a/bc_obps/reporting/tests/api/test_report_attachment_api.py
+++ b/bc_obps/reporting/tests/api/test_report_attachment_api.py
@@ -90,9 +90,5 @@ class TestReportAttachmentEndpoints(CommonTestSetup):
         mock_get_attachments.assert_called_once_with(self.report_version.id)
 
     def test_validates_report_version_id(self):
-        assert_report_version_ownership_is_validated(
-            "get_report_attachments", version_id_param_name="report_version_id"
-        )
-        assert_report_version_ownership_is_validated(
-            "save_report_attachments", method="post", version_id_param_name="report_version_id"
-        )
+        assert_report_version_ownership_is_validated("get_report_attachments")
+        assert_report_version_ownership_is_validated("save_report_attachments", method="post")

--- a/bc_obps/reporting/tests/api/test_report_emission_allocation_api.py
+++ b/bc_obps/reporting/tests/api/test_report_emission_allocation_api.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.utils import custom_reverse_lazy
 from registration.models.regulated_product import RegulatedProduct
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestReportEmissionAllocationApi(CommonTestSetup):
@@ -352,4 +353,15 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
             self.facility_uuid,
             self.mock_post_payload,
             self.test_user_guid,
+        )
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated(
+            "get_emission_allocations", version_id_param_name="report_version_id", facility_id="uuid"
+        )
+        assert_report_version_ownership_is_validated(
+            "save_emission_allocation_data",
+            method="post",
+            version_id_param_name="report_version_id",
+            facility_id="uuid",
         )

--- a/bc_obps/reporting/tests/api/test_report_emission_allocation_api.py
+++ b/bc_obps/reporting/tests/api/test_report_emission_allocation_api.py
@@ -298,7 +298,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
             "industry_user",
             custom_reverse_lazy(
                 "get_emission_allocations",
-                kwargs={"report_version_id": self.report_version_id, "facility_id": self.facility_uuid},
+                kwargs={"version_id": self.report_version_id, "facility_id": self.facility_uuid},
             ),
         )
         # Assert: Verify response status code
@@ -340,7 +340,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
             self.mock_post_payload,
             custom_reverse_lazy(
                 "save_emission_allocation_data",
-                kwargs={"report_version_id": self.report_version_id, "facility_id": self.facility_uuid},
+                kwargs={"version_id": self.report_version_id, "facility_id": self.facility_uuid},
             ),
         )
         # Assert: Verify response status code
@@ -356,12 +356,9 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
         )
 
     def test_validates_report_version_id(self):
-        assert_report_version_ownership_is_validated(
-            "get_emission_allocations", version_id_param_name="report_version_id", facility_id="uuid"
-        )
+        assert_report_version_ownership_is_validated("get_emission_allocations", facility_id="uuid")
         assert_report_version_ownership_is_validated(
             "save_emission_allocation_data",
             method="post",
-            version_id_param_name="report_version_id",
             facility_id="uuid",
         )

--- a/bc_obps/reporting/tests/api/test_report_emission_summary_api.py
+++ b/bc_obps/reporting/tests/api/test_report_emission_summary_api.py
@@ -1,0 +1,10 @@
+from registration.tests.utils.helpers import CommonTestSetup
+from reporting.tests.utils.report_access_validation import (
+    assert_report_version_ownership_is_validated,
+)
+
+
+class TestReportEmissionSummaryEndpoints(CommonTestSetup):
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated("get_emission_summary_totals", facility_id="uuid")
+        assert_report_version_ownership_is_validated("get_operation_emission_summary_totals")

--- a/bc_obps/reporting/tests/api/test_report_facilities_api.py
+++ b/bc_obps/reporting/tests/api/test_report_facilities_api.py
@@ -2,6 +2,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.utils import custom_reverse_lazy
 from reporting.tests.utils.bakers import report_version_baker
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestReportFacilityListEndpoint(CommonTestSetup):
@@ -39,3 +40,6 @@ class TestReportFacilityListEndpoint(CommonTestSetup):
         assert len(response_json["facilities"]) == 2
         assert response_json["facilities"][0] == "Facility 1"
         assert response_json["facilities"][1] == "Facility 2"
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated("get_report_facility_list_by_version_id")

--- a/bc_obps/reporting/tests/api/test_report_new_entrant_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_new_entrant_endpoint.py
@@ -44,7 +44,7 @@ class TestNewEntrantDataApi(CommonTestSetup):
             "industry_user",
             custom_reverse_lazy(
                 "get_new_entrant_data",
-                kwargs={"report_version_id": self.report_version.id},
+                kwargs={"version_id": self.report_version.id},
             ),
         )
 
@@ -120,7 +120,7 @@ class TestNewEntrantDataApi(CommonTestSetup):
             "industry_user",
             custom_reverse_lazy(
                 "get_new_entrant_data",
-                kwargs={"report_version_id": self.report_version.id},
+                kwargs={"version_id": self.report_version.id},
             ),
         )
 
@@ -226,7 +226,7 @@ class TestNewEntrantDataApi(CommonTestSetup):
             payload.dict(),  # Pass the payload directly as it's already a dictionary
             custom_reverse_lazy(
                 "save_new_entrant_data",
-                kwargs={"report_version_id": self.report_version.id},
+                kwargs={"version_id": self.report_version.id},
             ),
         )
 
@@ -234,7 +234,5 @@ class TestNewEntrantDataApi(CommonTestSetup):
         assert response.status_code == 200
 
     def test_validates_report_version_id(self):
-        assert_report_version_ownership_is_validated("get_new_entrant_data", version_id_param_name="report_version_id")
-        assert_report_version_ownership_is_validated(
-            "save_new_entrant_data", method="post", version_id_param_name="report_version_id"
-        )
+        assert_report_version_ownership_is_validated("get_new_entrant_data")
+        assert_report_version_ownership_is_validated("save_new_entrant_data", method="post")

--- a/bc_obps/reporting/tests/api/test_report_new_entrant_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_new_entrant_endpoint.py
@@ -6,6 +6,7 @@ from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.utils import custom_reverse_lazy
 from reporting.models.emission_category import EmissionCategory
 from reporting.schema.report_new_entrant import ReportNewEntrantSchemaIn
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestNewEntrantDataApi(CommonTestSetup):
@@ -231,3 +232,9 @@ class TestNewEntrantDataApi(CommonTestSetup):
 
         # Assert: Verify response status
         assert response.status_code == 200
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated("get_new_entrant_data", version_id_param_name="report_version_id")
+        assert_report_version_ownership_is_validated(
+            "save_new_entrant_data", method="post", version_id_param_name="report_version_id"
+        )

--- a/bc_obps/reporting/tests/api/test_report_non_attributable_emissions_endpoint.py
+++ b/bc_obps/reporting/tests/api/test_report_non_attributable_emissions_endpoint.py
@@ -3,6 +3,7 @@ from model_bakery.baker import make
 from model_bakery.baker import make_recipe
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from reporting.models import ReportNonAttributableEmissions, EmissionCategory, GasType
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestReportNonAttributableEndpoints(CommonTestSetup):
@@ -52,3 +53,7 @@ class TestReportNonAttributableEndpoints(CommonTestSetup):
                 "gas_type": [gas.id for gas in mock_emissions[0].gas_type.all()],
             }
         ]
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated("get_report_non_attributable_by_version_id", facility_id="uuid")
+        assert_report_version_ownership_is_validated("save_report", method="post", facility_id="uuid")

--- a/bc_obps/reporting/tests/api/test_report_person_responsible_api.py
+++ b/bc_obps/reporting/tests/api/test_report_person_responsible_api.py
@@ -1,0 +1,8 @@
+from registration.tests.utils.helpers import CommonTestSetup
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
+
+
+class TestReportPersonResponsibleEndpoints(CommonTestSetup):
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated("get_report_person_responsible_by_version_id")
+        assert_report_version_ownership_is_validated("save_report_contact", method="post")

--- a/bc_obps/reporting/tests/api/test_report_product_endpoints.py
+++ b/bc_obps/reporting/tests/api/test_report_product_endpoints.py
@@ -2,6 +2,7 @@ from unittest.mock import patch, MagicMock
 from model_bakery.baker import make_recipe
 from registration.models.regulated_product import RegulatedProduct
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestReportProductEndpoints(CommonTestSetup):
@@ -144,4 +145,12 @@ class TestReportProductEndpoints(CommonTestSetup):
                 }
             ],
             self.user.user_guid,
+        )
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated(
+            "load_production_data", version_id_param_name="report_version_id", facility_id="uuid"
+        )
+        assert_report_version_ownership_is_validated(
+            "save_production_data", method="post", version_id_param_name="report_version_id", facility_id="uuid"
         )

--- a/bc_obps/reporting/tests/api/test_report_product_endpoints.py
+++ b/bc_obps/reporting/tests/api/test_report_product_endpoints.py
@@ -148,9 +148,5 @@ class TestReportProductEndpoints(CommonTestSetup):
         )
 
     def test_validates_report_version_id(self):
-        assert_report_version_ownership_is_validated(
-            "load_production_data", version_id_param_name="report_version_id", facility_id="uuid"
-        )
-        assert_report_version_ownership_is_validated(
-            "save_production_data", method="post", version_id_param_name="report_version_id", facility_id="uuid"
-        )
+        assert_report_version_ownership_is_validated("load_production_data", facility_id="uuid")
+        assert_report_version_ownership_is_validated("save_production_data", method="post", facility_id="uuid")

--- a/bc_obps/reporting/tests/api/test_report_review_facilities_api.py
+++ b/bc_obps/reporting/tests/api/test_report_review_facilities_api.py
@@ -33,7 +33,7 @@ class TestFacilitiesReviewEndpoints(CommonTestSetup):
             "industry_user",
             custom_reverse_lazy(
                 "get_selected_facilities",
-                kwargs={"report_version_id": self.report_version.id},
+                kwargs={"version_id": self.report_version.id},
             ),
         )
         assert response.status_code == 200
@@ -58,15 +58,11 @@ class TestFacilitiesReviewEndpoints(CommonTestSetup):
             payload,
             custom_reverse_lazy(
                 "save_selected_facilities",
-                kwargs={"report_version_id": self.report_version.id},
+                kwargs={"version_id": self.report_version.id},
             ),
         )
         assert response.status_code == 200
 
     def test_validates_report_version_id(self):
-        assert_report_version_ownership_is_validated(
-            "get_selected_facilities", version_id_param_name="report_version_id"
-        )
-        assert_report_version_ownership_is_validated(
-            "save_selected_facilities", method="post", version_id_param_name="report_version_id"
-        )
+        assert_report_version_ownership_is_validated("get_selected_facilities")
+        assert_report_version_ownership_is_validated("save_selected_facilities", method="post")

--- a/bc_obps/reporting/tests/api/test_report_review_facilities_api.py
+++ b/bc_obps/reporting/tests/api/test_report_review_facilities_api.py
@@ -4,6 +4,7 @@ from model_bakery import baker
 from unittest.mock import patch, MagicMock
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.utils import custom_reverse_lazy
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestFacilitiesReviewEndpoints(CommonTestSetup):
@@ -61,3 +62,11 @@ class TestFacilitiesReviewEndpoints(CommonTestSetup):
             ),
         )
         assert response.status_code == 200
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated(
+            "get_selected_facilities", version_id_param_name="report_version_id"
+        )
+        assert_report_version_ownership_is_validated(
+            "save_selected_facilities", method="post", version_id_param_name="report_version_id"
+        )

--- a/bc_obps/reporting/tests/api/test_report_supplementary_version_api.py
+++ b/bc_obps/reporting/tests/api/test_report_supplementary_version_api.py
@@ -2,6 +2,7 @@ from model_bakery import baker
 from unittest.mock import patch, MagicMock, AsyncMock
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.utils import custom_reverse_lazy
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestReportSupplementaryApi(CommonTestSetup):
@@ -43,3 +44,8 @@ class TestReportSupplementaryApi(CommonTestSetup):
 
         # Assert: Ensure the service method was called with the correct version_id
         mock_create_report_supplementary_version.assert_called_once_with(self.old_report_version.id)
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated(
+            "create_report_supplementary_version", method="post", version_id_param_name="report_version_id"
+        )

--- a/bc_obps/reporting/tests/api/test_report_supplementary_version_api.py
+++ b/bc_obps/reporting/tests/api/test_report_supplementary_version_api.py
@@ -26,7 +26,7 @@ class TestReportSupplementaryApi(CommonTestSetup):
 
         # Act: Authorize user and perform POST request
         endpoint_under_test = "create_report_supplementary_version"
-        endpoint_under_test_kwargs = {"report_version_id": self.old_report_version.id}
+        endpoint_under_test_kwargs = {"version_id": self.old_report_version.id}
         response = TestUtils.mock_post_with_auth_role(
             self,
             "industry_user",
@@ -46,6 +46,4 @@ class TestReportSupplementaryApi(CommonTestSetup):
         mock_create_report_supplementary_version.assert_called_once_with(self.old_report_version.id)
 
     def test_validates_report_version_id(self):
-        assert_report_version_ownership_is_validated(
-            "create_report_supplementary_version", method="post", version_id_param_name="report_version_id"
-        )
+        assert_report_version_ownership_is_validated("create_report_supplementary_version", method="post")

--- a/bc_obps/reporting/tests/api/test_report_verification_api.py
+++ b/bc_obps/reporting/tests/api/test_report_verification_api.py
@@ -4,6 +4,7 @@ from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.utils import custom_reverse_lazy
 from reporting.schema.report_verification import ReportVerificationIn
 from reporting.models.report_verification import ReportVerification
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestReportVerificationApi(CommonTestSetup):
@@ -149,3 +150,14 @@ class TestReportVerificationApi(CommonTestSetup):
             assert visit_data["visit_type"] == expected_visit.visit_type
             assert visit_data["visit_coordinates"] == expected_visit.visit_coordinates
             assert visit_data["is_other_visit"] == expected_visit.is_other_visit
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated(
+            "get_report_verification_by_version_id", version_id_param_name="report_version_id"
+        )
+        assert_report_version_ownership_is_validated(
+            "get_report_needs_verification", version_id_param_name="report_version_id"
+        )
+        assert_report_version_ownership_is_validated(
+            "save_report_verification", method="post", version_id_param_name="report_version_id"
+        )

--- a/bc_obps/reporting/tests/api/test_report_verification_api.py
+++ b/bc_obps/reporting/tests/api/test_report_verification_api.py
@@ -48,7 +48,7 @@ class TestReportVerificationApi(CommonTestSetup):
             "industry_user",
             custom_reverse_lazy(
                 "get_report_verification_by_version_id",
-                kwargs={"report_version_id": self.report_version.id},
+                kwargs={"version_id": self.report_version.id},
             ),
         )
 
@@ -123,7 +123,7 @@ class TestReportVerificationApi(CommonTestSetup):
             payload.dict(),
             custom_reverse_lazy(
                 "save_report_verification",
-                kwargs={"report_version_id": self.report_version.id},
+                kwargs={"version_id": self.report_version.id},
             ),
         )
 
@@ -152,12 +152,6 @@ class TestReportVerificationApi(CommonTestSetup):
             assert visit_data["is_other_visit"] == expected_visit.is_other_visit
 
     def test_validates_report_version_id(self):
-        assert_report_version_ownership_is_validated(
-            "get_report_verification_by_version_id", version_id_param_name="report_version_id"
-        )
-        assert_report_version_ownership_is_validated(
-            "get_report_needs_verification", version_id_param_name="report_version_id"
-        )
-        assert_report_version_ownership_is_validated(
-            "save_report_verification", method="post", version_id_param_name="report_version_id"
-        )
+        assert_report_version_ownership_is_validated("get_report_verification_by_version_id")
+        assert_report_version_ownership_is_validated("get_report_needs_verification")
+        assert_report_version_ownership_is_validated("save_report_verification", method="post")

--- a/bc_obps/reporting/tests/api/test_reports.py
+++ b/bc_obps/reporting/tests/api/test_reports.py
@@ -106,14 +106,6 @@ class TestReportsEndpoint(CommonTestSetup):
         assert response.json() == expected_data
         mock_get_registration_purpose.assert_called_once_with(report_version.id)
 
-    def test_validates_report_version_id(self):
-        assert_report_version_ownership_is_validated("get_report_operation_by_version_id")
-        assert_report_version_ownership_is_validated("save_report")
-        assert_report_version_ownership_is_validated("change_report_version_type", "post")
-        assert_report_version_ownership_is_validated("get_regulated_products_by_version_id")
-        assert_report_version_ownership_is_validated("get_report_type_by_version")
-        assert_report_version_ownership_is_validated("get_registration_purpose_by_version_id")
-
     def test_create_report_validates_operation_ownership(self):
         with patch("common.permissions.check_permission_for_role") as mock_check_permissions, patch(
             "reporting.api.permissions._validate_operation_ownership"
@@ -124,3 +116,11 @@ class TestReportsEndpoint(CommonTestSetup):
             call_endpoint(TestUtils.client, "post", endpoint, "industry_user")
 
             mock_validate_operation_ownership.assert_called_once()
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated("get_report_operation_by_version_id")
+        assert_report_version_ownership_is_validated("save_report")
+        assert_report_version_ownership_is_validated("change_report_version_type", "post")
+        assert_report_version_ownership_is_validated("get_regulated_products_by_version_id")
+        assert_report_version_ownership_is_validated("get_report_type_by_version")
+        assert_report_version_ownership_is_validated("get_registration_purpose_by_version_id")

--- a/bc_obps/reporting/tests/api/test_reports.py
+++ b/bc_obps/reporting/tests/api/test_reports.py
@@ -2,6 +2,7 @@ import json
 from typing import Any
 from unittest.mock import patch, MagicMock
 
+from common.tests.utils.call_endpoint import call_endpoint
 from django.http import HttpResponse
 from model_bakery import baker
 
@@ -112,3 +113,14 @@ class TestReportsEndpoint(CommonTestSetup):
         assert_report_version_ownership_is_validated("get_regulated_products_by_version_id")
         assert_report_version_ownership_is_validated("get_report_type_by_version")
         assert_report_version_ownership_is_validated("get_registration_purpose_by_version_id")
+
+    def test_create_report_validates_operation_ownership(self):
+        with patch("common.permissions.check_permission_for_role") as mock_check_permissions, patch(
+            "reporting.api.permissions._validate_operation_ownership"
+        ) as mock_validate_operation_ownership:
+            mock_check_permissions.return_value = True
+
+            endpoint = custom_reverse_lazy("start_report", kwargs={})
+            call_endpoint(TestUtils.client, "post", endpoint, "industry_user")
+
+            mock_validate_operation_ownership.assert_called_once()

--- a/bc_obps/reporting/tests/api/test_reports.py
+++ b/bc_obps/reporting/tests/api/test_reports.py
@@ -11,6 +11,7 @@ from registration.utils import custom_reverse_lazy
 from reporting.models import Report, ReportVersion
 from reporting.tests.utils.bakers import report_baker, reporting_year_baker
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
 
 
 class TestReportsEndpoint(CommonTestSetup):
@@ -103,3 +104,11 @@ class TestReportsEndpoint(CommonTestSetup):
         assert response.status_code == 200
         assert response.json() == expected_data
         mock_get_registration_purpose.assert_called_once_with(report_version.id)
+
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated("get_report_operation_by_version_id")
+        assert_report_version_ownership_is_validated("save_report")
+        assert_report_version_ownership_is_validated("change_report_version_type", "post")
+        assert_report_version_ownership_is_validated("get_regulated_products_by_version_id")
+        assert_report_version_ownership_is_validated("get_report_type_by_version")
+        assert_report_version_ownership_is_validated("get_registration_purpose_by_version_id")

--- a/bc_obps/reporting/tests/api/test_submit_api.py
+++ b/bc_obps/reporting/tests/api/test_submit_api.py
@@ -1,0 +1,7 @@
+from django.test import TestCase
+from reporting.tests.utils.report_access_validation import assert_report_version_ownership_is_validated
+
+
+class TestSubmitEndpoint(TestCase):
+    def test_validates_report_version_id(self):
+        assert_report_version_ownership_is_validated("submit_report_version", "post")

--- a/bc_obps/reporting/tests/utils/report_access_validation.py
+++ b/bc_obps/reporting/tests/utils/report_access_validation.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+
+from common.tests.utils.call_endpoint import call_endpoint
+from django.test import Client
+from registration.utils import custom_reverse_lazy
+
+client = Client()
+
+#
+# Testing utility to verify that an endpoint validates its report version with our
+# auth=authorize(..., validators) method
+#
+# params:
+#   reverse_api_function_name: the name of the function defined, the endpoint will be resolved by
+#                              calling custom_reverse_lazy on it.
+#   method: HTTP verb, lowercase
+#   version_id_param_name: the key containing the report version id in the URL
+#                          example: "submit" for an endpoint "report-version/{version_id}/submit"
+#   role: the user role to test with
+#
+def assert_report_version_ownership_is_validated(
+    reverse_api_function_name: str,
+    method="get",
+    version_id_param_name: str = "version_id",
+    role: str = "industry_user",
+):
+    with patch("common.permissions.check_permission_for_role") as mock_check_permissions, patch(
+        "reporting.api.permissions._validate_version_ownership_in_url"
+    ) as mock_validate_version_ownership:
+        mock_check_permissions.return_value = True
+
+        endpoint = custom_reverse_lazy(reverse_api_function_name, kwargs={version_id_param_name: 1234})
+        call_endpoint(client, method, endpoint, role)
+
+        mock_validate_version_ownership.assert_called_once()

--- a/bc_obps/reporting/tests/utils/report_access_validation.py
+++ b/bc_obps/reporting/tests/utils/report_access_validation.py
@@ -17,19 +17,21 @@ client = Client()
 #   version_id_param_name: the key containing the report version id in the URL
 #                          example: "submit" for an endpoint "report-version/{version_id}/submit"
 #   role: the user role to test with
+#   **kwargs: Any additional named arguments will be passed to the api endpoint resolver
 #
 def assert_report_version_ownership_is_validated(
-    reverse_api_function_name: str,
+    api_function_name: str,
     method="get",
     version_id_param_name: str = "version_id",
     role: str = "industry_user",
+    **kwargs
 ):
     with patch("common.permissions.check_permission_for_role") as mock_check_permissions, patch(
         "reporting.api.permissions._validate_version_ownership_in_url"
     ) as mock_validate_version_ownership:
         mock_check_permissions.return_value = True
 
-        endpoint = custom_reverse_lazy(reverse_api_function_name, kwargs={version_id_param_name: 1234})
+        endpoint = custom_reverse_lazy(api_function_name, kwargs={version_id_param_name: 1234, **kwargs})
         call_endpoint(client, method, endpoint, role)
 
         mock_validate_version_ownership.assert_called_once()


### PR DESCRIPTION
Work done:
- add a "composite_auth(...)" method to compose multiple authorization methods
- A generic method to check whether the request's `current_user` has access to the report version referenced by the URL 
- A generic test method to test whether an API endpoint has that validation in its `authorize` call
- Added the validation to all required reporting endpoints