### PR TITLE
chore: 657 Potential Reporting Operation Does Not Report

### DIFF
--- a/bc_obps/common/fixtures/dashboard/bciers/dev/external.json
+++ b/bc_obps/common/fixtures/dashboard/bciers/dev/external.json
@@ -166,10 +166,10 @@
             "content": "Submit, view and edit your annual reports or previous years’ reports.",
             "conditions": [
               {
-                "api": "registration/user-operators/current/has_registered_operation",
-                "field": "has_registered_operation",
+                "api": "reporting/validate-user-reporting-access",
+                "field": "status",
                 "operator": "equals",
-                "value": true
+                "value": "Registered"
               }
             ],
             "links": [

--- a/bc_obps/common/fixtures/dashboard/bciers/prod/external.json
+++ b/bc_obps/common/fixtures/dashboard/bciers/prod/external.json
@@ -166,10 +166,10 @@
             "content": "Submit, view and edit your annual reports or previous years’ reports.",
             "conditions": [
               {
-                "api": "registration/user-operators/current/has_registered_operation",
-                "field": "has_registered_operation",
+                "api": "reporting/validate-user-reporting-access",
+                "field": "status",
                 "operator": "equals",
-                "value": true
+                "value": "Registered"
               }
             ],
             "links": [

--- a/bc_obps/common/tests/endpoints/auth/constants.py
+++ b/bc_obps/common/tests/endpoints/auth/constants.py
@@ -51,7 +51,7 @@ ENDPOINTS = {
             "endpoint_name": "get_report_operation",
             "kwargs": {"report_id": MOCK_INT},
         },
-        {"method": "get", "endpoint_name": "validate_user_report_version"},
+        {"method": "get", "endpoint_name": "validate_user_reporting_access"},
         {
             "method": "get",
             "endpoint_name": "get_report_person_responsible_by_version_id",

--- a/bc_obps/reporting/api/__init__.py
+++ b/bc_obps/reporting/api/__init__.py
@@ -38,5 +38,5 @@ from .report_review_facilties import get_selected_facilities
 from .report_additional_data import get_report_additional_data_by_version_id
 from .report_additional_data import save_report_additional_data
 from .report_supplementary_version import create_report_supplementary_version, is_supplementary_report_version
-from .validate_user_report_version import validate_user_report_version
+from .validate_user_reporting_access import validate_user_reporting_access
 from .reports import get_update_report

--- a/bc_obps/reporting/api/validate_user_reporting_access.py
+++ b/bc_obps/reporting/api/validate_user_reporting_access.py
@@ -10,6 +10,9 @@ from registration.api._user_operators._current.has_registered_operation import (
 from .router import router
 from ..models import ReportVersion
 from ..schema.validate_reporting_user import UserStatusResponse
+from common.api.utils import get_current_user_guid
+from service.data_access_service.user_service import UserDataAccessService
+from service.data_access_service.operation_service import OperationDataAccessService
 
 
 class UserStatusEnum(Enum):
@@ -19,8 +22,8 @@ class UserStatusEnum(Enum):
     REGISTERED_AND_INVALID = "Registered and Invalid Report Version"
 
 
-@router.get("/validate_user_report_version", response=UserStatusResponse, auth=authorize("approved_industry_user"))
-def validate_user_report_version(request: HttpRequest, report_version_id: Optional[str] = Query(None)) -> dict:
+@router.get("/validate-user-reporting-access", response=UserStatusResponse, auth=authorize("approved_industry_user"))
+def validate_user_reporting_access(request: HttpRequest, report_version_id: Optional[str] = Query(None)) -> dict:
     status, has_registered_operation = get_current_user_operator_has_registered_operation(request)
 
     if not has_registered_operation:
@@ -32,6 +35,17 @@ def validate_user_report_version(request: HttpRequest, report_version_id: Option
             UserStatusEnum.REGISTERED_AND_VALID if report_version_exists else UserStatusEnum.REGISTERED_AND_INVALID
         )
         return {"status": user_status.value}
+
+    # Check if the userOperator's operator has at least one operation
+    # with status 'Registered'
+    # and registration_purpose not equal to POTENTIAL_REPORTING_OPERATION
+    operator = UserDataAccessService.get_operator_by_user(get_current_user_guid(request))
+    has_reporting_registered_operation = OperationDataAccessService.check_current_users_reporting_registered_operation(
+        operator.id
+    )
+
+    if not has_reporting_registered_operation:
+        return {"status": UserStatusEnum.NOT_REGISTERED.value}
 
     # If no report_version_id provided, return just the registration status
     return {"status": UserStatusEnum.REGISTERED.value}

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -60,6 +60,7 @@ class ReportingDashboardService:
         queryset = (
             OperationDataAccessService.get_all_operations_for_user(user)
             .filter(status=Operation.Statuses.REGISTERED)  # ✅ Filter operations with status "Registered"
+            .exclude(registration_purpose=Operation.Purposes.POTENTIAL_REPORTING_OPERATION)
             .annotate(
                 report_id=report_subquery.values("id"),
                 report_version_id=report_subquery.values("latest_version_id"),

--- a/bc_obps/reporting/tests/api/test_validate_user_reporting_access_api.py
+++ b/bc_obps/reporting/tests/api/test_validate_user_reporting_access_api.py
@@ -1,0 +1,139 @@
+from model_bakery import baker
+from unittest.mock import patch, MagicMock, AsyncMock
+from registration.tests.utils.bakers import user_baker
+
+from registration.tests.utils.helpers import CommonTestSetup, TestUtils
+from registration.utils import custom_reverse_lazy
+from reporting.api.validate_user_reporting_access import UserStatusEnum
+
+
+class TestValidateUserReportingAccessApi(CommonTestSetup):
+    def setup_method(self):
+        self.report_version = baker.make_recipe("reporting.tests.utils.report_version")
+        self.endpoint_under_test = "validate_user_reporting_access"
+        super().setup_method()
+        TestUtils.authorize_current_user_as_operator_user(self, operator=self.report_version.report.operator)
+
+    @patch(
+        "registration.api._user_operators._current.has_registered_operation.get_current_user_operator_has_registered_operation"
+    )
+    @patch("common.api.utils.get_current_user_guid")
+    @patch("service.data_access_service.user_service.UserDataAccessService.get_operator_by_user")
+    @patch(
+        "service.data_access_service.operation_service.OperationDataAccessService.check_current_users_reporting_registered_operation"
+    )
+    def test_returns_not_registered_if_no_registered_operation(
+        self,
+        mock_check_reporting: MagicMock | AsyncMock,
+        mock_get_operator: MagicMock | AsyncMock,
+        mock_get_current_user: MagicMock | AsyncMock,
+        mock_get_registered: MagicMock | AsyncMock,
+    ):
+        # Simulate that the current user does NOT have any registered operation.
+        mock_get_registered.return_value = (None, False)
+        # Dummy operator for if any subsequent lookup occurs.
+        dummy_operator = baker.make_recipe("registration.tests.utils.operator")
+        mock_get_operator.return_value = dummy_operator
+        mock_check_reporting.return_value = False
+        mock_get_current_user.return_value = user_baker()
+        # Build the URL with report_version_id set to "null"
+        url = custom_reverse_lazy(self.endpoint_under_test) + "?report_version_id=null"
+        response = TestUtils.mock_get_with_auth_role(self, "industry_user", url)
+
+        assert response.status_code == 200
+        assert response.json() == {"status": UserStatusEnum.NOT_REGISTERED.value}
+
+    @patch(
+        "registration.api._user_operators._current.has_registered_operation.get_current_user_operator_has_registered_operation"
+    )
+    @patch("reporting.models.report_version.ReportVersion.objects.filter")
+    def test_returns_registered_and_valid_if_report_version_exists(
+        self, mock_filter: MagicMock, mock_get_registered: MagicMock
+    ):
+        # Simulate that there is a registered operation.
+        mock_get_registered.return_value = (None, True)
+        # Simulate that the report version exists.
+        mock_filter.return_value.exists.return_value = True
+
+        url = custom_reverse_lazy(self.endpoint_under_test) + f"?report_version_id={self.report_version.id}"
+        response = TestUtils.mock_get_with_auth_role(self, "industry_user", url)
+
+        assert response.status_code == 200
+        # Expect "REGISTERED_AND_VALID" when provided report_version_id exists.
+        assert response.json() == {"status": UserStatusEnum.REGISTERED_AND_VALID.value}
+
+    @patch(
+        "registration.api._user_operators._current.has_registered_operation.get_current_user_operator_has_registered_operation"
+    )
+    @patch("reporting.models.report_version.ReportVersion.objects.filter")
+    def test_returns_registered_and_invalid_if_report_version_does_not_exist(
+        self, mock_filter: MagicMock, mock_get_registered: MagicMock
+    ):
+        # Simulate that there is a registered operation.
+        mock_get_registered.return_value = (None, True)
+        # Simulate that the report version does NOT exist.
+        mock_filter.return_value.exists.return_value = False
+
+        url = custom_reverse_lazy(self.endpoint_under_test) + "?report_version_id=nonexistent"
+        response = TestUtils.mock_get_with_auth_role(self, "industry_user", url)
+
+        assert response.status_code == 200
+        # Expect "REGISTERED_AND_INVALID" when report_version_id is provided but not found.
+        assert response.json() == {"status": UserStatusEnum.REGISTERED_AND_INVALID.value}
+
+    @patch(
+        "registration.api._user_operators._current.has_registered_operation.get_current_user_operator_has_registered_operation"
+    )
+    @patch("service.data_access_service.user_service.UserDataAccessService.get_operator_by_user")
+    @patch(
+        "service.data_access_service.operation_service.OperationDataAccessService.check_current_users_reporting_registered_operation"
+    )
+    def test_returns_registered_when_no_report_version_id_and_valid_reporting_registered_op(
+        self,
+        mock_check_reporting: MagicMock,
+        mock_get_operator: MagicMock,
+        mock_get_registered: MagicMock,
+    ):
+        # Simulate that the user does have a registered operation.
+        mock_get_registered.return_value = (None, True)
+        # Simulate returning an operator from the current user.
+        operator = baker.make_recipe("registration.tests.utils.operator")
+        mock_get_operator.return_value = operator
+        # Simulate that the operator has at least one valid reporting registered operation.
+        mock_check_reporting.return_value = True
+
+        # Build a URL without a report_version_id query parameter.
+        url = custom_reverse_lazy(self.endpoint_under_test)
+        response = TestUtils.mock_get_with_auth_role(self, "industry_user", url)
+
+        assert response.status_code == 200
+        # Expect a status of "REGISTERED" when no report_version_id is provided and reporting op is valid.
+        assert response.json() == {"status": UserStatusEnum.REGISTERED.value}
+
+    @patch(
+        "registration.api._user_operators._current.has_registered_operation.get_current_user_operator_has_registered_operation"
+    )
+    @patch("service.data_access_service.user_service.UserDataAccessService.get_operator_by_user")
+    @patch(
+        "service.data_access_service.operation_service.OperationDataAccessService.check_current_users_reporting_registered_operation"
+    )
+    def test_returns_not_registered_if_no_valid_reporting_registered_op(
+        self,
+        mock_check_reporting: MagicMock,
+        mock_get_operator: MagicMock,
+        mock_get_registered: MagicMock,
+    ):
+        # Simulate that the user has a registered operation overall.
+        mock_get_registered.return_value = (None, True)
+        # Return a dummy operator.
+        operator = baker.make_recipe("registration.tests.utils.operator")
+        mock_get_operator.return_value = operator
+        # Simulate that no valid reporting registered operation exists.
+        mock_check_reporting.return_value = False
+
+        url = custom_reverse_lazy(self.endpoint_under_test)
+        response = TestUtils.mock_get_with_auth_role(self, "industry_user", url)
+
+        assert response.status_code == 200
+        # Expect "NOT_REGISTERED" since reporting registered operation check fails.
+        assert response.json() == {"status": UserStatusEnum.NOT_REGISTERED.value}

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -25,7 +25,7 @@ class TestReportingDashboardService:
 
         year = reporting_year_baker(reporting_year=5091)
         operator = operator_baker()
-        operations = operation_baker(operator_id=operator.id, _quantity=4)
+        operations = operation_baker(operator_id=operator.id, _quantity=5)
 
         sort_field: Optional[str] = "name"
         sort_order: Optional[str] = "asc"
@@ -47,6 +47,7 @@ class TestReportingDashboardService:
         operations[1].status = Operation.Statuses.REGISTERED
         operations[2].status = Operation.Statuses.REGISTERED
         operations[3].status = Operation.Statuses.NOT_STARTED
+        operations[4].registration_purpose = Operation.Purposes.POTENTIAL_REPORTING_OPERATION
         for op in operations:
             op.save()
 

--- a/bc_obps/service/data_access_service/operation_service.py
+++ b/bc_obps/service/data_access_service/operation_service.py
@@ -39,6 +39,18 @@ class OperationDataAccessService:
         return Operation.objects.filter(operator_id=operator_id, status=Operation.Statuses.REGISTERED).exists()
 
     @classmethod
+    def check_current_users_reporting_registered_operation(cls, operator_id: UUID) -> bool:
+        """
+        Returns True if the userOperator's operator has at least one operation with status 'Registered'
+        and registration_purpose not equal to POTENTIAL_REPORTING_OPERATION, False otherwise.
+        """
+        return (
+            Operation.objects.filter(operator_id=operator_id, status=Operation.Statuses.REGISTERED)
+            .exclude(registration_purpose=Operation.Purposes.POTENTIAL_REPORTING_OPERATION)
+            .exists()
+        )
+
+    @classmethod
     def create_operation(
         cls,
         user_guid: UUID,

--- a/bciers/apps/reporting/src/middlewares/withResponseReport.test.ts
+++ b/bciers/apps/reporting/src/middlewares/withResponseReport.test.ts
@@ -33,7 +33,7 @@ describe("withResponseReport middleware", () => {
     // Mock the fetch response for operator has registered operation
     fetch.mockResponseOnce(
       JSON.stringify({
-        has_registered_operation: true,
+        status: "Registered",
       }),
     );
 

--- a/bciers/apps/reporting/src/middlewares/withRuleHasRegisteredOperation.ts
+++ b/bciers/apps/reporting/src/middlewares/withRuleHasRegisteredOperation.ts
@@ -31,7 +31,7 @@ const checkUserStatus = async (request: NextRequest, token: any) => {
 
     // 🛸 Make a single API call to validate the user and, if necessary, report version
     let response = await fetchResponse(
-      `reporting/validate_user_report_version?report_version_id=${reportVersionId}`,
+      `reporting/validate-user-reporting-access?report_version_id=${reportVersionId}`,
       token.user_guid,
     );
 
@@ -58,7 +58,10 @@ const checkUserStatus = async (request: NextRequest, token: any) => {
         return null;
 
       default:
-        return null;
+        // 🛸 Redirect to onboarding page if the user is not registered
+        return NextResponse.redirect(
+          new URL(AppRoutes.ONBOARDING, request.url),
+        );
     }
   } catch (error) {
     // 🛸 Handle error (e.g., redirect to onboarding in case of failure)


### PR DESCRIPTION
Addresses: 
[657](https://github.com/bcgov/cas-reporting/issues/657)

### 🚀 Impact:

- Prevents Registered Operation with reporting purpose ="Potential Reporting Operation" from accessing reporting app


## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

---

### Test Dashboard Condition: user does not have Operator

1. Navigate to `http://localhost:3000`
2. Click button "Log in with Business BCeID"
3. Sign in to Keycloak using `bc-cas-dev-secondary`
**Expected results:** 
![image](https://github.com/user-attachments/assets/8795830f-bd74-4441-b7e1-13186e53128a)
- NO Registration tile
- NO Reporting tile
4. Navigate to http://localhost:3000/reporting
**Expected results:** 
- Navigation re-routes to `Dashboard`
4. Navigate to http://localhost:3000/reporting/reports
**Expected results:** 
- Navigation re-routes to `Dashboard`

---

### Test Dashboard Condition: userOperator's Operator does not have Registered Operation

1. Navigate to `http://localhost:3000`
2. Click button "Log in with Business BCeID"
3. Sign in to Keycloak using `bc-cas-dev-secondary`
4. Click link `Administration\Select an Operator` 
5. Click link `Add Operator`
6. Complete required fields
7. Click button `Submit`
**Expected results:** 
- Form submits and creates a new approved operator with an approved admin user operator
8. Click breadcrumb `Dashboard`
**Expected results:** 
![image](https://github.com/user-attachments/assets/c0d33ab6-0659-4e6f-9a13-b06743035315)
- Registration tile has link `Register an Operation * (action required)` 
- NO Reporting tile
9. Navigate to http://localhost:3000/reporting
**Expected results:** 
- Navigation re-routes to `Dashboard`
10. Navigate to http://localhost:3000/reporting/reports
**Expected results:** 
- Navigation re-routes to `Dashboard`


---


### Test Dashboard Condition: userOperator's Operator has a Registered Operation with reporting purpose ="Potential Reporting Operation"

1. After `Test Dashboard Condition: userOperator's Operator does not have Registered Operation`
2. Click link `Registration\Register an Operation * (action required)` 
3. Register an Operation with Reporting Purpose =`Potential Reporting Operation`
**Expected results:** 
- Form submits and registers the operation
4. Click breadcrumb `Dashboard`
**Expected results:** 
- NO Reporting tile
5. Navigate to http://localhost:3000/reporting
**Expected results:** 
- Navigation re-routes to `Dashboard`
6. Navigate to http://localhost:3000/reporting/reports
**Expected results:** 
- Navigation re-routes to `Dashboard`


---


### Test Dashboard Condition: userOperator's Operator has Registered Operation with mixed reporting purposes

1. After `Test Dashboard Condition: userOperator's Operator has a Registered Operation with reporting purpose ="Potential Reporting Operation`
2. Click link `Registration\Register an Operation` 
3. Register an Operation with Reporting Purpose NOT = `Potential Reporting Operation`
**Expected results:** 
- Form submits and registers the operation
4. Click breadcrumb `Dashboard`
**Expected results:** 
![image](https://github.com/user-attachments/assets/b5deaa0b-71f8-4cb2-8d67-f6685ed7a124)
- Reporting tile displays
7. Navigate to http://localhost:3000/reporting/reports
**Expected results:** 
![image](https://github.com/user-attachments/assets/1e2853aa-9ac7-4ea7-9ec2-2a3b23812363)
- `Reports` grid displays
-  Operation with Reporting Purpose = `Potential Reporting Operation` does not display

