### PR TITLE
chore: fix operation_report_type typo

### DIFF
--- a/bciers/apps/reporting/src/data/jsonSchema/operations.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/operations.tsx
@@ -127,7 +127,7 @@ export const buildOperationReviewSchema = (
           {
             properties: {
               operation_report_type: {
-                enum: [ANNUAL_REPORT],
+                enum: [SIMPLE_REPORT],
               },
             },
           },


### PR DESCRIPTION
## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button
5. Log in using `bc-cas-dev`

### Testing: `OBPS Regulated Operation`

#### **Steps**  
1. Navigate to http://localhost:3000/reporting/reports/
2. Select operation with `Registration Purpose` ==  `OBPS Regulated Operation`
3. Click `Start`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/9776f9bb-1297-444b-a383-2d2a7abec6c8)


### Testing: `Reporting Operation`
#### **Steps**  
1. Navigate to http://localhost:3000/reporting/reports/
2. Select operation with `Registration Purpose` ==  `Reporting Operation`
3. Click `Start`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/d1fc8c23-9ae4-4b1e-9745-9d8633a35238)

