### PR TITLE
chore: 2542 reduce backend docker image size

### DIFF
--- a/bc_obps/.dockerignore
+++ b/bc_obps/.dockerignore
@@ -1,7 +1,48 @@
+# Python and Poetry-related files
 .venv
-.git
-.gitignore
-.vscode
+env/
 **/__pycache__
 **/*.pyc
+*.pyo
+*.pyd
+.Python
 python_cache
+#.env
+#*.env
+#.env.example
+
+# Django-specific exclusions
+*.log
+staticfiles/
+media/
+
+# asdf-related exclusions
+.asdf/
+
+# Git and version control
+.git
+.gitignore
+
+# Development and testing files
+.vscode
+**/tests
+*.pytest_cache/
+pytest.ini
+.coveragerc
+.coverage
+htmlcov/
+test_*.py
+mypy.ini
+bandit.yaml
+
+# Miscellaneous
+Makefile
+*.md
+Dockerfile
+docker-compose.yml
+*.swp
+*.bak
+*.tmp
+node_modules/  # If you have any frontend dependencies
+dist/
+build/

--- a/bc_obps/.dockerignore
+++ b/bc_obps/.dockerignore
@@ -7,9 +7,9 @@ env/
 *.pyd
 .Python
 python_cache
-#.env
-#*.env
-#.env.example
+.env
+*.env
+.env.example
 
 # Django-specific exclusions
 *.log

--- a/bc_obps/.env.example
+++ b/bc_obps/.env.example
@@ -23,7 +23,9 @@ ELICENSING_AUTH_TOKEN=""
 
 ALLOWED_HOSTS=localhost,0.0.0.0,127.0.0.1
 
-ENVIRONMENT=dev
+ENVIRONMENT=local
+# to enable Django Debugging tools
+DEBUG=<True/False>
 # to bypass role assignment for internal users
 BYPASS_ROLE_ASSIGNMENT=<True/False>
 # Sentry
@@ -32,5 +34,5 @@ SENTRY_ENVIRONMENT=development # for local development, prod for production
 SENTRY_TRACE_SAMPLE_RATE=0 # float between 0.0 and 1.0 to trace all requests
 
 # SUPERUSER settings (To access the admin panel)
-SUPERUSER_USERNAME=your_superuser_username
-SUPERUSER_PASSWORD=your_superuser_password
+DJANGO_SUPERUSER_USERNAME=your_superuser_username
+DJANGO_SUPERUSER_PASSWORD=your_superuser_password

--- a/bc_obps/Dockerfile
+++ b/bc_obps/Dockerfile
@@ -1,58 +1,109 @@
-# Use an official Python runtime as a parent image
-FROM python:3.12.3 AS main
+####################
+# Base Stage
+####################
+FROM python:3.12.3-slim AS base
 
-# Install system dependencies and clean up
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git gnupg curl build-essential && \
-    apt-get clean
-
-# Set environment variables
+# Prevent Python from writing .pyc files to disk
 ENV PYTHONDONTWRITEBYTECODE=1 \
+# Ensure Python output is sent straight to terminal (no buffering)
     PYTHONUNBUFFERED=1 \
+# Define a user ID for the non-root user
     USER_ID=1001 \
-    HOME=/root
+# Set the home and working directory to /app
+    HOME=/app \
+# Prevent apt-get from prompting during installs
+    DEBIAN_FRONTEND=noninteractive
 
 WORKDIR ${HOME}
-# Make everything in the home group-writable to support OpenShift's restricted SCC
-# Needs to be done as root to chown
-RUN useradd -ms /bin/bash -d ${HOME} --uid ${USER_ID} -g root bc_obps
 
