### PR TITLE
refactor: uncouple report sign-off data type from api

### DIFF
--- a/bc_obps/reporting/api/submit.py
+++ b/bc_obps/reporting/api/submit.py
@@ -1,4 +1,5 @@
 from uuid import UUID
+from reporting.service.report_sign_off_service import ReportSignOffData
 from reporting.schema.report_sign_off import ReportSignOffIn
 from common.api.utils.current_user_utils import get_current_user_guid
 from django.http import HttpRequest
@@ -19,5 +20,13 @@ from .router import router
 )
 def submit_report_version(request: HttpRequest, version_id: int, payload: ReportSignOffIn) -> int:
     user_guid: UUID = get_current_user_guid(request)
-    ReportSubmissionService.submit_report(version_id, user_guid, payload)
+    data = ReportSignOffData(
+        acknowledgement_of_possible_costs=payload.acknowledgement_of_possible_costs,
+        acknowledgement_of_records=payload.acknowledgement_of_records,
+        acknowledgement_of_review=payload.acknowledgement_of_review,
+        acknowledgement_of_information=payload.acknowledgement_of_information,
+        acknowledgement_of_new_version=payload.acknowledgement_of_new_version,
+        signature=payload.signature,
+    )
+    ReportSubmissionService.submit_report(version_id, user_guid, data)
     return version_id

--- a/bc_obps/reporting/api/submit.py
+++ b/bc_obps/reporting/api/submit.py
@@ -27,6 +27,7 @@ def submit_report_version(request: HttpRequest, version_id: int, payload: Report
             payload.acknowledgement_of_information,
             payload.acknowledgement_of_possible_costs,
             payload.acknowledgement_of_new_version,
+            payload.acknowledgement_of_corrections,
         ),
         signature=payload.signature,
     )

--- a/bc_obps/reporting/api/submit.py
+++ b/bc_obps/reporting/api/submit.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from reporting.service.report_sign_off_service import ReportSignOffData
+from reporting.service.report_sign_off_service import ReportSignOffAcknowledgements, ReportSignOffData
 from reporting.schema.report_sign_off import ReportSignOffIn
 from common.api.utils.current_user_utils import get_current_user_guid
 from django.http import HttpRequest
@@ -21,11 +21,13 @@ from .router import router
 def submit_report_version(request: HttpRequest, version_id: int, payload: ReportSignOffIn) -> int:
     user_guid: UUID = get_current_user_guid(request)
     data = ReportSignOffData(
-        acknowledgement_of_possible_costs=payload.acknowledgement_of_possible_costs,
-        acknowledgement_of_records=payload.acknowledgement_of_records,
-        acknowledgement_of_review=payload.acknowledgement_of_review,
-        acknowledgement_of_information=payload.acknowledgement_of_information,
-        acknowledgement_of_new_version=payload.acknowledgement_of_new_version,
+        acknowledgements=ReportSignOffAcknowledgements(
+            payload.acknowledgement_of_review,
+            payload.acknowledgement_of_records,
+            payload.acknowledgement_of_information,
+            payload.acknowledgement_of_possible_costs,
+            payload.acknowledgement_of_new_version,
+        ),
         signature=payload.signature,
     )
     ReportSubmissionService.submit_report(version_id, user_guid, data)

--- a/bc_obps/reporting/schema/report_sign_off.py
+++ b/bc_obps/reporting/schema/report_sign_off.py
@@ -1,10 +1,13 @@
+from typing import Optional
+
 from ninja import Schema
 
 
 class ReportSignOffIn(Schema):
     acknowledgement_of_review: bool
     acknowledgement_of_records: bool
-    acknowledgement_of_information: bool | None
-    acknowledgement_of_possible_costs: bool
-    acknowledgement_of_new_version: bool | None
+    acknowledgement_of_information: Optional[bool] = None
+    acknowledgement_of_possible_costs: Optional[bool] = None
+    acknowledgement_of_new_version: Optional[bool] = None
+    acknowledgement_of_corrections: Optional[bool] = None
     signature: str

--- a/bc_obps/reporting/schema/report_sign_off.py
+++ b/bc_obps/reporting/schema/report_sign_off.py
@@ -1,17 +1,10 @@
-from typing import Optional
-
 from ninja import Schema
 
 
