### PR TITLE
chore: 677 Final Review hides activity array delete icons

### DIFF
--- a/bciers/libs/components/src/form/fields/NestedArrayFieldTemplate.test.tsx
+++ b/bciers/libs/components/src/form/fields/NestedArrayFieldTemplate.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RJSFSchema } from "@rjsf/utils";
+import FormBase from "@bciers/components/form/FormBase";
+import BasicFieldTemplate from "@bciers/components/form/fields/BasicFieldTemplate";
+import NestedArrayFieldTemplate from "./NestedArrayFieldTemplate";
+
+const schema: RJSFSchema = {
+  type: "object",
+  properties: {
+    units: {
+      type: "array",
+      title: "Units",
+      items: {
+        type: "object",
+        properties: {
+          unitName: { type: "string", title: "Unit Name" },
+        },
+      },
+    },
+  },
+};
+
+const uiSchema = {
+  units: {
+    "ui:ArrayFieldTemplate": NestedArrayFieldTemplate,
+    "ui:options": {
+      arrayAddLabel: "Add Unit",
+      title: "Unit",
+      bgColor: "#f2f2f2",
+      showHr: true, // set to true to test the horizontal rule rendering
+      padding: "p-2",
+      verticalBorder: true,
+    },
+    "ui:FieldTemplate": BasicFieldTemplate,
+  },
+};
+
+describe("NestedArrayFieldTemplate in FormBase", () => {
+  const formDataMultiple = {
+    units: [{ unitName: "Test Unit 1" }, { unitName: "Test Unit 2" }],
+  };
+  const formDataSingle = {
+    units: [{ unitName: "Test Unit" }],
+  };
+
+  it("renders the remove button when readonly is false", () => {
+    render(
+      <FormBase
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={formDataMultiple}
+        readonly={false}
+      />,
+    );
+    // Expect at least one remove button (identified by aria-label "Remove item")
+    const removeButtons = screen.getAllByRole("button", {
+      name: /remove item/i,
+    });
+    expect(removeButtons.length).toBeGreaterThan(0);
+
+    // Optionally, simulate a click on the first remove button
+    fireEvent.click(removeButtons[0]);
+    // In a real-world scenario, you might check that the item was removed from the form data.
+  });
+
+  it("does not render the remove button when readonly is true", () => {
+    render(
+      <FormBase
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={formDataMultiple}
+        readonly={true}
+      />,
+    );
+    const removeButton = screen.queryByRole("button", {
+      name: /remove item/i,
+    });
+    expect(removeButton).toBeNull();
+  });
+
+  it("renders the add button when form is not readonly and can add", () => {
+    render(
+      <FormBase
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={formDataSingle}
+        readonly={false}
+      />,
+    );
+    const addButton = screen.getByRole("button", { name: /add unit/i });
+    expect(addButton).toBeVisible();
+
+    // Optionally, simulate a click on the add button
+    fireEvent.click(addButton);
+    // Further checks can verify that the form data was updated with a new item.
+  });
+
+  it("does not render the add button when form is readonly", () => {
+    render(
+      <FormBase
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={formDataSingle}
+        readonly={true}
+      />,
+    );
+    const addButton = screen.queryByRole("button", { name: /add unit/i });
+    expect(addButton).toBeNull();
+  });
+
+  it("renders custom title with correct index for each item", () => {
+    render(
+      <FormBase
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={formDataMultiple}
+        readonly={false}
+      />,
+    );
+    // Custom titles are rendered with an index (starting at 1)
+    expect(screen.getByText("Unit 1")).toBeInTheDocument();
+    expect(screen.getByText("Unit 2")).toBeInTheDocument();
+  });
+
+  it("renders a horizontal rule when showHr is true", () => {
+    render(
+      <FormBase
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={formDataMultiple}
+        readonly={false}
+      />,
+    );
+    // <hr> elements are recognized with the "separator" role
+    const hrElements = screen.getAllByRole("separator");
+    expect(hrElements.length).toBeGreaterThan(0);
+  });
+});

--- a/bciers/libs/components/src/form/fields/NestedArrayFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/NestedArrayFieldTemplate.tsx
@@ -59,13 +59,15 @@ const NestedArrayFieldTemplate = ({
                   {customTitleName} {i + 1}
                 </span>
               )}
-              <button
-                onClick={item.onDropIndexClick(item.index)}
-                className="border-none bg-transparent"
-                aria-label="Remove item"
-              >
-                <DeleteForeverOutlinedIcon />
-              </button>
+              {!readonly && (
+                <button
+                  onClick={item.onDropIndexClick(item.index)}
+                  className="border-none bg-transparent"
+                  aria-label="Remove item"
+                >
+                  <DeleteForeverOutlinedIcon />
+                </button>
+              )}
               {{
                 ...item.children,
                 props: {


### PR DESCRIPTION
Addresses: [677](https://github.com/bcgov/cas-reporting/issues/677)

### 🚀 Impact:

- `Final Review` page `NestedArrayFieldTemplate` has hidden remove icon 
- Updated  `NestedArrayFieldTemplate` to hide  remove icons when form is `readOnly`
- Added tests to verify that Remove and Add buttons are rendered when form is NOT read-only.
- Added tests to verify that Remove and Add buttons are NOT rendered when form is read-only.


## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button
5. Log in using `bc-cas-dev`


### Test: Activity displays array remove icon(s)

#### **Steps**  
1. Navigate to http://localhost:3000/reporting/reports/
2. Select operation `Bugle SFO - Registered` 
3. Click `Continue`
4. Navigate to `Activities`, ex: http://localhost:3000/reporting/reports/1/facilities/f486f2fb-62ed-438d-bb3e-0819b51e3aff/activities
5. Select `General stationary combustion excluding line tracing\General stationary combustion of fuel or waste with production of useful energy`
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/cfc8161f-4ef0-4cec-ba37-7f3947f0f303)
- Remove icons display
- Remove icons function as expected


### Test: Final Review\Activity does NOT display array remove icon(s)

#### **Steps**  
1. Navigate to http://localhost:3000/reporting/reports/
2. Select operation `Bugle SFO - Registered` 
3. Click `Continue`
4. Navigate to `Final Review`, ex: http://localhost:3000/reporting/reports/1/final-review
#### **Expected Result**  
✅ 
![image](https://github.com/user-attachments/assets/9a3e0aa9-6fee-4261-a96d-546450aafabe)
- Remove icons DO NOT display


![image](https://github.com/user-attachments/assets/00f6aef0-73e4-40ce-acef-dba2a7763138)
