### PR TITLE
Chore/705 unregulated product handling

### DIFF
--- a/bc_obps/reporting/service/report_product_service.py
+++ b/bc_obps/reporting/service/report_product_service.py
@@ -58,18 +58,18 @@ class ReportProductService:
             )
 
         # Add a report_product record for unregulated products reported by this operation (for emission allocation only)
-        for unregulated_product_id in unregulated_product_ids:
-            if unregulated_product_id in ReportOperation.objects.get(
-                report_version_id=report_version_id
-            ).regulated_products.values_list("id", flat=True):
+        for r_product_id in ReportOperation.objects.get(
+            report_version_id=report_version_id
+        ).regulated_products.values_list("id", flat=True):
+            if r_product_id in unregulated_product_ids:
                 ReportProduct.objects.update_or_create(
                     report_version_id=report_version_id,
                     facility_report=facility_report,
-                    product_id=unregulated_product_id,
+                    product_id=r_product_id,
                     defaults={
                         "report_version_id": report_version_id,
                         "facility_report": facility_report,
-                        "product_id": unregulated_product_id,
+                        "product_id": r_product_id,
                         "annual_production": 0,
                         "production_data_apr_dec": 0,
                         "production_methodology": "other",

--- a/bc_obps/reporting/service/report_product_service.py
+++ b/bc_obps/reporting/service/report_product_service.py
@@ -17,9 +17,7 @@ class ReportProductService:
     ) -> None:
 
         facility_report = FacilityReport.objects.get(report_version_id=report_version_id, facility_id=facility_id)
-        fog_product_id = RegulatedProduct.objects.get(
-            name='Fat, oil and grease collection, refining and storage', is_regulated=False
-        ).id
+        unregulated_product_ids = RegulatedProduct.objects.filter(is_regulated=False).values_list("id", flat=True)
 
         # Delete the report products that are not in the data
 
@@ -36,8 +34,8 @@ class ReportProductService:
                 "Data was submitted for a product that is not in the products allowed for this facility. "
                 + f"Allowed products ids: {list(allowed_product_ids)}, Submitted product ids: {product_ids}"
             )
-        # Do not remove auto-generated report_product record for Fat, Oil & Grease unregulated product
-        product_ids.append(fog_product_id)
+        # Do not remove auto-generated report_product records for unregulated products
+        product_ids.extend(unregulated_product_ids)
         ReportProduct.objects.filter(
             report_version_id=report_version_id, facility_report__facility_id=facility_id
         ).exclude(product_id__in=product_ids).delete()
@@ -59,24 +57,25 @@ class ReportProductService:
                 },
             )
 
-        # Add reportProduct for Fat, Oil & Grease unregulated product for emission allocation only
-        if fog_product_id in ReportOperation.objects.get(
-            report_version_id=report_version_id
-        ).regulated_products.values_list("id", flat=True):
-            ReportProduct.objects.update_or_create(
-                report_version_id=report_version_id,
-                facility_report=facility_report,
-                product_id=fog_product_id,
-                defaults={
-                    "report_version_id": report_version_id,
-                    "facility_report": facility_report,
-                    "product_id": fog_product_id,
-                    "annual_production": 0,
-                    "production_data_apr_dec": 0,
-                    "production_methodology": "other",
-                    "production_methodology_description": "auto-generated report_product record for unregulated product",
-                },
-            )
+        # Add a report_product record for unregulated products reported by this operation (for emission allocation only)
+        for unregulated_product_id in unregulated_product_ids:
+            if unregulated_product_id in ReportOperation.objects.get(
+                report_version_id=report_version_id
+            ).regulated_products.values_list("id", flat=True):
+                ReportProduct.objects.update_or_create(
+                    report_version_id=report_version_id,
+                    facility_report=facility_report,
+                    product_id=unregulated_product_id,
+                    defaults={
+                        "report_version_id": report_version_id,
+                        "facility_report": facility_report,
+                        "product_id": unregulated_product_id,
+                        "annual_production": 0,
+                        "production_data_apr_dec": 0,
+                        "production_methodology": "other",
+                        "production_methodology_description": "auto-generated report_product record for unregulated product",
+                    },
+                )
 
     @classmethod
     def get_production_data(cls, report_version_id: int, facility_id: UUID) -> QuerySet[ReportProduct]:


### PR DESCRIPTION
This PR adds handling for all unregulated products in the same way as the FOG product. There are 3 unregulated products in our system. An example of how the handling should work is outlined in the [ticket](https://github.com/bcgov/cas-reporting/issues/705).

To test this:
- Add one or more unregulated products to a report in the operation review page and at least one regulated product
- Add emissions for an activity. The emissions should have a combination of excluded & non-excluded fuels (suggest using Fuel Combustion Mobile activity for this)
- On the product data page, it should not show the unregulated products
- Upon saving on the product data page, report_product records should be created in the db by the backend for the unregulated products with production values of 0
- On the emission allocation page, the unregulated products should show up & allow for allocation of emissions to those products
- Allocate some emissions to all products in all categories (including the excluded categories)
- On the compliance summary page, the reporting-only emissions should be a sum of: Emissions from basic categories allocated to unregulated products + Emissions from excluded categories allocated to regulated_products.
- The reporting-only emissions should not include emissions allocated from excluded categories to unregulated products (double counting)