### PR TITLE
fix: Attempt to fix personResponsible page in dev by ensuring factory item for review page doesn't overwrite jsonSchema

### DIFF
--- a/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/personResponsibleFactoryItem.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/personResponsibleFactoryItem.ts
@@ -12,7 +12,12 @@ const personResponsibleFactoryItem: ReviewDataFactoryItem = async (
   const { sync_button: any, ...personResponsibleUiSchemaWithoutSyncButton } =
     personResponsibleUiSchema;
 
-  personResponsibleSchema.properties = {
+  // Deep copy to avoid long-lived module JSON mutation persistence
+  const localFactoryPersonResponsibleSchema = JSON.parse(
+    JSON.stringify(personResponsibleSchema),
+  );
+
+  localFactoryPersonResponsibleSchema.properties = {
     person_responsible: { type: "string", title: " " },
   };
 
@@ -21,7 +26,7 @@ const personResponsibleFactoryItem: ReviewDataFactoryItem = async (
   return [
     {
       schema: createPersonResponsibleSchema(
-        personResponsibleSchema,
+        localFactoryPersonResponsibleSchema,
         [],
         1,
         contactData,


### PR DESCRIPTION
After taking a look at the components in dev, title is shown to be set to " ". This is only ever done in the `personResponsibleFactoryItem`. In this item, the jsonSchema is being directly set for the review page. I'm hoping that it is as simple as a shared object mutation and that this will fix dev and prod by referencing the schema with a deep copy.