### PR TITLE
sessionUtils vitests

### DIFF
--- a/bciers/libs/testConfig/src/global.tsx
+++ b/bciers/libs/testConfig/src/global.tsx
@@ -28,6 +28,7 @@ import {
   useSessionRole,
   getSessionRole,
   getSession,
+  useContext,
 } from "./mocks";
 import createFetchMock from "vitest-fetch-mock";
 
@@ -39,6 +40,14 @@ declare module "vitest" {
 
 // Extend the global expect object with the custom matchers from jest-dom
 expect.extend(matchers);
+
+vi.mock("react", async () => {
+  const actualReact = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actualReact,
+    useContext: useContext,
+  };
+});
 
 vi.mock("next/navigation", () => ({
   useRouter,

--- a/bciers/libs/testConfig/src/mocks.ts
+++ b/bciers/libs/testConfig/src/mocks.ts
@@ -34,6 +34,7 @@ const useSession = vi.fn();
 const getSessionRole = vi.fn();
 const getSession = vi.fn();
 const useSessionRole = vi.fn();
+const useContext = vi.fn();
 const auth = vi.fn();
 const fetchTransferEventsPageData = vi.fn();
 const getUserOperatorsPageData = vi.fn();
@@ -78,4 +79,5 @@ export {
   getSessionRole,
   useSessionRole,
   getSession,
+  useContext,
 };

--- a/bciers/libs/utils/src/sessionUtils.test.ts
+++ b/bciers/libs/utils/src/sessionUtils.test.ts
@@ -1,40 +1,37 @@
-/* eslint-disable */
-import { auth, useSession } from "@bciers/testConfig/mocks";
+import { auth, useContext } from "@bciers/testConfig/mocks";
+// we need both unmocks or else the sessionUtils will be spies instead of the actual functions
+vi.unmock("@bciers/utils/src/sessionUtils");
+vi.unmock("./sessionUtils");
 import { getSessionRole, useSessionRole } from "./sessionUtils";
-
-useSession.mockReturnValue({
-  get: vi.fn(),
-});
+import { FrontEndRoles } from "./enums";
 
 describe("Operator component", () => {
   beforeEach(async () => {
-    vi.resetAllMocks();
+    vi.restoreAllMocks();
   });
+
   it("getSessionRole throws error when there is no role", async () => {
-    // await expect(getSessionRole()).rejects.toThrow(
-    //   "Failed to retrieve session role",
-    // );
+    await expect(getSessionRole()).rejects.toThrow(
+      "Failed to retrieve session role",
+    );
   });
+
   it("getSessionRole returns role", async () => {
-    // auth.mockReturnValueOnce({
-    //   user: { app_role: "industry_user" },
-    // });
-    // await expect(getSessionRole()).resolves.toBe("industry_user");
+    auth.mockReturnValueOnce({
+      user: { app_role: FrontEndRoles.INDUSTRY_USER },
+    });
+    await expect(getSessionRole()).resolves.toBe(FrontEndRoles.INDUSTRY_USER);
   });
+
   it("useSessionRole throws error when there is no role", () => {
-    // useSession.mockReturnValue({
-    //   data: null,
-    // });
-    // expect(() => useSessionRole()).toThrow("Failed to retrieve session role");
+    useContext.mockReturnValue(null);
+    expect(() => useSessionRole()).toThrow(
+      "Session role is not available in the context",
+    );
   });
+
   it("useSessionRole returns role", () => {
-    // useSession.mockReturnValue({
-    //   data: {
-    //     user: {
-    //       app_role: "cas_admin",
-    //     },
-    //   },
-    // });
-    // expect(useSessionRole()).toBe("cas_admin");
+    useContext.mockReturnValue(FrontEndRoles.CAS_ADMIN);
+    expect(useSessionRole()).toBe(FrontEndRoles.CAS_ADMIN);
   });
 });


### PR DESCRIPTION
card: https://github.com/bcgov/cas-reporting/issues/795

This PR:
- updates the vitests for sessionUtils, tech debt from #3408 