### PR TITLE
chore: fixed report history page version number

### DIFF
--- a/bc_obps/reporting/schema/report_history.py
+++ b/bc_obps/reporting/schema/report_history.py
@@ -1,5 +1,5 @@
 from ninja import ModelSchema
-from typing import Optional, Any
+from typing import Optional
 
 from registration.models import Operation
 from reporting.models import ReportVersion
@@ -13,18 +13,6 @@ class ReportHistoryResponse(ModelSchema):
     report_id: int
     submitted_by: Optional[str] = None
     version: Optional[str] = None
-
-    @staticmethod
-    def resolve_version(obj: Any) -> str:
-        all_ids = [version.id for version in obj._meta.model.objects.filter(report_id=obj.report_id)]
-        max_id = max(all_ids)
-        min_id = min(all_ids)
-
-        if obj.id == max_id:
-            return "Current Version"
-        elif obj.id == min_id:
-            return "Version 1"
-        return f"Version {obj.version_number}"
 
     @staticmethod
     def resolve_submitted_by(obj: ReportVersion) -> Optional[str]:

--- a/bc_obps/reporting/service/report_history_dashboard_service.py
+++ b/bc_obps/reporting/service/report_history_dashboard_service.py
@@ -1,19 +1,28 @@
-from django.db.models import QuerySet, Window
-from django.db.models.functions import RowNumber
+from django.db.models import Window, QuerySet, Case, When, Value, CharField
+from django.db.models.functions import RowNumber, Cast, Concat
 from django.db.models import F
 from reporting.models import ReportVersion
 
 
 class ReportingHistoryDashboardService:
     """
-    Service providing data operations for the reporting dashboard
+    Service providing data operations for the report history dashboard
     """
 
     @classmethod
     def get_report_versions_for_report_history_dashboard(cls, report_id: int) -> QuerySet[ReportVersion]:
+        total_versions = ReportVersion.objects.filter(report_id=report_id).count()
         report_versions = (
             ReportVersion.objects.filter(report_id=report_id)
             .annotate(version_number=Window(expression=RowNumber(), order_by=F("id").desc()))
-            .order_by("-id")
+            .annotate(
+                version=Case(
+                    When(version_number=1, then=Value("Current Version")),
+                    default=Concat(Value("Version "), Cast(total_versions - F("version_number") + 1, CharField())),
+                    output_field=CharField(),
+                )
+            )
+            .order_by("version_number")
         )
+
         return report_versions

--- a/bc_obps/reporting/tests/service/test_report_history_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_report_history_dashboard_service.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 from model_bakery import baker
 from reporting.service.report_history_dashboard_service import ReportingHistoryDashboardService
-from reporting.schema.report_history import ReportHistoryResponse
 
 
 class TestReportingHistoryDashboardService(TestCase):
@@ -30,5 +29,5 @@ class TestReportingHistoryDashboardService(TestCase):
         self.assertEqual(report_versions[0].id, self.report_version_2.id)
         self.assertEqual(report_versions[1].id, self.report_version_1.id)
 
-        self.assertEqual(ReportHistoryResponse.resolve_version(report_versions[0]), "Current Version")
-        self.assertEqual(ReportHistoryResponse.resolve_version(report_versions[1]), "Version 1")
+        self.assertEqual(report_versions[0].version, "Current Version")
+        self.assertEqual(report_versions[1].version, "Version 1")


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/691
A small PR to fix how the version is generated

To test 
Create multiple report versions using supplementart reports and go to 
http://localhost:3000/reporting/reports/report-history/{report_id}
You should see like 
<img width="1345" alt="image" src="https://github.com/user-attachments/assets/0b0ff4b2-7daf-4748-9dbc-c913edefa3e7" />
