### PR TITLE
chore: add attachment note

### DIFF
--- a/bciers/apps/reporting/src/app/components/attachments/AttachmentsForm.tsx
+++ b/bciers/apps/reporting/src/app/components/attachments/AttachmentsForm.tsx
@@ -11,6 +11,8 @@ import { useRouter } from "next/navigation";
 import { NavigationInformation } from "../taskList/types";
 import { getDictFromAttachmentArray } from "./AttachmentsPage";
 import { Checkbox } from "@mui/material";
+import Alert from "@mui/material/Alert";
+import AlertIcon from "@bciers/components/icons/AlertIcon";
 
 interface Props extends HasReportVersion {
   initialUploadedAttachments: {
@@ -190,6 +192,12 @@ const AttachmentsForm: React.FC<Props> = ({
         noFormSave={() => handleSubmit(false)}
         submitButtonDisabled={submitDisabled}
       >
+        {isSupplementaryReport && (
+          <Alert severity="warning" icon={<AlertIcon fill="#635231" />}>
+            Review your attachments and replace any that are no longer
+            applicable to this report.
+          </Alert>
+        )}
         <p>
           Please upload any of the documents below that is applicable to your
           report:


### PR DESCRIPTION
Addresses: 
[746](https://github.com/bcgov/cas-reporting/issues/746)


### 🚀 Impact:

- Adding missing note in supplementary report attachments form


## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  

2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button
5. Log in using `bc-cas-dev`



### **Test 1: Supplementary Report - Attachments note**  

#### **Steps:**  

1.  Navigate to reports table, http://localhost:3000/reporting/reports
2.  On `Bugle SFO - Registered`, click `Continue`
3. Complete all forms until `Attachments`
**Expected Results**
✅  
![image](https://github.com/user-attachments/assets/bc1d0a0b-3826-4d86-bb01-b895e99f4853)
- No note
4. Complete all forms until `Sign-off`
5. On form `Sign-off` click button `Submit`
**Expected Results**
✅  
- Form is submitted
6. Navigate to reports table, http://localhost:3000/reporting/reports
7. On `Bugle SFO - Registered`, click `More Actions\Create Supplementary Report`
8. Complete all forms until `Attachments`
**Expected Results**
✅  
![image](https://github.com/user-attachments/assets/d75318cb-a10e-4684-8202-33e5994536e6)

- Note displays
