### PR TITLE
chore: allow delete of first element on activities

### DIFF
--- a/bciers/libs/components/src/form/fields/NestedArrayFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/NestedArrayFieldTemplate.tsx
@@ -59,15 +59,13 @@ const NestedArrayFieldTemplate = ({
                   {customTitleName} {i + 1}
                 </span>
               )}
-              {i !== 0 && (
-                <button
-                  onClick={item.onDropIndexClick(item.index)}
-                  className="border-none bg-transparent"
-                  aria-label="Remove item"
-                >
-                  <DeleteForeverOutlinedIcon />
-                </button>
-              )}
+              <button
+                onClick={item.onDropIndexClick(item.index)}
+                className="border-none bg-transparent"
+                aria-label="Remove item"
+              >
+                <DeleteForeverOutlinedIcon />
+              </button>
               {{
                 ...item.children,
                 props: {


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/622

### Changes
   - Removed the condition on rendering the delete button on NestedArray activity elements

### To test
   - go to any activity form and see that there is a delete button shown for the first instance of any unit, fuel, emission field components