### PR TITLE
added info note for verfication page

### DIFF
--- a/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
@@ -8,13 +8,9 @@ import {
   cancelUrlReports,
 } from "@reporting/src/app/utils/constants";
 import { actionHandler } from "@bciers/actions";
-import { lfoUiSchema } from "@reporting/src/data/jsonSchema/verification/verification";
-import { sfoUiSchema } from "@reporting/src/data/jsonSchema/verification/verification";
 import { handleVerificationData } from "@reporting/src/app/utils/verification/handleVerificationData";
-import { OperationTypes } from "@bciers/utils/src/enums";
 import { NavigationInformation } from "../taskList/types";
-import { TitleOnlyFieldTemplate } from "@bciers/components/form/fields";
-import { infoNote } from "@reporting/src/data/jsonSchema/verification/supplementaryReportNote";
+import { createVerificationUISchema } from "@reporting/src/app/components/verification/createVerificationUISchema";
 // TEMPORARY: remmed to support #607
 // import { mergeVerificationData } from "@reporting/src/app/utils/verification/mergeVerificationData";
 
@@ -37,10 +33,6 @@ export default function VerificationForm({
 }: Props) {
   const [formData, setFormData] = useState(initialData);
   const [errors, setErrors] = useState<string[]>();
-
-  const verificationUiSchema =
-    operationType === OperationTypes.SFO ? sfoUiSchema : lfoUiSchema;
-
   // 🛠️ Function to handle form changes affecting ui schema
   const handleChange = (e: IChangeEvent) => {
     const updatedData = { ...e.formData };
@@ -51,6 +43,10 @@ export default function VerificationForm({
     // 🔄 Update the form data state with the modified data
     setFormData(updatedData);
   };
+  const uiSchema = createVerificationUISchema(
+    operationType,
+    isSupplementaryReport,
+  );
 
   // 🛠️ Function to handle form submit
   const handleSubmit = async () => {
@@ -95,28 +91,8 @@ export default function VerificationForm({
       steps={navigationInformation.headerSteps}
       initialStep={navigationInformation.headerStepIndex}
       taskListElements={navigationInformation.taskList}
-      schema={
-        isSupplementaryReport
-          ? {
-              ...verificationSchema,
-              properties: {
-                ...verificationSchema.properties,
-                info_note: { type: "object" },
-              },
-            }
-          : verificationSchema
-      }
-      uiSchema={
-        isSupplementaryReport
-          ? {
-              ...verificationUiSchema,
-              info_note: {
-                "ui:FieldTemplate": TitleOnlyFieldTemplate,
-                "ui:title": infoNote(),
-              },
-            }
-          : verificationUiSchema
-      }
+      schema={verificationSchema}
+      uiSchema={uiSchema}
       formData={formData}
       baseUrl={baseUrlReports}
       cancelUrl={cancelUrlReports}

--- a/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/verification/VerificationForm.tsx
@@ -13,6 +13,8 @@ import { sfoUiSchema } from "@reporting/src/data/jsonSchema/verification/verific
 import { handleVerificationData } from "@reporting/src/app/utils/verification/handleVerificationData";
 import { OperationTypes } from "@bciers/utils/src/enums";
 import { NavigationInformation } from "../taskList/types";
+import { TitleOnlyFieldTemplate } from "@bciers/components/form/fields";
+import { infoNote } from "@reporting/src/data/jsonSchema/verification/supplementaryReportNote";
 // TEMPORARY: remmed to support #607
 // import { mergeVerificationData } from "@reporting/src/app/utils/verification/mergeVerificationData";
 
@@ -22,6 +24,7 @@ interface Props {
   verificationSchema: RJSFSchema;
   initialData: any;
   navigationInformation: NavigationInformation;
+  isSupplementaryReport: boolean;
 }
 
 export default function VerificationForm({
@@ -30,6 +33,7 @@ export default function VerificationForm({
   verificationSchema,
   initialData,
   navigationInformation,
+  isSupplementaryReport,
 }: Props) {
   const [formData, setFormData] = useState(initialData);
   const [errors, setErrors] = useState<string[]>();
@@ -91,8 +95,28 @@ export default function VerificationForm({
       steps={navigationInformation.headerSteps}
       initialStep={navigationInformation.headerStepIndex}
       taskListElements={navigationInformation.taskList}
-      schema={verificationSchema}
-      uiSchema={verificationUiSchema}
+      schema={
+        isSupplementaryReport
+          ? {
+              ...verificationSchema,
+              properties: {
+                ...verificationSchema.properties,
+                info_note: { type: "object" },
+              },
+            }
+          : verificationSchema
+      }
+      uiSchema={
+        isSupplementaryReport
+          ? {
+              ...verificationUiSchema,
+              info_note: {
+                "ui:FieldTemplate": TitleOnlyFieldTemplate,
+                "ui:title": infoNote(),
+              },
+            }
+          : verificationUiSchema
+      }
       formData={formData}
       baseUrl={baseUrlReports}
       cancelUrl={cancelUrlReports}

--- a/bciers/apps/reporting/src/app/components/verification/VerificationPage.tsx
+++ b/bciers/apps/reporting/src/app/components/verification/VerificationPage.tsx
@@ -26,11 +26,11 @@ export default async function VerificationPage({
   // 🚀 Fetch the list of facilities associated with the specified version ID
   const facilityList = await getReportFacilityList(version_id);
   const isSupplementaryReport = await getIsSupplementaryReport(version_id);
-
   // Create schema with dynamic facility list for operation type
   const verificationSchema = createVerificationSchema(
     facilityList.facilities,
     operationType,
+    isSupplementaryReport.is_supplementary_report_version,
   );
 
   //🔍 Check if reports need verification

--- a/bciers/apps/reporting/src/app/components/verification/VerificationPage.tsx
+++ b/bciers/apps/reporting/src/app/components/verification/VerificationPage.tsx
@@ -8,6 +8,7 @@ import { getReportingOperation } from "@reporting/src/app/utils/getReportingOper
 import { extendVerificationData } from "@reporting/src/app/utils/verification/extendVerificationData";
 import { getNavigationInformation } from "../taskList/navigationInformation";
 import { HeaderStep, ReportingPage } from "../taskList/types";
+import { getIsSupplementaryReport } from "@reporting/src/app/utils/getIsSupplementaryReport";
 
 // import { verificationSchema } from "@reporting/src/data/jsonSchema/verification/verification";
 export default async function VerificationPage({
@@ -24,6 +25,7 @@ export default async function VerificationPage({
 
   // 🚀 Fetch the list of facilities associated with the specified version ID
   const facilityList = await getReportFacilityList(version_id);
+  const isSupplementaryReport = await getIsSupplementaryReport(version_id);
 
   // Create schema with dynamic facility list for operation type
   const verificationSchema = createVerificationSchema(
@@ -51,6 +53,9 @@ export default async function VerificationPage({
         verificationSchema={verificationSchema}
         initialData={transformedData}
         navigationInformation={navInfo}
+        isSupplementaryReport={
+          isSupplementaryReport.is_supplementary_report_version
+        }
       />
     </>
   );

--- a/bciers/apps/reporting/src/app/components/verification/createVerificationSchema.ts
+++ b/bciers/apps/reporting/src/app/components/verification/createVerificationSchema.ts
@@ -1,23 +1,20 @@
 import { RJSFSchema } from "@rjsf/utils";
-import { lfoSchema } from "@reporting/src/data/jsonSchema/verification/verification";
-import { sfoSchema } from "@reporting/src/data/jsonSchema/verification/verification";
 import { OperationTypes } from "@bciers/utils/src/enums";
+import {
+  lfoSchema,
+  sfoSchema,
+} from "@reporting/src/data/jsonSchema/verification/verification";
 
-// TEMPORARY: remmed outcode to support #607
 export const createVerificationSchema = (
   facilities: string[],
   schemaType: string,
+  isSupplementaryReport: boolean,
 ): RJSFSchema => {
-  // Determine the schema based on the schemaType
-  const localSchema: RJSFSchema =
-    schemaType === OperationTypes.SFO ? { ...sfoSchema } : { ...lfoSchema };
+  const schema = schemaType === OperationTypes.SFO ? sfoSchema : lfoSchema;
 
-  // const defaultVisistValues = ["None", "Other"];
-  // (localSchema.properties?.visit_names as any).items.enum = [
-  //   ...defaultVisistValues,
-  //   ...facilities,
-  // ];
-
-  // Return the customized schema.
-  return localSchema;
+  if (isSupplementaryReport) {
+    schema.properties = schema.properties || {};
+    schema.properties.info_note = { type: "object", readOnly: true };
+  }
+  return schema;
 };

--- a/bciers/apps/reporting/src/app/components/verification/createVerificationUISchema.ts
+++ b/bciers/apps/reporting/src/app/components/verification/createVerificationUISchema.ts
@@ -1,0 +1,24 @@
+import { UiSchema } from "@rjsf/utils";
+import {
+  lfoUiSchema,
+  sfoUiSchema,
+} from "@reporting/src/data/jsonSchema/verification/verification";
+import { OperationTypes } from "@bciers/utils/src/enums";
+import { TitleOnlyFieldTemplate } from "@bciers/components/form/fields";
+import { infoNote } from "@reporting/src/data/jsonSchema/verification/supplementaryReportNote";
+
+export const createVerificationUISchema = (
+  schemaType: string,
+  isSupplementaryReport: boolean,
+): UiSchema => {
+  const schema = schemaType === OperationTypes.SFO ? sfoUiSchema : lfoUiSchema;
+
+  if (isSupplementaryReport) {
+    schema.info_note = {
+      "ui:FieldTemplate": TitleOnlyFieldTemplate,
+      "ui:title": infoNote(),
+    };
+  }
+
+  return schema;
+};

--- a/bciers/apps/reporting/src/data/jsonSchema/verification/supplementaryReportNote.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/verification/supplementaryReportNote.tsx
@@ -1,0 +1,23 @@
+import { Box, Link, Typography } from "@mui/material";
+import React from "react";
+export const infoNote = () => (
+  <Box sx={{ display: "flex", alignItems: "center" }}>
+    <Typography variant="body2">
+      <strong>Note:</strong> If you are submitting an updated report to correct
+      an error in a previous report, and were required to have this updated
+      report verified, then you must upload a new verification statement in the
+      attachments page. For guidance on whether verification is required, please
+      refer to the{" "}
+      <Link
+        href={
+          " https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/reporting/verify"
+        }
+        target="_blank"
+        rel="noopener noreferrer"
+        sx={{ color: "inherit", textDecoration: "none" }}
+      >
+        verification guidance webpage.
+      </Link>
+    </Typography>
+  </Box>
+);

--- a/bciers/apps/reporting/src/data/jsonSchema/verification/verification.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/verification/verification.tsx
@@ -118,6 +118,7 @@ const sharedUiSchema: UiSchema = {
  * Shared ui:order for SFO and LFO schemas
  */
 const sharedUIOrder = [
+  "info_note",
   "verification_body_name",
   "accredited_by",
   // "scope_of_verification",

--- a/bciers/apps/reporting/src/tests/components/verification/VerificationForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/verification/VerificationForm.test.tsx
@@ -78,6 +78,7 @@ const renderVerificationForm = (operationType: string) => {
           continueUrl: "continue",
         } as any
       }
+      isSupplementaryReport={false}
     />,
   );
 };

--- a/bciers/apps/reporting/src/tests/components/verification/VerificationPage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/verification/VerificationPage.test.tsx
@@ -9,6 +9,7 @@ import { getReportingOperation } from "@reporting/src/app/utils/getReportingOper
 import { OperationTypes } from "@bciers/utils/src/enums";
 import { getNavigationInformation } from "@reporting/src/app/components/taskList/navigationInformation";
 import { dummyNavigationInformation } from "../taskList/utils";
+import { getIsSupplementaryReport } from "@reporting/src/app/utils/getIsSupplementaryReport";
 
 vi.mock("@reporting/src/app/components/verification/VerificationForm", () => ({
   default: vi.fn(),
@@ -40,11 +41,15 @@ vi.mock("@reporting/src/app/utils/getReportingOperation", () => ({
 vi.mock("@reporting/src/app/components/taskList/navigationInformation", () => ({
   getNavigationInformation: vi.fn(),
 }));
+vi.mock("@reporting/src/app/utils/getIsSupplementaryReport", () => ({
+  getIsSupplementaryReport: vi.fn(),
+}));
 
 const mockVerificationForm = VerificationForm as ReturnType<typeof vi.fn>;
 const mockGetReportVerification = getReportVerification as ReturnType<
   typeof vi.fn
 >;
+
 const mockGetReportFacilityList = getReportFacilityList as ReturnType<
   typeof vi.fn
 >;
@@ -58,6 +63,9 @@ const mockGetReportingOperation = getReportingOperation as ReturnType<
   typeof vi.fn
 >;
 const mockGetNavigationInformation = getNavigationInformation as ReturnType<
+  typeof vi.fn
+>;
+const mockGetIsSupplementaryReport = getIsSupplementaryReport as ReturnType<
   typeof vi.fn
 >;
 
@@ -81,6 +89,9 @@ describe("VerificationPage component", () => {
     mockCreateVerificationSchema.mockReturnValue(mockVerificationSchema);
     mockGetReportNeedsVerification.mockResolvedValue(true);
     mockGetReportingOperation.mockResolvedValue(mockReportOperation);
+    mockGetIsSupplementaryReport.mockResolvedValue({
+      is_supplementary_report_version: false,
+    });
     mockGetNavigationInformation.mockResolvedValue(dummyNavigationInformation);
 
     render(await VerificationPage({ version_id: mockVersionId }));
@@ -91,6 +102,7 @@ describe("VerificationPage component", () => {
     expect(mockCreateVerificationSchema).toHaveBeenCalledWith(
       mockFacilityList.facilities,
       OperationTypes.SFO,
+      false,
     );
 
     expect(mockVerificationForm).toHaveBeenCalledWith(
@@ -100,6 +112,8 @@ describe("VerificationPage component", () => {
         verificationSchema: mockVerificationSchema,
         initialData: mockInitialData,
         navigationInformation: dummyNavigationInformation,
+        isSupplementaryReport: (await mockGetIsSupplementaryReport())
+          .is_supplementary_report_version,
       },
       {},
     );


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/482
Changes:
added info note for supplementary report(verification page)
Updated shcema and ui schema to have info note for supplementary report verification page. 

To Test:-
1. Create a supplementary report 
2. Go to verification page 
3. You wil see a note like 
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/e9138d08-939b-434a-9ddd-e66d78238cdc" />
