### PR TITLE
3268 logout redirect

### DIFF
--- a/bciers/apps/dashboard/auth/index.ts
+++ b/bciers/apps/dashboard/auth/index.ts
@@ -7,7 +7,7 @@ import authConfig from "./auth.config";
 export const { handlers, auth, signIn, signOut } = NextAuth({
   session: {
     strategy: "jwt",
-    maxAge: 60 * 3, // 30 minutes matching Keycloak token expiration time
+    maxAge: 60, // 30 minutes matching Keycloak token expiration time
   },
   ...authConfig,
 });

--- a/bciers/apps/dashboard/auth/index.ts
+++ b/bciers/apps/dashboard/auth/index.ts
@@ -7,7 +7,7 @@ import authConfig from "./auth.config";
 export const { handlers, auth, signIn, signOut } = NextAuth({
   session: {
     strategy: "jwt",
-    maxAge: 30, // 30 minutes matching Keycloak token expiration time
+    maxAge: 60 * 3, // 30 minutes matching Keycloak token expiration time
   },
   ...authConfig,
 });

--- a/bciers/apps/dashboard/auth/index.ts
+++ b/bciers/apps/dashboard/auth/index.ts
@@ -7,7 +7,7 @@ import authConfig from "./auth.config";
 export const { handlers, auth, signIn, signOut } = NextAuth({
   session: {
     strategy: "jwt",
-    maxAge: 60, // 30 minutes matching Keycloak token expiration time
+    maxAge: 30 * 60, // 30 minutes matching Keycloak token expiration time
   },
   ...authConfig,
 });

--- a/bciers/apps/dashboard/auth/index.ts
+++ b/bciers/apps/dashboard/auth/index.ts
@@ -7,7 +7,7 @@ import authConfig from "./auth.config";
 export const { handlers, auth, signIn, signOut } = NextAuth({
   session: {
     strategy: "jwt",
-    maxAge: 30 * 60, // 30 minutes matching Keycloak token expiration time
+    maxAge: 30, // 30 minutes matching Keycloak token expiration time
   },
   ...authConfig,
 });

--- a/bciers/apps/dashboard/auth/index.ts
+++ b/bciers/apps/dashboard/auth/index.ts
@@ -7,7 +7,7 @@ import authConfig from "./auth.config";
 export const { handlers, auth, signIn, signOut } = NextAuth({
   session: {
     strategy: "jwt",
-    maxAge: 30 * 60, // 30 minutes matching Keycloak token expiration time
+    maxAge: 60, // 30 minutes matching Keycloak token expiration time
   },
   ...authConfig,
 });

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.test.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.test.tsx
@@ -2,11 +2,9 @@ import { expect, beforeEach } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { useSession, signOut } from "next-auth/react";
 import SessionTimeoutHandler, {
-  ACTIVITY_THROTTLE_SECONDS,
   MODAL_DISPLAY_SECONDS,
 } from "@bciers/components/auth/SessionTimeoutHandler";
 import { getEnvValue, getToken } from "@bciers/actions";
-import createThrottledEventHandler from "@bciers/components/auth/throttleEventsEffect";
 import { LogoutWarningModalProps } from "@bciers/components/auth/LogoutWarningModal";
 import * as Sentry from "@sentry/nextjs";
 
