### PR TITLE
Fix: 649 report submitted routing

### DIFF
--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user/reports/[version_id]/submission/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user/reports/[version_id]/submission/page.tsx
@@ -1,0 +1,4 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import Page from "@reporting/src/app/components/signOff/SubmissionPage";
+
+export default defaultPageFactory(Page);

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/reports/[version_id]/submission/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/reports/[version_id]/submission/page.tsx
@@ -1,0 +1,4 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import Page from "@reporting/src/app/components/signOff/SubmissionPage";
+
+export default defaultPageFactory(Page);

--- a/bciers/apps/reporting/src/app/components/signOff/SignOffForm.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SignOffForm.tsx
@@ -7,16 +7,14 @@ import {
 } from "@reporting/src/data/jsonSchema/signOff/signOff";
 import { IChangeEvent } from "@rjsf/core";
 import { SignOffFormItems } from "@reporting/src/app/components/signOff/types";
-import ReportSubmission from "@reporting/src/app/components/signOff/Success";
 import { getTodaysDateForReportSignOff } from "@reporting/src/app/utils/formatDate";
 import { HasReportVersion } from "@reporting/src/app/utils/defaultPageFactoryTypes";
 import postSubmitReport from "@bciers/actions/api/postSubmitReport";
 import reportValidationMessages from "./reportValidationMessages";
 import { NavigationInformation } from "../taskList/types";
 import safeJsonParse from "@bciers/utils/src/safeJsonParse";
+import { useRouter } from "next/navigation";
 
-const baseUrl = "/reports";
-const cancelUrl = "/reports";
 interface Props extends HasReportVersion {
   navigationInformation: NavigationInformation;
 }
@@ -24,9 +22,9 @@ export default function SignOffForm({
   version_id,
   navigationInformation,
 }: Props) {
+  const router = useRouter();
   const [formState, setFormState] = useState({});
   const [errors, setErrors] = useState<string[]>();
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitButtonDisabled, setSubmitButtonDisabled] = useState(true);
 
   const allChecked = (formData: SignOffFormItems) => {
@@ -45,6 +43,9 @@ export default function SignOffForm({
 
   const handleSubmit = async () => {
     if (!submitButtonDisabled) {
+      setErrors(undefined);
+      setSubmitButtonDisabled(true);
+
       const payload = safeJsonParse(JSON.stringify(formState));
       const response: any = await postSubmitReport(version_id, payload);
 
@@ -52,38 +53,28 @@ export default function SignOffForm({
         setErrors([reportValidationMessages[response.error]]);
         return false;
       }
-      setErrors(undefined);
-      setIsSubmitting(true);
-      setSubmitButtonDisabled(true);
+      router.push(navigationInformation.continueUrl);
+      return true;
     }
-
     return true;
   };
 
   return (
-    <>
-      {isSubmitting ? (
-        <ReportSubmission />
-      ) : (
-        <MultiStepFormWithTaskList
-          initialStep={navigationInformation.headerStepIndex}
-          steps={navigationInformation.headerSteps}
-          taskListElements={navigationInformation.taskList}
-          schema={signOffSchema}
-          uiSchema={signOffUiSchema}
-          formData={formState}
-          baseUrl={baseUrl}
-          cancelUrl={cancelUrl}
-          onSubmit={handleSubmit}
-          buttonText={"Submit Report"}
-          onChange={handleChange}
-          saveButtonDisabled={true}
-          submitButtonDisabled={submitButtonDisabled} // Disable button if not all checkboxes are checked
-          continueUrl={""}
-          backUrl={navigationInformation.backUrl}
-          errors={errors}
-        />
-      )}
-    </>
+    <MultiStepFormWithTaskList
+      initialStep={navigationInformation.headerStepIndex}
+      steps={navigationInformation.headerSteps}
+      taskListElements={navigationInformation.taskList}
+      schema={signOffSchema}
+      uiSchema={signOffUiSchema}
+      formData={formState}
+      onSubmit={handleSubmit}
+      buttonText={"Submit Report"}
+      onChange={handleChange}
+      saveButtonDisabled={true}
+      submitButtonDisabled={submitButtonDisabled} // Disable button if not all checkboxes are checked
+      continueUrl={navigationInformation.continueUrl}
+      backUrl={navigationInformation.backUrl}
+      errors={errors}
+    />
   );
 }

--- a/bciers/apps/reporting/src/app/components/signOff/SubmissionPage.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SubmissionPage.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { getTodaysDateWithTime } from "@reporting/src/app/utils/formatDate";
 import formatTimestamp from "@bciers/utils/src/formatTimestamp";
 
-const ReportSubmission = () => {
+const SubmissionPage = () => {
   const currentDate = formatTimestamp(getTodaysDateWithTime());
 
   return (
@@ -29,4 +29,4 @@ const ReportSubmission = () => {
   );
 };
 
-export default ReportSubmission;
+export default SubmissionPage;

--- a/bciers/apps/reporting/src/app/components/taskList/taskListPages/5_signOffSubmit.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/taskListPages/5_signOffSubmit.ts
@@ -39,5 +39,6 @@ export const signOffSubmitPageFactories: {
       link: `/reports/${reportVersionId}/sign-off`,
       isActive: activePage === ReportingPage.SignOff,
     },
+    continueUrl: `/reports/${reportVersionId}/submission`,
   }),
 };

--- a/bciers/apps/reporting/src/middlewares/constants.ts
+++ b/bciers/apps/reporting/src/middlewares/constants.ts
@@ -91,7 +91,7 @@ export const reportRoutesLFO = [
 ];
 
 // App routes for submitted report
-export const reportRoutesSubmitted = ["submitted"];
+export const reportRoutesSubmitted = ["submitted", "submission"];
 
 // App routes restricted to New Entrant
 export const restrictedRoutesNewEntrant = ["new-entrant-information"];

--- a/bciers/apps/reporting/src/middlewares/withRuleHasReportRouteAccess.test.ts
+++ b/bciers/apps/reporting/src/middlewares/withRuleHasReportRouteAccess.test.ts
@@ -97,7 +97,7 @@ describe("withRuleHasReportRouteAccess middleware", () => {
         { operation_report_status: ReportOperationStatus.SUBMITTED }, // For routeSubmittedReport (pass)
       ],
       routeMocks: {
-        reportRoutesSubmitted: constants.reportRoutesSubmitted, // Expected value, e.g. ["submitted"]
+        reportRoutesSubmitted: ["submitted", "submission"],
       },
     });
     expect(nextMiddleware).toHaveBeenCalledOnce();


### PR DESCRIPTION
Addresses: 
[649](https://github.com/bcgov/cas-reporting/issues/649)

###  ⚠️ Issue:
After clicking `Submit Report` the report status becomes `Submitted` resulting in the `sign-off` route becoming an "unauthorized" route; so, the middleware redirects the user to the "authorized" route `/submitted`.

### 🚀 Impact:

- Updated `SignOffForm` to route to new authorized route `submission`
- Updated `middleware` to a permit "Submitted" record routes: `submitted`:`submission`


## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button
5. Log in using `bc-cas-dev`



### **Test: Report Sign-Off\Submit Report**  

#### **Steps**  
1. Navigate to http://localhost:3000/reporting/reports/
2. Select a `Submitted` and click `More Actions\Create Supplementary Report`
3. Navigate to `/sign-off`
4. Complete the form and click `Submit Report`
#### **Expected Result**  
✅ 
- Router navigates to `/submission`
![image](https://github.com/user-attachments/assets/6bb1d529-9786-4a0d-a9c2-e319ec7961f2)
- No redirect from page `/submission`
