### PR TITLE
fix: disable sticky sessions in k8s routes to even out load among pods

### DIFF
--- a/helm/cas-bciers/templates/administration/route.yaml
+++ b/helm/cas-bciers/templates/administration/route.yaml
@@ -20,7 +20,7 @@ metadata:
     haproxy.router.openshift.io/rewrite-target: {{ .Values.administrationFrontend.route.path }}
     haproxy.router.openshift.io/disable_cookies: 'true'
     "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 
 spec:
   host: {{ .Values.administrationFrontend.route.host }}

--- a/helm/cas-bciers/templates/administration/route.yaml
+++ b/helm/cas-bciers/templates/administration/route.yaml
@@ -18,6 +18,9 @@ metadata:
   annotations:
     haproxy.router.openshift.io/balance: roundrobin
     haproxy.router.openshift.io/rewrite-target: {{ .Values.administrationFrontend.route.path }}
+    haproxy.router.openshift.io/disable_cookies: 'true'
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 
 spec:
   host: {{ .Values.administrationFrontend.route.host }}

--- a/helm/cas-bciers/templates/compliance/route.yaml
+++ b/helm/cas-bciers/templates/compliance/route.yaml
@@ -20,7 +20,7 @@ metadata:
     haproxy.router.openshift.io/rewrite-target: {{ .Values.complianceFrontend.route.path }}
     haproxy.router.openshift.io/disable_cookies: 'true'
     "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 
 spec:
   host: {{ .Values.complianceFrontend.route.host }}

--- a/helm/cas-bciers/templates/compliance/route.yaml
+++ b/helm/cas-bciers/templates/compliance/route.yaml
@@ -18,6 +18,9 @@ metadata:
   annotations:
     haproxy.router.openshift.io/balance: roundrobin
     haproxy.router.openshift.io/rewrite-target: {{ .Values.complianceFrontend.route.path }}
+    haproxy.router.openshift.io/disable_cookies: 'true'
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 
 spec:
   host: {{ .Values.complianceFrontend.route.host }}

--- a/helm/cas-bciers/templates/dashboard/route.yaml
+++ b/helm/cas-bciers/templates/dashboard/route.yaml
@@ -20,8 +20,7 @@ metadata:
     haproxy.router.openshift.io/rewrite-target: /
     haproxy.router.openshift.io/disable_cookies: 'true'
     "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   host: {{ .Values.dashboardFrontend.route.host }}
   path: {{ .Values.dashboardFrontend.route.path }}

--- a/helm/cas-bciers/templates/dashboard/route.yaml
+++ b/helm/cas-bciers/templates/dashboard/route.yaml
@@ -18,6 +18,9 @@ metadata:
   annotations:
     haproxy.router.openshift.io/balance: roundrobin
     haproxy.router.openshift.io/rewrite-target: /
+    haproxy.router.openshift.io/disable_cookies: 'true'
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 
 spec:
   host: {{ .Values.dashboardFrontend.route.host }}

--- a/helm/cas-bciers/templates/registration/route.yaml
+++ b/helm/cas-bciers/templates/registration/route.yaml
@@ -18,6 +18,9 @@ metadata:
   annotations:
     haproxy.router.openshift.io/balance: roundrobin
     haproxy.router.openshift.io/rewrite-target: {{ .Values.registrationFrontend.route.path }}
+    haproxy.router.openshift.io/disable_cookies: 'true'
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 
 spec:
   host: {{ .Values.registrationFrontend.route.host }}

--- a/helm/cas-bciers/templates/registration/route.yaml
+++ b/helm/cas-bciers/templates/registration/route.yaml
@@ -20,7 +20,7 @@ metadata:
     haproxy.router.openshift.io/rewrite-target: {{ .Values.registrationFrontend.route.path }}
     haproxy.router.openshift.io/disable_cookies: 'true'
     "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 
 spec:
   host: {{ .Values.registrationFrontend.route.host }}

--- a/helm/cas-bciers/templates/reporting/route.yaml
+++ b/helm/cas-bciers/templates/reporting/route.yaml
@@ -18,6 +18,9 @@ metadata:
   annotations:
     haproxy.router.openshift.io/balance: roundrobin
     haproxy.router.openshift.io/rewrite-target: {{ .Values.reportingFrontend.route.path }}
+    haproxy.router.openshift.io/disable_cookies: 'true'
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 
 spec:
   host: {{ .Values.reportingFrontend.route.host }}

--- a/helm/cas-bciers/templates/reporting/route.yaml
+++ b/helm/cas-bciers/templates/reporting/route.yaml
@@ -20,7 +20,7 @@ metadata:
     haproxy.router.openshift.io/rewrite-target: {{ .Values.reportingFrontend.route.path }}
     haproxy.router.openshift.io/disable_cookies: 'true'
     "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 
 spec:
   host: {{ .Values.reportingFrontend.route.host }}


### PR DESCRIPTION
Our routes were configured to send all requests to one pod in the service's endpoints list, making our HPA pointless. 
Disabling sticky sessions will allow our balancing method to come into effect and even out the load across all pods in the service's endpoints.