### PR TITLE
chore: support PUT for SFO in registration

### DIFF
--- a/bciers/apps/registration/app/components/operations/registration/FacilityInformationForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/FacilityInformationForm.tsx
@@ -27,9 +27,11 @@ export default function FacilityInformationForm({
   operationName,
   step,
   steps,
+  isCreating,
 }: FacilityInformationFormProps) {
   return isOperationSfo ? (
     <FacilitySfoForm
+      isCreating={isCreating}
       facilityId={facilityId}
       step={step}
       steps={steps}

--- a/bciers/apps/registration/app/components/operations/registration/FacilitySfoForm.tsx
+++ b/bciers/apps/registration/app/components/operations/registration/FacilitySfoForm.tsx
@@ -19,6 +19,7 @@ interface FacilitySfoFormProps {
   operationId: UUID | "create";
   step: number;
   steps: string[];
+  isCreating: boolean;
 }
 
 const FacilitySfoForm = ({
@@ -26,6 +27,8 @@ const FacilitySfoForm = ({
   operationId,
   step,
   steps,
+  facilityId,
+  isCreating,
 }: FacilitySfoFormProps) => {
   const [formState, setFormState] = useState(formData ?? {});
   // Get the list of sections in the SFO schema - used to unnest the formData
@@ -41,20 +44,26 @@ const FacilitySfoForm = ({
   );
 
   const handleSubmit = async (e: IChangeEvent) => {
-    const body = [
-      {
-        ...createUnnestedFormData(e.formData, formSectionListSfo),
-        operation_id: operationId,
-      },
-    ];
-    const response = await actionHandler(
-      "registration/facilities",
-      "POST",
-      "",
-      {
-        body: JSON.stringify(body),
-      },
-    );
+    const method = isCreating ? "POST" : "PUT";
+
+    const endpoint = isCreating
+      ? "registration/facilities"
+      : `registration/facilities/${facilityId}`;
+
+    const sfoFormData = {
+      ...createUnnestedFormData(e.formData, formSectionListSfo),
+      operation_id: operationId,
+      facility_id: facilityId,
+    };
+
+    // We may want to update the PUT route to accept an array of facilities
+    // just as we do in the POST route
+    const body = isCreating ? [sfoFormData] : sfoFormData;
+
+    const response = await actionHandler(endpoint, method, "", {
+      body: JSON.stringify(body),
+    });
+
     if (!response || response?.error) {
       return { error: response.error };
     }

--- a/bciers/apps/registration/tests/components/operations/registration/FacilitySfoForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/FacilitySfoForm.test.tsx
@@ -45,6 +45,7 @@ const defaultProps = {
   formData: {},
   step: 2,
   steps: allOperationRegistrationSteps,
+  isCreating: true,
 };
 
 describe("the FacilitySfoForm component", () => {


### PR DESCRIPTION
card #3202 

This PR:
- re-adds the code for PUT (necessary when navigating backwards through reg to avoid the "Operation can only have facility... error)