### PR TITLE
chore: remove operation type from sync

### DIFF
--- a/bc_obps/service/report_service.py
+++ b/bc_obps/service/report_service.py
@@ -176,7 +176,6 @@ class ReportService:
         operation = report_operation.report_version.report.operation
         operator = report_operation.report_version.report.operator
         report_operation.operation_name = operation.name
-        report_operation.operation_type = operation.type
         report_operation.operation_bcghgid = operation.bcghg_id.id if operation.bcghg_id else None
         report_operation.bc_obps_regulated_operation_id = (
             operation.bc_obps_regulated_operation.id if operation.bc_obps_regulated_operation else ""

--- a/bc_obps/service/tests/test_report_service.py
+++ b/bc_obps/service/tests/test_report_service.py
@@ -231,7 +231,6 @@ class TestReportService(TestCase):
         report_operation = baker.make_recipe('reporting.tests.utils.report_operation', report_version=report_version)
 
         operation.name = "New Operation Name"
-        operation.type = Operation.Types.SFO
         operation.registration_purpose = Operation.Purposes.REPORTING_OPERATION
         operation.save()
 
@@ -240,7 +239,6 @@ class TestReportService(TestCase):
         report_operation.refresh_from_db()
 
         assert report_operation.operation_name == "New Operation Name"
-        assert report_operation.operation_type == Operation.Types.SFO
         assert report_operation.registration_purpose == Operation.Purposes.REPORTING_OPERATION
 
     def test_deletes_child_report_product_records_on_product_set_change(self):


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/712
A small PR to remove operation type from sync