### PR TITLE
chore: fix additional statement in supplementary report

### DIFF
--- a/bciers/apps/reporting/src/app/components/signOff/createSignOffSchema.ts
+++ b/bciers/apps/reporting/src/app/components/signOff/createSignOffSchema.ts
@@ -20,7 +20,7 @@ export const createSignOffSchema = (
         },
         acknowledgement_of_new_version: {
           title:
-            "I understand that, by submitting these changes, I am creating a new version of this annual report that will, effective immediately, be the annual report for the reporting and or compliance period that it pertains to.",
+            "I understand that, by submitting these changes, I am creating a new version of this annual report that will, effective immediately, be the annual report for the reporting and/or compliance period that it pertains to.",
           type: "boolean",
           default: false,
         },


### PR DESCRIPTION
Quick fix to add "/" in supplementary report sign-off page. The wireframe originally didn't have the statement as "and/or", verified with Zoey that it's supposed to be "and/or"

Statement that will be updated:
I understand that, by submitting these changes, I am creating a new version of this annual report that will, effective immediately, be the annual report for the reporting and or compliance period that it pertains to.

To be changed to:
I understand that, by submitting these changes, I am creating a new version of this annual report that will, effective immediately, be the annual report for the reporting **and/or** compliance period that it pertains to.