### PR TITLE
chore: util for checking document scan

### DIFF
--- a/bc_obps/registration/tests/test_utils.py
+++ b/bc_obps/registration/tests/test_utils.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import base64
 from model_bakery import baker
@@ -14,7 +13,7 @@ from registration.utils import (
 )
 from django.core.exceptions import ValidationError
 from ninja.errors import HttpError
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from registration.tests.utils.bakers import document_baker, user_operator_baker
 import requests
 from service.tests.test_operation_service import set_up_valid_mock_operation
@@ -292,8 +291,8 @@ class TestDataUrlToFile:
 
 class TestDocumentScanStatus:
     @staticmethod
-    def test_is_document_scan_complete_skipped_in_ci(monkeypatch):
-        monkeypatch.setattr(os, "environ", {"ENVIRONMENT": "develop", "CI": "true"})
+    @override_settings(ENVIRONMENT="develop", CI="true")
+    def test_is_document_scan_complete_skipped_in_ci():
 
         operation = set_up_valid_mock_operation(
             Operation.Purposes.OPTED_IN_OPERATION, document_scan_status="Quarantined"
@@ -302,8 +301,8 @@ class TestDocumentScanStatus:
         assert is_document_scan_complete(operation) is True
 
     @staticmethod
-    def test_is_document_scan_complete_skipped_in_local(monkeypatch):
-        monkeypatch.setattr(os, "environ", {"ENVIRONMENT": "local", "CI": "true"})
+    @override_settings(ENVIRONMENT="local", CI="true")
+    def test_is_document_scan_complete_skipped_in_local():
 
         operation = set_up_valid_mock_operation(
             Operation.Purposes.OPTED_IN_OPERATION, document_scan_status="Quarantined"
@@ -312,15 +311,15 @@ class TestDocumentScanStatus:
         assert is_document_scan_complete(operation) is True
 
     @staticmethod
-    def test_is_document_scan_complete_runs_fail(monkeypatch):
-        monkeypatch.setattr(os, "environ", {"ENVIRONMENT": "develop", "CI": "false"})
+    @override_settings(ENVIRONMENT="develop", CI="false")
+    def test_is_document_scan_complete_runs_fail():
         operation = set_up_valid_mock_operation(Operation.Purposes.OPTED_IN_OPERATION, document_scan_status="Unscanned")
 
         assert is_document_scan_complete(operation) is False
 
     @staticmethod
-    def test_is_document_scan_complete_runs_success(monkeypatch):
-        monkeypatch.setattr(os, "environ", {"ENVIRONMENT": "develop", "CI": "false"})
+    @override_settings(ENVIRONMENT="develop", CI="false")
+    def test_is_document_scan_complete_runs_success():
         operation = set_up_valid_mock_operation(Operation.Purposes.OPTED_IN_OPERATION, document_scan_status="Clean")
 
         assert is_document_scan_complete(operation) is True

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -156,10 +156,9 @@ class CustomPagination(PageNumberPagination):
 
 
 def is_document_scan_complete(operation: Operation) -> bool:
-    # If we're in the CI or local environment, we don't need to check for document scanning
+    # If we're in the local environment, we don't hit GCS; we use local file storage (see settings.py)
     ENVIRONMENT = settings.ENVIRONMENT
-    CI = settings.CI
-    if CI == 'true' or ENVIRONMENT == 'local':
+    if ENVIRONMENT == 'local':
         return True
 
     return not operation.documents.filter(status=Document.FileStatus.UNSCANNED).exists()

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from ninja.errors import ValidationError as NinjaValidationError
 from django.db import IntegrityError, models
 from registration.constants import DEFAULT_API_NAMESPACE
+from registration.models.operation import Operation
 import requests
 import base64
 import re
@@ -151,3 +152,17 @@ class CustomPagination(PageNumberPagination):
             "items": queryset[offset : offset + page_size],
             "count": self._items_count(queryset),
         }  # noqa: E203
+
+
+def is_document_scan_complete(operation: Operation) -> bool:
+    # If we're in the CI or local environment, we don't need to check for document scanning
+    ENVIRONMENT = os.environ.get("ENVIRONMENT")
+    CI = os.environ.get("CI")
+    if CI == 'true' or ENVIRONMENT == 'local':
+        return True
+
+    if not operation.documents.filter(
+        status=Document.FileStatus.UNSCANNED,
+    ).exists():
+        return True
+    return False

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -15,6 +15,7 @@ from registration.models import Document
 from django.urls import reverse_lazy
 from ninja.types import DictStrAny
 from ninja.pagination import PageNumberPagination
+from django.conf import settings
 
 
 logger = logging.getLogger(__name__)
@@ -156,13 +157,9 @@ class CustomPagination(PageNumberPagination):
 
 def is_document_scan_complete(operation: Operation) -> bool:
     # If we're in the CI or local environment, we don't need to check for document scanning
-    ENVIRONMENT = os.environ.get("ENVIRONMENT")
-    CI = os.environ.get("CI")
+    ENVIRONMENT = settings.ENVIRONMENT
+    CI = settings.CI
     if CI == 'true' or ENVIRONMENT == 'local':
         return True
 
-    if not operation.documents.filter(
-        status=Document.FileStatus.UNSCANNED,
-    ).exists():
-        return True
-    return False
+    return not operation.documents.filter(status=Document.FileStatus.UNSCANNED).exists()

--- a/bc_obps/service/operation_service.py
+++ b/bc_obps/service/operation_service.py
@@ -49,6 +49,7 @@ from django.db.models import Q
 from datetime import datetime
 from zoneinfo import ZoneInfo
 from registration.models.operation_designated_operator_timeline import OperationDesignatedOperatorTimeline
+from django.conf import settings
 
 
 class OperationService:
@@ -576,7 +577,7 @@ class OperationService:
 
             # Check if operation documents have been scanned for malware
             yield (
-                lambda: is_document_scan_complete(operation),
+                lambda: not settings.CI and is_document_scan_complete(operation),
                 "Please wait. Your attachments are being scanned for malware, this may take a few minutes.",
             )
             # Check if operation documents are malware free

--- a/bc_obps/service/operation_service.py
+++ b/bc_obps/service/operation_service.py
@@ -575,9 +575,9 @@ class OperationService:
                 "Operation must have a process flow diagram and a boundary map.",
             )
 
