### PR TITLE
chore: removed link and text for past submissions from reporting tile

### DIFF
--- a/bc_obps/common/fixtures/dashboard/bciers/dev/external.json
+++ b/bc_obps/common/fixtures/dashboard/bciers/dev/external.json
@@ -176,10 +176,6 @@
               {
                 "title": "Submit Annual Report(s)",
                 "href": "/reporting/reports"
-              },
-              {
-                "title": "View Past Submissions",
-                "href": "/reporting/reports/previous-years"
               }
             ]
           },

--- a/bc_obps/common/fixtures/dashboard/bciers/prod/external.json
+++ b/bc_obps/common/fixtures/dashboard/bciers/prod/external.json
@@ -176,10 +176,6 @@
               {
                 "title": "Submit Annual Report(s)",
                 "href": "/reporting/reports"
-              },
-              {
-                "title": "View Past Submissions",
-                "href": "/reporting/reports/previous-years"
               }
             ]
           },


### PR DESCRIPTION
Card: N/A
A small PR to remove "View Past Submission" from reporting tile on the dashboard
To test:-
1. make loadfixtures
2. go to http://localhost:3000/dashboard
3. You will only one linke under reporting(Submit Annual Report) 
![image](https://github.com/user-attachments/assets/e1f56be2-4afa-42a0-be8b-75b582cba692)

