### PR TITLE
chore: fixed endpoint  not allowed error

### DIFF
--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.test.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.test.tsx
@@ -164,7 +164,7 @@ describe("SessionTimeoutHandler", () => {
     screen.getByText("Logout").click();
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalledWith({
-        callbackUrl: "http://logout.url", // NOSONAR
+        redirectTo: "http://logout.url", // NOSONAR
       });
     });
   });

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -30,7 +30,7 @@ const SessionTimeoutHandler: React.FC = () => {
       .catch((error) => console.error("Failed to fetch logout URL:", error));
   }, []);
 
-  const handleLogout = () => signOut({ callbackUrl: logoutUrl });
+  const handleLogout = () => signOut({ redirectTo: logoutUrl });
 
   // Refreshes the session and updates the timeout based on new expiration
   const refreshSession = async (): Promise<void> => {

--- a/bciers/libs/components/src/error/ErrorBoundary.tsx
+++ b/bciers/libs/components/src/error/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import * as Sentry from "@sentry/nextjs";
-
+import { signIn } from "next-auth/react";
 import { Alert, AlertTitle } from "@mui/material";
 
 interface Props {
@@ -11,6 +11,12 @@ export default function ErrorBoundary({ error }: Props) {
   useEffect(() => {
     if (error) {
       try {
+        if (error.message === "Unauthorized user") {
+          signIn();
+          // Skip logging to Sentry
+          return;
+        }
+
         // Attempt to log the error to Sentry
         const id = Sentry.captureException(error);
         setEventId(id); // Store Sentry event ID

--- a/bciers/libs/utils/src/actions.test.ts
+++ b/bciers/libs/utils/src/actions.test.ts
@@ -157,7 +157,7 @@ describe("actionHandler function", () => {
     expect(result).toEqual({ test_data: "test" });
   });
 
-  it("should return an error if fetching token fails and the endpoint is not allowed", async () => {
+  it("should return an error if fetching token fails and unauthorized user", async () => {
     // getToken fetch
     fetch.mockResponseOnce(JSON.stringify({ message: "Error message" }), {
       status: 400,
@@ -171,8 +171,7 @@ describe("actionHandler function", () => {
     );
 
     expect(result).toEqual({
-      error:
-        "An error occurred while fetching /endpoint: Endpoint is not allowed",
+      error: "An error occurred while fetching /endpoint: Unauthorized user",
     });
   });
 

--- a/bciers/libs/utils/src/getUUIDFromEndpoint.test.ts
+++ b/bciers/libs/utils/src/getUUIDFromEndpoint.test.ts
@@ -27,7 +27,7 @@ describe("getUUIDFromEndpoint", () => {
   it("should throw an error if the endpoint is not allowed", () => {
     const endpoint = "registration/user/not-allowed-endpoint";
     expect(() => getUUIDFromEndpoint(endpoint)).toThrowError(
-      "Endpoint is not allowed",
+      "Unauthorized user",
     );
   });
 });

--- a/bciers/libs/utils/src/getUUIDFromEndpoint.ts
+++ b/bciers/libs/utils/src/getUUIDFromEndpoint.ts
@@ -11,7 +11,7 @@ function getUUIDFromEndpoint(endpoint: string): string | null {
   );
 
   if (!isEndpointAllowed) {
-    throw new Error("Endpoint is not allowed");
+    throw new Error("Unauthorized user");
   }
   // Split the endpoint URL by '/'
   const segments = endpoint.split("/");


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/741
Changes:
1. Updated error message from "Endpoint not allowed" to "Unauthorized user".
2. Enhanced the error boundary logic to detect "Unauthorized user" errors and trigger an automatic sign-out.

To test:-
1. Open bciers/apps/dashboard/auth/index.ts and update the session maxAge to 60 seconds.
2. Navigate to: http://localhost:3000/reporting/reports.
3. Click on any report .
4. Leave the tab idle, switch to another window, or open a new tab for over a minute.
5. Return to the original tab. You should automatically be signed out and see the following screen:
![image](https://github.com/user-attachments/assets/77fc8279-3966-4c01-88f9-8d28c30e1e3f)
