### PR TITLE
2743 back and cancel buttons

### DIFF
--- a/bciers/apps/administration/app/components/operators/OperatorForm.tsx
+++ b/bciers/apps/administration/app/components/operators/OperatorForm.tsx
@@ -19,7 +19,7 @@ interface Props {
   isCreating?: boolean;
   isInternalUser: boolean;
   showTasklist?: boolean;
-  showCancelButton?: boolean;
+  showCancelOrBackButton?: boolean;
 }
 export default function OperatorForm({
   formData,
@@ -27,7 +27,7 @@ export default function OperatorForm({
   isCreating,
   isInternalUser,
   showTasklist = true,
-  showCancelButton = true,
+  showCancelOrBackButton = true,
 }: Readonly<Props>) {
   // @ ts-ignore
 
@@ -38,7 +38,7 @@ export default function OperatorForm({
   const { update } = useSession();
   return (
     <SingleStepTaskListForm
-      showCancelButton={showCancelButton}
+      showCancelOrBackButton={showCancelOrBackButton}
       showTasklist={showTasklist}
       error={error}
       schema={schema}

--- a/bciers/apps/administration/app/components/userOperators/UserOperatorReviewForm.tsx
+++ b/bciers/apps/administration/app/components/userOperators/UserOperatorReviewForm.tsx
@@ -36,7 +36,7 @@ const UserOperatorReviewForm = ({
           title: "Operation Information",
           component: (
             <OperatorForm
-              showCancelButton={false}
+              showCancelOrBackButton={false}
               showTasklist={false}
               schema={operatorSchema}
               formData={formData}

--- a/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
@@ -140,8 +140,8 @@ describe("ContactForm component", () => {
     checkInlineMessage();
 
     // Buttons
-    expect(screen.getByRole("button", { name: /submit/i })).toBeEnabled();
-    expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /back/i })).toBeEnabled();
   });
   it("loads existing readonly contact form data for an internal user", async () => {
     useSession.mockReturnValue({
@@ -215,9 +215,9 @@ describe("ContactForm component", () => {
         isCreating
       />,
     );
-    const submitButton = screen.getByRole("button", { name: /submit/i });
+    const saveButton = screen.getByRole("button", { name: /save/i });
     act(() => {
-      submitButton.click();
+      saveButton.click();
     });
     expect(screen.getAllByText(/Required field/i)).toHaveLength(9);
   });
@@ -245,7 +245,7 @@ describe("ContactForm component", () => {
 
       await fillContactForm();
       // Submit
-      await userEvent.click(screen.getByRole("button", { name: /submit/i }));
+      await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
       await waitFor(() => {
         expect(actionHandler).toHaveBeenNthCalledWith(
@@ -332,7 +332,7 @@ describe("ContactForm component", () => {
       await userEvent.type(screen.getByLabelText(/Postal Code+/i), "H0H 0H0");
 
       // Submit
-      await userEvent.click(screen.getByRole("button", { name: /submit/i }));
+      await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
       // assert first invocation: POST
       expect(actionHandler).toHaveBeenNthCalledWith(
@@ -375,7 +375,7 @@ describe("ContactForm component", () => {
       actionHandler.mockReturnValueOnce(response);
 
       // Submit
-      await userEvent.click(screen.getByRole("button", { name: /submit/i }));
+      await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
       // assert second invocation: PUT
       expect(actionHandler).toHaveBeenNthCalledWith(
@@ -428,7 +428,7 @@ describe("ContactForm component", () => {
     actionHandler.mockReturnValueOnce(response);
 
     // Submit
-    await userEvent.click(screen.getByRole("button", { name: /submit/i }));
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
     expect(actionHandler).toHaveBeenNthCalledWith(
       1,

--- a/bciers/apps/administration/tests/components/facilities/FacilityForm.test.tsx
+++ b/bciers/apps/administration/tests/components/facilities/FacilityForm.test.tsx
@@ -315,9 +315,9 @@ const assertFormPost = async (
   actionHandler.mockReturnValueOnce(response);
 
   // Find and click the submit button
-  const submitButton = screen.getByRole("button", { name: /submit/i });
+  const saveButton = screen.getByRole("button", { name: /save/i });
   act(() => {
-    userEvent.click(submitButton);
+    userEvent.click(saveButton);
   });
 
   // Add some delay to allow async processes to complete
@@ -343,9 +343,9 @@ const assertFormPost = async (
 // ⛏️ Helper function to simulate form PUT submission and assert the result
 const assertFormPut = async (): Promise<void> => {
   // Submit valid form data
-  const submitButton = screen.getByRole("button", { name: /submit/i });
+  const saveButton = screen.getByRole("button", { name: /save/i });
   act(() => {
-    userEvent.click(submitButton);
+    userEvent.click(saveButton);
   });
   actionHandler.mockReturnValue({ error: null });
   await waitFor(() => {
@@ -399,8 +399,8 @@ describe("FacilityForm component", () => {
       screen.getByLabelText(/Longitude of Largest Point of Emissions+/i),
     ).toHaveValue(null);
     // submit button
-    const submitButton = screen.getByRole("button", { name: /submit/i });
-    expect(submitButton).toBeEnabled();
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    expect(saveButton).toBeEnabled();
   });
   it("renders the empty LFO facility form when creating a new facility", async () => {
     const { container } = render(
@@ -424,8 +424,8 @@ describe("FacilityForm component", () => {
     );
 
     // submit button
-    const submitButton = screen.getByRole("button", { name: /submit/i });
-    expect(submitButton).toBeEnabled();
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    expect(saveButton).toBeEnabled();
   });
   it("loads existing readonly SFO form data", async () => {
     const { container } = render(
@@ -556,9 +556,9 @@ describe("FacilityForm component", () => {
         isCreating
       />,
     );
-    const submitButton = screen.getByRole("button", { name: /submit/i });
+    const saveButton = screen.getByRole("button", { name: /save/i });
     act(() => {
-      submitButton.click();
+      saveButton.click();
     });
     expect(screen.getAllByText(/Required field/i)).toHaveLength(4);
 
@@ -568,7 +568,7 @@ describe("FacilityForm component", () => {
     );
     act(() => {
       year.click();
-      submitButton.click();
+      saveButton.click();
     });
     expect(screen.getAllByText(/Required field/i)).toHaveLength(5);
   });
@@ -588,8 +588,8 @@ describe("FacilityForm component", () => {
 
     const editButton = screen.getByRole("button", { name: "Edit" });
     fireEvent.click(editButton);
-    const submitButton = screen.getByRole("button", { name: "Submit" });
-    fireEvent.click(submitButton);
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
     expect(screen.getAllByText(/Required field/i)).toHaveLength(1); // name
     expect(screen.getAllByText(/Format should be A1A 1A1/i)).toHaveLength(1);
     expect(screen.getAllByText(/must be >= -90/i)).toHaveLength(1);
@@ -637,8 +637,8 @@ describe("FacilityForm component", () => {
       { target: { value: 6 } },
     );
 
-    const submitButton = screen.getByRole("button", { name: "Submit" });
-    fireEvent.click(submitButton);
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
 
     // expect to see validation error for starting date
     expect(screen.getAllByText(/Starting Date must be between/i)).toHaveLength(
@@ -653,7 +653,7 @@ describe("FacilityForm component", () => {
       screen.getByLabelText(/Date of facility starting operations+/i),
       "202",
     );
-    fireEvent.click(submitButton);
+    fireEvent.click(saveButton);
 
     // expect to see format error for starting date
     expect(
@@ -765,7 +765,7 @@ describe("FacilityForm component", () => {
 
       // Buttons
       expect(screen.getByRole("button", { name: /edit/i })).toBeEnabled();
-      expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
+      expect(screen.getByRole("button", { name: /back/i })).toBeEnabled();
 
       const editButton = screen.getByRole("button", { name: /edit/i });
       act(() => {
@@ -773,7 +773,7 @@ describe("FacilityForm component", () => {
       });
 
       // Buttons
-      expect(screen.getByRole("button", { name: /submit/i })).toBeEnabled();
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
       expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
 
       // Edit form fields
@@ -799,7 +799,7 @@ describe("FacilityForm component", () => {
 
       // Buttons
       expect(screen.getByRole("button", { name: /edit/i })).toBeEnabled();
-      expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
+      expect(screen.getByRole("button", { name: /back/i })).toBeEnabled();
 
       const editButton = screen.getByRole("button", { name: /edit/i });
       act(() => {
@@ -807,7 +807,7 @@ describe("FacilityForm component", () => {
       });
 
       // Buttons
-      expect(screen.getByRole("button", { name: /submit/i })).toBeEnabled();
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
       expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
       // Edit form fields
       await editFormFields(facilitiesLfoSchema);
@@ -816,7 +816,7 @@ describe("FacilityForm component", () => {
       await assertFormPut();
     },
   );
-  it("redirects to the operation's facilities grid on cancel", async () => {
+  it("redirects to the operation's facilities grid on back", async () => {
     render(
       <FacilityForm
         schema={facilitiesSfoSchema}
@@ -826,10 +826,10 @@ describe("FacilityForm component", () => {
       />,
     );
 
-    const cancelButton = screen.getByRole("button", { name: /cancel/i });
+    const backButton = screen.getByRole("button", { name: /back/i });
 
     // Simulate the user clicking the cancel button
-    fireEvent.click(cancelButton);
+    fireEvent.click(backButton);
 
     // Assert that router.push was called with the correct URL
     expect(mockReplace).toHaveBeenCalledWith(urlOperationFacilities);

--- a/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
@@ -190,8 +190,8 @@ describe("the OperationInformationForm component", () => {
     expect(screen.getByText(/Operation Name/i)).toBeVisible();
     expect(screen.getByText(/Operation Type/i)).toBeVisible();
 
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Back" })).toBeVisible();
   });
 
   it("should render the form with the correct values for a non-EIO when formData is provided", async () => {
@@ -316,7 +316,7 @@ describe("the OperationInformationForm component", () => {
     expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
   });
 
-  it("should edit and submit the form", async () => {
+  it("should edit and save the form", async () => {
     render(
       <OperationInformationForm
         formData={formData}
@@ -341,9 +341,9 @@ describe("the OperationInformationForm component", () => {
       fireEvent.change(nameInput, { target: { value: "Operation 4" } });
     });
 
-    // Click the Submit button
+    // Click the Save button
     await act(async () => {
-      screen.getByRole("button", { name: "Submit" }).click();
+      screen.getByRole("button", { name: /save/i }).click();
     });
 
     expect(actionHandler).toHaveBeenCalledTimes(1);
@@ -363,7 +363,7 @@ describe("the OperationInformationForm component", () => {
     expect(screen.getByText(/Operation 4/i)).toBeVisible();
   });
 
-  it("should edit and submit opt-in operation details in the form", async () => {
+  it("should edit and save opt-in operation details in the form", async () => {
     render(
       <OperationInformationForm
         formData={optInFormData}
@@ -395,8 +395,8 @@ describe("the OperationInformationForm component", () => {
         expect(radioBtn).toBeChecked();
       });
 
-      // Click the Submit button
-      screen.getByRole("button", { name: "Submit" }).click();
+      // Click the Save button
+      screen.getByRole("button", { name: /save/i }).click();
     });
 
     expect(actionHandler).toHaveBeenCalledTimes(2);
@@ -428,7 +428,7 @@ describe("the OperationInformationForm component", () => {
     });
   });
 
-  it("should render the form in read-only mode and not show Edit/Submit button if the user is not an industry_user_admin", async () => {
+  it("should render the form in read-only mode and not show Edit/Save button if the user is not an industry_user_admin", async () => {
     useSession.mockReturnValue({
       data: {
         user: {
@@ -454,10 +454,10 @@ describe("the OperationInformationForm component", () => {
       screen.queryByRole("button", { name: "Edit" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Submit" }),
+      screen.queryByRole("button", { name: /save/i }),
     ).not.toBeInTheDocument();
-    // still show the cancel button
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+    // still show the back button
+    expect(screen.getByRole("button", { name: "Back" })).toBeVisible();
   });
 
   it("should render the opt-in information if purpose is opt-in", async () => {
@@ -761,7 +761,7 @@ describe("the OperationInformationForm component", () => {
     ).toHaveAttribute("href", mockDataUri);
   });
 
-  it("should edit and submit the new entrant application form", async () => {
+  it("should edit and save the new entrant application form", async () => {
     useSession.mockReturnValue({
       data: {
         user: {
@@ -854,10 +854,10 @@ describe("the OperationInformationForm component", () => {
       "data-name",
       "mock_file.pdf",
     );
-    const submitButton = screen.getByRole("button", {
-      name: "Submit",
+    const saveButton = screen.getByRole("button", {
+      name: /save/i,
     });
-    await userEvent.click(submitButton);
+    await userEvent.click(saveButton);
     expect(actionHandler).toHaveBeenCalledTimes(1);
     expect(actionHandler).toHaveBeenCalledWith(
       `registration/operations/${operationId}`,
@@ -906,10 +906,10 @@ describe("the OperationInformationForm component", () => {
     await userEvent.click(cancelChipIcon[2]); // 0-1 are activities
     expect(screen.queryByText(/ivy/i)).not.toBeInTheDocument();
 
-    const submitButton = screen.getByRole("button", {
-      name: "Submit",
+    const saveButton = screen.getByRole("button", {
+      name: /save/i,
     });
-    await userEvent.click(submitButton);
+    await userEvent.click(saveButton);
     expect(actionHandler).toHaveBeenCalledTimes(0);
     expect(screen.getByText(/Must not have fewer than 1 items/i)).toBeVisible();
   });
@@ -972,10 +972,10 @@ describe("the OperationInformationForm component", () => {
         "Jack King{enter}",
       );
 
-      const submitButton = screen.getByRole("button", {
-        name: "Submit",
+      const saveButton = screen.getByRole("button", {
+        name: /save/i,
       });
-      await userEvent.click(submitButton);
+      await userEvent.click(saveButton);
       expect(actionHandler).toHaveBeenCalledTimes(1);
       expect(actionHandler).toHaveBeenCalledWith(
         `registration/operations/${operationId}`,

--- a/bciers/apps/administration/tests/components/operators/OperatorForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operators/OperatorForm.test.tsx
@@ -324,8 +324,8 @@ describe("OperatorForm component", () => {
         /Does this operator have one or more parent company/i,
       ),
     ).not.toBeChecked();
-    expectButton("Submit");
-    expectButton("Cancel");
+    expectButton("Save");
+    expectButton("Back");
   });
   it("does not allow new operator form submission if there are validation errors", async () => {
     render(
@@ -336,11 +336,11 @@ describe("OperatorForm component", () => {
         isInternalUser={false}
       />,
     );
-    const submitButton = screen.getByRole("button", { name: /submit/i });
+    const saveButton = screen.getByRole("button", { name: /save/i });
 
     // Wrap the click event in act()
     act(() => {
-      submitButton.click();
+      saveButton.click();
     });
 
     // Assert on the validation errors
@@ -366,9 +366,9 @@ describe("OperatorForm component", () => {
     actionHandler.mockReturnValueOnce(res);
 
     // Submit the form
-    const submitButton = screen.getByRole("button", { name: /submit/i });
+    const saveButton = screen.getByRole("button", { name: /save/i });
     act(() => {
-      submitButton.click();
+      saveButton.click();
     });
 
     // Ensure actionHandler is called with the correct arguments
@@ -409,11 +409,11 @@ describe("OperatorForm component", () => {
 
     // Submit
     actionHandler.mockReturnValueOnce(response);
-    const submitButton = screen.getByRole("button", {
-      name: /submit/i,
+    const saveButton = screen.getByRole("button", {
+      name: /save/i,
     });
     act(() => {
-      submitButton.click();
+      saveButton.click();
     });
 
     expect(actionHandler).toHaveBeenNthCalledWith(
@@ -535,8 +535,8 @@ describe("OperatorForm component", () => {
     await userEvent.type(screen.getByLabelText(/tax id number+/i), "edit");
 
     // SUBMIT
-    const submitButton = screen.getByRole("button", { name: /submit/i });
-    userEvent.click(submitButton);
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    userEvent.click(saveButton);
 
     await waitFor(() => {
       expect(actionHandler).toHaveBeenCalledWith(
@@ -727,7 +727,7 @@ describe("OperatorForm component", () => {
         isInternalUser={false}
       />,
     );
-    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await userEvent.click(screen.getByRole("button", { name: /back/i }));
     expect(mockRouterBack).toHaveBeenCalledTimes(1);
   });
   it("calls the router.back function if user is internal", async () => {
@@ -738,7 +738,7 @@ describe("OperatorForm component", () => {
         isInternalUser={true}
       />,
     );
-    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await userEvent.click(screen.getByRole("button", { name: /back/i }));
     expect(mockRouterBack).toHaveBeenCalledTimes(1);
   });
   it("calls the router.push function if user is not internal and is not creating", async () => {
@@ -750,7 +750,7 @@ describe("OperatorForm component", () => {
         isInternalUser={false}
       />,
     );
-    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await userEvent.click(screen.getByRole("button", { name: /back/i }));
     expect(mockRouterPush).toHaveBeenCalledTimes(1);
   });
 });

--- a/bciers/libs/components/src/form/SingleStepTaskListForm.test.tsx
+++ b/bciers/libs/components/src/form/SingleStepTaskListForm.test.tsx
@@ -4,6 +4,7 @@ import SectionFieldTemplate from "@bciers/components/form/fields/SectionFieldTem
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import { FormMode } from "@bciers/utils/src/enums";
 import { FrontendMessages } from "@bciers/utils/src/enums";
+
 const section1: RJSFSchema = {
   type: "object",
   title: "Section 1",
@@ -142,9 +143,9 @@ describe("the SingleStepTaskListForm component", () => {
     expect(screen.getByLabelText("Address*")).toBeVisible();
     expect(screen.getByLabelText("City*")).toBeVisible();
 
-    // It should render the submit and cancel buttons
-    expect(screen.getByRole("button", { name: "Submit" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+    // It should render the submit and back buttons
+    expect(screen.getByRole("button", { name: "Save" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Back" })).toBeVisible();
   });
   it("should show the confirmation snackbar when new form is submitted (when creating)", async () => {
     const schemaNonRequired: RJSFSchema = {
@@ -170,8 +171,8 @@ describe("the SingleStepTaskListForm component", () => {
         }}
       />,
     );
-    const submitButton = screen.getByRole("button", { name: "Submit" });
-    fireEvent.click(submitButton);
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
     await waitFor(() => {
       expect(
         screen.getByText(FrontendMessages.SUBMIT_CONFIRMATION),
@@ -208,7 +209,7 @@ describe("the SingleStepTaskListForm component", () => {
     expect(screen.getByLabelText("City*")).toHaveValue("Victoria");
 
     // It should render the correct buttons
-    expect(screen.getByRole("button", { name: "Submit" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Save" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
     expect(screen.getByText("Testing inline message")).toBeVisible();
   });
@@ -232,8 +233,8 @@ describe("the SingleStepTaskListForm component", () => {
     );
     const editButton = screen.getByRole("button", { name: "Edit" });
     fireEvent.click(editButton);
-    const submitButton = screen.getByRole("button", { name: "Submit" });
-    fireEvent.click(submitButton);
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
     await waitFor(() => {
       expect(
         screen.getByText(FrontendMessages.SUBMIT_CONFIRMATION),
@@ -265,6 +266,7 @@ describe("the SingleStepTaskListForm component", () => {
           // eslint-disable-next-line no-console
           console.log("submit", e);
         }}
+        mode={FormMode.EDIT}
       />,
     );
 
@@ -291,8 +293,8 @@ describe("the SingleStepTaskListForm component", () => {
       />,
     );
 
-    const submitButton = screen.getByRole("button", { name: "Submit" });
-    fireEvent.click(submitButton);
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
 
     const errorMessages = screen.getAllByText("Required field");
 
@@ -325,8 +327,8 @@ describe("the SingleStepTaskListForm component", () => {
 
     expect(inputBorderElement).toHaveStyle(defaultStyle);
 
-    const submitButton = screen.getByRole("button", { name: "Submit" });
-    fireEvent.click(submitButton);
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
 
     expect(inputBorderElement).toHaveStyle(errorStyle);
 
@@ -376,17 +378,17 @@ describe("the SingleStepTaskListForm component", () => {
       />,
     );
     expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Submit" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
   });
 
-  it("should not render the Tasklist sidebar or Cancel button when showTasklist  and showCancelButton is false", () => {
+  it("should not render the Tasklist sidebar or Cancel button when showTasklist and showCancelOrBackButton is false", () => {
     render(
       <SingleStepTaskListForm
         schema={schema}
         uiSchema={uiSchema}
         formData={{}}
         showTasklist={false}
-        showCancelButton={false}
+        showCancelOrBackButton={false}
         onCancel={() => {
           // eslint-disable-next-line no-console
           console.log("cancel");
@@ -410,6 +412,76 @@ describe("the SingleStepTaskListForm component", () => {
     expect(
       screen.queryByRole("button", { name: "Cancel" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("should render the Back button when readonly", () => {
+    render(
+      <SingleStepTaskListForm
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={{}}
+        onCancel={() => {
+          // eslint-disable-next-line no-console
+          console.log("cancel");
+        }}
+        onSubmit={async (e) => {
+          // eslint-disable-next-line no-console
+          console.log("submit", e);
+        }}
+        mode={FormMode.READ_ONLY}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Cancel" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back" })).toBeVisible();
+  });
+
+  it("should render the Cancel button when editing", () => {
+    render(
+      <SingleStepTaskListForm
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={{}}
+        onCancel={() => {
+          // eslint-disable-next-line no-console
+          console.log("cancel");
+        }}
+        onSubmit={async (e) => {
+          // eslint-disable-next-line no-console
+          console.log("submit", e);
+        }}
+        mode={FormMode.EDIT}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Back" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+  });
+  it("should render the Back button when creating", () => {
+    render(
+      <SingleStepTaskListForm
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={{}}
+        onCancel={() => {
+          // eslint-disable-next-line no-console
+          console.log("cancel");
+        }}
+        onSubmit={async (e) => {
+          // eslint-disable-next-line no-console
+          console.log("submit", e);
+        }}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Cancel" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back" })).toBeVisible();
   });
 });
 

--- a/bciers/libs/components/src/form/SingleStepTaskListForm.test.tsx
+++ b/bciers/libs/components/src/form/SingleStepTaskListForm.test.tsx
@@ -143,7 +143,7 @@ describe("the SingleStepTaskListForm component", () => {
     expect(screen.getByLabelText("Address*")).toBeVisible();
     expect(screen.getByLabelText("City*")).toBeVisible();
 
-    // It should render the submit and back buttons
+    // It should render the save and back buttons
     expect(screen.getByRole("button", { name: "Save" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Back" })).toBeVisible();
   });

--- a/bciers/libs/components/src/form/SingleStepTaskListForm.tsx
+++ b/bciers/libs/components/src/form/SingleStepTaskListForm.tsx
@@ -28,7 +28,7 @@ interface SingleStepTaskListFormProps {
   allowEdit?: boolean;
   formContext?: { [key: string]: any };
   showTasklist?: boolean;
-  showCancelButton?: boolean;
+  showCancelOrBackButton?: boolean;
   customButtonSection?: React.ReactNode;
 }
 
@@ -46,12 +46,13 @@ const SingleStepTaskListForm = ({
   allowEdit = true,
   formContext,
   showTasklist = true,
-  showCancelButton = true,
+  showCancelOrBackButton = true,
   customButtonSection,
 }: SingleStepTaskListFormProps) => {
   const hasFormData = Object.keys(rawFormData).length > 0;
   const formData = hasFormData ? createNestedFormData(rawFormData, schema) : {};
   const [formState, setFormState] = useState(formData);
+  const [modeState, setModeState] = useState(mode);
   const [isDisabled, setIsDisabled] = useState(
     disabled || mode === FormMode.READ_ONLY,
   );
@@ -117,7 +118,10 @@ const SingleStepTaskListForm = ({
           formData={formState}
           onChange={handleFormChange}
           // onError={handleError}
-          onSubmit={submitHandler}
+          onSubmit={(e) => {
+            submitHandler(e);
+            setModeState(FormMode.READ_ONLY);
+          }}
           omitExtraData={true}
         >
           {inlineMessage && <div className="mt-10 mb-5">{inlineMessage}</div>}
@@ -125,15 +129,26 @@ const SingleStepTaskListForm = ({
             {error && <Alert severity="error">{error}</Alert>}
           </div>
           {customButtonSection || (
-            <div className="w-full flex justify-end mt-8">
+            <div className="w-full flex justify-start mt-8">
+              {showCancelOrBackButton && (
+                <Button
+                  className="mr-4"
+                  variant="outlined"
+                  type="button"
+                  onClick={onCancel}
+                >
+                  {modeState === FormMode.EDIT ? "Cancel" : "Back"}
+                </Button>
+              )}
               {allowEdit && (
-                <div>
+                <>
                   {isDisabled ? (
                     <Button
                       variant="contained"
                       onClick={() => {
                         setIsDisabled(false);
                         setIsSnackbarOpen(false);
+                        setModeState(FormMode.EDIT);
                       }}
                     >
                       Edit
@@ -143,20 +158,10 @@ const SingleStepTaskListForm = ({
                       disabled={isSubmitting}
                       isSubmitting={isSubmitting}
                     >
-                      Submit
+                      Save
                     </SubmitButton>
                   )}
-                </div>
-              )}
-              {showCancelButton && (
-                <Button
-                  className="ml-4"
-                  variant="outlined"
-                  type="button"
-                  onClick={onCancel}
-                >
-                  Cancel
-                </Button>
+                </>
               )}
             </div>
           )}


### PR DESCRIPTION
card: https://github.com/bcgov/cas-registration/issues/2743

This PR:
- makes button text conditional on FormMode in single step tasklist
- update vitests
- update `showCancelButton` prop name