### PR TITLE
Chore: 3127 Reword the BCeID error message when selecting an operator

### DIFF
--- a/bc_obps/service/application_access_service.py
+++ b/bc_obps/service/application_access_service.py
@@ -30,7 +30,7 @@ class ApplicationAccessService:
 
         if operators_business_bceid != users_business_bceid:
             raise Exception(
-                "Your business BCeID does not have access to this operator. Please contact your operator's administrator to request the correct business BCeID. If this issue persists, please contact <a href='mailto:GHGRegulator@gov.bc.ca'>ghgregulator@gov.bc.ca</a>"
+                "Your business BCeID does not have access to this operator. Please contact your operator's administrator to request the correct business BCeID. If this issue persists, please contact"
             )
         return True
 

--- a/bc_obps/service/application_access_service.py
+++ b/bc_obps/service/application_access_service.py
@@ -29,7 +29,9 @@ class ApplicationAccessService:
         users_business_bceid = UserDataAccessService.get_by_guid(user_guid).business_guid
 
         if operators_business_bceid != users_business_bceid:
-            raise Exception("Your business bceid does not match that of the approved admin.")
+            raise Exception(
+                "Your business BCeID does not have access to this operator. Please contact your operator's administrator to request the correct business BCeID. If this issue persists, please contact <a href='mailto:GHGRegulator@gov.bc.ca'>ghgregulator@gov.bc.ca</a>"
+            )
         return True
 
     # check_users_admin_request_eligibility

--- a/bc_obps/service/tests/test_application_access_service.py
+++ b/bc_obps/service/tests/test_application_access_service.py
@@ -115,6 +115,6 @@ class TestCheckUserAdminRequestEligibility:
         )
         with pytest.raises(
             Exception,
-            match="Your business BCeID does not have access to this operator. Please contact your operator's administrator to request the correct business BCeID. If this issue persists, please contact <a href='mailto:GHGRegulator@gov.bc.ca'>ghgregulator@gov.bc.ca</a>",
+            match="Your business BCeID does not have access to this operator. Please contact your operator's administrator to request the correct business BCeID. If this issue persists, please contact",
         ):
             ApplicationAccessService.is_user_eligible_to_request_access(operator.id, user.user_guid)

--- a/bc_obps/service/tests/test_application_access_service.py
+++ b/bc_obps/service/tests/test_application_access_service.py
@@ -113,5 +113,8 @@ class TestCheckUserAdminRequestEligibility:
             role=UserOperator.Roles.ADMIN,
             status=UserOperator.Statuses.APPROVED,
         )
-        with pytest.raises(Exception, match="Your business bceid does not match that of the approved admin."):
+        with pytest.raises(
+            Exception,
+            match="Your business BCeID does not have access to this operator. Please contact your operator's administrator to request the correct business BCeID. If this issue persists, please contact <a href='mailto:GHGRegulator@gov.bc.ca'>ghgregulator@gov.bc.ca</a>",
+        ):
             ApplicationAccessService.is_user_eligible_to_request_access(operator.id, user.user_guid)

--- a/bciers/apps/administration/app/components/buttons/RequestAccessButton.tsx
+++ b/bciers/apps/administration/app/components/buttons/RequestAccessButton.tsx
@@ -18,7 +18,7 @@ export default function RequestAccessButton({
   isAdminRequest = false,
 }: Readonly<RequestAccessButtonProps>) {
   const router = useRouter();
-  const [errorList, setErrorList] = useState([] as any[]);
+  const [error, setError] = useState(undefined);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const label = isAdminRequest
@@ -32,8 +32,8 @@ export default function RequestAccessButton({
   const handleRequestAccess = async () => {
     setIsSubmitting(true);
     const response = await actionHandler(endpointUrl, "POST", "");
-    if (response.error) {
-      setErrorList([{ message: response.error }]);
+    if (response?.error) {
+      setError(response.error);
       setIsSubmitting(false);
       return;
     }
@@ -45,12 +45,13 @@ export default function RequestAccessButton({
 
   return (
     <>
-      {errorList.length > 0 &&
-        errorList.map((e: any) => (
-          <Alert key={e.message} severity="error">
-            {e.message}
+      <div className="min-h-6 flex justify-center">
+        {error && (
+          <Alert severity="error" className="w-2/3">
+            <div dangerouslySetInnerHTML={{ __html: error }}></div>
           </Alert>
-        ))}
+        )}
+      </div>
       <Button
         className="my-10"
         sx={{ textTransform: "none" }} //to remove uppercase text

--- a/bciers/apps/administration/app/components/buttons/RequestAccessButton.tsx
+++ b/bciers/apps/administration/app/components/buttons/RequestAccessButton.tsx
@@ -5,6 +5,7 @@ import { actionHandler } from "@bciers/actions";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Alert } from "@mui/material";
+import { ghgRegulatorEmail } from "@bciers/utils/src/urls";
 
 interface RequestAccessButtonProps {
   operatorId: number;
@@ -18,8 +19,8 @@ export default function RequestAccessButton({
   isAdminRequest = false,
 }: Readonly<RequestAccessButtonProps>) {
   const router = useRouter();
-  const [error, setError] = useState(undefined);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const label = isAdminRequest
     ? "Request administrator access"
@@ -28,6 +29,19 @@ export default function RequestAccessButton({
   const endpointUrl = `registration/operators/${operatorId}/${
     isAdminRequest ? "request-admin-access" : "request-access"
   }`;
+
+  const errorMessageJSX: JSX.Element = (
+    <>
+      {error}
+      {error?.includes(
+        "Your business BCeID does not have access to this operator.",
+      ) && (
+        <a className="ps-1" href={ghgRegulatorEmail}>
+          ghgregulator@gov.bc.ca
+        </a>
+      )}
+    </>
+  );
 
   const handleRequestAccess = async () => {
     setIsSubmitting(true);
@@ -48,7 +62,7 @@ export default function RequestAccessButton({
       <div className="min-h-6 flex justify-center">
         {error && (
           <Alert severity="error" className="w-2/3">
-            <div dangerouslySetInnerHTML={{ __html: error }}></div>
+            {errorMessageJSX}
           </Alert>
         )}
       </div>


### PR DESCRIPTION
[ISSUE 3127](https://github.com/bcgov/cas-registration/issues/3127)

**TO TEST:**  
- Log in as `bc-cas-three`.  
- Select an operator where the Business BCeID does not match the one for the user (e.g., `Alpha Enterprises`).  
- Confirm the request access.  
- A message like the one below should appear.

![Screenshot 2025-04-03 at 3 56 30 PM](https://github.com/user-attachments/assets/b5ff98b6-4358-46a6-899a-3557a61dd7cd)
