### PR TITLE
fix: report_product data should be deleted if product removed from report_operation

### DIFF
--- a/bc_obps/reporting/schema/facility_report.py
+++ b/bc_obps/reporting/schema/facility_report.py
@@ -41,6 +41,7 @@ class FacilityReportIn(ModelSchema):
     facility_type: str
     facility_bcghgid: Optional[str]
     activities: List[int]
+    regulated_products: List[int]
 
     class Meta:
         alias_generator = to_snake

--- a/bc_obps/reporting/tests/api/test_facility_report_api.py
+++ b/bc_obps/reporting/tests/api/test_facility_report_api.py
@@ -70,7 +70,7 @@ class TestFacilityReportEndpoints(CommonTestSetup):
             "facility_type": "Single Facility Operation",
             "facility_bcghgid": "abc12345",
             "activities": ["1", "2", "3"],
-            "products": [],
+            "regulated_products": [],
         }
 
         TestUtils.mock_post_with_auth_role(
@@ -80,6 +80,7 @@ class TestFacilityReportEndpoints(CommonTestSetup):
             request_data,
             endpoint_under_test,
         )
+
         assert FacilityReport.objects.get(pk=facility_report.id).facility_name == "CHANGED"
         assert FacilityReport.objects.get(pk=facility_report.id).activities.count() == 3
 

--- a/bc_obps/service/facility_report_service.py
+++ b/bc_obps/service/facility_report_service.py
@@ -3,7 +3,7 @@ from django.db import transaction
 from typing import Any, List, Optional, Tuple, cast
 from ninja import Query
 from registration.models import Activity, Facility
-from reporting.models import ReportActivity, ReportEmissionAllocation, ReportProductEmissionAllocation
+from reporting.models import ReportActivity, ReportEmissionAllocation, ReportProductEmissionAllocation, ReportProduct
 from reporting.models.facility_report import FacilityReport
 from reporting.schema.facility_report import FacilityReportListInSchema, FacilityReportFilterSchema
 from django.db.models import QuerySet
@@ -12,12 +12,18 @@ from django.db.models import F
 
 class SaveFacilityReportData:
     def __init__(
-        self, facility_name: str, facility_type: str, activities: List[int], facility_bcghgid: Optional[str] = None
+        self,
+        facility_name: str,
+        facility_type: str,
+        activities: List[int],
+        regulated_products: List[int],
+        facility_bcghgid: Optional[str] = None,
     ):
         self.facility_name = facility_name
         self.facility_type = facility_type
         self.facility_bcghgid = facility_bcghgid
         self.activities = activities
+        self.regulated_products = regulated_products
 
 
 class FacilityReportService:
@@ -45,8 +51,7 @@ class FacilityReportService:
     @classmethod
     def set_activities_for_facility_report(cls, facility_report: FacilityReport, activities: List[int]) -> None:
         facility_report.activities.set(Activity.objects.filter(id__in=activities))
-        # If activities are removed from a facility_report, then the corresponding report_activity data must be delete-cascaded
-        ReportActivity.objects.filter(facility_report_id=facility_report.id).exclude(
+        report_activities_to_prune = ReportActivity.objects.filter(facility_report_id=facility_report.id).exclude(
             activity_id__in=activities
         ).delete()
         # If activities are removed from a facility report, then the allocation of emissions to products must be deleted & re-allocated by the user
@@ -54,6 +59,28 @@ class FacilityReportService:
             facility_report_id=facility_report.id
         ).first()
         ReportProductEmissionAllocation.objects.filter(report_emission_allocation=report_emission_allocation).delete()
+        )
+        if report_activities_to_prune:
+            # If activities are removed from a facility_report, then the corresponding report_activity data must be delete-cascaded
+            report_activities_to_prune.delete()
+            # If activities are removed from a facility report, then the allocation of emissions to all products must be deleted & re-allocated by the user
+            ReportProductEmissionAllocation.objects.filter(facility_report_id=facility_report.id).delete()
+
+    @classmethod
+    def prune_report_product_data_for_facility_report(
+        cls, facility_report: FacilityReport, regulated_products: List[int]
+    ) -> None:
+        report_products_to_prune = ReportProduct.objects.filter(facility_report_id=facility_report.id).exclude(
+            product_id__in=regulated_products
+        )
+        if report_products_to_prune:
+            report_product_ids = report_products_to_prune.values_list("id", flat=True)
+            # If regulated_products are removed from a report_operation, then the corresponding report_product data must be deleted
+            report_products_to_prune.delete()
+            # If regulated_products are removed from a report_operation, then the allocation of emissions to those products must be deleted & re-allocated by the user
+            ReportProductEmissionAllocation.objects.filter(
+                facility_report_id=facility_report.id, report_product_id__in=report_product_ids
+            ).delete()
 
     @classmethod
     @transaction.atomic()
@@ -75,9 +102,13 @@ class FacilityReportService:
         facility_report.facility_name = data.facility_name.strip()
         facility_report.facility_type = data.facility_type.strip()
 
-        # Update ManyToMany fields (activities)
+        # Update ManyToMany fields (activities, report_products)
         if data.activities:
             cls.set_activities_for_facility_report(facility_report=facility_report, activities=data.activities)
