### PR TITLE
3186: add sameSite= "strict" to auth cookies

### DIFF
--- a/bciers/apps/dashboard/app/onboarding/page.tsx
+++ b/bciers/apps/dashboard/app/onboarding/page.tsx
@@ -36,11 +36,12 @@ export default function Page() {
   };
 
   useEffect(() => {
+    console.log(status, session);
     if (status === "loading" || session === undefined) {
       // Session is still loading, do nothing
       return;
     }
-    if (session) {
+    if (session && status === "authenticated") {
       // Handle authenticated user without a role
       if (!session.user.app_role || session.user.app_role === "") {
         // 🛸 Redirect cross-zone from dashboard to admininistration

--- a/bciers/apps/dashboard/app/onboarding/page.tsx
+++ b/bciers/apps/dashboard/app/onboarding/page.tsx
@@ -47,7 +47,12 @@ export default function Page() {
       console.log("Session exists:", session);
       // Handle authenticated user without a role
       if (!session.user.app_role || session.user.app_role === "") {
-        router.push(`/${paths.administration}/${paths.profile}`);
+        // 🛸 Redirect cross-zone from dashboard to admininistration
+        // For cross‐zone navigation, use a full page reload to avoid missing‐chunk errors.
+        // router.push would attempt to load “/administration/profile” from the dashboard chunk manifest,
+        // but since “profile” lives in the administration zone, those chunks don’t exist here.
+        // window.location.href forces a hard reload into the administration zone’s build.
+        window.location.href = `/${paths.administration}/${paths.profile}`;
         return;
       }
       router.push(`/${paths.dashboard}`);

--- a/bciers/apps/dashboard/app/onboarding/page.tsx
+++ b/bciers/apps/dashboard/app/onboarding/page.tsx
@@ -15,6 +15,7 @@ import {
 
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
+import Loading from "@bciers/components/loading/SkeletonSpinner";
 
 /*
 📚
@@ -40,7 +41,7 @@ export default function Page() {
   useEffect(() => {
     if (status === "loading") {
       // Session is still loading, do nothing
-      return;
+      return <Loading />
     }
 
     if (session) {

--- a/bciers/apps/dashboard/app/onboarding/page.tsx
+++ b/bciers/apps/dashboard/app/onboarding/page.tsx
@@ -11,6 +11,10 @@ import {
   bcObpsGuidanceLink,
   carbonTaxExemptionLink,
 } from "@bciers/utils/src/urls";
+
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+
 /*
 📚
 In the app directory, nested folders are normally mapped to URL paths.
@@ -20,6 +24,13 @@ e.g. app\(onboarding)\home maps to route: http://localhost:3000/home
 */
 
 export default function Page() {
+  const { data: session } = useSession();
+  if (session) {
+    // If we are here, then we need a
+    // browser‑driven navigation to carry the sameSite: strict cookie
+    const router = useRouter();
+    return router.push("/dashboard");
+  }
   const headerStyle = "text-bc-bg-blue text-2xl";
   const tableBorder = "border border-solid border-bc-bg-dark-grey";
 

--- a/bciers/apps/dashboard/app/onboarding/page.tsx
+++ b/bciers/apps/dashboard/app/onboarding/page.tsx
@@ -36,7 +36,6 @@ export default function Page() {
   };
 
   useEffect(() => {
-    console.log(status, session);
     if (status === "loading" || session === undefined) {
       // Session is still loading, do nothing
       return;

--- a/bciers/apps/dashboard/app/onboarding/page.tsx
+++ b/bciers/apps/dashboard/app/onboarding/page.tsx
@@ -27,8 +27,6 @@ e.g. app\(onboarding)\home maps to route: http://localhost:3000/home
 export default function Page() {
   const { data: session, status } = useSession();
   const router = useRouter();
-  // no point using useSessionRole here - we know that there's no sessionRole
-  // const sessionRole = useSessionRole();
 
   const paths = {
     profile: "profile",
@@ -39,12 +37,10 @@ export default function Page() {
 
   useEffect(() => {
     if (status === "loading" || session === undefined) {
-      console.log("Session is loading, waiting for authentication...");
       // Session is still loading, do nothing
       return;
     }
     if (session) {
-      console.log("Session exists:", session);
       // Handle authenticated user without a role
       if (!session.user.app_role || session.user.app_role === "") {
         // 🛸 Redirect cross-zone from dashboard to admininistration
@@ -59,7 +55,6 @@ export default function Page() {
       return;
     } else if (status === "unauthenticated") {
       // Handle unauthenticated user
-      console.log("User is unauthenticated, redirecting to onboarding");
       router.push(`/${paths.onboarding}`);
       return;
     }

--- a/bciers/apps/dashboard/app/onboarding/page.tsx
+++ b/bciers/apps/dashboard/app/onboarding/page.tsx
@@ -15,7 +15,6 @@ import {
 
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import Loading from "@bciers/components/loading/SkeletonSpinner";
 
 /*
 📚
@@ -39,33 +38,26 @@ export default function Page() {
   };
 
   useEffect(() => {
-    if (status === "loading") {
+    if (status === "loading" || session === undefined) {
+      console.log("Session is loading, waiting for authentication...");
       // Session is still loading, do nothing
-      return <Loading />
+      return;
     }
-
     if (session) {
-      // console.log("Session role:", sessionRole);
-
-      if (session) {
-        console.log("Session exists:", session);
-        // Handle authenticated user without a role
-        if (!session.user.app_role || session.user.app_role === "") {
-          router.push(`/${paths.administration}/${paths.profile}`);
-          router.refresh()
-          return;
-        }
-
-        router.push(`/${paths.dashboard}`);
-        return;
-      } else if (status === "unauthenticated") {
-        // Handle unauthenticated user
-        console.log("User is unauthenticated, redirecting to onboarding");
-        router.push(`/${paths.onboarding}`);
+      console.log("Session exists:", session);
+      // Handle authenticated user without a role
+      if (!session.user.app_role || session.user.app_role === "") {
+        router.push(`/${paths.administration}/${paths.profile}`);
         return;
       }
-    };
-
+      router.push(`/${paths.dashboard}`);
+      return;
+    } else if (status === "unauthenticated") {
+      // Handle unauthenticated user
+      console.log("User is unauthenticated, redirecting to onboarding");
+      router.push(`/${paths.onboarding}`);
+      return;
+    }
   }, [router, session, status]);
 
   const headerStyle = "text-bc-bg-blue text-2xl";

--- a/bciers/apps/dashboard/auth/auth.config.test.ts
+++ b/bciers/apps/dashboard/auth/auth.config.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import authConfig from "./auth.config";
+
+describe("auth.config cookies", () => {
+  it("should set sameSite to 'strict' for sessionToken", () => {
+    expect(authConfig.cookies.sessionToken.options.sameSite).toBe("strict");
+  });
+
+  it("should set sameSite to 'strict' for callbackUrl", () => {
+    expect(authConfig.cookies.callbackUrl.options.sameSite).toBe("strict");
+  });
+
+  it("should set sameSite to 'strict' for csrfToken", () => {
+    expect(authConfig.cookies.csrfToken.options.sameSite).toBe("strict");
+  });
+});

--- a/bciers/apps/dashboard/auth/auth.config.ts
+++ b/bciers/apps/dashboard/auth/auth.config.ts
@@ -73,6 +73,33 @@ export default {
       },
     }),
   ],
+  cookies: {
+    sessionToken: {
+      name: "authjs.session-token",
+      options: {
+        httpOnly: true,
+        sameSite: "strict", // default
+        path: "/",
+        // secure: process.env.NODE_ENV === 'production',
+      },
+    },
+    callbackUrl: {
+      name: "authjs.callback-url",
+      options: {
+        sameSite: "strict",
+        path: "/",
+        // secure: process.env.NODE_ENV === 'production',
+      },
+    },
+    csrfToken: {
+      name: "authjs.csrf-token",
+      options: {
+        sameSite: "strict",
+        path: "/",
+        // secure: process.env.NODE_ENV === 'production',
+      },
+    },
+  },
   secret: `${process.env.NEXTAUTH_SECRET}`,
   pages: {
     error: "/auth/error", // Error code passed in query string as ?error=

--- a/bciers/apps/dashboard/auth/auth.config.ts
+++ b/bciers/apps/dashboard/auth/auth.config.ts
@@ -56,6 +56,16 @@ declare module "next-auth" {
 📌 Make one central auth config that can be imported to auth.ts or middleware when required
 */
 export const AUTH_BASE_PATH = "/api/auth";
+const isProd = process.env.NODE_ENV === "production";
+const isCI = process.env.CI === "true";
+
+/**
+ * Prefix with "__Secure-" when on a real production HTTPS host,
+ * but fall back to the un‑prefixed name for local dev or CI.
+ */
+function makeCookieName(base: string) {
+  return isProd && !isCI ? `__Secure-${base}` : base;
+}
 export default {
   //In a Docker environment, make sure to set either trustHost: true in your Auth.js configuration or the AUTH_TRUST_HOST environment variable to true.
   trustHost: true,
@@ -75,7 +85,7 @@ export default {
   ],
   cookies: {
     sessionToken: {
-      name: "authjs.session-token",
+      name: makeCookieName("authjs.session-token"),
       options: {
         httpOnly: true,
         sameSite: "strict", // default
@@ -84,7 +94,7 @@ export default {
       },
     },
     callbackUrl: {
-      name: "authjs.callback-url",
+      name: makeCookieName("authjs.callback-url"),
       options: {
         sameSite: "strict",
         path: "/",

--- a/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.test.ts
+++ b/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.test.ts
@@ -59,28 +59,6 @@ describe("withAuthorizationDashboard middleware", () => {
     expect(result?.status).toBe(200);
   });
 
-  it("redirects to the administration profile page if the user has no app role", async () => {
-    getToken.mockResolvedValue(mockBaseToken);
-    const nextUrl = new NextURL(`${domain}/dashboard`);
-
-    when(mockedRequest.nextUrl).thenReturn(nextUrl);
-    when(mockedRequest.url).thenReturn(domain);
-
-    const result = await middleware(
-      instance(mockedRequest),
-      mockNextFetchEvent,
-    );
-
-    expect(NextResponse.redirect).toHaveBeenCalledOnce();
-    expect(NextResponse.redirect).toHaveBeenCalledWith(
-      new URL("/administration/profile", domain),
-    );
-    expect(result).toBeInstanceOf(NextResponse);
-
-    // 307 is the status code for a temporary redirect
-    expect(result?.status).toBe(307);
-  });
-
   it("calls NextMiddleware if the user has no app role and the route ends in /profile", async () => {
     getToken.mockResolvedValue(mockBaseToken);
     const nextUrl = new NextURL(`${domain}/profile`);
@@ -202,32 +180,5 @@ describe("withAuthorizationDashboard middleware", () => {
       );
       expect(result?.status).toBe(200);
     }
-  });
-
-  it("redirects authenticated, NON-authorized cas_user to the common dashboard if the route is /administration, /compliance, /onboarding, /registration, /reporting", async () => {
-    getToken.mockResolvedValue(mockCasPendingToken);
-    const paths = [
-      "/administration",
-      "/compliance",
-      "/onboarding",
-      "/registration",
-      "/reporting",
-    ];
-
-    for (const path of paths) {
-      const nextUrl = new NextURL(path, domain);
-
-      when(mockedRequest.nextUrl).thenReturn(nextUrl);
-      when(mockedRequest.url).thenReturn(domain);
-
-      const result = await middleware(
-        instance(mockedRequest),
-        mockNextFetchEvent,
-      );
-      expect(NextResponse.redirect).toHaveBeenCalledWith(dashboardUrl);
-      expect(result?.status).toBe(307);
-    }
-
-    expect(NextResponse.redirect).toHaveBeenCalledTimes(paths.length);
   });
 });

--- a/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.ts
+++ b/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.ts
@@ -8,6 +8,7 @@ import {
 import { MiddlewareFactory } from "@bciers/middlewares";
 import { getToken } from "@bciers/actions";
 import isInAllowedPath from "@bciers/utils/src/isInAllowedList";
+import { FrontEndRoles } from "@bciers/utils/src/enums";
 /*
 Access control logic is managed using Next.js middleware and NextAuth.js authentication JWT session.
 The middleware intercepts requests, and for restricted areas...
@@ -22,6 +23,7 @@ const paths = {
   dashboard: "dashboard",
   profile: "profile",
   declined: "declined",
+  administration: "administration",
 };
 export const authAllowedPaths = [paths.dashboard, paths.profile];
 const unauthAllowedPaths = [paths.auth, paths.unauth, paths.declined];
@@ -32,25 +34,8 @@ export const withAuthorizationDashboard: MiddlewareFactory = (
 ) => {
   return async (request: NextRequest, _next: NextFetchEvent) => {
     const { pathname } = request.nextUrl;
-    // Check if the path is in the unauthenticated allow list
-    if (isInAllowedPath(pathname, unauthAllowedPaths)) {
-      // 🛸 Route to next middleware
-      return next(request, _next);
-    }
 
-    // Check if the user is authenticated via the jwt encoded in server side cookie
-    const token = await getToken();
-    if (token) {
-      if (pathname === "/" || pathname === `/${paths.onboarding}`) {
-        // 🛸 Redirect to dashboard
-        return NextResponse.redirect(
-          new URL(`/${paths.dashboard}`, request.url),
-        );
-      } else {
-        // 🛸 Route to next middleware
-        return next(request, _next);
-      }
-    } else {
+    const routeWithNoToken = () => {
       if (pathname.endsWith(`/${paths.onboarding}`)) {
         // 🛸 Route to next middleware
         return next(request, _next);
@@ -60,6 +45,64 @@ export const withAuthorizationDashboard: MiddlewareFactory = (
           new URL(`/${paths.onboarding}`, request.url),
         );
       }
+    };
+
+    const routeWithNoAppRole = () => {
+      if (pathname.endsWith(`/${paths.profile}`)) {
+        // route to next middleware
+        return next(request, _next);
+      } else {
+        return NextResponse.redirect(
+          new URL(`/${paths.administration}/${paths.profile}`, request.url),
+        );
+      }
+    };
+
+    const routeForRoleCasPending = () => {
+      if (isInAllowedPath(pathname, authAllowedPaths)) {
+        // 🛸 Route to next middleware
+        return next(request, _next);
+      } else {
+        // 🛸 Redirect to dashboard
+        return NextResponse.redirect(
+          new URL(`/${paths.dashboard}`, request.url),
+        );
+      }
+    };
+
+    const routeForOtherAppRoles = () => {
+      if (pathname === "/" || pathname === `/${paths.onboarding}`) {
+        // 🛸 Redirect to dashboard
+        return NextResponse.redirect(
+          new URL(`/${paths.dashboard}`, request.url),
+        );
+      } else {
+        // 🛸 Route to next middleware
+        return next(request, _next);
+      }
+    };
+
+    // Check if the path is in the unauthenticated allow list
+    if (isInAllowedPath(pathname, unauthAllowedPaths)) {
+      // 🛸 Route to next middleware
+      return next(request, _next);
+    }
+
+    // Check if the user is authenticated via the jwt encoded in server side cookie
+    const token = await getToken();
+    if (token) {
+      // Handle user without token.user.app_role
+      if (!token.app_role || token.app_role === "") {
+        return routeWithNoAppRole();
+      }
+      // Handle user with token.user.app_role = cas_pending
+      if (token.app_role === FrontEndRoles.CAS_PENDING) {
+        return routeForRoleCasPending();
+      }
+      // else Handle user with token.user.app_role that isn't cas_pending
+      return routeForOtherAppRoles();
+    } else {
+      return routeWithNoToken();
     }
   };
 };

--- a/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.ts
+++ b/bciers/apps/dashboard/middlewares/withAuthorizationDashboard.ts
@@ -7,7 +7,6 @@ import {
 
 import { MiddlewareFactory } from "@bciers/middlewares";
 import { getToken } from "@bciers/actions";
-import { FrontEndRoles } from "@bciers/utils/src/enums";
 import isInAllowedPath from "@bciers/utils/src/isInAllowedList";
 /*
 Access control logic is managed using Next.js middleware and NextAuth.js authentication JWT session.
@@ -42,31 +41,6 @@ export const withAuthorizationDashboard: MiddlewareFactory = (
     // Check if the user is authenticated via the jwt encoded in server side cookie
     const token = await getToken();
     if (token) {
-      // Handle user without token.user.app_role
-      if (!token.app_role || token.app_role === "") {
-        if (pathname.endsWith(`/${paths.profile}`)) {
-          // 🛸 Route to next middleware
-          return next(request, _next);
-        } else {
-          // 🛸 Redirect to profile
-          return NextResponse.redirect(
-            new URL(`/administration/${paths.profile}`, request.url),
-          );
-        }
-      }
-      // Handle user with token.user.app_role = cas_pending
-      if (token.app_role === FrontEndRoles.CAS_PENDING) {
-        if (isInAllowedPath(pathname, authAllowedPaths)) {
-          // 🛸 Route to next middleware
-          return next(request, _next);
-        } else {
-          // 🛸 Redirect to dashboard
-          return NextResponse.redirect(
-            new URL(`/${paths.dashboard}`, request.url),
-          );
-        }
-      }
-
       if (pathname === "/" || pathname === `/${paths.onboarding}`) {
         // 🛸 Redirect to dashboard
         return NextResponse.redirect(

--- a/bciers/libs/components/src/navigation/Bread.tsx
+++ b/bciers/libs/components/src/navigation/Bread.tsx
@@ -64,10 +64,6 @@ export default function Bread({
   const slicedPathNames =
     lastLinkIndex !== -1 ? pathNames.slice(0, lastLinkIndex + 1) : pathNames;
 
-  console.log(
-    "Breadcrumbs slicedPathNames:",
-    slicedPathNames,)
-
   /**
    * Transforms a path segment for use in the breadcrumb.
    *

--- a/bciers/libs/components/src/navigation/Bread.tsx
+++ b/bciers/libs/components/src/navigation/Bread.tsx
@@ -64,6 +64,10 @@ export default function Bread({
   const slicedPathNames =
     lastLinkIndex !== -1 ? pathNames.slice(0, lastLinkIndex + 1) : pathNames;
 
+  console.log(
+    "Breadcrumbs slicedPathNames:",
+    slicedPathNames,)
+
   /**
    * Transforms a path segment for use in the breadcrumb.
    *

--- a/bciers/libs/e2e/src/utils/helpers.ts
+++ b/bciers/libs/e2e/src/utils/helpers.ts
@@ -383,6 +383,11 @@ export async function setupTestEnvironment(
 ) {
   let browser: Browser | null = null;
 
+  const configs = {
+    headless: true,
+    args: ["--disable-animations"],
+  };
+
   // Attempt launching browsers in order of preference
   for (const browserType of ["chromium", "firefox", "webkit"]) {
     //    console.log(browserType);  // ? always Chromium in e2e:ui
@@ -390,11 +395,11 @@ export async function setupTestEnvironment(
       browser = await (async () => {
         switch (browserType) {
           case "chromium":
-            return chromium.launch();
+            return chromium.launch(configs);
           case "firefox":
-            return firefox.launch();
+            return firefox.launch(configs);
           case "webkit":
-            return webkit.launch();
+            return webkit.launch(configs);
           default:
             throw new Error(`Unsupported browser: ${browserType}`);
         }


### PR DESCRIPTION
Card: #3186 


### 🚀 Impact:

- In `auth.config` using prefix ` __Secure` in production
- In  `/onboarding`  forces a true top‑level GET to `/dashboard`
- added routing logic from withAuthorizationDashboard (SSR) also in /onboarding page (CSR)

### 🧪 Testing:
- if testing in your local env: I'd recommend trying the steps below twice, with `reactStrictMode` set to both `true` (which we normally use in local envs) and `false` (matches our DEV, TEST, and PROD environments). This setting can be changed in `bciers/next.config.base.js` within the `baseConfig` dict. When reactStrictMode is set to true, all React components are rendered twice. The behaviour should be the same now for both (but it wasn't always this way, and gave me trouble).
- in a fresh clean browser session (so either clear your cookies & cache, or start a new Incognito browser window), sign in with your IDIR. Once you've authenticated and been redirected to either the profile page or the main dashboard, inspect your cookies for the Application. You should cookies for `session-token`, `csrf-token`, and `callback-url`, and for each of them, the SameSite attribute should be set to "Strict" (where before it was set to "Lax" by default)
- - repeat the same when logging in with Business BCeID

### ❗ Help
- E2E tests pass in local, consistently fail in CI. I don't know why. Please let me know if you have any ideas/suggestions.