### PR TITLE
Chore: remove regulated products from pydantic schema

### DIFF
--- a/bc_obps/reporting/schema/facility_report.py
+++ b/bc_obps/reporting/schema/facility_report.py
@@ -41,7 +41,6 @@ class FacilityReportIn(ModelSchema):
     facility_type: str
     facility_bcghgid: Optional[str]
     activities: List[int]
-    regulated_products: List[int]
 
     class Meta:
         alias_generator = to_snake

--- a/bc_obps/reporting/tests/api/test_facility_report_api.py
+++ b/bc_obps/reporting/tests/api/test_facility_report_api.py
@@ -70,7 +70,6 @@ class TestFacilityReportEndpoints(CommonTestSetup):
             "facility_type": "Single Facility Operation",
             "facility_bcghgid": "abc12345",
             "activities": ["1", "2", "3"],
-            "regulated_products": [],
         }
 
         TestUtils.mock_post_with_auth_role(
@@ -136,7 +135,6 @@ class TestFacilityReportEndpoints(CommonTestSetup):
             "facility_type": "Single Facility Operation",
             "facility_bcghgid": "xyz98765",
             "activities": ["1", "2", "3"],
-            "products": [],
         }
 
         response = TestUtils.mock_put_with_auth_role(

--- a/bc_obps/service/facility_report_service.py
+++ b/bc_obps/service/facility_report_service.py
@@ -16,7 +16,7 @@ class SaveFacilityReportData:
         facility_name: str,
         facility_type: str,
         activities: List[int],
-        regulated_products: List[int],
+        regulated_products: Optional[List[int]],
         facility_bcghgid: Optional[str] = None,
     ):
         self.facility_name = facility_name
@@ -103,9 +103,9 @@ class FacilityReportService:
         facility_report.facility_name = data.facility_name.strip()
         facility_report.facility_type = data.facility_type.strip()
         # Update ManyToMany fields (activities, report_products)
-        if data.activities:
+        if hasattr(data, 'activities'):
             cls.set_activities_for_facility_report(facility_report=facility_report, activities=data.activities)
-        if data.regulated_products:
+        if hasattr(data, 'regulated_products'):
             cls.prune_report_product_data_for_facility_report(
                 facility_report=facility_report, regulated_products=data.regulated_products
             )

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -2,8 +2,7 @@ from django.test import TestCase
 from django.core.exceptions import ObjectDoesNotExist
 from reporting.models.report_emission_allocation import ReportEmissionAllocation
 from reporting.tests.utils.bakers import activity_baker
-from service.facility_report_service import FacilityReportService
-from reporting.schema.facility_report import FacilityReportIn
+from service.facility_report_service import FacilityReportService, SaveFacilityReportData
 from model_bakery import baker
 from common.tests.utils.model_inspection import get_cascading_models
 from reporting.models import (
@@ -69,7 +68,7 @@ class TestFacilityReportService(TestCase):
     def test_saves_facility_report_form_data():
         facility_report = baker.make_recipe('reporting.tests.utils.facility_report', facility_bcghgid='abc')
 
-        data = FacilityReportIn(
+        data = SaveFacilityReportData(
             facility_name="CHANGED",
             facility_type=facility_report.facility_type,
             facility_bcghgid=facility_report.facility_bcghgid,
@@ -133,7 +132,7 @@ class TestFacilityReportService(TestCase):
             report_emission_allocation=report_emission_allocation,
         )
 
-        data = FacilityReportIn(
+        data = SaveFacilityReportData(
             facility_name="CHANGED",
             facility_type=facility_report.facility_type,
             facility_bcghgid=facility_report.facility_bcghgid,


### PR DESCRIPTION
Fixes an issue introduced in #3193. regulated_products should not be part of the pydantic schema. The LFO flow was also failing because of the condition `if data.regulated_products..` because the schema does not have that attribute & it is not passed from the frontend via the API. Replaced that with `if hasattr(data, 'regulated_products')` as that value can be passed as part of the `save_report_operation` service function.