@@ -163,6 +161,7 @@ describe("SessionTimeoutHandler", () => {
     );
 
     screen.getByText("Extend").click();
+    expect(postMessage).toHaveBeenCalledWith("extend-session");
     await waitFor(() => {
       expect(mockUpdate).toHaveBeenCalled();
       expect(screen.queryByTestId("logout-modal")).not.toBeInTheDocument();
@@ -217,6 +216,7 @@ describe("SessionTimeoutHandler", () => {
     );
 
     screen.getByText("Extend").click();
+    expect(postMessage).toHaveBeenCalledWith("logout");
 
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalledWith({

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -23,7 +23,7 @@ const SessionTimeoutHandler: React.FC = () => {
     getExpirationTimeInSeconds(session?.expires),
   );
   const [logoutUrl, setLogoutUrl] = useState<string>("/");
-
+  console.log("-----------logoutUrl", logoutUrl);
   useEffect(() => {
     // Fetch the logout URL from environment variables when component mounts
     getEnvValue("SITEMINDER_KEYCLOAK_LOGOUT_URL")
@@ -35,7 +35,6 @@ const SessionTimeoutHandler: React.FC = () => {
   }, []);
 
   const handleLogout = () => signOut({ redirectTo: logoutUrl });
-
   // Refreshes the session and updates the timeout based on new expiration
   const refreshSession = async (): Promise<void> => {
     if (status !== "authenticated") {

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -119,8 +119,7 @@ const SessionTimeoutHandler: React.FC = () => {
 
     let modalTimeoutId: NodeJS.Timeout | undefined;
 
-    if (sessionTimeout === Infinity)
-      return; // No timeout set, exit early
+    if (sessionTimeout === Infinity) return; // No timeout set, exit early
     else if (sessionTimeout <= 0) handleLogout();
     else if (sessionTimeout > MODAL_DISPLAY_SECONDS) {
       setShowModal(false);

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -6,7 +6,7 @@ import { getEnvValue, getToken } from "@bciers/actions";
 import { Session } from "next-auth";
 import * as Sentry from "@sentry/nextjs";
 import { signOut, useSession } from "next-auth/react";
-import { BroadcastChannel } from "broadcast-channel";
+// import { BroadcastChannel } from "broadcast-channel";
 
 export const ACTIVITY_THROTTLE_SECONDS = 15;
 export const MODAL_DISPLAY_SECONDS = 20;
@@ -23,22 +23,22 @@ const SessionTimeoutHandler: React.FC = () => {
     getExpirationTimeInSeconds(session?.expires),
   );
 
-  const logoutChannelRef = useRef<BroadcastChannel | null>(null);
+  // const logoutChannelRef = useRef<BroadcastChannel | null>(null);
 
-  useEffect(() => {
-    const channel = new BroadcastChannel("logout");
-    logoutChannelRef.current = channel;
+  // useEffect(() => {
+  //   const channel = new BroadcastChannel("logout");
+  //   logoutChannelRef.current = channel;
 
-    channel.onmessage = (event) => {
-      if (event === "logout") {
-        window.location.href = "/your-logout-page"; // or `logoutUrl`
-      }
-    };
+  //   channel.onmessage = (event) => {
+  //     if (event === "logout") {
+  //       window.location.href = "/your-logout-page"; // or `logoutUrl`
+  //     }
+  //   };
 
-    return () => {
-      channel.close();
-    };
-  }, []);
+  //   return () => {
+  //     channel.close();
+  //   };
+  // }, []);
 
   const handleLogout = async () => {
     const logoutUrl = await getEnvValue("SITEMINDER_KEYCLOAK_LOGOUT_URL");
@@ -48,7 +48,7 @@ const SessionTimeoutHandler: React.FC = () => {
     }
 
     // Use ref to send message only if channel is still open
-    logoutChannelRef.current?.postMessage("logout");
+    // logoutChannelRef.current?.postMessage("logout");
 
     await signOut({ redirectTo: logoutUrl || "/" });
   };

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -5,7 +5,7 @@ import LogoutWarningModal from "@bciers/components/auth/LogoutWarningModal";
 import { getEnvValue, getToken } from "@bciers/actions";
 import { Session } from "next-auth";
 import * as Sentry from "@sentry/nextjs";
-import { useSession } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
 
 export const ACTIVITY_THROTTLE_SECONDS = 15; // Throttle user activity checks (4 minutes)
 export const MODAL_DISPLAY_SECONDS = 20; // Seconds before timeout to show logout warning modal (5 minutes)
@@ -70,16 +70,13 @@ const SessionTimeoutHandler: React.FC = () => {
 
     async function fetchAndCompare() {
       try {
-        const token = await getToken();
         // 1. Get the JWT exp claim (in seconds since epoch)
+        const token = await getToken();
         const expiration = token.exp;
-
-        console.log("Token expiration:", expiration);
 
         // 2. Compute how many seconds are left
         const nowSec = Math.floor(Date.now() / 1000);
         const secondsRemain = Math.max(0, expiration - nowSec);
-        console.log("Seconds remaining:", secondsRemain);
 
         // 3. Update countdown state directly from token.exp
         setSessionTimeout(secondsRemain);

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -134,7 +134,6 @@ const SessionTimeoutHandler: React.FC = () => {
     if (sessionTimeout === Infinity) return;
     else if (sessionTimeout <= 0) handleLogout();
     else if (sessionTimeout > MODAL_DISPLAY_SECONDS) {
-      console.log("---------------------in first else if---------------------");
       setShowModal(false);
       modalTimeoutId = setTimeout(
         () => {
@@ -143,7 +142,6 @@ const SessionTimeoutHandler: React.FC = () => {
         (sessionTimeout - MODAL_DISPLAY_SECONDS) * 1000,
       );
     } else {
-      console.log("---------------------in else");
       setShowModal(true);
     }
 

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -9,7 +9,7 @@ import { signOut, useSession } from "next-auth/react";
 import { BroadcastChannel } from "broadcast-channel";
 
 export const ACTIVITY_THROTTLE_SECONDS = 15;
-export const MODAL_DISPLAY_SECONDS = 20;
+export const MODAL_DISPLAY_SECONDS = 5 * 60; // Seconds before timeout to show logout warning modal (5 minutes);
 
 const getExpirationTimeInSeconds = (expires: string | undefined): number => {
   if (!expires) return Infinity;
@@ -134,6 +134,7 @@ const SessionTimeoutHandler: React.FC = () => {
     if (sessionTimeout === Infinity) return;
     else if (sessionTimeout <= 0) handleLogout();
     else if (sessionTimeout > MODAL_DISPLAY_SECONDS) {
+      console.log("---------------------in first else if---------------------");
       setShowModal(false);
       modalTimeoutId = setTimeout(
         () => {
@@ -142,6 +143,7 @@ const SessionTimeoutHandler: React.FC = () => {
         (sessionTimeout - MODAL_DISPLAY_SECONDS) * 1000,
       );
     } else {
+      console.log("---------------------in else");
       setShowModal(true);
     }
 

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -8,8 +8,8 @@ import createThrottledEventHandler from "@bciers/components/auth/throttleEventsE
 import { Session } from "next-auth";
 import * as Sentry from "@sentry/nextjs";
 
-export const ACTIVITY_THROTTLE_SECONDS = 2 * 60; // Throttle user activity checks (4 minutes)
-export const MODAL_DISPLAY_SECONDS = 5 * 60; // Seconds before timeout to show logout warning modal (5 minutes)
+export const ACTIVITY_THROTTLE_SECONDS = 15; // Throttle user activity checks (4 minutes)
+export const MODAL_DISPLAY_SECONDS = 20; // Seconds before timeout to show logout warning modal (5 minutes)
 
 const getExpirationTimeInSeconds = (expires: string | undefined): number => {
   if (!expires) return Infinity; // No expiration set, return infinite timeout
@@ -69,7 +69,8 @@ const SessionTimeoutHandler: React.FC = () => {
 
     const refreshIfNotExpired = async () => {
       const session = await getSession();
-      if (session && new Date(session.expires).getTime() < Date.now()) {
+      if (session && new Date(session.expires).getTime() > Date.now()) {
+        console.log("do i get called");
         await refreshSession();
       }
     };

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -7,6 +7,7 @@ import { getEnvValue } from "@bciers/actions";
 import createThrottledEventHandler from "@bciers/components/auth/throttleEventsEffect";
 import { Session } from "next-auth";
 import * as Sentry from "@sentry/nextjs";
+import { debug } from "console";
 
 export const ACTIVITY_THROTTLE_SECONDS = 15; // Throttle user activity checks (4 minutes)
 export const MODAL_DISPLAY_SECONDS = 20; // Seconds before timeout to show logout warning modal (5 minutes)
@@ -74,11 +75,10 @@ const SessionTimeoutHandler: React.FC = () => {
         await refreshSession();
       }
     };
-    createThrottledEventHandler(
-      refreshIfNotExpired,
-      [],
-      ACTIVITY_THROTTLE_SECONDS,
-    );
+
+    const interval = setInterval(() => {
+      refreshIfNotExpired();
+    }, ACTIVITY_THROTTLE_SECONDS * 1000);
 
     let cleanup: (() => void) | undefined;
 
@@ -118,6 +118,7 @@ const SessionTimeoutHandler: React.FC = () => {
 
     return () => {
       if (cleanup) cleanup(); // Cleanup function to remove event listeners when showModal changes or component unmounts
+      clearInterval(interval);
       document.removeEventListener(
         "visibilitychange",
         preventDefaultVisibilityChange,

--- a/bciers/libs/components/src/auth/throttleEventsEffect.ts
+++ b/bciers/libs/components/src/auth/throttleEventsEffect.ts
@@ -9,7 +9,7 @@ import throttle from "lodash.throttle";
  * @returns A setup function that returns a cleanup function.
  */
 const createThrottledEventHandler = (
-  callback: () => void,
+  callback: (event: Event) => void,
   events: string[],
   throttleTime: number = 60 * 5, // 5 minutes default
 ): (() => () => void) => {

--- a/bciers/libs/middlewares/src/withAuthorization.ts
+++ b/bciers/libs/middlewares/src/withAuthorization.ts
@@ -18,6 +18,10 @@ export const withAuthorization: MiddlewareFactory = (next: NextMiddleware) => {
   return async (request: NextRequest, _next: NextFetchEvent) => {
     // Check if the user is authenticated via the jwt encoded in server side cookie
     const token = await getToken();
+    console.log(
+      "token in middleware!!!!!!!!!!!!!!!!!--------------------",
+      token,
+    );
 
     if (token) {
       const response = await actionHandler(

--- a/bciers/package.json
+++ b/bciers/package.json
@@ -71,6 +71,7 @@
     "@types/react-dom": "18.3.0",
     "@types/react-outside-click-handler": "^1.3.3",
     "autoprefixer": "^10.4.16",
+    "broadcast-channel": "^7.1.0",
     "classnames": "^2.3.2",
     "dayjs": "^1.11.11",
     "dotenv": "^16.3.1",

--- a/bciers/yarn.lock
+++ b/bciers/yarn.lock
@@ -1588,21 +1588,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:7.27.0, @babel/runtime@npm:^7.27.0":
+  version: 7.27.0
+  resolution: "@babel/runtime@npm:7.27.0"
+  dependencies:
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 10c0/35091ea9de48bd7fd26fb177693d64f4d195eb58ab2b142b893b7f3fa0f1d7c677604d36499ae0621a3703f35ba0c6a8f6c572cc8f7dc0317213841e493cf663
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.22.6, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.6, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.26.10
   resolution: "@babel/runtime@npm:7.26.10"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
   checksum: 10c0/6dc6d88c7908f505c4f7770fb4677dfa61f68f659b943c2be1f2a99cb6680343462867abf2d49822adc435932919b36c77ac60125793e719ea8745f2073d3745
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.27.0":
-  version: 7.27.0
-  resolution: "@babel/runtime@npm:7.27.0"
-  dependencies:
-    regenerator-runtime: "npm:^0.14.0"
-  checksum: 10c0/35091ea9de48bd7fd26fb177693d64f4d195eb58ab2b142b893b7f3fa0f1d7c677604d36499ae0621a3703f35ba0c6a8f6c572cc8f7dc0317213841e493cf663
   languageName: node
   linkType: hard
 
@@ -1730,6 +1730,7 @@ __metadata:
     "@vitest/expect": "npm:^3.0.3"
     "@vitest/ui": "npm:^3.0.3"
     autoprefixer: "npm:^10.4.16"
+    broadcast-channel: "npm:^7.1.0"
     classnames: "npm:^2.3.2"
     dayjs: "npm:^1.11.11"
     dotenv: "npm:^16.3.1"
@@ -8060,6 +8061,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"broadcast-channel@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "broadcast-channel@npm:7.1.0"
+  dependencies:
+    "@babel/runtime": "npm:7.27.0"
+    oblivious-set: "npm:1.4.0"
+    p-queue: "npm:6.6.2"
+    unload: "npm:2.4.1"
+  checksum: 10c0/202e48f2322cb5a6796eb18c530010e3a80ef4f06321962a64393bbd27acf6b9443106530b28f666ecb98e48a4938dd6c6ac0981b29e47def2fe1188555d7b53
+  languageName: node
+  linkType: hard
+
 "browser-process-hrtime@npm:^1.0.0":
   version: 1.0.0
   resolution: "browser-process-hrtime@npm:1.0.0"
@@ -10570,7 +10583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^4.0.0":
+"eventemitter3@npm:^4.0.0, eventemitter3@npm:^4.0.4":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 10c0/5f6d97cbcbac47be798e6355e3a7639a84ee1f7d9b199a07017f1d2f1e2fe236004d14fa5dfaeba661f94ea57805385e326236a6debbc7145c8877fbc0297c6b
@@ -14499,6 +14512,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oblivious-set@npm:1.4.0":
+  version: 1.4.0
+  resolution: "oblivious-set@npm:1.4.0"
+  checksum: 10c0/92fc4e0ed3e4e5a120f17e32964dc40671549704474aee94656ea8978837d8539d6e1655cc0ad42500315583eec41097fe38b58acd138ad8068a8083d0db2773
+  languageName: node
+  linkType: hard
+
 "obuf@npm:^1.0.0, obuf@npm:^1.1.2":
   version: 1.1.2
   resolution: "obuf@npm:1.1.2"
@@ -14669,6 +14689,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-finally@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "p-finally@npm:1.0.0"
+  checksum: 10c0/6b8552339a71fe7bd424d01d8451eea92d379a711fc62f6b2fe64cad8a472c7259a236c9a22b4733abca0b5666ad503cb497792a0478c5af31ded793d00937e7
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^3.0.2":
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
@@ -14714,6 +14741,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-queue@npm:6.6.2":
+  version: 6.6.2
+  resolution: "p-queue@npm:6.6.2"
+  dependencies:
+    eventemitter3: "npm:^4.0.4"
+    p-timeout: "npm:^3.2.0"
+  checksum: 10c0/5739ecf5806bbeadf8e463793d5e3004d08bb3f6177bd1a44a005da8fd81bb90f80e4633e1fb6f1dfd35ee663a5c0229abe26aebb36f547ad5a858347c7b0d3e
+  languageName: node
+  linkType: hard
+
 "p-retry@npm:^6.2.0":
   version: 6.2.0
   resolution: "p-retry@npm:6.2.0"
@@ -14722,6 +14759,15 @@ __metadata:
     is-network-error: "npm:^1.0.0"
     retry: "npm:^0.13.1"
   checksum: 10c0/3277f2a8450fb1429c29c432d24c5965b32f187228f1beea56f5d49209717588a7dc0415def1c653f60e0d15ed72c56dacaa2d5fdfa71b0f860592b0aa6ce823
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "p-timeout@npm:3.2.0"
+  dependencies:
+    p-finally: "npm:^1.0.0"
+  checksum: 10c0/524b393711a6ba8e1d48137c5924749f29c93d70b671e6db761afa784726572ca06149c715632da8f70c090073afb2af1c05730303f915604fd38ee207b70a61
   languageName: node
   linkType: hard
 
@@ -18473,6 +18519,13 @@ __metadata:
   version: 2.0.1
   resolution: "universalify@npm:2.0.1"
   checksum: 10c0/73e8ee3809041ca8b818efb141801a1004e3fc0002727f1531f4de613ea281b494a40909596dae4a042a4fb6cd385af5d4db2e137b1362e0e91384b828effd3a
+  languageName: node
+  linkType: hard
+
+"unload@npm:2.4.1":
+  version: 2.4.1
+  resolution: "unload@npm:2.4.1"
+  checksum: 10c0/98bb7f276a217afc51b9ee330610a04324e4718649451b6068667a2b2f77504cdde54d344e80d2fc2843cf431e6c2ec8d57786551f296b03b51eaaca7cbdbe36
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
card: https://github.com/bcgov/cas-registration/issues/3268

This card talks about two things:
- logout modal doesn't show
- user is not redirected after logout (Zoey's comment `The "you've been signed out" page doesn't always appear. I left the tab open yesterday on the final review page, and came back today to the tab and it was still on the final review page instead of on the "you've been signed out"`)

These problems are caused by having the app open in more than one tab. The non-active tab logs the user out of all tabs after 30 minutes but only redirects them from the tab the triggered the logout. This makes it seem like the modal never showed up (it did, but it was in the inactive tab). It also makes it seem like the user is still logged in when they're not because they're not redirected to the logout page (only the inactive tab redirected).

We considered polling the token expiration and using that as a proxy for user activity. However, the token's expiry is only updated when `useSession` (client components) or `getSession` (server components) is called. This doesn't happen often enough to be a good indicator of user activity, e.g., you can get through the whole registration workflow without updating expiry. (Sidenote, calling `getToken` in the middleware does not refresh the session--can't refresh from middleware because it runs before cookies are set, and `getToken` is just a getter anyway). 

In the end, we used Broadcast Channel to send updates across the tabs. ([Nextauth already uses broadcast channel](https://leapcell.medium.com/deep-dive-into-nextauth-js-a-powerful-and-flexible-authentication-solution-c9b4ebd37b42) to sign users out of all tabs if they sign out of one.) 

This PR:
- set the throttle value lower
- fetch the `logoutUrl differrently
- set a default `logoutUrl`
- tab handling as part of user activity monitoring
- set up Sentry error capturing specifically for log out
- updated deprecated `callbackUrl` to `redirectTo`
- channel for redirecting extra tabs to the logout page, as Nextauth doesn't seem to handle that
- channel to refresh session in the extra tabs anytime (throttled) there's user activity

To test:
- change maxAge, MODAL_DISPLAY_SECONDS, and ACTIVITY_THROTTLE_SECONDS so you don't have to wait half an hour
- open the app in two tabs. The logout and extend session buttons should affect both apps
- let the timer rundown and you should be logged out and redirected to the keycloak logout page
- to test the fallback, temporarily delete `SITEMINDER_KEYCLOAK_LOGOUT_URL` from your env and you'll be redirected to the onboarding page instead of logout page


Notes:
Every once in awhile I'll get "logout failed" on one of the tabs: 
![image](https://github.com/user-attachments/assets/9ec4fa3c-0796-4272-bba5-dbcc5091c8f2). I ~think this is because I've already been logged out by one of the other tabs

