### PR TITLE
3332 end correct email template to confirm registration

### DIFF
--- a/bc_obps/common/tests/test_email_service.py
+++ b/bc_obps/common/tests/test_email_service.py
@@ -134,40 +134,6 @@ def test_health_check(email_service: EmailService, health_check_data, mocker):
     email_service._make_request.assert_called_once_with("/health")
 
 
-@pytest.mark.skip(reason="only run this if you want to receive an actual email")
-def test_send_real_email():
-    # creates a real instance of EmailService, instead of using the fixture
-    email_service = EmailService()
-    real_recipient = 'andrea.williams@gov.bc.ca'
-    real_email_data = {
-        'bodyType': 'text',
-        'body': 'This is the body of a test email for BCIERS Email Service',
-        'from': 'ggircs@gov.bc.ca',
-        'subject': 'Automated Test of Email_Service',
-        'to': [real_recipient],
-    }
-    response = email_service.send_email(real_email_data)
-    assert len(response['messages']) == 1
-    assert response['messages'][0]['to'] == [real_recipient]
-    assert response['messages'][0]['msgId'] is not None
-    assert response['txId'] is not None
-
-
-def test_send_email(email_service: EmailService, email_data, mocker):
-    mock_send_email_request = mocker.patch.object(email_service, '_make_request')
-    mock_send_email_request.return_value.json.return_value = {
-        'messages': [{'msgId': '0000000-00000-0000-0000001', 'to': ['sample@email.com']}],
-        'txId': '00000000-0000-0000-0000-000000000000',
-    }
-
-    response = email_service.send_email(email_data)
-    assert len(response['messages']) == 1
-    assert response['txId'] == '00000000-0000-0000-0000-000000000000'
-    assert response['messages'][0]['msgId'] == '0000000-00000-0000-0000001'
-    assert response['messages'][0]['to'] == ['sample@email.com']
-    email_service._get_token.assert_called_once()
-
-
 def test_get_message_status(email_service: EmailService, mocker):
     mock_get_status_request = mocker.patch.object(email_service, '_make_request')
     mock_get_status_request.return_value.json.return_value = {

--- a/bc_obps/registration/emails.py
+++ b/bc_obps/registration/emails.py
@@ -1,8 +1,7 @@
 from typing import List, Optional
-from registration.enums.enums import AccessRequestStates, AccessRequestTypes
+from registration.enums.enums import AccessRequestStates, AccessRequestTypes, EmailTemplateNames
 from registration.models.operation import Operation
 from service.email.email_service import EmailService
-from registration.enums.enums import BoroEmailTemplateNames
 import logging
 
 from registration.models import User
@@ -28,7 +27,7 @@ class Recipient:
 
 
 def send_registration_and_boro_id_email(
-    template_name: BoroEmailTemplateNames,
+    template_name: EmailTemplateNames,
     operator_legal_name: str,
     operation: Operation,
     registration_creator: Optional[User] = None,

--- a/bc_obps/registration/enums/enums.py
+++ b/bc_obps/registration/enums/enums.py
@@ -6,9 +6,9 @@ class IdPs(Enum):
     BCEIDBUSINESS = "bceidbusiness"
 
 
-class BoroEmailTemplateNames(Enum):
-    CONFIRMATION = 'BORO ID Application Confirmation'
-    ISSUANCE = 'BORO ID Issuance'
+class EmailTemplateNames(Enum):
+    REGISTRATION_CONFIRMATION = "Registration Submission Acknowledgement"
+    BORO_ID_ISSUANCE = 'BORO ID Issuance'
 
 
 class AccessRequestStates(Enum):

--- a/bc_obps/registration/tests/test_emails.py
+++ b/bc_obps/registration/tests/test_emails.py
@@ -2,7 +2,7 @@ import uuid
 from common.models import EmailNotification
 from service.email.email_service import EmailService
 from registration.emails import send_registration_and_boro_id_email, send_operator_access_request_email
-from registration.enums.enums import AccessRequestStates, AccessRequestTypes, BoroEmailTemplateNames
+from registration.enums.enums import AccessRequestStates, AccessRequestTypes, EmailTemplateNames
 import pytest
 from registration.models import Operation, User
 from registration.tests.utils.bakers import operation_baker, user_baker
@@ -111,7 +111,7 @@ class TestSendBoroIdApplicationEmail:
         )
         return mocked_send_email_by_template, expected_email_notifications_after_sending
 
-    @pytest.mark.parametrize("template_name", list(BoroEmailTemplateNames))
+    @pytest.mark.parametrize("template_name", list(EmailTemplateNames))
     def test_send_registration_and_boro_id_email_with_the_same_recipients(self, template_name, mocker):
         assert EmailNotification.objects.count() == 0
         template_instance = EmailNotificationTemplateService.get_template_by_name(template_name.value)

--- a/bc_obps/service/email/email_service.py
+++ b/bc_obps/service/email/email_service.py
@@ -129,35 +129,6 @@ class EmailService(object):
             logger.error(f'Logger: Exception retrieving message status for {message_id} - {str(exc)}')
             raise
 
-    def send_email(self, email_data: Dict) -> Optional[Any]:
-        """
-        Email (content in either text or HTML format) is queued to be sent to each recipient listed in 'to'.
-
-        Required input data:
-            {
-                'bodyType': 'text' | 'html',
-                'body': str,
-                'from': str (email),
-                'subject': 'str,
-                'to': List[str] (one email per str),
-            }
-
-        See {self.api_url}/docs for more (optional) fields.
-
-        Response contains 'msgId' (message ID) and 'txId' (transaction ID), to be used as identifiers when querying message or transaction status.
-        """
-        self._get_token()
-        try:
-            response = self._make_request(
-                '/email',
-                method='POST',
-                data=email_data,
-            )
-            return response.json()
-        except Exception as exc:
-            logger.error(f'Logger: Exception in send_email {str(exc)}')
-            raise
-
     def merge_template_and_send(self, email_template_data: Dict) -> Optional[Any]:
         """
         Given an email template with variables for customized content, CHES API merges the template with the given

--- a/bc_obps/service/operation_service.py
+++ b/bc_obps/service/operation_service.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional, Tuple, Callable, Generator, Union
 from django.db.models import QuerySet
 from registration.emails import send_registration_and_boro_id_email
-from registration.enums.enums import BoroEmailTemplateNames
+from registration.enums.enums import EmailTemplateNames
 from registration.models.facility import Facility
 from service.contact_service import ContactService
 from service.data_access_service.document_service import DocumentDataAccessService
@@ -109,7 +109,7 @@ class OperationService:
         # (not from the Admin module), and once an operation is registered, it can no longer be accessed from the Registration workflow.
         if operation.status == Operation.Statuses.REGISTERED:
             send_registration_and_boro_id_email(
-                BoroEmailTemplateNames.CONFIRMATION,
+                EmailTemplateNames.REGISTRATION_CONFIRMATION,
                 operation.operator.legal_name,
                 operation,
                 UserDataAccessService.get_by_guid(user_guid),
@@ -622,7 +622,9 @@ class OperationService:
             raise Exception('Failed to create a BORO ID for the operation.')
 
         # send an email to every Operation Representative for the operation, notifying them that a BORO ID has been issued.
-        send_registration_and_boro_id_email(BoroEmailTemplateNames.ISSUANCE, operation.operator.legal_name, operation)
+        send_registration_and_boro_id_email(
+            EmailTemplateNames.BORO_ID_ISSUANCE, operation.operator.legal_name, operation
+        )
         return operation.bc_obps_regulated_operation
 
     @classmethod

--- a/bc_obps/service/tests/test_operation_service.py
+++ b/bc_obps/service/tests/test_operation_service.py
@@ -27,7 +27,7 @@ from registration.schema import (
     MultipleOperatorIn,
     OperationInformationIn,
 )
-from registration.enums.enums import BoroEmailTemplateNames
+from registration.enums.enums import EmailTemplateNames
 from service.data_access_service.operation_service import OperationDataAccessService
 from service.operation_service import OperationService
 from service.email.email_service import EmailService
@@ -161,7 +161,7 @@ class TestOperationService:
         assert updated_operation.registration_purpose == Operation.Purposes.OPTED_IN_OPERATION
 
         mock_email_service.assert_called_once_with(
-            BoroEmailTemplateNames.CONFIRMATION,
+            EmailTemplateNames.REGISTRATION_CONFIRMATION,
             users_operation.operator.legal_name,
             users_operation,
             approved_user_operator.user,
@@ -1599,7 +1599,7 @@ class TestGenerateBoroId:
         assert operation.bc_obps_regulated_operation.issued_by == cas_director
 
         mock_send_email.assert_called_once_with(
-            BoroEmailTemplateNames.ISSUANCE,
+            EmailTemplateNames.BORO_ID_ISSUANCE,
             operation.operator.legal_name,
             operation,
         )

--- a/docs/backend/data-models.md
+++ b/docs/backend/data-models.md
@@ -7,11 +7,10 @@ Common data models used in the OBPS application are located in the `bc_obps/comm
 ## Email Notifications
 
 Email notifications are an essential part of the application's communication strategy. They provide users with important information, updates, and alerts. We use CHES (Common Hosted Email Service) to send email notifications to users.
-To send real emails, you need to set up CHES credentials in your environment variables. You can find the required CHES credentials in the 1Password document `OBPS backend ENV`.
+
+If you want to send emails locally, you need to set up CHES credentials in your environment variables. You can find the required CHES credentials in the 1Password document `OBPS backend ENV`. (Comment them out to stop sending emails.)
 
 You also need to set up the `EmailService` singleton object (like `email_service = EmailService()`) in the `.py` file to access the `EmailService` object.
-
-**Note**: Make sure to not send real emails in the development environment by commenting out the CHES credentials in the `bc_obps/.env` file.
 
 ## Audit Trail Implementation
 


### PR DESCRIPTION
card: https://github.com/bcgov/cas-registration/issues/3332

This PR:
- removes the `send_email` service (we weren't using)
- renames the email template enums for hopefully more clarity
- uses the new email template in operation_service
- pytests for ^
- tweak docs to explain how to test emails in local

I've also made a tech debt ticket with some nice-to-haves for emails: https://github.com/bcgov/cas-registration/issues/3336