### PR TITLE
3178 missing validation

### DIFF
--- a/bciers/apps/registration/app/data/jsonSchema/operationInformation/registrationPurpose.ts
+++ b/bciers/apps/registration/app/data/jsonSchema/operationInformation/registrationPurpose.ts
@@ -85,62 +85,65 @@ export const createRegistrationPurposeSchema = async () => {
       },
     },
 
-    dependencies: {
-      registration_purpose: {
-        oneOf: registrationPurposes.map((purpose: RegistrationPurposes) => {
-          const isRegulatedProducts =
-            regulatedOperationPurposes.includes(purpose);
-          const isReportingActivities =
-            reportingOperationPurposes.includes(purpose);
+    allOf: registrationPurposes.map((purpose) => {
+      const isRegulatedProducts = regulatedOperationPurposes.includes(purpose);
+      const isReportingActivities =
+        reportingOperationPurposes.includes(purpose);
 
-          // have to determine required fields dynamically based on purpose
-          const requiredFields = [];
-          if (isRegulatedProducts) requiredFields.push("regulated_products");
-          if (isReportingActivities) requiredFields.push("activities");
-          return {
-            properties: {
-              registration_purpose: {
-                type: "string",
-                const: purpose,
-              },
-              ...(isRegulatedProducts && {
-                regulated_products: {
-                  title: "Regulated Product Name(s)",
-                  type: "array",
-                  minItems: 1,
-                  items: {
-                    enum: regulatedProducts.map((product) => product.id),
-                    enumNames: regulatedProducts.map((product) => product.name),
-                  },
-                },
-              }),
-              ...(isReportingActivities && {
-                activities: {
-                  title: "Reporting Activities",
-                  type: "array",
-                  minItems: 1,
-                  items: {
-                    type: "number",
-                    enum: reportingActivities.map(
-                      (activity: {
-                        id: number;
-                        applicable_to: string;
-                        name: string;
-                      }) => activity.id,
-                    ),
-                    enumNames: reportingActivities.map(
-                      (activity: { applicable_to: string; name: string }) =>
-                        activity.name,
-                    ),
-                  },
-                },
-              }),
+      // have to determine required fields dynamically based on purpose
+      const requiredFields = [];
+      if (isRegulatedProducts) requiredFields.push("regulated_products");
+      if (isReportingActivities) requiredFields.push("activities");
+
+      return {
+        if: {
+          properties: {
+            registration_purpose: {
+              const: purpose,
             },
-            ...(requiredFields.length > 0 ? { required: requiredFields } : {}),
-          };
-        }),
-      },
-    },
+          },
+        },
+        then: {
+          properties: {
+            ...(isRegulatedProducts && {
+              regulated_products: {
+                title: "Regulated Product Name(s)",
+                type: "array",
+                minItems: 1,
+                default: [],
+                items: {
+                  enum: regulatedProducts.map((product) => product.id),
+                  enumNames: regulatedProducts.map((product) => product.name),
+                },
+              },
+            }),
+            ...(isReportingActivities && {
+              activities: {
+                title: "Reporting Activities",
+                type: "array",
+                minItems: 1,
+                default: [],
+                items: {
+                  type: "number",
+                  enum: reportingActivities.map(
+                    (activity: {
+                      id: number;
+                      applicable_to: string;
+                      name: string;
+                    }) => activity.id,
+                  ),
+                  enumNames: reportingActivities.map(
+                    (activity: { applicable_to: string; name: string }) =>
+                      activity.name,
+                  ),
+                },
+              },
+            }),
+          },
+          ...(requiredFields.length > 0 ? { required: requiredFields } : {}),
+        },
+      };
+    }),
   };
   return operationInformationSchema;
 };

--- a/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
@@ -561,7 +561,7 @@ describe("the OperationInformationForm component", () => {
     await userEvent.click(
       screen.getByRole("button", { name: /save and continue/i }),
     );
-    expect(screen.getAllByRole("alert")).toHaveLength(7);
+    expect(screen.getAllByRole("alert")).toHaveLength(9);
     expect(
       screen.getByText(
         /Select an operation or add a new operation in the form below/i,

--- a/bciers/libs/utils/src/customTransformErrors.ts
+++ b/bciers/libs/utils/src/customTransformErrors.ts
@@ -56,6 +56,16 @@ const customTransformErrors = (
       }
       if (
         // we use some because fields can be nested in sections
+        ["acitivities", "regulated_products"].some((field) => {
+          // @ts-ignore - we already checked for error.property's existance above
+          return error?.name === "required" && error.property.includes(field);
+        })
+      ) {
+        error.message = `Select at least one option`;
+        return error;
+      }
+      if (
+        // we use some because fields can be nested in sections
         [
           "cra_business_number",
           "po_cra_business_number",


### PR DESCRIPTION
card:https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=105741444&issue=bcgov%7Ccas-registration%7C3178

Notes:
- In a `oneOf` schema, it appears when the docs say exactly one schema must match, that means required fields too. So we will always get a `must be const` error on registration purpose if activities or products are missing. To deal with this, I moved to if/then. This makes activities and products appear on the page on initial load. Zoey is okay with this.
- There's some interaction between the form (state-related?) and the MultiStepWidget that's producing weird behaviour. Only the last widget on the page that uses the widget gets a value of []. The other keys don't even show in the form data. E.g. {activities: []}. This means that activities correctly gets the minItems error, but the other fields get no error (or required, if we turn it on). e.g. ![image](https://github.com/user-attachments/assets/8288d588-c449-4054-9d34-6ab6d9b2294f). I tried to untangle this and it has something to do with the `onChange` in MultiSelectWidget, but I didn't  figure it out and this is low probability bug, so I fixed it with customTransformErrors instead.


