### PR TITLE
Fix/639 incorrectly persisted report data

### DIFF
--- a/bc_obps/reporting/api/facility_report.py
+++ b/bc_obps/reporting/api/facility_report.py
@@ -7,14 +7,13 @@ from service.facility_report_service import FacilityReportService
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from .router import router
 from reporting.schema.facility_report import (
-    FacilityReportOut,
     FacilityReportIn,
+    FacilityReportOut,
     FacilityReportListSchema,
     FacilityReportListInSchema,
     FacilityReportFilterSchema,
 )
 from reporting.schema.activity import FacilityReportActivityDataOut
-from common.api.utils import get_current_user_guid
 from registration.models import Activity, Operation
 from reporting.models import FacilityReport, ReportVersion, Report
 from ninja.pagination import paginate
@@ -84,8 +83,7 @@ def save_facility_report(
         Tuple: HTTP status code and the response data or an error message.
     """
     # Fetch the existing facility report or create a new one
-    user_guid = get_current_user_guid(request)
-    facility_report = FacilityReportService.save_facility_report(version_id, facility_id, payload, user_guid)
+    facility_report = FacilityReportService.save_facility_report(version_id, facility_id, payload)
 
     # Prepare the response data
     return 201, facility_report

--- a/bc_obps/reporting/api/reports.py
+++ b/bc_obps/reporting/api/reports.py
@@ -17,12 +17,12 @@ from reporting.schema.report_operation import ReportOperationIn, ReportOperation
 from reporting.schema.reporting_year import ReportingYearOut
 from .router import router
 from ..schema.report_regulated_products import RegulatedProductOut
-from ..models import ReportingYear, ReportVersion
 from ..schema.report_version import ReportVersionTypeIn, ReportingVersionOut
 from reporting.api.permissions import (
     approved_industry_user_report_version_composite_auth,
     approved_authorized_roles_report_version_composite_auth,
 )
+from reporting.models import ReportingYear, ReportVersion, ReportOperation
 
 
 @router.post(
@@ -30,7 +30,6 @@ from reporting.api.permissions import (
     response={201: int, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Starts a report for a given operation and reporting year, by creating the underlying data structures and
-    pre-populating them with facility, operation and operator information. Returns the id of the report that was created.
     This endpoint only allows the creation of a report for an operation / operator to which the current user has access.""",
     auth=compose_auth(authorize("approved_industry_user"), check_operation_ownership()),
 )
@@ -61,9 +60,9 @@ def get_report_operation_by_version_id(request: HttpRequest, version_id: int) ->
 )
 def save_report(
     request: HttpRequest, version_id: int, payload: ReportOperationIn
-) -> Tuple[Literal[201], ReportOperationOut]:
+) -> Tuple[Literal[201], ReportOperation]:
     report_operation = ReportService.save_report_operation(version_id, payload)
