### PR TITLE
Chore/fix cronjob labels

### DIFF
--- a/helm/cas-bciers/templates/NetworkPolicy/postgresJobIngress.yaml
+++ b/helm/cas-bciers/templates/NetworkPolicy/postgresJobIngress.yaml
@@ -1,0 +1,19 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-postgres-job-ingress
+  labels: {{ include "cas-bciers.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cas-obps-postgres
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          release: {{ include "cas-bciers.fullname" . }}
+          component: job-with-database-access
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: {{ include "cas-bciers.fullname" . }}
+          component: job-with-database-access

--- a/helm/cas-bciers/templates/backend/job/add-django-admin.yaml
+++ b/helm/cas-bciers/templates/backend/job/add-django-admin.yaml
@@ -4,7 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels: {{- include "cas-bciers.labels" . | nindent 4 }}
-    component: backend
+    component: job-with-database-access
   name: {{ template "cas-bciers.fullname" . }}-add-django-admin
   namespace: {{ .Release.Namespace }}
   annotations:

--- a/helm/cas-bciers/templates/backend/job/reset-database.yaml
+++ b/helm/cas-bciers/templates/backend/job/reset-database.yaml
@@ -5,7 +5,7 @@ kind: Job
 metadata:
   labels:
 {{- include "cas-bciers.labels" . | nindent 4 }}
-    component: backend
+    component: job-with-database-access
   name: {{ template "cas-bciers.fullname" . }}-reset-database
   namespace: {{ .Release.Namespace }}
   annotations:
@@ -18,7 +18,7 @@ spec:
       name: {{ template "cas-bciers.fullname" . }}-reset-database
       labels:
 {{- include "cas-bciers.labels" . | nindent 8 }}
-        component: backend
+        component: job-with-database-access
     spec:
       activeDeadlineSeconds: 180
       containers:

--- a/helm/cas-bciers/templates/cronJobs/check-file-status-pvc.yaml
+++ b/helm/cas-bciers/templates/cronJobs/check-file-status-pvc.yaml
@@ -3,7 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: check-document-file-status-lock-pvc
   labels: {{- include "cas-bciers.labels" . | nindent 4 }}
-    component: backend
   namespace: {{ .Release.Namespace }}
 spec:
   accessModes:

--- a/helm/cas-bciers/templates/cronJobs/check-file-status.yaml
+++ b/helm/cas-bciers/templates/cronJobs/check-file-status.yaml
@@ -3,7 +3,6 @@ kind: CronJob
 metadata:
   name: check-document-file-status
   labels: {{- include "cas-bciers.labels" . | nindent 4 }}
-    component: backend
   namespace: {{ .Release.Namespace }}
 spec:
   suspend: false
@@ -15,7 +14,7 @@ spec:
       template:
         metadata:
           labels: {{ include "cas-bciers.labels" . | nindent 12 }}
-            component: backend
+            component: job-with-database-access
         spec:
           activeDeadlineSeconds: 1800
           restartPolicy: Never

--- a/helm/cas-bciers/templates/cronJobs/process-due-transfer-events.yaml
+++ b/helm/cas-bciers/templates/cronJobs/process-due-transfer-events.yaml
@@ -3,7 +3,6 @@ kind: CronJob
 metadata:
   name: process-due-transfer-events
   labels: {{- include "cas-bciers.labels" . | nindent 4 }}
-    component: backend
   namespace: {{ .Release.Namespace }}
 spec:
   suspend: true # This cron job is intended to be triggered manually by Airflow
@@ -15,7 +14,7 @@ spec:
       template:
         metadata:
           labels: {{ include "cas-bciers.labels" . | nindent 12 }}
-            component: backend
+            component: job-with-database-access
         spec:
           activeDeadlineSeconds: 600
           restartPolicy: Never


### PR DESCRIPTION
Gives jobs their own component label & adds a KNP to allow access to the DB based on that label. This creates a distinction between the backend and jobs that we were missing