### PR TITLE
fix: do not reapply rls operations unnecessarily on container startup

### DIFF
--- a/bc_obps/common/management/commands/custom_migrate.py
+++ b/bc_obps/common/management/commands/custom_migrate.py
@@ -3,6 +3,26 @@ from django.core.management.base import BaseCommand
 from django.core.management import call_command
 from rls.utils.manager import RlsManager
 from registration.models import Operation
+from django.db.migrations.loader import MigrationLoader
+from django.db import connections
+
+
+def has_unapplied_migrations(connection_alias='default'):
+    # Initialize the MigrationLoader with the database connection
+    loader = MigrationLoader(connections[connection_alias])
+
+    # Load migration information from disk
+    loader.load_disk()  # Loads migrations from disk
+
+    # Get all migrations (on disk) and applied migrations (from database)
+    all_migrations = loader.disk_migrations  # Dict of migrations on disk
+    applied_migrations = loader.applied_migrations  # Set of applied migrations
+
+    # Check for unapplied migrations
+    for migration_key in all_migrations:
+        if migration_key not in applied_migrations:
+            return True
+    return False
 
 
 class Command(BaseCommand):
@@ -10,8 +30,15 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         environment = settings.ENVIRONMENT
+
+        has_migrations = has_unapplied_migrations()
         call_command('migrate')
-        RlsManager.re_apply_rls()
+        if has_migrations:
+            print('Applying RLS Operations')
+            RlsManager.re_apply_rls()
+        else:
+            print('Skipping RLS Operations')
+
         if environment != 'prod':
             self.load_env_specific_fixtures(environment)
 


### PR DESCRIPTION
hotfix to stop our backend pods from reapplying rls whenever scaled up by the horizontal pod autoscaler