### PR TITLE
Fix/reporting routes/780 782

### DIFF
--- a/bciers/apps/reporting/src/app/components/changeReview/ChangeReviewPage.tsx
+++ b/bciers/apps/reporting/src/app/components/changeReview/ChangeReviewPage.tsx
@@ -32,8 +32,6 @@ export default async function ChangeReviewPage({
       skipChangeReview: !isSupplementaryReport,
     },
   );
-  console.log("skipVerificationPage:", !showVerificationPage);
-  console.log("skipChangeReview:", !isSupplementaryReport);
   return (
     <ChangeReviewForm
       versionId={version_id}

--- a/bciers/apps/reporting/src/app/components/finalReview/FinalReviewPage.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FinalReviewPage.tsx
@@ -31,8 +31,6 @@ export default async function FinalReviewPage({
   const { show_verification_page: showVerificationPage } =
     await getReportVerificationStatus(version_id);
 
-  console.log("skipVerificationPage:", !showVerificationPage);
-  console.log("skipChangeReview:", !isSupplementaryReport);
   const navInfo = await getNavigationInformation(
     HeaderStep.SignOffSubmit,
     ReportingPage.FinalReview,

--- a/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
@@ -19,9 +19,6 @@ export default async function SignOffPage({ version_id }: HasReportVersion) {
   //🔍 Check if reports need verification
   const { show_verification_page: showVerificationPage } =
     await getReportVerificationStatus(version_id);
-  console.log("checking to see if verification page should be shown", {
-    showVerificationPage,
-  });
 
   const navInfo = await getNavigationInformation(
     HeaderStep.SignOffSubmit,
@@ -33,7 +30,6 @@ export default async function SignOffPage({ version_id }: HasReportVersion) {
       skipChangeReview: !isSupplementaryReport,
     },
   );
-  console.log("navigation info", navInfo);
   const flow = await getFlow(version_id);
 
   const schema = buildSignOffSchema(

--- a/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
+++ b/bciers/apps/reporting/src/app/components/signOff/SignOffPage.tsx
@@ -19,6 +19,9 @@ export default async function SignOffPage({ version_id }: HasReportVersion) {
   //🔍 Check if reports need verification
   const { show_verification_page: showVerificationPage } =
     await getReportVerificationStatus(version_id);
+  console.log("checking to see if verification page should be shown", {
+    showVerificationPage,
+  });
 
   const navInfo = await getNavigationInformation(
     HeaderStep.SignOffSubmit,
@@ -30,6 +33,7 @@ export default async function SignOffPage({ version_id }: HasReportVersion) {
       skipChangeReview: !isSupplementaryReport,
     },
   );
+  console.log("navigation info", navInfo);
   const flow = await getFlow(version_id);
 
   const schema = buildSignOffSchema(

--- a/bciers/apps/reporting/src/app/components/taskList/navigationInformation.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/navigationInformation.ts
@@ -11,7 +11,6 @@ import { headerElementFactory } from "./headerElementFactory";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import {
   getFlow,
-  getFlowData,
   reportingFlows,
 } from "@reporting/src/app/components/taskList/reportingFlows";
 
@@ -68,19 +67,12 @@ export async function getNavigationInformation(
   // get flow
   const flow = await getFlow(reportVersionId);
 
-  console.log("from page ", page);
-  console.log("[getNavigationInformation] flow:", flow);
-
   // build tasklist from factories
   const flowData = reportingFlows[flow] as ReportingFlowDescription;
 
-  console.log("[getNavigationInformation] flowData:", flowData);
   if (!flowData) throw Error(`No reporting flow found for ${flow}`);
 
   const headerSteps: HeaderStep[] = Object.keys(flowData) as HeaderStep[];
-
-  console.log("[getNavigationInformation] context", context);
-  console.log("[getNavigationInformation] original pages:", flowData[step]);
 
   // Original pages array from flowData
   const pages = [...(flowData[step] as ReportingPage[])]; // make a shallow copy
@@ -92,40 +84,19 @@ export async function getNavigationInformation(
     ),
   );
 
-  console.log(
-    "[getNavigationInformation] tasklistPagesTemp after factory calls:",
-    tasklistPagesTemp,
-  );
-
   // Remove corresponding pages where tasklistPagesTemp has extraOptions.skip === true
   for (let i = tasklistPagesTemp.length - 1; i >= 0; i--) {
     if (tasklistPagesTemp[i].extraOptions?.skip) {
-      console.log(
-        `[getNavigationInformation] removing page at index ${i} (${pages[i]}) due to skip flag`,
-      );
       pages.splice(i, 1);
     }
   }
-  console.log("[getNavigationInformation] filtered pages:", pages);
 
   // Filter tasklistPages when element has extraOptions.skip === true
   const tasklistPages = tasklistPagesTemp.filter((p) => {
     const keep = !p.extraOptions?.skip;
-    if (!keep) {
-      console.log(
-        `[getNavigationInformation] filtering out tasklist page (${JSON.stringify(
-          p.element,
-          null,
-          2,
-        )})`,
-      );
-    }
+
     return keep;
   });
-  console.log(
-    "[getNavigationInformation] tasklistPages after filtering:",
-    tasklistPages,
-  );
 
   const [taskListHeaderPages, taskListNonHeaderPages] =
     splitHeaderElements(tasklistPages);

--- a/bciers/apps/reporting/src/app/components/taskList/navigationInformation.ts
+++ b/bciers/apps/reporting/src/app/components/taskList/navigationInformation.ts
@@ -11,6 +11,7 @@ import { headerElementFactory } from "./headerElementFactory";
 import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import {
   getFlow,
+  getFlowData,
   reportingFlows,
 } from "@reporting/src/app/components/taskList/reportingFlows";
 
@@ -67,10 +68,12 @@ export async function getNavigationInformation(
   // get flow
   const flow = await getFlow(reportVersionId);
 
+  console.log("from page ", page);
   console.log("[getNavigationInformation] flow:", flow);
 
   // build tasklist from factories
   const flowData = reportingFlows[flow] as ReportingFlowDescription;
+
   console.log("[getNavigationInformation] flowData:", flowData);
   if (!flowData) throw Error(`No reporting flow found for ${flow}`);
 
@@ -80,13 +83,18 @@ export async function getNavigationInformation(
   console.log("[getNavigationInformation] original pages:", flowData[step]);
 
   // Original pages array from flowData
-  const pages = flowData[step] as ReportingPage[];
+  const pages = [...(flowData[step] as ReportingPage[])]; // make a shallow copy
 
   // Build tasklistPages from the factories
   const tasklistPagesTemp = await Promise.all(
     pages.map(async (p) =>
       pageElementFactory(p, page, reportVersionId, facilityId, context),
     ),
+  );
+
+  console.log(
+    "[getNavigationInformation] tasklistPagesTemp after factory calls:",
+    tasklistPagesTemp,
   );
 
   // Remove corresponding pages where tasklistPagesTemp has extraOptions.skip === true

--- a/bciers/apps/reporting/src/middlewares/withRuleHasReportRouteAccess.ts
+++ b/bciers/apps/reporting/src/middlewares/withRuleHasReportRouteAccess.ts
@@ -361,7 +361,6 @@ const checkHasPathAccess = async (request: NextRequest) => {
     if (!reportVersionId) return null;
     // Create a caching context for this request
     const context = createRuleContext();
-    console.log("context", context);
     // Iterate over each rule and validate if it applies
     for (const rule of permissionRules) {
       if (await rule.isApplicable(request, reportVersionId, context)) {
@@ -392,7 +391,6 @@ export const withRuleHasReportRouteAccess: MiddlewareFactory = (
     if (role === IDP.BCEIDBUSINESS) {
       try {
         const response = await checkHasPathAccess(request);
-        console.log("Response from checkHasPathAccess:", response);
         if (response) {
           return response;
         }

--- a/bciers/apps/reporting/src/middlewares/withRuleHasReportRouteAccess.ts
+++ b/bciers/apps/reporting/src/middlewares/withRuleHasReportRouteAccess.ts
@@ -228,7 +228,6 @@ export const permissionRules: PermissionRule[] = [
     validate: async (reportVersionId, _request, context) => {
       const verificationStatus =
         await await context!.getReportVerificationStatus(reportVersionId);
-      console.log("Verification Status:", verificationStatus);
       return verificationStatus.show_verification_page;
     },
     redirect: (reportVersionId, request) =>
@@ -251,7 +250,6 @@ export const permissionRules: PermissionRule[] = [
     validate: async (reportVersionId, _request, context) => {
       const isSupplementaryReport =
         await context!.getIsSupplementaryReport(reportVersionId);
-      console.log("isSupplementaryReport:", isSupplementaryReport);
 
       return isSupplementaryReport === true;
     },
@@ -365,9 +363,7 @@ const checkHasPathAccess = async (request: NextRequest) => {
     for (const rule of permissionRules) {
       if (await rule.isApplicable(request, reportVersionId, context)) {
         const isValid = await rule.validate(reportVersionId, request, context);
-        console.log(
-          `Rule: ${rule.name}, isValid: ${isValid}, reportVersionId: ${reportVersionId}`,
-        );
+
         if (!isValid) {
           return rule.redirect(reportVersionId, request);
         }

--- a/bciers/apps/reporting/src/middlewares/withRuleHasReportRouteAccess.ts
+++ b/bciers/apps/reporting/src/middlewares/withRuleHasReportRouteAccess.ts
@@ -227,7 +227,7 @@ export const permissionRules: PermissionRule[] = [
     },
     validate: async (reportVersionId, _request, context) => {
       const verificationStatus =
-        await await context!.getReportVerificationStatus(reportVersionId);
+        await context!.getReportVerificationStatus(reportVersionId);
       return verificationStatus.show_verification_page;
     },
     redirect: (reportVersionId, request) =>


### PR DESCRIPTION
Cards: #780, #782

The problem: `pages` in `navigationInformation.ts` was a deep copy, so if a page was removed from navigation, it would then not get added back in. 
The fix: make a shallow copy of `pages` instead.

To test https://github.com/bcgov/cas-reporting/issues/780:
- create an operation with registration purpose "Reporting Operation", and register it
- create a new report for your operation, and first set the operation's total emissions to below 25k. Navigate all the way through to the Sign Off & Submit section, but don't submit yet. The "Verification" page should not appear because emissions < 25k.
- navigate back to the emissions reporting section, and edit the emissions to be above 25k. Then click through all the way to Sign Off & Submit
- you should now see the "Verification" page because total emissions exceed 25k.

To test https://github.com/bcgov/cas-reporting/issues/782:
(this was only found to be reproducible in DEV, not local)
- create a supplementary report from a submitted annual report
- make arbitrary change to the report's data
- navigate through to Sign Off & Submit section, confirm that "Change Review" page appears