### PR TITLE
feat: added signal for registration purspose change

### DIFF
--- a/bc_obps/events/signals.py
+++ b/bc_obps/events/signals.py
@@ -27,4 +27,6 @@ from django.dispatch import Signal
 report_submitted = Signal()
 # Signal parameters: 'version_id', 'user_guid'
 
+# Registration signals
+operation_registration_purpose_changed = Signal()
 # Add more signals as needed for different app domains

--- a/bc_obps/reporting/apps.py
+++ b/bc_obps/reporting/apps.py
@@ -15,3 +15,4 @@ class ReportingConfig(AppConfig):
 
     def ready(self):
         pre_migrate.connect(create_erc_schemas, sender=self)
+        from . import signals  # noqa: F401

--- a/bc_obps/reporting/signals.py
+++ b/bc_obps/reporting/signals.py
@@ -1,0 +1,37 @@
+import logging
+from typing import Type, Any
+
+from django.dispatch import receiver
+
+from events.signals import operation_registration_purpose_changed
+from reporting.models import ReportVersion
+from service.report_version_service import ReportVersionService
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(operation_registration_purpose_changed)
+def handle_registration_purpose_changed(sender: Type[Any], **kwargs: Any) -> None:
+    """
+    Signal handler that deletes the draft report version for an operation
+    whose registration purpose has changed.
+
+    Args:
+        sender: The class that sent the signal
+        **kwargs: Signal arguments including operation_id and user_guid
+    """
+    operation_id = kwargs.get('operation_id')
+    if not operation_id:
+        logger.warning("Missing operation_id in signal kwargs")
+        return
+
+    draft_version = ReportVersion.objects.filter(
+        report__operation_id=operation_id, status=ReportVersion.ReportVersionStatus.Draft
+    ).first()
+
+    if not draft_version:
+        logger.info(f"No draft report version found for operation_id={operation_id}")
+        return
+
+    logger.info(f"Deleting draft report version ID={draft_version.id} for operation_id={operation_id}")
+    ReportVersionService.delete_report_version(draft_version.id)

--- a/bc_obps/service/operation_service.py
+++ b/bc_obps/service/operation_service.py
@@ -46,6 +46,7 @@ from django.db.models import Q
 from datetime import datetime
 from zoneinfo import ZoneInfo
 from registration.models.operation_designated_operator_timeline import OperationDesignatedOperatorTimeline
+from events.signals import operation_registration_purpose_changed
 
 
 class OperationService:
@@ -389,6 +390,11 @@ class OperationService:
 
         if payload.registration_purpose != operation.registration_purpose:
             payload = cls.handle_change_of_registration_purpose(user_guid, operation, payload)
+            # send a signal that the registration purpose has changed
+            operation_registration_purpose_changed.send(
+                sender=OperationService,
+                operation_id=operation.id,
+            )
 
         operation_data = payload.dict(
             include={

--- a/bciers/apps/registration/app/components/operations/registration/ConfirmChangeOfRegistrationPurposeModal.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/ConfirmChangeOfRegistrationPurposeModal.tsx
@@ -21,8 +21,14 @@ export default function ConfirmChangeOfRegistrationPurposeModal({
       onConfirm={confirmRegistrationPurposeChange}
       confirmText="Change registration purpose"
     >
-      Are you sure you want to change your registration purpose? If you proceed,
-      some of the form data you have entered will be lost.
+      <div>Are you sure you want to change your registration purpose?</div>
+      <ul className="list-disc pl-5 mt-2">
+        <li>Some operation information you have entered will be deleted.</li>
+        <li>
+          If this operation’s report is in progress, it will be deleted and
+          restarted.
+        </li>
+      </ul>
     </SimpleModal>
   );
 }


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/721
Changes:

1. Updated the confirmation modal text when the registration purpose is changed.
2. Emit a Django signal on confirmation of registration purpose change.
3. Created a signal receiver in the Reporting app that listens for this signal.
4. Used delete report version service to delete the report version 


To test:-
1. Go to any report which is in draft : http://localhost:3000/reporting/reports/2/review-operation-information
2. On Review Operation Information page click on update operation information
which wil take you to administration/opertaion 
![image](https://github.com/user-attachments/assets/ef8f3171-55f6-4850-9cd2-c440465f5244)

3. click on edit and update the registration purpose, you will see updated modal text
![image](https://github.com/user-attachments/assets/ebea6629-9ae0-4dbd-8140-c488e0ec82ec)
4. Click on Change registration purspose in the modal and then go to http://localhost:3000/reporting/reports, The draft report wil be deleted 
![image](https://github.com/user-attachments/assets/3570f502-50a3-412e-b1f7-289803de04a0)



