### PR TITLE
chore: Added default page for activity not implemented

### DIFF
--- a/bc_obps/reporting/tests/api/test_build_form_schema.py
+++ b/bc_obps/reporting/tests/api/test_build_form_schema.py
@@ -34,7 +34,7 @@ class TestBuildFormSchema(CommonTestSetup):
         assert response.status_code == 422
 
     # SCHEMAS
-    def test_error_if_no_valid_activity_schema(self):
+    def test_returns_fallback_schema_if_no_valid_activity_schema(self):
         report_version = baker.make_recipe("reporting.tests.utils.report_version", report__reporting_year_id=2024)
         facility_report = baker.make_recipe("reporting.tests.utils.facility_report", report_version=report_version)
         operator = report_version.report.operator
@@ -45,8 +45,9 @@ class TestBuildFormSchema(CommonTestSetup):
             "industry_user",
             f'{self.endpoint}?activity=0&report_version_id={report_version.id}&facility_id={facility_report.facility.id}',
         )
-        assert response.status_code == 404
-        assert response.json().get('message') == "Not Found"
+        assert response.status_code == 200
+        response_object = json.loads(response.json())
+        assert response_object["schema"]["isFallbackSchema"] is True
 
     def test_error_if_no_valid_source_type_schema(self):
         report_version = baker.make_recipe("reporting.tests.utils.report_version", report__reporting_year_id=2024)

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -126,8 +126,8 @@ export default function ActivityForm({
   // 🛠️ Function to submit user form data to API
   const submitHandler = async (e: IChangeEvent) => {
     if (isFallbackSchema) {
-      console.log("Fallback schema, skipping submit");
-      return true; // Exit early
+      //if the schema is a fallback schema, we just return true
+      return true;
     }
 
     setErrorList([]);
@@ -187,9 +187,6 @@ export default function ActivityForm({
 
     return false;
   };
-  console.log("initialJsonSchema", initialJsonSchema);
-  console.log("uischema", getUiSchema(currentActivity.slug));
-
   return (
     <MultiStepFormWithTaskList
       steps={navigationInformation.headerSteps}

--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -59,9 +59,8 @@ export default function ActivityForm({
   const [selectedSourceTypeIds, setSelectedSourceTypeIds] = useState(
     initialSelectedSourceTypeIds,
   );
-
   const { activityId, sourceTypeMap } = activityData;
-
+  const isFallbackSchema = initialJsonSchema?.isFallbackSchema;
   const arrayEquals = (x: string[], y: string[]) => {
     x = x.sort((a, b) => a.localeCompare(b));
     y = y.sort((a, b) => a.localeCompare(b));
@@ -126,8 +125,14 @@ export default function ActivityForm({
 
   // 🛠️ Function to submit user form data to API
   const submitHandler = async (e: IChangeEvent) => {
+    if (isFallbackSchema) {
+      console.log("Fallback schema, skipping submit");
+      return true; // Exit early
+    }
+
     setErrorList([]);
     const sourceTypeCount = Object.keys(sourceTypeMap).length;
+
     // Ensure we use the filtered formData with omitted extra data
     const filteredData = e.formData;
 
@@ -182,6 +187,8 @@ export default function ActivityForm({
 
     return false;
   };
+  console.log("initialJsonSchema", initialJsonSchema);
+  console.log("uischema", getUiSchema(currentActivity.slug));
 
   return (
     <MultiStepFormWithTaskList
@@ -191,6 +198,7 @@ export default function ActivityForm({
       onSubmit={submitHandler}
       schema={jsonSchema}
       fields={CUSTOM_FIELDS}
+      noSaveButton={isFallbackSchema}
       formData={formState}
       uiSchema={getUiSchema(currentActivity.slug)}
       onChange={debounce(handleFormChange, 200)}
@@ -202,6 +210,7 @@ export default function ActivityForm({
       formContext={{
         gasTypes,
       }}
+      buttonText={isFallbackSchema ? "Continue" : "Save and Continue"}
     />
   );
 }

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/custom.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/custom.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+export const CustomHelpText = (
+  <Box>
+    <Typography variant="body1" sx={{ mb: 2 }}>
+      This activity form is currently not available in BCIERS.
+    </Typography>
+    <Typography variant="body1">
+      If you believe you need to report under this activity, please contact
+      ghgregulator@gov.bc.ca.
+    </Typography>
+  </Box>
+);

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/fallbackUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/fallbackUiSchema.ts
@@ -1,0 +1,13 @@
+import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
+import { TitleOnlyFieldTemplate } from "@bciers/components/form/fields";
+import { CustomHelpText } from "@reporting/src/app/components/activities/uiSchemas/custom";
+
+const uiSchema = {
+  "ui:FieldTemplate": FieldTemplate,
+  "ui:classNames": "form-heading-label",
+  description: {
+    "ui:FieldTemplate": TitleOnlyFieldTemplate,
+    "ui:title": CustomHelpText,
+  },
+};
+export default uiSchema;

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/schemaMaps.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/schemaMaps.tsx
@@ -23,6 +23,7 @@ import coalStorageUiSchema from "./coalStorageUiSchema";
 import zincProductionUiSchema from "./zincProductionUiSchema";
 import petroleumRefiningUiSchema from "./petroleumRefiningUiSchema";
 import leadProductionUiSchema from "./leadProductionUiSchema";
+import fallbackUiSchema from "./fallbackUiSchema";
 
 type UiSchemaMap = {
   [key: string]: any;
@@ -56,6 +57,17 @@ export const uiSchemaMap: UiSchemaMap = {
   zinc_production: zincProductionUiSchema,
   petroleum_refining: petroleumRefiningUiSchema,
   lead_production: leadProductionUiSchema,
+  electronics_manufacturing: fallbackUiSchema,
+  ammonia_production: fallbackUiSchema,
+  underground_coal_mining: fallbackUiSchema,
+  copper_nickel_refining: fallbackUiSchema,
+  ferroalloy_production: fallbackUiSchema,
+  glass_manufacturing: fallbackUiSchema,
+  magnesium_production: fallbackUiSchema,
+  nitric_acid_manufacturing: fallbackUiSchema,
+  petrochemical_production: fallbackUiSchema,
+  phos_acid_production: fallbackUiSchema,
+  electricity_transmission: fallbackUiSchema,
 };
 
 export const getUiSchema = (slug: string) => {


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/754
Changes: 
1. Implemented logic to return a fallback schema when no valid ActivityJsonSchema is found for the specified activity_id.
2. Updated Activity form to check for fallbackSchema, if exist then update the form according and do not  mak a post request.
3. Updated tests

To test:-
1. Go to http://localhost:3000/reporting/reports
2. Start a report and select activities like Electronics manufacturing, Phosphorous acid Production or other activities which havent been implemented yet on http://localhost:3000/reporting/reports/1/review-operation-information. 
3. On activities page select this activities and you will see page like 
<img width="1383" alt="image" src="https://github.com/user-attachments/assets/9cf1cae0-71f1-4cf1-a20d-5fa29d1d3a97" />
