### PR TITLE
chore: add friendly message mapping

### DIFF
--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -14,6 +14,7 @@ import { findPathsWithNegativeNumbers } from "@bciers/utils/src/findInObject";
 import { calculateMobileAnnualAmount } from "@bciers/utils/src/customReportingActivityFormCalculations";
 import { IChangeEvent } from "@rjsf/core";
 import { NavigationInformation } from "../taskList/types";
+import { getValidationErrorMessage } from "@reporting/src/app/utils/reportValidationMessages";
 
 const CUSTOM_FIELDS = {
   fuelType: (props: FieldProps) => <FuelFields {...props} />,
@@ -164,7 +165,7 @@ export default function ActivityForm({
     );
 
     if (response.error) {
-      setErrorList([response.error]);
+      setErrorList([getValidationErrorMessage(response.error)]);
       return false;
     }
     if (response) {

--- a/bciers/apps/reporting/src/app/components/signOff/SignOffForm.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SignOffForm.tsx
@@ -10,8 +10,8 @@ import { SignOffFormItems } from "@reporting/src/app/components/signOff/types";
 import { getTodaysDateForReportSignOff } from "@reporting/src/app/utils/formatDate";
 import { HasReportVersion } from "@reporting/src/app/utils/defaultPageFactoryTypes";
 import postSubmitReport from "@bciers/actions/api/postSubmitReport";
-import reportValidationMessages from "./reportValidationMessages";
-import { NavigationInformation } from "../taskList/types";
+import { NavigationInformation } from "@reporting/src/app/components/taskList/types";
+import { getValidationErrorMessage } from "@reporting/src/app/utils/reportValidationMessages";
 import safeJsonParse from "@bciers/utils/src/safeJsonParse";
 import { useRouter } from "next/navigation";
 
@@ -52,7 +52,7 @@ export default function SignOffForm({
       const response: any = await postSubmitReport(version_id, payload);
 
       if (response?.error) {
-        setErrors([reportValidationMessages[response.error]]);
+        setErrors([getValidationErrorMessage(response.error)]);
         return false;
       }
       router.push(navigationInformation.continueUrl);

--- a/bciers/apps/reporting/src/app/components/signOff/reportValidationMessages.ts
+++ b/bciers/apps/reporting/src/app/components/signOff/reportValidationMessages.ts
@@ -1,8 +1,0 @@
-const reportValidationMessagesMap: { [key: string]: string } = {
-  missing_report_verification:
-    "Verification information must be completed with this report.  Please complete the Verification page.",
-  verification_statement:
-    "A verification statement must be uploaded with this report. Please upload a verification statement on the Attachments page.",
-};
-
-export default reportValidationMessagesMap;

--- a/bciers/apps/reporting/src/app/utils/reportValidationMessages.ts
+++ b/bciers/apps/reporting/src/app/utils/reportValidationMessages.ts
@@ -1,0 +1,55 @@
+type ReportValidationMessageKey =
+  | "missing_report_verification"
+  | "verification_statement"
+  | "emission"
+  | "fuelType"
+  | "gasType";
+
+const reportValidationMessagesMap: Record<ReportValidationMessageKey, string> =
+  {
+    missing_report_verification:
+      "Verification information must be completed with this report. Please complete the Verification page.",
+    verification_statement:
+      "A verification statement must be uploaded with this report. Please upload a verification statement on the Attachments page.",
+    emission: "Emission is missing Emission.",
+    fuelType: "Fuel is missing Fuel Name.",
+    gasType: "Emission is missing Gas Type.",
+  };
+
+function extractErrorKey(
+  error: unknown,
+): ReportValidationMessageKey | undefined {
+  const errorStr =
+    typeof error === "string"
+      ? error
+      : error instanceof Error
+      ? error.message
+      : "";
+
+  let trimmedError = errorStr.trim();
+
+  // If the error string is wrapped in single or double quotes, remove them.
+  if (
+    (trimmedError.startsWith("'") && trimmedError.endsWith("'")) ||
+    (trimmedError.startsWith('"') && trimmedError.endsWith('"'))
+  ) {
+    trimmedError = trimmedError.slice(1, -1).trim();
+  }
+
+  // Check if the error string exactly matches one of the keys.
+  for (const key of Object.keys(reportValidationMessagesMap)) {
+    if (trimmedError === key) {
+      return key as ReportValidationMessageKey;
+    }
+  }
+
+  return undefined;
+}
+
+export function getValidationErrorMessage(error: unknown): string {
+  const key = extractErrorKey(error);
+  if (key) {
+    return reportValidationMessagesMap[key];
+  }
+  return `${error}`;
+}


### PR DESCRIPTION
Addresses: [634](https://github.com/bcgov/cas-reporting/issues/634)

### 🚀 Impact:

- Transforms back-end errors such a `emission`; `fuelName`;s `gasType` into user friendly message.


## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button
5. Log in using `bc-cas-dev`


### Test: User friendly error messages

#### **Steps**  
1. Navigate to http://localhost:3000/reporting/reports/
2. Select operation `Bugle SFO - Registered` 
3. Click `Continue`
4. Navigate to activities, ex: http://localhost:3000/reporting/reports/1/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/activities
5. Select `General stationary combustion excluding line tracing\General stationary combustion of fuel or waste with production of useful energy`
6. Click `Save and Continue`
#### **Expected Result**  
✅ 
Error displays: "Fuel is expecting 'Fuel Name' data."  (transformed back-end error message)
![image](https://github.com/user-attachments/assets/05bc0a4e-3393-43c1-84ac-a17c1a44b9ca)

7. Complete `Fuel Name`
8. Click `Save and Continue`

#### **Expected Result**  
✅ 
Error displays: "Emission is expecting 'Gas Type' data."  (transformed back-end error message)
![image](https://github.com/user-attachments/assets/b014b13f-188c-4b13-a5e3-7bc7d3963516)

9. Complete `Gas Type`
10. Click `Save and Continue`

#### **Expected Result**  
✅ 
Error displays: "Emission is expecting 'Emission' data." (transformed back-end error message)
![image](https://github.com/user-attachments/assets/babfbb3f-0221-4c77-8306-fa67cb7c5eee)

11. Complete `Emission`
12. Click `Save and Continue`

#### **Expected Result**  
✅ 
Error displays: "Emission is expecting methodology data" (direct back-end error message)
![image](https://github.com/user-attachments/assets/4da16fed-5193-4bdd-a3e5-3006dfbdcb33)

13. Navigate to `sign-off`, ex: http://localhost:3000/reporting/reports/1/sign-off
14. Complete the form and click `Submit report`
#### **Expected Result**  
✅ 
Error displays: Verification information must be completed with this report. Please complete the Verification page.
![image](https://github.com/user-attachments/assets/e83b7f52-ff9d-4c2b-831a-cdd0057a3a92)

15. Navigate to `verification`, ex: http://localhost:3000/reporting/reports/1/verification
16. Complete the form and click `Save and Continue`
17. Navigate to `sign-off`, ex: http://localhost:3000/reporting/reports/1/sign-off
18. Complete the form and click `Submit report`
#### **Expected Result**  
✅ 
Error displays: A verification statement must be uploaded with this report. Please upload a verification statement on the Attachments page.
![image](https://github.com/user-attachments/assets/77503827-fb06-4923-9be6-3607596cf9d5)