-COPY ./ ${HOME}/
-
-# Install asdf
-RUN git clone https://github.com/asdf-vm/asdf.git ${HOME}/asdf --depth 1 --branch v0.11.2
-
-ENV BASH_ENV="${HOME}/asdf/asdf.sh"
-# Because asdf is loaded via BASH_ENV, all commands using adsf need to be executed using /usr/bin/env bash -c
-SHELL ["/usr/bin/env", "bash", "-c"]
-
-RUN sed -i -nr '/python|poetry/p' ${HOME}/.tool-versions && \
-    cat ${HOME}/.tool-versions | cut -f 1 -d ' ' | xargs -n 1 asdf plugin-add && \
-    asdf plugin-update --all && \
-    asdf install && \
-    asdf reshim
-
-# Extract the Poetry version dynamically
-ARG POETRY_VERSION
-RUN export POETRY_VERSION=$(grep '^poetry ' ${HOME}/.tool-versions | awk '{print $2}') && \
-    echo "Using Poetry version: $POETRY_VERSION"
-
-# Set the Poetry version as an environment variable
-ENV POETRY_VERSION=${POETRY_VERSION}
-ENV PATH="${HOME}/.asdf/installs/poetry/${POETRY_VERSION}/bin:${PATH}"
-
-RUN poetry config virtualenvs.create true && \
-	poetry config virtualenvs.in-project true
-
-# Change ownership and permissions
-RUN chown -R bc_obps:0 ${HOME} && \
+# Recreate bc_obps user with bash shell
+RUN useradd -ms /bin/bash -d ${HOME} --uid ${USER_ID} -g root bc_obps && \
+    chown -R bc_obps:0 ${HOME} && \
     chmod -R g+rwX ${HOME}
 
