### PR TITLE
chore fixed updatedat and submitted by

### DIFF
--- a/bciers/apps/reporting/src/app/components/datagrid/models/reportHistory/reportHistoryColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/reportHistory/reportHistoryColumns.tsx
@@ -1,9 +1,20 @@
 "use client";
-import { GridColDef } from "@mui/x-data-grid";
+import { GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import ReportHistoryActionCell from "@reporting/src/app/components/reportHistory/ActionCell";
 import formatTimestamp from "@bciers/utils/src/formatTimestamp";
+import { ReportOperationStatus } from "@bciers/utils/src/enums";
 
-export const OPERATOR_COLUMN_INDEX = 1;
+const UpdatedAtCell = ({ row, value }: GridRenderCellParams) => {
+  if (row.status === ReportOperationStatus.DRAFT) {
+    return "Not Submitted";
+  }
+  return value ? formatTimestamp(value) : "—";
+};
+const SubmittedByCell = ({ row }: GridRenderCellParams) => {
+  return row.status === ReportOperationStatus.DRAFT
+    ? "N/A"
+    : row.submitted_by || "—";
+};
 
 const reportHistoryColumns = (): GridColDef[] => {
   return [
@@ -17,17 +28,13 @@ const reportHistoryColumns = (): GridColDef[] => {
       field: "updated_at",
       headerName: "Date of submission",
       sortable: false,
-      renderCell: (params) => {
-        if (!params.value) {
-          return "";
-        }
-        return formatTimestamp(params.value);
-      },
+      renderCell: UpdatedAtCell,
       width: 400,
     },
     {
       field: "submitted_by",
       headerName: "Submitted by",
+      renderCell: SubmittedByCell,
       sortable: false,
       width: 400,
     },

--- a/bciers/apps/reporting/src/app/components/datagrid/models/reportHistory/reportHistoryColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/reportHistory/reportHistoryColumns.tsx
@@ -6,14 +6,12 @@ import { ReportOperationStatus } from "@bciers/utils/src/enums";
 
 const UpdatedAtCell = ({ row, value }: GridRenderCellParams) => {
   if (row.status === ReportOperationStatus.DRAFT) {
-    return "Not Submitted";
+    return "Not yet submitted";
   }
   return value ? formatTimestamp(value) : "—";
 };
 const SubmittedByCell = ({ row }: GridRenderCellParams) => {
-  return row.status === ReportOperationStatus.DRAFT
-    ? "N/A"
-    : row.submitted_by || "—";
+  return row.status === ReportOperationStatus.DRAFT ? "N/A" : row.submitted_by;
 };
 
 const reportHistoryColumns = (): GridColDef[] => {

--- a/bciers/apps/reporting/src/tests/components/dataGrid/model/reportHistory /reportHistoryColumns.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/dataGrid/model/reportHistory /reportHistoryColumns.test.tsx
@@ -43,8 +43,20 @@ describe("reportHistoryColumns function", () => {
 
   it("renders an empty string if updated_at is null", () => {
     const columns = reportHistoryColumns();
-    const params = { value: null };
-    expect(columns[1].renderCell(params)).toBe("");
+    const params = { row: { status: "Submitted", submitted_by: null } };
+    expect(columns[1].renderCell(params)).toBe("—");
+  });
+
+  it("renders 'Not yet submitted' if status is DRAFT", () => {
+    const columns = reportHistoryColumns();
+    const params = { row: { status: "Draft", submitted_by: null } };
+    expect(columns[1].renderCell(params)).toBe("Not yet submitted");
+  });
+
+  it("renders 'N/A' if status is DRAFT in SubmittedByCell", () => {
+    const columns = reportHistoryColumns();
+    const params = { row: { status: "Draft", submitted_by: null } };
+    expect(columns[2].renderCell(params)).toBe("N/A");
   });
 
   it("renders the Actions column correctly", () => {


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/674
A small PR to show date of submission as "Not yet submitted" and Submitted by as "N/A" if the status is draft on Report History Page 

To test: 
Click on report history for a report with Draft status and you should see like 
![image](https://github.com/user-attachments/assets/75c7276c-0627-4126-9dee-e30fd8270781)