### PR TITLE
added warning note for certain methodologies

### DIFF
--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/aluminumUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/aluminumUiSchema.ts
@@ -7,6 +7,7 @@ import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLe
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
 import { DateWidget, MultiSelectWidget } from "@bciers/components/form/widgets";
 import { SectionFieldTemplate } from "@bciers/components/form/fields";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -105,7 +106,7 @@ const uiSchema = {
               label: false,
             },
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
           },
         },
@@ -138,7 +139,7 @@ const uiSchema = {
               label: false,
             },
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
             lastDateOfSlopeCoefficientsMeasurement: {
               "ui:widget": DateWidget,
@@ -177,7 +178,7 @@ const uiSchema = {
               label: false,
             },
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
           },
         },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/carbonatesUseUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/carbonatesUseUiSchema.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -56,7 +57,7 @@ const uiSchema = {
               label: false,
             },
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
             annualMassOfCarbonateTypeConsumedTonnes: {
               "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/cementProductionUISchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/cementProductionUISchema.ts
@@ -6,6 +6,7 @@ import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxT
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
 import GridItemFieldTemplate from "@bciers/components/form/fields/GridItemFieldTemplate";
 import CollapsibleDefinitionFieldTemplate from "@bciers/components/form/fields/CollapsibleDefinitionFieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const gridSchema = {
   "ui:FieldTemplate": GridItemFieldTemplate,
@@ -84,7 +85,7 @@ const uiSchema = {
               "quarter4",
             ],
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
             description: {
               "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/coalStorageUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/coalStorageUiSchema.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -33,7 +34,7 @@ const uiSchema = {
               label: false,
             },
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
             coalPurchases: {
               "ui:ArrayFieldTemplate": NestedArrayFieldTemplate,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/common.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/common.ts
@@ -6,6 +6,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
 import GasTypeCasNumberFieldTemplate from "@bciers/components/form/fields/GasTypeCasNumberFieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 /**
  * Common Ui Schema fragments for building an activity's Ui Schema.
@@ -32,7 +33,7 @@ export const emissionsFieldsUiSchema = {
         label: false,
       },
       methodology: {
-        "ui:FieldTemplate": InlineFieldTemplate,
+        "ui:FieldTemplate": MethodologyFieldTemplate,
       },
     },
   },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/fuelCombustionMobileUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/fuelCombustionMobileUiSchema.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -95,7 +96,7 @@ const uiSchema = {
                   label: false,
                 },
                 methodology: {
-                  "ui:FieldTemplate": InlineFieldTemplate,
+                  "ui:FieldTemplate": MethodologyFieldTemplate,
                 },
               },
             },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscNonCompressionNonProcessingUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscNonCompressionNonProcessingUiSchema.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -105,7 +106,7 @@ const uiSchema = {
                       label: false,
                     },
                     methodology: {
-                      "ui:FieldTemplate": InlineFieldTemplate,
+                      "ui:FieldTemplate": MethodologyFieldTemplate,
                     },
                   },
                 },
@@ -184,7 +185,7 @@ const uiSchema = {
                       label: false,
                     },
                     methodology: {
-                      "ui:FieldTemplate": InlineFieldTemplate,
+                      "ui:FieldTemplate": MethodologyFieldTemplate,
                     },
                   },
                 },
@@ -263,7 +264,7 @@ const uiSchema = {
                       label: false,
                     },
                     methodology: {
-                      "ui:FieldTemplate": InlineFieldTemplate,
+                      "ui:FieldTemplate": MethodologyFieldTemplate,
                     },
                   },
                 },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscOtherThanNonCompression.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/gscOtherThanNonCompression.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -113,7 +114,7 @@ const uiSchema = {
                       label: false,
                     },
                     methodology: {
-                      "ui:FieldTemplate": InlineFieldTemplate,
+                      "ui:FieldTemplate": MethodologyFieldTemplate,
                     },
                   },
                 },
@@ -200,7 +201,7 @@ const uiSchema = {
                       label: false,
                     },
                     methodology: {
-                      "ui:FieldTemplate": InlineFieldTemplate,
+                      "ui:FieldTemplate": MethodologyFieldTemplate,
                     },
                   },
                 },
@@ -288,7 +289,7 @@ const uiSchema = {
                       label: false,
                     },
                     methodology: {
-                      "ui:FieldTemplate": InlineFieldTemplate,
+                      "ui:FieldTemplate": MethodologyFieldTemplate,
                     },
                   },
                 },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -68,7 +69,7 @@ const uiSchema = {
               ],
             },
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
 
             feedstocks: {

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/industrialWastewaterProcessingUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/industrialWastewaterProcessingUiSchema.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -67,7 +68,7 @@ const uiSchema = {
               label: false,
             },
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
           },
         },
