### PR TITLE
717 Prevent review facility submit with 0 activities

### DIFF
--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
@@ -38,6 +38,11 @@ const FacilityReview: React.FC<Props> = ({
     const method = "POST";
     const endpoint = `reporting/report-version/${version_id}/facility-report/${facility_id}`;
 
+    if ((formData as any).activities.length === 0) {
+      setErrors(["You must select at least one activity"]);
+      return false;
+    }
+
     const activityNameToIdMap = new Map(
       activitiesData.map((activity: ActivityData) => [
         activity.name,
@@ -53,6 +58,7 @@ const FacilityReview: React.FC<Props> = ({
         .filter((id: number | undefined) => id !== undefined) // Filter out undefined IDs
         .map(Number), // Ensure all IDs are numbers
     };
+
     const response = await actionHandler(endpoint, method, endpoint, {
       body: JSON.stringify(updatedFormData),
     });

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
@@ -137,3 +137,5 @@ export const FacilityReview: React.FC<Props> = ({
     </>
   );
 };
+
+export default FacilityReview;

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
@@ -17,11 +17,20 @@ interface Props {
   facility_id: string;
   activitiesData: ActivityData[];
   navigationInformation: NavigationInformation;
-  formsData: object;
+  formsData: FacilityReviewFormData;
   schema: RJSFSchema;
 }
 
-const FacilityReview: React.FC<Props> = ({
+export interface FacilityReviewFormData {
+  operation_id: string;
+  facility_name: string;
+  facility_type: string;
+  facility_bcghgid: string | null;
+  activities: string[];
+  facility: string;
+}
+
+export const FacilityReview: React.FC<Props> = ({
   version_id,
   operationId,
   facility_id,
@@ -30,7 +39,7 @@ const FacilityReview: React.FC<Props> = ({
   formsData,
   schema,
 }) => {
-  const [formData, setFormData] = useState<object>(formsData);
+  const [formData, setFormData] = useState<FacilityReviewFormData>(formsData);
   const [errors, setErrors] = useState<string[] | undefined>();
   const uiSchema = buildFacilityReviewUiSchema(operationId, facility_id);
   const [isSnackbarOpen, setIsSnackbarOpen] = useState(false);
@@ -38,7 +47,7 @@ const FacilityReview: React.FC<Props> = ({
     const method = "POST";
     const endpoint = `reporting/report-version/${version_id}/facility-report/${facility_id}`;
 
-    if ((formData as any).activities.length === 0) {
+    if (formData.activities.length === 0) {
       setErrors(["You must select at least one activity"]);
       return false;
     }
@@ -51,7 +60,7 @@ const FacilityReview: React.FC<Props> = ({
     );
     const updatedFormData = {
       ...formData,
-      activities: (formData as any).activities
+      activities: formData.activities
         .map((activityName: string) => {
           return activityNameToIdMap.get(activityName);
         })
@@ -81,7 +90,7 @@ const FacilityReview: React.FC<Props> = ({
       return;
     }
 
-    setFormData((prevFormData: object) => ({
+    setFormData((prevFormData: FacilityReviewFormData) => ({
       ...prevFormData,
       facility_name: getUpdatedFacilityData.facility_name,
       facility_type: getUpdatedFacilityData.facility_type,
@@ -106,8 +115,8 @@ const FacilityReview: React.FC<Props> = ({
         }}
         formData={formData}
         onSubmit={handleSubmit}
-        onChange={(data: { formData: object }) => {
-          setFormData((prevFormData: object) => ({
+        onChange={(data: { formData: FacilityReviewFormData }) => {
+          setFormData((prevFormData: FacilityReviewFormData) => ({
             ...prevFormData,
             ...data.formData,
           }));
@@ -128,5 +137,3 @@ const FacilityReview: React.FC<Props> = ({
     </>
   );
 };
-
-export default FacilityReview;


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/717

### Changes
 - Added a check to FacilityReviewForm handleSubmit(): if there are 0 activities selected, prevent submission and display error "You must select at least one activity"


### To Test
 1. Log in as industry user
 2. Navigate to Submit Annual Report(s)
 3. Click Start for Banana LFO
 4. Navigate all the way through the Review Facility Information page of Facility 1
 5. Uncheck activities
 6. Click Save & Continue
 Expect : An error to show up saying "You must select at least one activity"
 Previous behaviour: Would save and attempt to navigate to a non-existent activity form