-# Expose the port your Django application will run on (change as needed)
+####################
+# Builder Stage
+####################
+FROM base AS builder
+
+# Refresh package lists from repositories
+RUN apt-get update && \
+# Install minimal build tools required for asdf (git), curl for Poetry plugin, build-essential for compiling Python, and additional libs for Python
+    apt-get install -y --no-install-recommends build-essential curl git libc6-dev libffi-dev libssl-dev zlib1g-dev && \
+# Remove apt cache to reduce image size
+    apt-get clean && \
+# Delete package lists to further slim the image
+    rm -rf /var/lib/apt/lists/*
+
+# Copy version config and Poetry files with ownership set to bc_obps
+COPY --chown=bc_obps:0 .tool-versions pyproject.toml poetry.lock ${HOME}/
+
+USER ${USER_ID}
+
+# Clone asdf shallowly from GitHub
+RUN git clone --depth 1 --branch v0.11.2 https://github.com/asdf-vm/asdf.git ${HOME}/asdf
+
+# Ensure asdf is available in non-interactive shells
+ENV BASH_ENV="${HOME}/asdf/asdf.sh"
+
+# Use bash with environment sourcing for asdf commands
+SHELL ["/bin/bash", "-c"]
+
+# Filter .tool-versions for python and poetry
+RUN sed -i -nr '/python|poetry/p' ${HOME}/.tool-versions && \
+# Add plugins for each tool listed in .tool-versions
+    cat ${HOME}/.tool-versions | cut -f 1 -d ' ' | xargs -n 1 asdf plugin-add && \
+# Update all plugins to latest versions
+    asdf plugin-update --all && \
+# Install tools (Python, Poetry) from .tool-versions
+    asdf install && \
+# Regenerate shims for installed tools
+    asdf reshim
+
+# Extract Poetry version from .tool-versions
+RUN export POETRY_VERSION=$(grep '^poetry ' ${HOME}/.tool-versions | awk '{print $2}') && \
+# Add Poetry to PATH in bashrc
+    echo "export PATH=${HOME}/.asdf/installs/poetry/${POETRY_VERSION}/bin:${PATH}" >> ${HOME}/.bashrc
+
+RUN poetry config virtualenvs.create true && \
+# Keep virtualenv in project directory (.venv)
+    poetry config virtualenvs.in-project true && \
+# Install dependencies without dev group, non-interactively
+    poetry install --without dev --no-root --no-interaction --no-ansi
+
+# Copy all remaining files, owned by bc_obps
+COPY --chown=bc_obps:0 . ${HOME}/
+
+####################
+# Runner Stage
+####################
+FROM base AS runner
+
+# Refresh package lists from repositories
+RUN apt-get update && \
+# Install essential runner packages
+    apt-get install -y --no-install-recommends curl && \
+# Clean apt cache
+    apt-get clean && \
+# Remove package lists to reduce size
+    rm -rf /var/lib/apt/lists/*
+
+# Copy application from the builder stage
+COPY --from=builder --chown=bc_obps:0 ${HOME}/ ${HOME}/
+
+USER ${USER_ID}
+
+# Source asdf in non-interactive shells
+ENV BASH_ENV="${HOME}/asdf/asdf.sh"
+# Set PATH explicitly to include Poetry binary
+ENV PATH="${HOME}/.asdf/shims:${HOME}/.asdf/bin:${PATH}"
+
+# Make port 8000 available for external connections
 EXPOSE 8000
 
-# Install project dependencies using Poetry
-RUN poetry install --without dev
-USER ${USER_ID}
-CMD ["/usr/bin/env", "bash", "-c", "poetry run python manage.py collectstatic --noinput && poetry run python manage.py custom_migrate && poetry run gunicorn --access-logfile - bc_obps.wsgi:application --timeout 200 --workers 3 --bind '0.0.0.0:8000'"]
+# Check every 30s with a 3s timeout
+HEALTHCHECK --interval=30s --timeout=3s \
+# Fail if curl request fails
+    CMD curl -f http://localhost:8000/ || exit 1
+
+CMD ["/bin/bash", "-c", "poetry run python manage.py collectstatic --noinput && poetry run python manage.py custom_migrate && poetry run gunicorn --access-logfile - bc_obps.wsgi:application --timeout 200 --workers 3 --bind '0.0.0.0:8000'"]

--- a/bc_obps/Dockerfile
+++ b/bc_obps/Dockerfile
@@ -5,14 +5,16 @@ FROM python:3.12.3-slim AS base
 
 # Prevent Python from writing .pyc files to disk
 ENV PYTHONDONTWRITEBYTECODE=1 \
-# Ensure Python output is sent straight to terminal (no buffering)
+    # Ensure Python output is sent straight to terminal (no buffering)
     PYTHONUNBUFFERED=1 \
-# Define a user ID for the non-root user
+    # Define a user ID for the non-root user
     USER_ID=1001 \
-# Set the home and working directory to /app
+    # Set the home and working directory to /app
     HOME=/app \
-# Prevent apt-get from prompting during installs
-    DEBIAN_FRONTEND=noninteractive
+    # Prevent apt-get from prompting during installs
+    DEBIAN_FRONTEND=noninteractive \
+    # Set asdf version
+    ASDF_VERSION=0.15.0
 
 WORKDIR ${HOME}
 
@@ -41,7 +43,7 @@ COPY --chown=bc_obps:0 .tool-versions pyproject.toml poetry.lock ${HOME}/
 USER ${USER_ID}
 
 # Clone asdf shallowly from GitHub
-RUN git clone --depth 1 --branch v0.11.2 https://github.com/asdf-vm/asdf.git ${HOME}/asdf
+RUN git clone --depth 1 --branch v${ASDF_VERSION} https://github.com/asdf-vm/asdf.git ${HOME}/asdf
 
 # Ensure asdf is available in non-interactive shells
 ENV BASH_ENV="${HOME}/asdf/asdf.sh"
@@ -51,25 +53,25 @@ SHELL ["/bin/bash", "-c"]
 
 # Filter .tool-versions for python and poetry
 RUN sed -i -nr '/python|poetry/p' ${HOME}/.tool-versions && \
-# Add plugins for each tool listed in .tool-versions
+    # Add plugins for each tool listed in .tool-versions
     cat ${HOME}/.tool-versions | cut -f 1 -d ' ' | xargs -n 1 asdf plugin-add && \
-# Update all plugins to latest versions
+    # Update all plugins to latest versions
     asdf plugin-update --all && \
-# Install tools (Python, Poetry) from .tool-versions
+    # Install tools (Python, Poetry) from .tool-versions
     asdf install && \
-# Regenerate shims for installed tools
+    # Regenerate shims for installed tools
     asdf reshim
 
+# Configure Poetry and install dependencies
 # Extract Poetry version from .tool-versions
 RUN export POETRY_VERSION=$(grep '^poetry ' ${HOME}/.tool-versions | awk '{print $2}') && \
-# Add Poetry to PATH in bashrc
-    echo "export PATH=${HOME}/.asdf/installs/poetry/${POETRY_VERSION}/bin:${PATH}" >> ${HOME}/.bashrc
-
-RUN poetry config virtualenvs.create true && \
-# Keep virtualenv in project directory (.venv)
+    # Add Poetry to PATH in bashrc
+    echo "export PATH=${HOME}/.asdf/installs/poetry/${POETRY_VERSION}/bin:${PATH}" >> ${HOME}/.bashrc && \
+    # Keep virtualenv in project directory (.venv)
+    poetry config virtualenvs.create true && \
     poetry config virtualenvs.in-project true && \
-# Install dependencies without dev group, non-interactively
-    poetry install --without dev --no-root --no-interaction --no-ansi
+    # Install dependencies without dev group, non-interactively
+    poetry install --without dev --no-root --no-interaction --no-ansi --compile
 
 # Copy all remaining files, owned by bc_obps
 COPY --chown=bc_obps:0 . ${HOME}/
@@ -81,29 +83,31 @@ FROM base AS runner
 
 # Refresh package lists from repositories
 RUN apt-get update && \
-# Install essential runner packages
+    # Install essential runner packages
     apt-get install -y --no-install-recommends curl && \
-# Clean apt cache
+    # Clean apt cache
     apt-get clean && \
-# Remove package lists to reduce size
+    # Remove package lists to reduce size
     rm -rf /var/lib/apt/lists/*
 
 # Copy application from the builder stage
 COPY --from=builder --chown=bc_obps:0 ${HOME}/ ${HOME}/
 
-USER ${USER_ID}
+# Remove asdf and Poetry files
+RUN rm .tool-versions pyproject.toml poetry.lock
 
-# Source asdf in non-interactive shells
-ENV BASH_ENV="${HOME}/asdf/asdf.sh"
-# Set PATH explicitly to include Poetry binary
-ENV PATH="${HOME}/.asdf/shims:${HOME}/.asdf/bin:${PATH}"
+USER ${USER_ID}
 
 # Make port 8000 available for external connections
 EXPOSE 8000
 
 # Check every 30s with a 3s timeout
 HEALTHCHECK --interval=30s --timeout=3s \
-# Fail if curl request fails
+    # Fail if curl request fails
     CMD curl -f http://localhost:8000/ || exit 1
 
-CMD ["/bin/bash", "-c", "poetry run python manage.py collectstatic --noinput && poetry run python manage.py custom_migrate && poetry run gunicorn --access-logfile - bc_obps.wsgi:application --timeout 200 --workers 3 --bind '0.0.0.0:8000'"]
+# Collect static files using the virtual environment's Python
+RUN ${HOME}/.venv/bin/python manage.py collectstatic --noinput
+
+# Run migrations and start gunicorn directly from the virtual environment
+CMD ["/bin/bash", "-c", "${HOME}/.venv/bin/python manage.py custom_migrate && ${HOME}/.venv/bin/gunicorn --access-logfile - bc_obps.wsgi:application --timeout 200 --workers 3 --bind '0.0.0.0:8000'"]

--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -29,9 +29,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
+ENVIRONMENT = os.environ.get("ENVIRONMENT")
+CI = os.environ.get("CI")
 
 # If we're in the CI environment, don't hit Google Cloud Storage
-if os.environ.get('CI', None) == 'true':
+if CI == 'true' or ENVIRONMENT == 'local':
     # Use local file storage for tests
     MEDIA_ROOT = os.path.join(BASE_DIR, 'test_media/')
     STORAGES = {
@@ -63,11 +65,11 @@ SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG")
-ENVIRONMENT = os.environ.get("ENVIRONMENT")
 BYPASS_ROLE_ASSIGNMENT = os.environ.get("BYPASS_ROLE_ASSIGNMENT", False) == "True"
 
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "localhost").split(",")
 
+# CHES API settings
 CHES_CLIENT_ID = os.environ.get("CHES_CLIENT_ID")
 CHES_CLIENT_SECRET = os.environ.get("CHES_CLIENT_SECRET")
 CHES_TOKEN_ENDPOINT = os.environ.get("CHES_TOKEN_ENDPOINT")
@@ -92,7 +94,7 @@ RLS_GRANT_APPS = [
 ]
 
 # Only apply RLS policies for compliance app if ENVIRONMENT is dev or test
-if ENVIRONMENT in ["dev", "test"]:
+if ENVIRONMENT in ["local", "dev", "test"]:
     RLS_GRANT_APPS += ["compliance"]
 
 # Apps that should not be included in production migrations

--- a/bc_obps/bc_obps/storage_backends.py
+++ b/bc_obps/bc_obps/storage_backends.py
@@ -4,7 +4,7 @@ from django.core.files.storage import FileSystemStorage
 from storages.backends.gcloud import GoogleCloudStorage  # type: ignore
 
 # If we're in the CI environment, don't hit Google Cloud Storage
-if os.environ.get("CI", None) == "true":
+if settings.CI == "true" or settings.ENVIRONMENT == "local":
 
     class UnscannedLocal(FileSystemStorage):
         location = os.path.join(settings.MEDIA_ROOT, "unscanned")

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -1,5 +1,6 @@
 import logging
-import os
+
+from django.conf import settings
 from django.db.models import QuerySet
 from typing import Any, TypeVar, Union, Iterable, Dict, Optional
 from uuid import UUID
@@ -85,7 +86,7 @@ def file_to_data_url(document: Document) -> Optional[str]:  # type: ignore[retur
     """
     timeout_seconds = 10
     # Handles local storage when running in CI
-    if os.environ.get("CI", None) == "true":
+    if settings.CI == "true":
         encoded_content = base64.b64encode(document.get_file_content().read()).decode("utf-8")
         return "data:application/pdf;name=" + document.file.name.split("/")[-1] + ";scanstatus=" + document.status + ";base64," + encoded_content  # type: ignore[no-any-return]
     else:

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -1,6 +1,5 @@
 import logging
-
-from django.conf import settings
+import os
 from django.db.models import QuerySet
 from typing import Any, TypeVar, Union, Iterable, Dict, Optional
 from uuid import UUID
@@ -86,7 +85,7 @@ def file_to_data_url(document: Document) -> Optional[str]:  # type: ignore[retur
     """
     timeout_seconds = 10
     # Handles local storage when running in CI
-    if settings.CI == "true":
+    if os.environ.get("CI", None) == "true":
         encoded_content = base64.b64encode(document.get_file_content().read()).decode("utf-8")
         return "data:application/pdf;name=" + document.file.name.split("/")[-1] + ";scanstatus=" + document.status + ";base64," + encoded_content  # type: ignore[no-any-return]
     else:


### PR DESCRIPTION
[ISSUE 2542](https://github.com/bcgov/cas-registration/issues/2542)

Reduces the backend image size from **_2.5GB_** to **_900MB_**

**CHANGES:**
- Uses multi-stage build
- Uses python-<version>-slim image (This required adding some packages manually)

References to achieve this:
- https://dylancastillo.co/til/django-poetry-dockerfile.html
- https://www.docker.com/blog/how-to-dockerize-django-app/
- https://betterstack.com/community/guides/scaling-python/dockerize-django/#step-3-writing-a-dockerfile-for-your-django-app
- https://testdriven.io/blog/docker-best-practices/#use-multi-stage-builds
- https://hadolint.github.io/hadolint/