-    return 201, report_operation  # type: ignore
+    return 201, report_operation
 
 
 @router.post(
@@ -113,7 +112,7 @@ def get_regulated_products_by_version_id(
     description="Retrieve the report type for a specific reporting version, including the reporting year and due date.",
     auth=approved_industry_user_report_version_composite_auth,
 )
-def get_report_type_by_version(request: HttpRequest, version_id: int) -> tuple[Literal[200], ReportVersion]:
+def get_report_type_by_version(request: HttpRequest, version_id: int) -> Tuple[Literal[200], ReportVersion]:
     report_type = ReportService.get_report_type_by_version_id(version_id)
     return 200, report_type
 

--- a/bc_obps/reporting/schema/facility_report.py
+++ b/bc_obps/reporting/schema/facility_report.py
@@ -40,7 +40,7 @@ class FacilityReportIn(ModelSchema):
     facility_name: str
     facility_type: str
     facility_bcghgid: Optional[str]
-    activities: List[str]
+    activities: List[int]
 
     class Meta:
         alias_generator = to_snake

--- a/bc_obps/service/facility_report_service.py
+++ b/bc_obps/service/facility_report_service.py
@@ -1,13 +1,23 @@
 from uuid import UUID
 from django.db import transaction
-from typing import List, Optional, Tuple, cast
+from typing import Any, List, Optional, Tuple, cast
 from ninja import Query
 from registration.models import Activity, Facility
 from reporting.models import ReportActivity, ReportProductEmissionAllocation
 from reporting.models.facility_report import FacilityReport
-from reporting.schema.facility_report import FacilityReportIn, FacilityReportListInSchema, FacilityReportFilterSchema
+from reporting.schema.facility_report import FacilityReportListInSchema, FacilityReportFilterSchema
 from django.db.models import QuerySet
 from django.db.models import F
+
+
+class SaveFacilityReportData:
+    def __init__(
+        self, facility_name: str, facility_type: str, activities: List[int], facility_bcghgid: Optional[str] = None
+    ):
+        self.facility_name = facility_name
+        self.facility_type = facility_type
+        self.facility_bcghgid = facility_bcghgid
+        self.activities = activities
 
 
 class FacilityReportService:
@@ -33,21 +43,30 @@ class FacilityReportService:
         return list(facility_report.activities.values_list('id', flat=True))
 
     @classmethod
+    def set_activities_for_facility_report(cls, facility_report: FacilityReport, activities: List[int]) -> None:
+        facility_report.activities.set(Activity.objects.filter(id__in=activities))
+        # If activities are removed from a facility_report, then the corresponding report_activity data must be delete-cascaded
+        ReportActivity.objects.filter(facility_report_id=facility_report.id).exclude(
+            activity_id__in=activities
+        ).delete()
+        # If activities are removed from a facility report, then the allocation of emissions to products must be deleted & re-allocated by the user
+        ReportProductEmissionAllocation.objects.filter(facility_report_id=facility_report.id).delete()
+
+    @classmethod
     @transaction.atomic()
-    def save_facility_report(
-        cls, report_version_id: int, facility_id: UUID, data: FacilityReportIn, user_guid: UUID
-    ) -> FacilityReport:
+    def save_facility_report(cls, report_version_id: int, facility_id: UUID, data: Any) -> FacilityReport:
         """
         Update a facility report and its related activities.
 
         Args:
             report_version_id (int): The ID of the report version.
             facility_id (int): The ID of the facility.
-            data (FacilityReportIn): The input data for the facility report.
+            data (SaveFacilityReportData): The input data for the facility report.
 
         Returns:
             FacilityReport: The updated or created FacilityReport instance.
         """
+
         # Update FacilityReport instance
         facility_report = FacilityReport.objects.get(report_version_id=report_version_id, facility_id=facility_id)
         facility_report.facility_name = data.facility_name.strip()
@@ -55,13 +74,7 @@ class FacilityReportService:
 
         # Update ManyToMany fields (activities)
         if data.activities:
-            facility_report.activities.set(Activity.objects.filter(id__in=data.activities))
-            # If activities are removed from a facility_report, then the corresponding report_activity data must be delete-cascaded
-            ReportActivity.objects.filter(facility_report_id=facility_report.id).exclude(
-                activity_id__in=data.activities
-            ).delete()
-            # If activities are removed from a facility report, then the allocation of emissions to products must be deleted & re-allocated by the user
-            ReportProductEmissionAllocation.objects.filter(facility_report_id=facility_report.id).delete()
+            cls.set_activities_for_facility_report(facility_report=facility_report, activities=data.activities)
 
         # Save the updated FacilityReport instance
         facility_report.save()

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -5,6 +5,16 @@ from service.facility_report_service import FacilityReportService
 from reporting.schema.facility_report import FacilityReportIn
 from model_bakery import baker
 from registration.tests.utils.bakers import user_baker
+from common.tests.utils.model_inspection import get_cascading_models
+from reporting.models import (
+    ReportActivity,
+    ReportSourceType,
+    ReportFuel,
+    ReportUnit,
+    ReportEmission,
+    ReportMethodology,
+    ReportProductEmissionAllocation,
+)
 
 
 class TestFacilityReportService(TestCase):
@@ -97,3 +107,63 @@ class TestFacilityReportService(TestCase):
         assert updated_facility_report.facility_name == 'New Name'
         assert updated_facility_report.facility_type == 'Medium Facility'
         assert updated_facility_report.facility_bcghgid == facility_report.facility_bcghgid
+    
+    @staticmethod
+    def test_saves_facility_report_form_data_deletes_removed_activity_report_data():
+        facility_report = baker.make_recipe('reporting.tests.utils.facility_report', facility_bcghgid='abc')
+        activity_1 = baker.make_recipe(
+            'reporting.tests.utils.report_activity', activity_id=1, facility_report_id=facility_report.id
+        )
+        activity_2 = baker.make_recipe(
+            'reporting.tests.utils.report_activity', activity_id=2, facility_report_id=facility_report.id
+        )
+        source_type_1 = baker.make_recipe('reporting.tests.utils.report_source_type', report_activity_id=activity_1.id)
+        source_type_2 = baker.make_recipe('reporting.tests.utils.report_source_type', report_activity_id=activity_2.id)
+        unit_1 = baker.make_recipe('reporting.tests.utils.report_unit', report_source_type_id=source_type_1.id)
+        unit_2 = baker.make_recipe('reporting.tests.utils.report_unit', report_source_type_id=source_type_2.id)
+        fuel_1 = baker.make_recipe('reporting.tests.utils.report_fuel', report_unit_id=unit_1.id)
+        fuel_2 = baker.make_recipe('reporting.tests.utils.report_fuel', report_unit_id=unit_2.id)
+        emission_1 = baker.make_recipe('reporting.tests.utils.report_emission', report_fuel_id=fuel_1.id)
+        emission_2 = baker.make_recipe('reporting.tests.utils.report_emission', report_fuel_id=fuel_2.id)
+        baker.make_recipe('reporting.tests.utils.report_methodology', report_emission_id=emission_1.id)
+        baker.make_recipe('reporting.tests.utils.report_methodology', report_emission_id=emission_2.id)
+        baker.make_recipe(
+            'reporting.tests.utils.report_product_emission_allocation', facility_report_id=facility_report.id
+        )
+
+        data = FacilityReportIn(
+            facility_name="CHANGED",
+            facility_type=facility_report.facility_type,
+            facility_bcghgid=facility_report.facility_bcghgid,
+            activities=['1'],
+            products=[],
+        )
+        user = user_baker()
+        FacilityReportService.save_facility_report(
+            report_version_id=facility_report.report_version_id,
+            facility_id=facility_report.facility_id,
+            data=data,
+            user_guid=user.user_guid,
+        )
+        assert ReportActivity.objects.filter(facility_report=facility_report.id).count() == 1
+        assert ReportActivity.objects.filter(activity_id=2).count() == 0
+        assert ReportSourceType.objects.filter(report_activity_id=activity_2.id).count() == 0
+        assert ReportUnit.objects.filter(report_source_type_id=source_type_2.id).count() == 0
+        assert ReportFuel.objects.filter(report_unit_id=unit_2.id).count() == 0
+        assert ReportEmission.objects.filter(report_fuel_id=fuel_2.id).count() == 0
+        assert ReportMethodology.objects.filter(report_emission_id=emission_2.id).count() == 0
+        # ReportProductEmissionAllocation objects are not cascaded by the ReportActivity delete, but should also be cleared & re-entered if an activity is removed from the set
+        assert ReportProductEmissionAllocation.objects.filter(facility_report=facility_report.id).count() == 0
+
+    @staticmethod
+    def test_deleting_report_activity_data_cascades_correctly():
+        cascading_models_names = {m.__name__ for m in get_cascading_models(ReportActivity)}
+        print(cascading_models_names)
+
+        assert cascading_models_names == {
+            "ReportEmission",
+            "ReportFuel",
+            "ReportMethodology",
+            "ReportSourceType",
+            "ReportUnit",
+        }

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -104,7 +104,7 @@ class TestFacilityReportService(TestCase):
         assert updated_facility_report.facility_name == 'New Name'
         assert updated_facility_report.facility_type == 'Medium Facility'
         assert updated_facility_report.facility_bcghgid == facility_report.facility_bcghgid
-    
+
     @staticmethod
     def test_saves_facility_report_form_data_deletes_removed_activity_report_data():
         facility_report = baker.make_recipe('reporting.tests.utils.facility_report', facility_bcghgid='abc')
@@ -153,7 +153,6 @@ class TestFacilityReportService(TestCase):
     @staticmethod
     def test_deleting_report_activity_data_cascades_correctly():
         cascading_models_names = {m.__name__ for m in get_cascading_models(ReportActivity)}
-        print(cascading_models_names)
 
         assert cascading_models_names == {
             "ReportEmission",

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -4,7 +4,6 @@ from reporting.tests.utils.bakers import activity_baker
 from service.facility_report_service import FacilityReportService
 from reporting.schema.facility_report import FacilityReportIn
 from model_bakery import baker
-from registration.tests.utils.bakers import user_baker
 from common.tests.utils.model_inspection import get_cascading_models
 from reporting.models import (
     ReportActivity,
@@ -76,12 +75,10 @@ class TestFacilityReportService(TestCase):
             activities=[],
             products=[],
         )
-        user = user_baker()
         returned_data = FacilityReportService.save_facility_report(
             report_version_id=facility_report.report_version_id,
             facility_id=facility_report.facility_id,
             data=data,
-            user_guid=user.user_guid,
         )
         assert returned_data.facility_name == "CHANGED"
         assert returned_data.facility_type == facility_report.facility_type
@@ -138,12 +135,10 @@ class TestFacilityReportService(TestCase):
             activities=['1'],
             products=[],
         )
-        user = user_baker()
         FacilityReportService.save_facility_report(
             report_version_id=facility_report.report_version_id,
             facility_id=facility_report.facility_id,
             data=data,
-            user_guid=user.user_guid,
         )
         assert ReportActivity.objects.filter(facility_report=facility_report.id).count() == 1
         assert ReportActivity.objects.filter(activity_id=2).count() == 0

--- a/bc_obps/service/tests/test_report_service.py
+++ b/bc_obps/service/tests/test_report_service.py
@@ -165,6 +165,7 @@ class TestReportService(TestCase):
             mock.patch('service.report_service.ReportOperation.objects.get') as mock_get,
             mock.patch('service.report_service.ReportOperationRepresentative.objects.filter') as mock_filter,
             mock.patch('service.report_service.FacilityReport.objects.filter') as mock_facility_filter,
+            mock.patch('service.report_service.FacilityReport.objects.get') as mock_facility_get,
             mock.patch('service.report_service.Activity.objects.filter') as mock_activity_filter,
             mock.patch('service.report_service.RegulatedProduct.objects.filter') as mock_regulated_product_filter,
         ):