-class ReportSignOffAcknowledgements(Schema):
+class ReportSignOffIn(Schema):
     acknowledgement_of_review: bool
     acknowledgement_of_records: bool
-    acknowledgement_of_information: Optional[bool] = None
-    acknowledgement_of_possible_costs: Optional[bool] = None
-    acknowledgement_of_new_version: Optional[bool] = None
-    acknowledgement_of_corrections: Optional[bool] = None
-
-
-class ReportSignOffIn(Schema):
-    acknowledgements: ReportSignOffAcknowledgements
+    acknowledgement_of_information: bool | None
+    acknowledgement_of_possible_costs: bool
+    acknowledgement_of_new_version: bool | None
     signature: str

--- a/bc_obps/reporting/service/report_sign_off_service.py
+++ b/bc_obps/reporting/service/report_sign_off_service.py
@@ -1,14 +1,50 @@
 import datetime
 from django.db import transaction
 from reporting.models.report_sign_off import ReportSignOff
-from reporting.schema.report_sign_off import ReportSignOffAcknowledgements, ReportSignOffIn
 from django.core.exceptions import ValidationError
+
+
+class ReportSignOffAcknowledgements:
+    def __init__(
+        self,
+        acknowledgement_of_review: bool,
+        acknowledgement_of_records: bool,
+        acknowledgement_of_information: bool | None,
+        acknowledgement_of_possible_costs: bool,
+        acknowledgement_of_new_version: bool | None,
+    ):
+        self.acknowledgement_of_review = acknowledgement_of_review
+        self.acknowledgement_of_records = acknowledgement_of_records
+        self.acknowledgement_of_information = acknowledgement_of_information
+        self.acknowledgement_of_possible_costs = acknowledgement_of_possible_costs
+        self.acknowledgement_of_new_version = acknowledgement_of_new_version
+
+
+class ReportSignOffData:
+    def __init__(
+        self,
+        acknowledgement_of_review: bool,
+        acknowledgement_of_records: bool,
+        acknowledgement_of_information: bool | None,
+        acknowledgement_of_possible_costs: bool,
+        acknowledgement_of_new_version: bool | None,
+        signature: str,
+    ):
+        self.acknowledgements = ReportSignOffAcknowledgements(
+            acknowledgement_of_review=acknowledgement_of_review,
+            acknowledgement_of_records=acknowledgement_of_records,
+            acknowledgement_of_information=acknowledgement_of_information,
+            acknowledgement_of_possible_costs=acknowledgement_of_possible_costs,
+            acknowledgement_of_new_version=acknowledgement_of_new_version,
+        )
+
+        self.signature = signature
 
 
 class ReportSignOffService:
     @classmethod
     @transaction.atomic
