### PR TITLE
3268 3 logout redirect

### DIFF
--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.test.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.test.tsx
@@ -1,6 +1,6 @@
 import { expect, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
-import { useSession, signOut, getSession } from "next-auth/react";
+import { useSession, signOut } from "next-auth/react";
 import SessionTimeoutHandler, {
   ACTIVITY_THROTTLE_SECONDS,
   MODAL_DISPLAY_SECONDS,
@@ -67,7 +67,6 @@ describe("SessionTimeoutHandler", () => {
   const mockCreateThrottledEventHandler =
     createThrottledEventHandler as ReturnType<typeof vi.fn>;
   const mockGetToken = getToken as ReturnType<typeof vi.fn>;
-  const mockGetSession = getSession as ReturnType<typeof vi.fn>;
 
   const defaultSession = {
     data: { expires: new Date(Date.now() + 180 * 1000).toISOString() },
@@ -112,21 +111,21 @@ describe("SessionTimeoutHandler", () => {
     );
   });
 
-  it("updates session expiry on user activity when modal is not shown", async () => {
-    let capturedSession: (event: Event) => Promise<void> = () =>
+  it("refreshes session on user activity when modal is not shown", async () => {
+    let capturedRefreshSession: (event: Event) => Promise<void> = () =>
       Promise.resolve();
 
     mockCreateThrottledEventHandler.mockImplementation((refreshSession) => {
-      capturedSession = refreshSession;
+      capturedRefreshSession = refreshSession;
       return () => {}; // Return a no-op cleanup function
     });
 
     renderWithSession();
 
     // Manually invoke the refreshSession to simulate activity
-    await capturedSession(new Event("mousemove"));
+    await capturedRefreshSession(new Event("mousemove"));
 
-    await waitFor(() => expect(mockGetSession).toHaveBeenCalled());
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
   });
 
   it("logs out, broadcasts, and redirects when session timeout reaches zero", async () => {

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -9,8 +9,8 @@ import { getSession, signOut, useSession } from "next-auth/react";
 import { BroadcastChannel } from "broadcast-channel";
 import createThrottledEventHandler from "./throttleEventsEffect";
 
-export const ACTIVITY_THROTTLE_SECONDS = 10; // Seconds to throttle user activity events (2 minutes)
-export const MODAL_DISPLAY_SECONDS = 30; // Seconds before timeout to show logout warning modal (5 minutes);
+export const ACTIVITY_THROTTLE_SECONDS = 2 * 60; // Seconds to throttle user activity events (2 minutes)
+export const MODAL_DISPLAY_SECONDS = 5 * 60; // Seconds before timeout to show logout warning modal (5 minutes);
 
 const getExpirationTimeInSeconds = (expires: string | undefined): number => {
   if (!expires) return Infinity; // No expiration set, return infinite timeout

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -10,8 +10,8 @@ import { BroadcastChannel } from "broadcast-channel";
 import createThrottledEventHandler from "./throttleEventsEffect";
 import { useRouter } from "next/navigation";
 
-export const ACTIVITY_THROTTLE_SECONDS = 2 * 60; // Seconds to throttle user activity events (2 minutes)
-export const MODAL_DISPLAY_SECONDS = 5 * 60; // Seconds before timeout to show logout warning modal (5 minutes);
+export const ACTIVITY_THROTTLE_SECONDS = 15; // Seconds to throttle user activity events (2 minutes)
+export const MODAL_DISPLAY_SECONDS = 30; // Seconds before timeout to show logout warning modal (5 minutes);
 
 const getExpirationTimeInSeconds = (expires: string | undefined): number => {
   if (!expires) return Infinity; // No expiration set, return infinite timeout
@@ -40,12 +40,11 @@ const SessionTimeoutHandler: React.FC = () => {
   const handleLogout = async () => {
     // broadcast logout to other browser tabs
     logoutChannelRef.current?.postMessage("logout");
+    const logoutUrl = await getLogoutUrl();
     try {
-      const logoutUrl = await getLogoutUrl();
       await signOut({ redirect: true, redirectTo: logoutUrl || "/" });
     } finally {
       // signOut's redirectTo doesn't work in some cases, so we manually redirect as well https://github.com/nextauthjs/next-auth/issues/10944
-      const logoutUrl = await getLogoutUrl();
       router.push(logoutUrl || "/");
     }
   };

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -8,7 +8,6 @@ import * as Sentry from "@sentry/nextjs";
 import { getSession, signOut, useSession } from "next-auth/react";
 import { BroadcastChannel } from "broadcast-channel";
 import createThrottledEventHandler from "./throttleEventsEffect";
-import { useRouter } from "next/navigation";
 
 export const ACTIVITY_THROTTLE_SECONDS = 2 * 60; // Seconds to throttle user activity events (2 minutes)
 export const MODAL_DISPLAY_SECONDS = 5 * 60; // Seconds before timeout to show logout warning modal (5 minutes);
@@ -24,7 +23,7 @@ const SessionTimeoutHandler: React.FC = () => {
   const [sessionTimeout, setSessionTimeout] = useState<number>(
     getExpirationTimeInSeconds(session?.expires),
   );
-  const router = useRouter();
+
   const logoutChannelRef = useRef<BroadcastChannel | null>(null);
   const extendSessionChannelRef = useRef<BroadcastChannel | null>(null);
 
@@ -45,7 +44,7 @@ const SessionTimeoutHandler: React.FC = () => {
       await signOut({ redirect: true, redirectTo: logoutUrl || "/" });
     } finally {
       // signOut's redirectTo doesn't work in some cases, so we manually redirect as well https://github.com/nextauthjs/next-auth/issues/10944
-      router.push(logoutUrl || "/");
+      window.location.href = logoutUrl || "/";
     }
   };
 
@@ -78,7 +77,7 @@ const SessionTimeoutHandler: React.FC = () => {
     logoutChannel.onmessage = async (event) => {
       if (event === "logout") {
         const logoutUrl = await getLogoutUrl();
-        router.push(logoutUrl || "/");
+        window.location.href = logoutUrl || "/";
       }
     };
 

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -10,8 +10,8 @@ import { BroadcastChannel } from "broadcast-channel";
 import createThrottledEventHandler from "./throttleEventsEffect";
 import { useRouter } from "next/navigation";
 
-export const ACTIVITY_THROTTLE_SECONDS = 15; // Seconds to throttle user activity events (2 minutes)
-export const MODAL_DISPLAY_SECONDS = 30; // Seconds before timeout to show logout warning modal (5 minutes);
+export const ACTIVITY_THROTTLE_SECONDS = 2 * 60; // Seconds to throttle user activity events (2 minutes)
+export const MODAL_DISPLAY_SECONDS = 5 * 60; // Seconds before timeout to show logout warning modal (5 minutes);
 
 const getExpirationTimeInSeconds = (expires: string | undefined): number => {
   if (!expires) return Infinity; // No expiration set, return infinite timeout

--- a/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
+++ b/bciers/libs/components/src/auth/SessionTimeoutHandler.tsx
@@ -88,14 +88,14 @@ const SessionTimeoutHandler: React.FC = () => {
     };
   }, []);
 
-  // extend session broadcast channel (extend the session in all tabs if a user clicks the modal extend session button)
+  // extend session broadcast channel (get the new expiry in all tabs if a user clicks the modal extend session button)
   useEffect(() => {
     const extendSessionChannel = new BroadcastChannel("extend-session");
     extendSessionChannelRef.current = extendSessionChannel;
 
     extendSessionChannel.onmessage = async (event) => {
       if (event === "extend-session") {
-        await refreshSession();
+        await getSession();
       }
     };
 
@@ -132,9 +132,8 @@ const SessionTimeoutHandler: React.FC = () => {
       ) {
         return; // Ignore when tab is hidden
       }
-      // The session is refreshed every time `getSession` is called.
-      const updatedSession = await getSession();
-      setSessionTimeout(getExpirationTimeInSeconds(updatedSession?.expires));
+      extendSessionChannelRef.current?.postMessage("extend-session");
+      await refreshSession();
     };
 
     // Create a throttled handler to monitor user activity without overloading the system


### PR DESCRIPTION
card #3268 

This PR:
- removes the refresh from the broadcast useEffect and uses getSession instead (we think refreshing in multiple tabs made update not work). Also updates the local state
- activityHandler doesn't run if the modal is open
- puts redirectTo back in. @Sepehr-Sobhani wasn't being logged out properly without it