### PR TITLE
chore: update endpoint is not allowed error message

### DIFF
--- a/bciers/libs/actions/src/actions.ts
+++ b/bciers/libs/actions/src/actions.ts
@@ -9,7 +9,9 @@ and can be called from server components or from client components.
 
 import { cookies } from "next/headers";
 import { ContentItem } from "@bciers/types/tiles";
-import getUUIDFromEndpoint from "@bciers/utils/src/getUUIDFromEndpoint";
+import getUUIDFromEndpoint, {
+  ENDPOINT_NOT_ALLOWED_ERROR,
+} from "@bciers/utils/src/getUUIDFromEndpoint";
 import { revalidatePath } from "next/cache";
 import * as Sentry from "@sentry/nextjs";
 import safeJsonParse from "@bciers/utils/src/safeJsonParse";
@@ -112,12 +114,15 @@ export async function actionHandler(
         return data;
       } catch (error: unknown) {
         Sentry.captureException(error as Error);
-        // Handle any errors, including network issues
         if (error instanceof Error) {
           // eslint-disable-next-line no-console
           console.error(`An error occurred while fetching ${endpoint}:`, error);
+          if (error.message === ENDPOINT_NOT_ALLOWED_ERROR) {
+            return {
+              error: `Your session has timed out. Please log in again at https://industrialemissions.gov.bc.ca/onboarding to continue.`,
+            };
+          }
           return {
-            // eslint-disable-next-line no-console
             error: `An error occurred while fetching ${endpoint}: ${error.message}`,
           };
         } else {

--- a/bciers/libs/utils/src/actions.test.ts
+++ b/bciers/libs/utils/src/actions.test.ts
@@ -172,7 +172,7 @@ describe("actionHandler function", () => {
 
     expect(result).toEqual({
       error:
-        "An error occurred while fetching /endpoint: Endpoint is not allowed",
+        "Your session has timed out. Please log in again at https://industrialemissions.gov.bc.ca/onboarding to continue.",
     });
   });
 

--- a/bciers/libs/utils/src/getUUIDFromEndpoint.ts
+++ b/bciers/libs/utils/src/getUUIDFromEndpoint.ts
@@ -3,6 +3,7 @@ export const endpointAllowList = [
   "registration/user-operators/current/is-current-user-approved-admin",
   "registration/user/user-profile",
 ];
+export const ENDPOINT_NOT_ALLOWED_ERROR = "Endpoint is not allowed";
 
 // 🛠️ Function to get the last non-empty segment as a UUID from an endpoint URL
 function getUUIDFromEndpoint(endpoint: string): string | null {
@@ -11,7 +12,7 @@ function getUUIDFromEndpoint(endpoint: string): string | null {
   );
 
   if (!isEndpointAllowed) {
-    throw new Error("Endpoint is not allowed");
+    throw new Error(ENDPOINT_NOT_ALLOWED_ERROR);
   }
   // Split the endpoint URL by '/'
   const segments = endpoint.split("/");


### PR DESCRIPTION
card: https://github.com/bcgov/cas-registration/issues/3398

This PR:
- changes the wording of the endpoint is not allowed error 
- updates vitests
- I didn't want to use dangerouslySetInnerHtml, so checked with Patricia and having the link not hyperlinked is ok. If the reviewer has another fix though, would love to hear it! (It's impractical to transform the error on the FE like we did [here](https://teams.microsoft.com/l/message/19:81544b60877c4a5eb4fc7946ecbcb525@thread.tacv2/1743782396664?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&groupId=29821293-3244-455d-beae-e01d27762cfe&parentMessageId=1736798769019&teamName=External%3A%20CAS%20-%20Clean%20Growth%20Digital%20Service%20Team&channelName=Developers&createdTime=1743782396664&ngc=true) because this endpoint error can appear anywhere in the app vs. in a specific component)