@@ -174,7 +175,11 @@ class TestReportService(TestCase):
             mock_filter.return_value.update.return_value = None
 
             # Mock FacilityReport behavior
-            mock_facility_reports = [mock.MagicMock(spec=FacilityReport) for _ in range(3)]
+            mock_facility_report = mock.MagicMock(spec=FacilityReport, report_version_id=report_version.id, id=999)
+            mock_facility_reports = [
+                mock.MagicMock(spec=FacilityReport, report_version_id=report_version.id) for _ in range(3)
+            ]
+            mock_facility_get.return_value = mock_facility_report
             mock_facility_filter.return_value = mock_facility_reports
 
             # Mock Activity filtering

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
@@ -48,7 +48,7 @@ const FacilityReview: React.FC<Props> = ({
         activity.id,
       ]),
     );
-const updatedFormData = {
+    const updatedFormData = {
       ...formData,
       activities: (formData as any).activities
         .map((activityName: string) => {

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
@@ -48,14 +48,14 @@ const FacilityReview: React.FC<Props> = ({
         activity.id,
       ]),
     );
-    const updatedFormData = {
+const updatedFormData = {
       ...formData,
       activities: (formData as any).activities
         .map((activityName: string) => {
           return activityNameToIdMap.get(activityName);
         })
-        .filter((id: number | undefined) => id !== undefined)
-        .map(String),
+        .filter((id: number | undefined) => id !== undefined) // Filter out undefined IDs
+        .map(Number), // Ensure all IDs are numbers
     };
     const response = await actionHandler(endpoint, method, endpoint, {
       body: JSON.stringify(updatedFormData),

--- a/bciers/apps/reporting/src/tests/components/facility/FacilityReviewForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/facility/FacilityReviewForm.test.tsx
@@ -76,7 +76,7 @@ describe("The FacilityReview component", () => {
       "reporting/report-version/1000/facility-report/abcd",
       "POST",
       "reporting/report-version/1000/facility-report/abcd",
-      { body: '{"activities":["1"]}' },
+      { body: '{"activities":[1]}' },
     );
   });
 

--- a/docs/backend/testing.md
+++ b/docs/backend/testing.md
@@ -17,6 +17,7 @@ The easiest way to run these tests locally is by using commands from the Makefil
 > make pythontests ARGS='-k <TestClassname>' # run pytest for a specific class, e.g. make pythontests ARGS='-k TestNaicsCodeEndpoint'
 > make pythontests ARGS='-k <test_name>' # run pytest for a specific test, e.g. make pythontests ARGS='-k test_get_method_for_200_status' (note: if any tests have the same name, even if they're within different classes, this command will run them all)
 > make pythontests ARGS='--lf'  # run pytest with the --last-failed flag to re-run only the tests that failed in the last run
+> make pythontests ARGS='--reuse-db'  # run pytest with the --reuse-db flag. This flag will cause the db to persist & subsequent tests will reuse that db instance, which saves time when running a single test file & resetting the db entirely is not necessary.
 ```
 
 ## Testing Helpers


### PR DESCRIPTION
Should fix cas-reporting issues [639](https://github.com/bcgov/cas-reporting/issues/639), [643](https://github.com/bcgov/cas-reporting/issues/643), [652](https://github.com/bcgov/cas-reporting/issues/652), [651](https://github.com/bcgov/cas-reporting/issues/651).

The root problem for all of these issues was that on removing activities from the facility review or operation review pages, the many to many tables were being updated, but the actual report data was persisted. This fix delete/cascades all report_activity data for the removed activity IDs & all allocation records as well (as they will be incorrect now that we've removed an activity worth of emission data).

Also found & fixed during this work: LFOs were using the `FacilityReportService` when updating facility_report data, but SFOs were not. SFOs were only updating the set of activity IDs when changes were made on the OperationReview page directly in the `ReportService`.

Refactored some issues with the services being dependent on ninja schemas.