-    def save_report_sign_off(cls, report_version_id: int, data: ReportSignOffIn) -> ReportSignOff | None:
+    def save_report_sign_off(cls, report_version_id: int, data: ReportSignOffData) -> ReportSignOff | None:
         acknowledgements = data.acknowledgements
         if ReportSignOffService.validate_report_sign_off(acknowledgements):
             report_sign_off_record, _ = ReportSignOff.objects.update_or_create(

--- a/bc_obps/reporting/service/report_sign_off_service.py
+++ b/bc_obps/reporting/service/report_sign_off_service.py
@@ -1,44 +1,23 @@
+from dataclasses import dataclass
 import datetime
 from django.db import transaction
 from reporting.models.report_sign_off import ReportSignOff
 from django.core.exceptions import ValidationError
 
 
+@dataclass
 class ReportSignOffAcknowledgements:
-    def __init__(
-        self,
-        acknowledgement_of_review: bool,
-        acknowledgement_of_records: bool,
-        acknowledgement_of_information: bool | None,
-        acknowledgement_of_possible_costs: bool,
-        acknowledgement_of_new_version: bool | None,
-    ):
-        self.acknowledgement_of_review = acknowledgement_of_review
-        self.acknowledgement_of_records = acknowledgement_of_records
-        self.acknowledgement_of_information = acknowledgement_of_information
-        self.acknowledgement_of_possible_costs = acknowledgement_of_possible_costs
-        self.acknowledgement_of_new_version = acknowledgement_of_new_version
+    acknowledgement_of_review: bool
+    acknowledgement_of_records: bool
+    acknowledgement_of_information: bool | None
+    acknowledgement_of_possible_costs: bool
+    acknowledgement_of_new_version: bool | None
 
 
+@dataclass
 class ReportSignOffData:
-    def __init__(
-        self,
-        acknowledgement_of_review: bool,
-        acknowledgement_of_records: bool,
-        acknowledgement_of_information: bool | None,
-        acknowledgement_of_possible_costs: bool,
-        acknowledgement_of_new_version: bool | None,
-        signature: str,
-    ):
-        self.acknowledgements = ReportSignOffAcknowledgements(
-            acknowledgement_of_review=acknowledgement_of_review,
-            acknowledgement_of_records=acknowledgement_of_records,
-            acknowledgement_of_information=acknowledgement_of_information,
-            acknowledgement_of_possible_costs=acknowledgement_of_possible_costs,
-            acknowledgement_of_new_version=acknowledgement_of_new_version,
-        )
-
-        self.signature = signature
+    acknowledgements: ReportSignOffAcknowledgements
+    signature: str
 
 
 class ReportSignOffService:

--- a/bc_obps/reporting/service/report_sign_off_service.py
+++ b/bc_obps/reporting/service/report_sign_off_service.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 import datetime
+from typing import Optional
+
 from django.db import transaction
 from reporting.models.report_sign_off import ReportSignOff
 from django.core.exceptions import ValidationError
@@ -9,9 +11,10 @@ from django.core.exceptions import ValidationError
 class ReportSignOffAcknowledgements:
     acknowledgement_of_review: bool
     acknowledgement_of_records: bool
-    acknowledgement_of_information: bool | None
-    acknowledgement_of_possible_costs: bool
-    acknowledgement_of_new_version: bool | None
+    acknowledgement_of_information: Optional[bool]
+    acknowledgement_of_possible_costs: Optional[bool]
+    acknowledgement_of_new_version: Optional[bool]
+    acknowledgement_of_corrections: Optional[bool]
 
 
 @dataclass

--- a/bc_obps/reporting/service/report_submission_service.py
+++ b/bc_obps/reporting/service/report_submission_service.py
@@ -2,6 +2,10 @@ from uuid import UUID
 from django.core.exceptions import ValidationError
 from reporting.service.report_sign_off_service import ReportSignOffService
 from reporting.schema.report_sign_off import ReportSignOffIn
+from django.core.exceptions import ObjectDoesNotExist
+from reporting.service.report_sign_off_service import ReportSignOffData, ReportSignOffService
+from reporting.models.report_verification import ReportVerification
+from reporting.models.report_attachment import ReportAttachment
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_service import (
     ReportValidationService,
@@ -18,6 +22,36 @@ class ReportSubmissionService:
     """
 
     @staticmethod
+    def validate_report(version_id: int) -> None:
+        """
+        Future implementation could create a specific exception housing all the issues a report would have
+        Django-ninja could then have a special way of parsing that error with a custom error code.
+
+        Validates that the report meets necessary requirements before submission:
+        - If report verification is required, ensures that a `ReportVerification` entry exists.
+        - If a verification statement is required, ensures the presence of a corresponding attachment.
+        """
+        try:
+            # Check if verification is mandatory
+            isVerificationMandatory = ReportVerificationService.get_report_needs_verification(version_id)
+
+            if isVerificationMandatory:
+                # Check for the ReportVerification entry
+                try:
+                    ReportVerification.objects.get(report_version_id=version_id)  # attempt to get the object.
+                except ObjectDoesNotExist:
+                    raise Exception("missing_report_verification")
+
+                # Check for the attachment only if mandatory
+                ReportAttachment.objects.get(
+                    report_version_id=version_id,
+                    attachment_type=ReportAttachment.ReportAttachmentType.VERIFICATION_STATEMENT,
+                )
+        except ReportAttachment.DoesNotExist:
+            raise Exception("verification_statement")
+
+    @staticmethod
+    def submit_report(version_id: int, user_guid: UUID, sign_off_data: ReportSignOffData) -> ReportVersion:
     @transaction.atomic()
     def submit_report(version_id: int, user_guid: UUID, sign_off_data: ReportSignOffIn) -> ReportVersion:
         report_version = ReportVersion.objects.get(id=version_id)

--- a/bc_obps/reporting/service/report_submission_service.py
+++ b/bc_obps/reporting/service/report_submission_service.py
@@ -1,7 +1,5 @@
 from uuid import UUID
 from django.core.exceptions import ValidationError
-from reporting.service.report_sign_off_service import ReportSignOffService
-from reporting.schema.report_sign_off import ReportSignOffIn
 from django.core.exceptions import ObjectDoesNotExist
 from reporting.service.report_sign_off_service import ReportSignOffData, ReportSignOffService
 from reporting.models.report_verification import ReportVerification
@@ -14,6 +12,8 @@ from events.signals import report_submitted
 from common.lib import pgtrigger
 from django.db import transaction
 from reporting.service.compliance_service import ComplianceService
+
+from reporting.service.report_verification_service import ReportVerificationService
 
 
 class ReportSubmissionService:
@@ -51,9 +51,8 @@ class ReportSubmissionService:
             raise Exception("verification_statement")
 
     @staticmethod
-    def submit_report(version_id: int, user_guid: UUID, sign_off_data: ReportSignOffData) -> ReportVersion:
     @transaction.atomic()
-    def submit_report(version_id: int, user_guid: UUID, sign_off_data: ReportSignOffIn) -> ReportVersion:
+    def submit_report(version_id: int, user_guid: UUID, sign_off_data: ReportSignOffData) -> ReportVersion:
         report_version = ReportVersion.objects.get(id=version_id)
 
         validation_result = ReportValidationService.validate_report_version(version_id)

--- a/bc_obps/reporting/service/report_submission_service.py
+++ b/bc_obps/reporting/service/report_submission_service.py
@@ -1,9 +1,6 @@
 from uuid import UUID
 from django.core.exceptions import ValidationError
-from django.core.exceptions import ObjectDoesNotExist
 from reporting.service.report_sign_off_service import ReportSignOffData, ReportSignOffService
-from reporting.models.report_verification import ReportVerification
-from reporting.models.report_attachment import ReportAttachment
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_service import (
     ReportValidationService,
@@ -13,42 +10,11 @@ from common.lib import pgtrigger
 from django.db import transaction
 from reporting.service.compliance_service import ComplianceService
 
-from reporting.service.report_verification_service import ReportVerificationService
-
 
 class ReportSubmissionService:
     """
     A service to submit reports and handle the errors
     """
-
-    @staticmethod
-    def validate_report(version_id: int) -> None:
-        """
-        Future implementation could create a specific exception housing all the issues a report would have
-        Django-ninja could then have a special way of parsing that error with a custom error code.
-
-        Validates that the report meets necessary requirements before submission:
-        - If report verification is required, ensures that a `ReportVerification` entry exists.
-        - If a verification statement is required, ensures the presence of a corresponding attachment.
-        """
-        try:
-            # Check if verification is mandatory
-            isVerificationMandatory = ReportVerificationService.get_report_needs_verification(version_id)
-
-            if isVerificationMandatory:
-                # Check for the ReportVerification entry
-                try:
-                    ReportVerification.objects.get(report_version_id=version_id)  # attempt to get the object.
-                except ObjectDoesNotExist:
-                    raise Exception("missing_report_verification")
-
-                # Check for the attachment only if mandatory
-                ReportAttachment.objects.get(
-                    report_version_id=version_id,
-                    attachment_type=ReportAttachment.ReportAttachmentType.VERIFICATION_STATEMENT,
-                )
-        except ReportAttachment.DoesNotExist:
-            raise Exception("verification_statement")
 
     @staticmethod
     @transaction.atomic()

--- a/bc_obps/reporting/tests/service/test_report_sign_off_service.py
+++ b/bc_obps/reporting/tests/service/test_report_sign_off_service.py
@@ -21,6 +21,7 @@ class TestReportSignOffService(TestCase):
                 acknowledgement_of_information=True,
                 acknowledgement_of_possible_costs=True,
                 acknowledgement_of_new_version=None,
+                acknowledgement_of_corrections=None,
             ),
             signature="signature",
         )

--- a/bc_obps/reporting/tests/service/test_report_sign_off_service.py
+++ b/bc_obps/reporting/tests/service/test_report_sign_off_service.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
-from reporting.schema.report_sign_off import ReportSignOffAcknowledgements, ReportSignOffIn
 from reporting.models.report_sign_off import ReportSignOff
-from reporting.service.report_sign_off_service import ReportSignOffService
+from reporting.service.report_sign_off_service import ReportSignOffData, ReportSignOffService
 import pytest
 from model_bakery.baker import make_recipe
 
@@ -10,15 +9,13 @@ from model_bakery.baker import make_recipe
 class TestReportSignOffService(TestCase):
     def test_save_report_sign_off(self):
         # Arrange
-        data = ReportSignOffIn(
-            acknowledgements=ReportSignOffAcknowledgements(
-                acknowledgement_of_review=True,
-                acknowledgement_of_records=True,
-                acknowledgement_of_information=True,
-                acknowledgement_of_possible_costs=True,
-                acknowledgement_of_new_version=None,
-                acknowledgement_of_corrections=None,
-            ),
+        data = ReportSignOffData(
+            acknowledgement_of_review=True,
+            acknowledgement_of_records=True,
+            acknowledgement_of_information=True,
+            acknowledgement_of_possible_costs=True,
+            acknowledgement_of_new_version=None,
+            acknowledgement_of_corrections=None,
             signature="signature",
         )
         report_version = make_recipe(

--- a/bc_obps/reporting/tests/service/test_report_sign_off_service.py
+++ b/bc_obps/reporting/tests/service/test_report_sign_off_service.py
@@ -1,8 +1,13 @@
 from django.test import TestCase
 from reporting.models.report_sign_off import ReportSignOff
-from reporting.service.report_sign_off_service import ReportSignOffData, ReportSignOffService
 import pytest
 from model_bakery.baker import make_recipe
+
+from reporting.service.report_sign_off_service import (
+    ReportSignOffData,
+    ReportSignOffAcknowledgements,
+    ReportSignOffService,
+)
 
 
 @pytest.mark.django_db
@@ -10,12 +15,13 @@ class TestReportSignOffService(TestCase):
     def test_save_report_sign_off(self):
         # Arrange
         data = ReportSignOffData(
-            acknowledgement_of_review=True,
-            acknowledgement_of_records=True,
-            acknowledgement_of_information=True,
-            acknowledgement_of_possible_costs=True,
-            acknowledgement_of_new_version=None,
-            acknowledgement_of_corrections=None,
+            acknowledgements=ReportSignOffAcknowledgements(
+                acknowledgement_of_review=True,
+                acknowledgement_of_records=True,
+                acknowledgement_of_information=True,
+                acknowledgement_of_possible_costs=True,
+                acknowledgement_of_new_version=None,
+            ),
             signature="signature",
         )
         report_version = make_recipe(
@@ -28,11 +34,18 @@ class TestReportSignOffService(TestCase):
         sign_off = ReportSignOff.objects.get(report_version_id=report_version.id)
 
         # Assert
-        self.assertEqual(sign_off.acknowledgement_of_review, data.acknowledgements.acknowledgement_of_review)
-        self.assertEqual(sign_off.acknowledgement_of_records, data.acknowledgements.acknowledgement_of_records)
-        self.assertEqual(sign_off.acknowledgement_of_information, data.acknowledgements.acknowledgement_of_information)
-        self.assertEqual(
-            sign_off.acknowledgement_of_possible_costs, data.acknowledgements.acknowledgement_of_possible_costs
-        )
+        fields_to_check = {
+            "acknowledgement_of_review": "acknowledgement_of_review",
+            "acknowledgement_of_records": "acknowledgement_of_records",
+            "acknowledgement_of_information": "acknowledgement_of_information",
+            "acknowledgement_of_possible_costs": "acknowledgement_of_possible_costs",
+        }
+
+        for sign_off_field, data_field in fields_to_check.items():
+            self.assertEqual(
+                getattr(sign_off, sign_off_field),
+                getattr(data.acknowledgements, data_field),
+            )
+
         self.assertEqual(sign_off.signature, data.signature)
         self.assertIsNotNone(sign_off.signing_date)

--- a/bc_obps/reporting/tests/service/test_report_submission_service.py
+++ b/bc_obps/reporting/tests/service/test_report_submission_service.py
@@ -32,6 +32,7 @@ class TestReportSubmissionService:
         # Arrange
         version_id = 1
         user_guid = uuid.uuid4()
+        mock_validate_report_version.return_value = {}
 
         # Create a fake Report instance object
         fake_operation = MagicMock()

--- a/bc_obps/reporting/tests/service/test_report_submission_service.py
+++ b/bc_obps/reporting/tests/service/test_report_submission_service.py
@@ -4,7 +4,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 from reporting.service.report_submission_service import ReportSubmissionService
 from reporting.models.report_version import ReportVersion
-from reporting.service.report_sign_off_service import ReportSignOffData
+from reporting.service.report_sign_off_service import ReportSignOffAcknowledgements, ReportSignOffData
 import uuid
 
 from reporting.service.report_validation.report_validation_error import ReportValidationError, Severity
@@ -52,12 +52,14 @@ class TestReportSubmissionService:
         mock_filter.return_value = mock_filter_instance
 
         fake_sign_off_data = ReportSignOffData(
-            acknowledgement_of_review=True,
-            acknowledgement_of_records=True,
-            acknowledgement_of_information=True,
-            acknowledgement_of_possible_costs=True,
-            acknowledgement_of_new_version=None,
-            acknowledgement_of_corrections=None,
+            acknowledgements=ReportSignOffAcknowledgements(
+                acknowledgement_of_review=True,
+                acknowledgement_of_records=True,
+                acknowledgement_of_information=True,
+                acknowledgement_of_possible_costs=True,
+                acknowledgement_of_new_version=None,
+                acknowledgement_of_corrections=None,
+            ),
             signature="signature",
         )
 

--- a/bc_obps/reporting/tests/service/test_report_submission_service.py
+++ b/bc_obps/reporting/tests/service/test_report_submission_service.py
@@ -4,7 +4,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 from reporting.service.report_submission_service import ReportSubmissionService
 from reporting.models.report_version import ReportVersion
-from reporting.schema.report_sign_off import ReportSignOffAcknowledgements, ReportSignOffIn
+from reporting.service.report_sign_off_service import ReportSignOffData
 import uuid
 
 from reporting.service.report_validation.report_validation_error import ReportValidationError, Severity
@@ -32,7 +32,6 @@ class TestReportSubmissionService:
         # Arrange
         version_id = 1
         user_guid = uuid.uuid4()
-        mock_validate_report_version.return_value = {}
 
         # Create a fake Report instance object
         fake_operation = MagicMock()
@@ -52,15 +51,13 @@ class TestReportSubmissionService:
         mock_filter_instance = MagicMock()
         mock_filter.return_value = mock_filter_instance
 
-        fake_sign_off_data = ReportSignOffIn(
-            acknowledgements=ReportSignOffAcknowledgements(
-                acknowledgement_of_review=True,
-                acknowledgement_of_records=True,
-                acknowledgement_of_information=True,
-                acknowledgement_of_possible_costs=True,
-                acknowledgement_of_new_version=None,
-                acknowledgement_of_corrections=None,
-            ),
+        fake_sign_off_data = ReportSignOffData(
+            acknowledgement_of_review=True,
+            acknowledgement_of_records=True,
+            acknowledgement_of_information=True,
+            acknowledgement_of_possible_costs=True,
+            acknowledgement_of_new_version=None,
+            acknowledgement_of_corrections=None,
             signature="signature",
         )
 

--- a/bciers/apps/reporting/src/app/components/signOff/SignOffForm.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SignOffForm.tsx
@@ -66,10 +66,8 @@ export default function SignOffForm({
       const { supplementary = {}, signature, date, ...rest } = formState;
 
       const payload = {
-        acknowledgements: {
-          ...rest,
-          ...supplementary,
-        },
+        ...rest,
+        ...supplementary,
         signature,
         date,
       };

--- a/bciers/apps/reporting/src/app/components/signOff/SignOffForm.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SignOffForm.tsx
@@ -63,15 +63,7 @@ export default function SignOffForm({
       setErrors(undefined);
       setSubmitButtonDisabled(true);
 
-      const { supplementary = {}, signature, date, ...rest } = formState;
-
-      const payload = {
-        ...rest,
-        ...supplementary,
-        signature,
-        date,
-      };
-      const response: any = await postSubmitReport(version_id, payload);
+      const response: any = await postSubmitReport(version_id, formState);
       setSubmitButtonDisabled(false);
 
       if (response?.error) {


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/663
Related Card: https://github.com/bcgov/cas-reporting/issues/451

#### Changes
Refactored report_sign_off_service to not use ninja schema data type that was also used by API. service data type has been uncoupled and is now defined within the service. 

Other changes were refactoring the data to and in the API to lower transformations away from the base formData.