### PR TITLE
3340 transfers and contacts

### DIFF
--- a/bc_obps/registration/models/rls_configs/operation.py
+++ b/bc_obps/registration/models/rls_configs/operation.py
@@ -25,7 +25,10 @@ class Rls:
             ],
             RlsRoles.CAS_DIRECTOR: [RlsOperations.SELECT],
             RlsRoles.CAS_ADMIN: [RlsOperations.SELECT],
-            RlsRoles.CAS_ANALYST: [RlsOperations.SELECT],
+            RlsRoles.CAS_ANALYST: [
+                RlsOperations.SELECT,
+                RlsOperations.DELETE,
+            ],  # Granting this permission so that user can remove the instance from the through table when transferring an operation,
             RlsRoles.CAS_VIEW_ONLY: [RlsOperations.SELECT],
         },
         RegistrationTableNames.OPERATION_REGULATED_PRODUCTS: {

--- a/bc_obps/service/transfer_event_service.py
+++ b/bc_obps/service/transfer_event_service.py
@@ -277,11 +277,10 @@ class TransferEventService:
             )
 
         # remove contacts that belong to the original operator
-        operation_contacts = event.operation.contacts.all()  # type: ignore # we are sure that operation is not None
+        operation_contacts = event.operation.contacts.filter(operator=event.from_operator)  # type: ignore # we are sure that operation is not None
         for contact in operation_contacts:
-            if contact.operator == event.from_operator:
-                # remove the contact from the operation (without deleting the contact - it might be used elsewhere)
-                event.operation.contacts.remove(contact)  # type: ignore # we are sure that operation is not None
+            # remove the contact from the operation (without deleting the contact - it might be used elsewhere)
+            event.operation.contacts.remove(contact)  # type: ignore # we are sure that operation is not None
 
         # Create a new timeline
         OperationDesignatedOperatorTimelineDataAccessService.create_operation_designated_operator_timeline(

--- a/bc_obps/service/transfer_event_service.py
+++ b/bc_obps/service/transfer_event_service.py
@@ -257,12 +257,11 @@ class TransferEventService:
             # update the facility's operation
             FacilityService.update_operation_for_facility(user_guid=user_guid, facility=facility, operation_id=event.to_operation.id)  # type: ignore # we are sure that operation is not None
 
-    # @transaction.atomic()
     @classmethod
     @transaction.atomic()
     def _process_operation_transfer(cls, event: TransferEvent, user_guid: UUID) -> None:
         """
-        Process an operation transfer event. Updates the timelines for the associated operation. Deletes operation_contacts that belong to the original operator.
+        Process an operation transfer event. Updates the timelines for the associated operation. Deletes the link between the contacts and the  original operator (ie, deletes the record in the operation_contacts through table). Does not delete the contact record in the contact table.
         """
 
         # get the current timeline for the operation and operator


### PR DESCRIPTION
card: https://github.com/bcgov/cas-registration/issues/3340

This PR:
- Updates_process_operation_transfer and removes contacts belonging to the original operator.
- Enhances tests to verify that the contacts are detached (but not deleted) correctly.
- Updates RLS configurations to include DELETE permission for the CAS_ANALYST role, supporting transfer operations.