### PR TITLE
Feat/521 activity form builder caching

### DIFF
--- a/bc_obps/bc_obps/settings.py
+++ b/bc_obps/bc_obps/settings.py
@@ -251,3 +251,17 @@ QUERYCOUNT = {
     # print the 2 most duplicated queries
     'DISPLAY_DUPLICATES': 2,
 }
+
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "default_local_memcache",
+    },
+    "form_builder": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "form_builder_memcache",
+        # Cache keys don't expire, since we don't update program configuration without a release.
+        "TIMEOUT": None,
+    },
+}

--- a/bc_obps/service/form_builder_service.py
+++ b/bc_obps/service/form_builder_service.py
@@ -258,6 +258,7 @@ def build_source_type_schema(
     form_builder_cache = caches["form_builder"]
     cache_key = f"{config_id}-{activity_id}-{source_type_id}"
     cache_hit: Dict = form_builder_cache.get(cache_key)
+
     if cache_hit:
         return cache_hit
 

--- a/bc_obps/service/form_builder_service.py
+++ b/bc_obps/service/form_builder_service.py
@@ -253,6 +253,11 @@ def build_source_type_schema(
     activity_id: int,
     source_type_id: int,
 ) -> Dict:
+    # PIERRE: caching should happen here. These are completely static. We could either:
+    # - Cache at compile time
+    # - Cache at bootstrap time
+    # - Cache at access time
+
     try:
         source_type_schema = ActivitySourceTypeJsonSchema.objects.get(
             activity_id=activity_id,

--- a/bc_obps/service/tests/test_form_builder_service.py
+++ b/bc_obps/service/tests/test_form_builder_service.py
@@ -1,6 +1,11 @@
+from unittest.mock import MagicMock
+from django.core.cache import caches
 from model_bakery.baker import prepare_recipe
 import pytest
-from service.form_builder_service import handle_source_type_schema
+from registration.models.activity import Activity
+from reporting.models.configuration import Configuration
+from reporting.models.source_type import SourceType
+from service.form_builder_service import build_source_type_schema, handle_source_type_schema
 
 
 pytestmark = pytest.mark.django_db
@@ -172,3 +177,30 @@ class TestHandleSourceTypeMethod:
             returned_schema["properties"]["emissions"]["items"]["properties"]["gasType"]["enum"] == self.gas_type_enum
         )
         assert returned_schema["properties"]["emissions"]["items"]["dependencies"] == self.gas_type_one_of
+
+    def test_form_builder_uses_cache(self):
+
+        mock_cache = MagicMock()
+        caches["form_builder"] = mock_cache
+
+        config_id = Configuration.objects.first().id
+        activity_id = Activity.objects.first().id
+        source_type_id = SourceType.objects.first().id
+
+        # Nothing in cache, so the 'set' method is called
+        mock_cache.get.return_value = None
+        build_source_type_schema(config_id, activity_id, source_type_id)
+
+        assert len(mock_cache.get.mock_calls) == 1
+        mock_cache.get.assert_called_once_with(f"{config_id}-{activity_id}-{source_type_id}")
+        assert len(mock_cache.set.mock_calls) == 1
+
+        mock_cache.reset_mock()
+
+        # Something in cache, so the 'set' method is not called
+        # And we return the cached value
+        mock_cache.get.return_value = "cached"
+        return_value = build_source_type_schema(config_id, activity_id, source_type_id)
+        assert return_value == "cached"
+        assert len(mock_cache.get.mock_calls) == 1
+        assert len(mock_cache.set.mock_calls) == 0


### PR DESCRIPTION
- Adding a caching strategy for the source type pieces when building activity forms.
- Fixed an N+1 query where we weren't using the prefetched data