@@ -111,7 +112,7 @@ const uiSchema = {
               label: false,
             },
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
           },
         },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/leadProductionUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/leadProductionUiSchema.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -47,7 +48,7 @@ const uiSchema = {
               "reducingAgents",
             ],
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
             measuredCarbonContent: {
               "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/limeManufacturingUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/limeManufacturingUiSchema.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -46,7 +47,7 @@ const uiSchema = {
               "missingDataProcedures",
             ],
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
             limeTypes: {
               "ui:ArrayFieldTemplate": NestedArrayFieldTemplate,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/openPitCoalMining.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/openPitCoalMining.ts
@@ -1,4 +1,5 @@
 import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArrayFieldTemplate";
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
@@ -49,6 +50,9 @@ const uiSchema = {
             ],
             quantityOfCoalUnit: {
               "ui:widget": ReadOnlyWidget,
+            },
+            methodology: {
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
           },
         },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/pulpAndPaperUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/pulpAndPaperUiSchema.ts
@@ -2,6 +2,7 @@ import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArrayFieldTemplate";
 import { InlineFieldTemplate } from "@bciers/components/form/fields";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -50,7 +51,7 @@ const uiSchema = {
               label: false,
             },
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
             isWoodyBiomass: {
               "ui:options": {

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/refineryFuelGasUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/refineryFuelGasUiSchema.ts
@@ -2,6 +2,7 @@ import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
 import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArrayFieldTemplate";
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -63,7 +64,7 @@ const uiSchema = {
                   label: false,
                 },
                 methodology: {
-                  "ui:FieldTemplate": InlineFieldTemplate,
+                  "ui:FieldTemplate": MethodologyFieldTemplate,
                 },
               },
             },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/storageOfPetroleumProductsUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/storageOfPetroleumProductsUiSchema.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import CheckboxWidgetLeft from "@bciers/components/form/widgets/CheckboxWidgetLeft";
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -46,7 +47,7 @@ const uiSchema = {
               label: false,
             },
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
             description: {
               "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/zincProductionUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/zincProductionUiSchema.ts
@@ -3,6 +3,7 @@ import NestedArrayFieldTemplate from "@bciers/components/form/fields/NestedArray
 import InlineFieldTemplate from "@bciers/components/form/fields/InlineFieldTemplate";
 import SourceTypeBoxTemplate from "@bciers/components/form/fields/SourceTypeBoxTemplate";
 import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
+import MethodologyFieldTemplate from "@bciers/components/form/fields/MethodologyFieldTemplate";
 
 const uiSchema = {
   "ui:FieldTemplate": FieldTemplate,
@@ -46,7 +47,7 @@ const uiSchema = {
               "reducingAgents",
             ],
             methodology: {
-              "ui:FieldTemplate": InlineFieldTemplate,
+              "ui:FieldTemplate": MethodologyFieldTemplate,
             },
             monthsMissingDataProcedures: {
               "ui:FieldTemplate": InlineFieldTemplate,

--- a/bciers/libs/components/src/form/fields/MethodologyFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/MethodologyFieldTemplate.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { FieldTemplateProps } from "@rjsf/utils";
+import InlineFieldTemplate from "./InlineFieldTemplate";
+import { JSXElementConstructor, ReactElement } from "react";
+
+function MethodologyFieldTemplate(props: FieldTemplateProps) {
+  const { formData } = props;
+
+  const notedMethodologies = [
+    "Alternative Parameter Measurement Methodology",
+    "Replacement Methodology",
+  ];
+
+  let note: ReactElement<any, string | JSXElementConstructor<any>> | undefined =
+    undefined;
+  if (formData && notedMethodologies.includes(formData)) {
+    note = (
+      <small>
+        * By selecting {formData}, you may be contacted by Ministry staff to
+        verify compliance
+      </small>
+    );
+  }
+
+  return <InlineFieldTemplate {...props} description={note} />;
+}
+
+export default MethodologyFieldTemplate;


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/571

### Changes
 - Created MethodologyFieldTemplate that sets the "description" value to the desired warning note if the selected methodology should display a warning : ```* By selecting {methodology}, you may be contacted by Ministry staff to
        verify compliance``` if the ```methodology``` is "Alternative Parameter Measurement Methodology" or
    "Replacement Methodology"
 - Replaced InlineFieldTemplate with MethodologyFieldTemplate in all activity uischemas
 
### The Why
```description``` is a field that is already checked by the InlineFieldTemplate for displaying notes on a field. That is why all the MethodologyFieldTemplate does is set that ```description``` value.

I tried some other methods around trying to inject the ```description``` property into the formSchema. I was unsuccessful in trying to mutate the formSchema directly in the front end. And in the backend, we could add the ```description``` field to the methodology object in the oneOf dependency array, but then it wouldn't render for some reason. And if we added it to the parent ```methodology``` object, it *would* render, but unconditionally for every selected methodology.

### To Test

 1. With the front-end and back-end running, progress through the Report Submission process to any activity form that includes emissions.
 2. Select a gas type to show the methodology field.
 3. Select either Alternative Parameter Measurement Methodology" or "Replacement Methodology" to show the warning message displayed below the field.
 4. Select any other methodology to see the warning note disappear.