+        if data.regulated_products:
+            cls.prune_report_product_data_for_facility_report(
+                facility_report=facility_report, regulated_products=data.regulated_products
+            )
 
         # Save the updated FacilityReport instance
         facility_report.save()

--- a/bc_obps/service/facility_report_service.py
+++ b/bc_obps/service/facility_report_service.py
@@ -3,7 +3,7 @@ from django.db import transaction
 from typing import Any, List, Optional, Tuple, cast
 from ninja import Query
 from registration.models import Activity, Facility
-from reporting.models import ReportActivity, ReportEmissionAllocation, ReportProductEmissionAllocation, ReportProduct
+from reporting.models import ReportActivity, ReportProductEmissionAllocation, ReportProduct
 from reporting.models.facility_report import FacilityReport
 from reporting.schema.facility_report import FacilityReportListInSchema, FacilityReportFilterSchema
 from django.db.models import QuerySet
@@ -53,18 +53,15 @@ class FacilityReportService:
         facility_report.activities.set(Activity.objects.filter(id__in=activities))
         report_activities_to_prune = ReportActivity.objects.filter(facility_report_id=facility_report.id).exclude(
             activity_id__in=activities
-        ).delete()
-        # If activities are removed from a facility report, then the allocation of emissions to products must be deleted & re-allocated by the user
-        report_emission_allocation = ReportEmissionAllocation.objects.filter(
-            facility_report_id=facility_report.id
-        ).first()
-        ReportProductEmissionAllocation.objects.filter(report_emission_allocation=report_emission_allocation).delete()
         )
+
         if report_activities_to_prune:
             # If activities are removed from a facility_report, then the corresponding report_activity data must be delete-cascaded
             report_activities_to_prune.delete()
             # If activities are removed from a facility report, then the allocation of emissions to all products must be deleted & re-allocated by the user
-            ReportProductEmissionAllocation.objects.filter(facility_report_id=facility_report.id).delete()
+            ReportProductEmissionAllocation.objects.filter(
+                report_emission_allocation__facility_report_id=facility_report.id
+            ).delete()
 
     @classmethod
     def prune_report_product_data_for_facility_report(
@@ -73,13 +70,17 @@ class FacilityReportService:
         report_products_to_prune = ReportProduct.objects.filter(facility_report_id=facility_report.id).exclude(
             product_id__in=regulated_products
         )
+
         if report_products_to_prune:
             report_product_ids = report_products_to_prune.values_list("id", flat=True)
             # If regulated_products are removed from a report_operation, then the corresponding report_product data must be deleted
-            report_products_to_prune.delete()
+            ReportProduct.objects.filter(facility_report_id=facility_report.id).exclude(
+                product_id__in=regulated_products
+            ).delete()
             # If regulated_products are removed from a report_operation, then the allocation of emissions to those products must be deleted & re-allocated by the user
             ReportProductEmissionAllocation.objects.filter(
-                facility_report_id=facility_report.id, report_product_id__in=report_product_ids
+                report_emission_allocation__facility_report_id=facility_report.id,
+                report_product_id__in=report_product_ids,
             ).delete()
 
     @classmethod
@@ -101,7 +102,6 @@ class FacilityReportService:
         facility_report = FacilityReport.objects.get(report_version_id=report_version_id, facility_id=facility_id)
         facility_report.facility_name = data.facility_name.strip()
         facility_report.facility_type = data.facility_type.strip()
-
         # Update ManyToMany fields (activities, report_products)
         if data.activities:
             cls.set_activities_for_facility_report(facility_report=facility_report, activities=data.activities)

--- a/bc_obps/service/report_service.py
+++ b/bc_obps/service/report_service.py
@@ -133,12 +133,16 @@ class ReportService:
             )
             for f in facility_reports:
                 FacilityReportService.set_activities_for_facility_report(facility_report=f, activities=data.activities)
+                FacilityReportService.prune_report_product_data_for_facility_report(
+                    facility_report=f, regulated_products=data.regulated_products
+                )
         else:
             facility_report: FacilityReport = FacilityReport.objects.get(report_version__id=report_version_id)
             facility_report_save_data = SaveFacilityReportData(
                 facility_name=report_operation.operation_name,
                 facility_type=facility_report.facility_type,
                 activities=data.activities,
+                regulated_products=data.regulated_products,
             )
             FacilityReportService.save_facility_report(
                 report_version_id=facility_report.report_version_id,

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -74,7 +74,7 @@ class TestFacilityReportService(TestCase):
             facility_type=facility_report.facility_type,
             facility_bcghgid=facility_report.facility_bcghgid,
             activities=[],
-            products=[],
+            regulated_products=[],
         )
         returned_data = FacilityReportService.save_facility_report(
             report_version_id=facility_report.report_version_id,
@@ -138,7 +138,7 @@ class TestFacilityReportService(TestCase):
             facility_type=facility_report.facility_type,
             facility_bcghgid=facility_report.facility_bcghgid,
             activities=['1'],
-            products=[],
+            regulated_products=[],
         )
         FacilityReportService.save_facility_report(
             report_version_id=facility_report.report_version_id,


### PR DESCRIPTION
Follow up to #3114. Pretty much the same fix, just for report_products.

To test this work:
- Create a report with a couple regulated_products
- Go through the report and report data on the products
- Go back to the review operation page & remove one of the products from the set
- Confirm that the associated report_product record has been deleted