-            # Check if operation documents have been scanned for malware
+            # Check if operation documents have been scanned for malware (skip the check in CI because we don't hit GCS)
             yield (
-                lambda: not settings.CI and is_document_scan_complete(operation),
+                lambda: True if settings.CI == 'true' else is_document_scan_complete(operation),
                 "Please wait. Your attachments are being scanned for malware, this may take a few minutes.",
             )
             # Check if operation documents are malware free

--- a/bc_obps/service/operation_service.py
+++ b/bc_obps/service/operation_service.py
@@ -1,4 +1,3 @@
-import os
 from typing import List, Optional, Tuple, Callable, Generator, Union
 from django.db.models import QuerySet
 from common.exceptions import UserError
@@ -6,6 +5,7 @@ from registration.emails import send_registration_and_boro_id_email
 from registration.enums.enums import EmailTemplateNames
 from registration.models.facility import Facility
 from registration.signals.signals import operation_registration_purpose_changed
+from registration.utils import is_document_scan_complete
 from service.contact_service import ContactService
 from service.data_access_service.document_service import DocumentDataAccessService
 from service.data_access_service.operation_designated_operator_timeline_service import (
@@ -573,26 +573,21 @@ class OperationService:
                 ),
                 "Operation must have a process flow diagram and a boundary map.",
             )
-            # Check if operation documents have been scanned for malware
-            ENVIRONMENT = os.environ.get("ENVIRONMENT")
-            CI = os.environ.get("CI")
 
-            if CI != 'true' and ENVIRONMENT != 'local':
-                yield (
-                    lambda: not operation.documents.filter(
-                        status=Document.FileStatus.UNSCANNED,
-                    ).exists(),
-                    "Please wait. Your attachments are being scanned for malware, this may take a few minutes.",
-                )
-                # Check if operation documents are malware free
-                yield (
-                    lambda: not operation.documents.filter(
-                        status=Document.FileStatus.QUARANTINED,
-                    ).exists(),
-                    f"Potential threat detected in "
-                    f"{', '.join(operation.documents.filter(status=Document.FileStatus.QUARANTINED).values_list('file', flat=True))}. "
-                    f"Please go back and replace these attachments before submitting.",
-                )
+            # Check if operation documents have been scanned for malware
+            yield (
+                lambda: is_document_scan_complete(operation),
+                "Please wait. Your attachments are being scanned for malware, this may take a few minutes.",
+            )
+            # Check if operation documents are malware free
+            yield (
+                lambda: not operation.documents.filter(
+                    status=Document.FileStatus.QUARANTINED,
+                ).exists(),
+                f"Potential threat detected in "
+                f"{', '.join(operation.documents.filter(status=Document.FileStatus.QUARANTINED).values_list('file', flat=True))}. "
+                f"Please go back and replace these attachments before submitting.",
+            )
             yield (
                 lambda: not (
                     operation.registration_purpose == Operation.Purposes.NEW_ENTRANT_OPERATION

--- a/bc_obps/service/tests/test_operation_service.py
+++ b/bc_obps/service/tests/test_operation_service.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import os
 from unittest.mock import patch, MagicMock
+from django.test import override_settings
 import pytest
 from common.lib import pgtrigger
 from uuid import uuid4
@@ -1485,9 +1486,9 @@ class TestRaiseExceptionIfOperationRegistrationDataIncomplete:
             OperationService.raise_exception_if_operation_missing_registration_information(operation)
 
     @staticmethod
-    def test_raises_exception_if_documents_are_still_unscanned(monkeypatch):
+    @override_settings(ENVIRONMENT="develop", CI="false")
+    def test_raises_exception_if_documents_are_still_unscanned():
         # This test doesn't actually hit GCS, so we want to change the env variables to hit the check for document scans
-        monkeypatch.setattr(os, "environ", {"ENVIRONMENT": "develop", "CI": "false"})
         operation = set_up_valid_mock_operation(Operation.Purposes.OPTED_IN_OPERATION, document_scan_status="Unscanned")
 
         with pytest.raises(


### PR DESCRIPTION
Part of https://github.com/bcgov/cas-registration/issues/3055

This PR:
- moves the conditionality about ignoring document scan in CI/local to a helper
- uses the helper in operation_service
- pytests (operation_service already had tests for this (search monkeypatch), so the new ones are only for the util)