### PR TITLE
3180 transfers show all operations

### DIFF
--- a/bc_obps/service/data_access_service/operation_designated_operator_timeline_service.py
+++ b/bc_obps/service/data_access_service/operation_designated_operator_timeline_service.py
@@ -77,8 +77,8 @@ class OperationDesignatedOperatorTimelineDataAccessService:
         )
 
         if user.is_irc_user():
-            # IRC users only see registered operations
-            return queryset.filter(operation__status=Operation.Statuses.REGISTERED, end_date__isnull=True)
+            # IRC users see all operations (subject to filtering that's done on the endpoint)
+            return queryset.filter(end_date__isnull=True)
         else:
             # Industry users can only see operations associated with their own operator
             user_operator = UserOperatorService.get_current_user_approved_user_operator_or_raise(user)

--- a/bc_obps/service/tests/data_access_service/test_data_access_operation_designated_operator_timeline.py
+++ b/bc_obps/service/tests/data_access_service/test_data_access_operation_designated_operator_timeline.py
@@ -57,13 +57,17 @@ class TestDataAccessOperationDesignatedOperatorTimelineService:
 
     @staticmethod
     def test_get_operations_for_internal_user():
-        # non-registered operation - should not be returned
+        # non-registered operation - should be returned
         baker.make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
-            operation=baker.make_recipe('registration.tests.utils.operation', status=Operation.Statuses.DRAFT),
+            operation=baker.make_recipe(
+                'registration.tests.utils.operation',
+                status=Operation.Statuses.DRAFT,
+            ),
+            end_date=None,
         )
 
-        # transferred operation
+        # transferred operation - should not be returned, has an end date
         baker.make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
             operation=baker.make_recipe(
@@ -88,4 +92,4 @@ class TestDataAccessOperationDesignatedOperatorTimelineService:
             baker.make_recipe('registration.tests.utils.cas_admin')
         )
 
-        assert timeline.count() == 20
+        assert timeline.count() == 21

--- a/bciers/apps/administration/app/components/operations/OperationDataGrid.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationDataGrid.tsx
@@ -7,18 +7,20 @@ import OperationsActionCell from "@bciers/components/datagrid/cells/operations/O
 import OperationFacilitiesActionCell from "apps/administration/app/components/operations/cells/OperationFacilitiesActionCell";
 import operationColumns from "@/administration/app/components/datagrid/models/operations/operationColumns";
 import operationGroupColumns from "@/administration/app/components/datagrid/models/operations/operationGroupColumns";
-import { OperationRow } from "./types";
+import { OperationRow, OperationsSearchParams } from "./types";
 import { fetchOperationsPageData } from "@bciers/actions/api";
 
 const OperationDataGrid = ({
   initialData,
   isInternalUser = false,
+  filteredSearchParams,
 }: {
   isInternalUser?: boolean;
   initialData: {
     rows: OperationRow[];
     row_count: number;
   };
+  filteredSearchParams: OperationsSearchParams;
 }) => {
   const [lastFocusedField, setLastFocusedField] = useState<string | null>(null);
   const SearchCell = useMemo(
@@ -41,11 +43,18 @@ const OperationDataGrid = ({
     [SearchCell, isInternalUser],
   );
 
+  const fetchPageDataWithFilters = async (params: OperationsSearchParams) => {
+    return fetchOperationsPageData({
+      ...filteredSearchParams,
+      ...params,
+    });
+  };
+
   return (
     <DataGrid
       columns={columns}
       columnGroupModel={columnGroup}
-      fetchPageData={fetchOperationsPageData}
+      fetchPageData={fetchPageDataWithFilters}
       paginationMode="server"
       initialData={initialData}
     />

--- a/bciers/apps/administration/app/components/operations/OperationDataGridPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationDataGridPage.tsx
@@ -14,12 +14,16 @@ export default async function OperationDataGridPage({
   const role = await getSessionRole();
   const isInternalUser = role.includes("cas_");
 
+  // IRC users should only see Registered operations
+  const filteredSearchParams = isInternalUser
+    ? { ...searchParams, operation__status: "Registered" }
+    : searchParams;
+
   // Fetch operations data
   const operations: {
     rows: OperationRow[];
     row_count: number;
-  } = await fetchOperationsPageData(searchParams);
-
+  } = await fetchOperationsPageData(filteredSearchParams);
   if (!operations || "error" in operations)
     throw new Error("Failed to retrieve operations");
 

--- a/bciers/apps/administration/app/components/operations/OperationDataGridPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationDataGridPage.tsx
@@ -34,6 +34,7 @@ export default async function OperationDataGridPage({
         <OperationDataGrid
           initialData={operations}
           isInternalUser={isInternalUser}
+          filteredSearchParams={filteredSearchParams}
         />
       </div>
     </Suspense>


### PR DESCRIPTION
card: https://github.com/bcgov/cas-registration/issues/3180

This PR:
- changes the service that pulls operation data for IRC users to not filter automatically on status
- use the status filter on the endpoint instead (sent via the front end grid component)
- I chose to do this^ to avoid making a new endpoint/service that was specific to filtering on the operation status. I don't ~think there's any problem with having the service fetch all operation statuses by default. If IRC users are allowed to see everything in transfers, then we aren't restricting it in the grid for security, just for convenience
- update pytests