### PR TITLE
720 convert facility_total_emissions to string for consistency

### DIFF
--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -154,7 +154,8 @@ export default function FacilityEmissionAllocationForm({
         .filter((category: any) => category.category_type === "fuel_excluded")
         .map(calculateEmissionData),
     total_emission_allocations: {
-      facility_total_emissions: initialData.facility_total_emissions,
+      facility_total_emissions:
+        initialData.facility_total_emissions?.toString(),
       products: initialData.report_product_emission_allocation_totals,
     },
   }));
@@ -181,7 +182,8 @@ export default function FacilityEmissionAllocationForm({
             )
             .map(calculateEmissionData),
         total_emission_allocations: {
-          facility_total_emissions: initialData.facility_total_emissions,
+          facility_total_emissions:
+            initialData.facility_total_emissions?.toString(),
           products: initialData.report_product_emission_allocation_totals,
         },
       });


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/720

#### Reason for bug:
```facility_total_emissions``` is a read only text field that shows the total of all emissions reported through activities. Despite being read only, the field is part of the schema and is therefore validated by the frontend form validator.

When there is ANY amount of emission data, the server responds with a decimal value like ```Decimal('1234.5678')```. In order to preserve accuracy, JS interprets this as a string, and so that is the type the schema was written to expect. BUT when there is NO emission data reported, the server responds with an int value of ```0```. And Javascript has no problem seeing this as a number. And so when you try to submit, validation fails because a number is where a string is expected.

#### The fix:
To resolve, I just cast the initial data from the server to a string when setting the formData.