### PR TITLE
chore: assign SFO operation BCGHGID to facility too

### DIFF
--- a/bc_obps/registration/fixtures/mock/bc_greenhouse_gas_id.json
+++ b/bc_obps/registration/fixtures/mock/bc_greenhouse_gas_id.json
@@ -26,14 +26,6 @@
   {
     "model": "registration.bcgreenhousegasid",
     "fields": {
-      "id": "23219990002",
-      "issued_at": "2023-10-13T15:27:00.000Z",
-      "comments": "For Operation 4"
-    }
-  },
-  {
-    "model": "registration.bcgreenhousegasid",
-    "fields": {
       "id": "23219990001",
       "issued_at": "2023-10-13T15:27:00.000Z",
       "comments": "For Operation 5"
@@ -328,13 +320,6 @@
     "model": "registration.bcgreenhousegasid",
     "fields": {
       "id": "13219990025",
-      "issued_at": "2024-10-31T15:27:00.000Z"
-    }
-  },
-  {
-    "model": "registration.bcgreenhousegasid",
-    "fields": {
-      "id": "13219990026",
       "issued_at": "2024-10-31T15:27:00.000Z"
     }
   },

--- a/bc_obps/registration/fixtures/mock/bc_obps_regulated_operation.json
+++ b/bc_obps/registration/fixtures/mock/bc_obps_regulated_operation.json
@@ -10,14 +10,6 @@
   {
     "model": "registration.bcobpsregulatedoperation",
     "fields": {
-      "id": "23-0002",
-      "issued_at": "2023-10-13T15:27:00.000Z",
-      "comments": "Test comment"
-    }
-  },
-  {
-    "model": "registration.bcobpsregulatedoperation",
-    "fields": {
       "id": "24-0003",
       "issued_at": "2024-10-13T15:27:00.000Z",
       "comments": "Test comment"

--- a/bc_obps/registration/fixtures/mock/facility.json
+++ b/bc_obps/registration/fixtures/mock/facility.json
@@ -314,12 +314,11 @@
       "name": "Facility 22",
       "type": "Single Facility",
       "swrs_facility_id": 1022,
-      "bcghg_id": "13219990026",
+      "bcghg_id": "23219990003",
       "latitude_of_largest_emissions": 43.5,
       "longitude_of_largest_emissions": -123.5
     }
   },
-
   {
     "model": "registration.facility",
     "pk": "4486f2fb-62ed-438d-bb3e-0819b51e3aff",
@@ -359,6 +358,7 @@
       "name": "Bubblegum",
       "type": "Single Facility",
       "swrs_facility_id": 1026,
+      "bcghg_id": "23219990001",
       "latitude_of_largest_emissions": 43.5,
       "longitude_of_largest_emissions": -123.5
     }
@@ -373,6 +373,7 @@
       "name": "Alleyoop",
       "type": "Single Facility",
       "swrs_facility_id": 1027,
+      "bcghg_id": "23219999999",
       "latitude_of_largest_emissions": 43.5,
       "longitude_of_largest_emissions": -123.5
     }

--- a/bc_obps/registration/fixtures/mock/operation.json
+++ b/bc_obps/registration/fixtures/mock/operation.json
@@ -70,13 +70,11 @@
     "fields": {
       "operator": "685d581b-5698-411f-ae00-de1d97334a71",
       "submission_date": "2024-01-12T15:27:00.000Z",
-      "name": "Alien SFO - Registered - no facility",
+      "name": "Alien SFO - Draft - no facility",
       "type": "Single Facility Operation",
       "naics_code": 21,
-      "bcghg_id": "23219990002",
       "regulated_products": [1],
-      "status": "Registered",
-      "bc_obps_regulated_operation": "23-0002",
+      "status": "Draft",
       "activities": [1, 5],
       "registration_purpose": "OBPS Regulated Operation",
       "contacts": [1]

--- a/bc_obps/registration/tests/endpoints/_operations/_operation_id/test_bcghg_id.py
+++ b/bc_obps/registration/tests/endpoints/_operations/_operation_id/test_bcghg_id.py
@@ -8,6 +8,11 @@ from model_bakery import baker
 class TestOperationBcghgIdEndpoint(CommonTestSetup):
     def test_authorized_role_can_issue_id(self):
         operation = baker.make_recipe('registration.tests.utils.operation', status=Operation.Statuses.REGISTERED)
+        # facility
+        baker.make_recipe(
+            'registration.tests.utils.facility',
+            operation=operation,
+        )
 
         response = TestUtils.mock_patch_with_auth_role(
             self,

--- a/bc_obps/service/operation_service.py
+++ b/bc_obps/service/operation_service.py
@@ -654,6 +654,7 @@ class OperationService:
 
         # For SFOs, facility should also have the BCGHG ID
         if operation.type == Operation.Types.SFO:
+            # an operation muse be registered before it can be issued a BCGHG ID, so there will always be a facility
             sfo_facility = Facility.objects.get(operation=operation)
             sfo_facility.bcghg_id = operation.bcghg_id
             sfo_facility.save(update_fields=['bcghg_id'])


### PR DESCRIPTION
card: https://github.com/orgs/bcgov/projects/123/views/16?pane=issue&itemId=108763205&issue=bcgov%7Ccas-registration%7C3287

This PR:
- Introduces tests in TestGenerateBCGHGId to validate user access and proper BCGHG ID assignment for SFO and non-assignment for LFO.
- Wraps the generate_bcghg_id method in a transactional block and updates the facility’s BCGHG ID for SFO operations.
- Updates mock data so SFO facilities have the same BCGHG IDs as their operations. Also made Alien a draft because it can't be registered if it doesn't have a facility

Note that we don't show BCGHG ID on the SFO form (will be added in https://github.com/bcgov/cas-registration/issues/3286), so to test this, you'll have to temporarily add it, or check in the db.