### PR TITLE
chore: fixed cas regsitry number in final review page

### DIFF
--- a/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
@@ -4,6 +4,7 @@ import safeJsonParse from "@bciers/utils/src/safeJsonParse";
 import { getActivityInitData } from "@reporting/src/app/utils/getActivityInitData";
 import { getActivityFormData } from "@reporting/src/app/utils/getActivityFormData";
 import { getActivitySchema } from "@reporting/src/app/utils/getActivitySchema";
+import { getAllGasTypes } from "@reporting/src/app/utils/getAllGasTypes";
 
 const activityFactoryItem: ReviewDataFactoryItem = async (
   versionId: number,
@@ -26,6 +27,7 @@ const activityFactoryItem: ReviewDataFactoryItem = async (
       facilityId,
       activity.id,
     );
+    const gasTypes = await getAllGasTypes();
 
     const sourceTypeQueryString = formData?.sourceTypes
       ? Object.entries(initData.sourceTypeMap)
@@ -46,6 +48,7 @@ const activityFactoryItem: ReviewDataFactoryItem = async (
       schema: schema,
       uiSchema: activity.slug,
       data: formData,
+      context: { gasTypes, isFinalReview: true },
     });
   }
 

--- a/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
@@ -48,7 +48,7 @@ const activityFactoryItem: ReviewDataFactoryItem = async (
       schema: schema,
       uiSchema: activity.slug,
       data: formData,
-      context: { gasTypes, isFinalReview: true },
+      context: { gasTypes, readOnly: true },
     });
   }
 

--- a/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/reviewDataFactory/activityFactoryItem.ts
@@ -48,7 +48,7 @@ const activityFactoryItem: ReviewDataFactoryItem = async (
       schema: schema,
       uiSchema: activity.slug,
       data: formData,
-      context: { gasTypes, readOnly: true },
+      context: { gasTypes },
     });
   }
 

--- a/bciers/libs/components/src/form/fields/GasTypeCasNumberFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/GasTypeCasNumberFieldTemplate.tsx
@@ -78,13 +78,19 @@ function InlineFieldTemplate({
           </div>
         )}
         <div className={`relative flex items-center w-full ${cellWidth}`}>
-          <TextField
-            id="outlined-basic"
-            variant="outlined"
-            fullWidth
-            disabled
-            defaultValue={selectedGasTypeObject?.cas_number}
-          />
+          {formContext?.isFinalReview ? (
+            <span className="ml-2 font-medium">
+              {selectedGasTypeObject?.cas_number}
+            </span>
+          ) : (
+            <TextField
+              id="outlined-basic"
+              variant="outlined"
+              fullWidth
+              disabled
+              defaultValue={selectedGasTypeObject?.cas_number}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/bciers/libs/components/src/form/fields/GasTypeCasNumberFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/GasTypeCasNumberFieldTemplate.tsx
@@ -14,6 +14,7 @@ function InlineFieldTemplate({
   classNames,
   formContext,
   formData,
+  readonly,
 }: FieldTemplateProps) {
   const isHidden = uiSchema?.["ui:widget"] === "hidden";
   if (isHidden) return null;
@@ -78,7 +79,7 @@ function InlineFieldTemplate({
           </div>
         )}
         <div className={`relative flex items-center w-full ${cellWidth}`}>
-          {formContext?.isFinalReview ? (
+          {readonly ? (
             <span className="ml-2 font-medium">
               {selectedGasTypeObject?.cas_number}
             </span>


### PR DESCRIPTION
**Card:** [bcgov/cas-reporting #730](https://github.com/bcgov/cas-reporting/issues/730)
**Summary of changes:**
1. Fixed an issue on the Activity page where gasTypes were missing from the formContext in the final activityDataFactory. Now, gasTypes are correctly passed as part of the form context.
2. Updated the field template to properly display the CAS Registry Number:
3. On the Final Review page, the CAS Registry Number is displayed as plain text.
4. On the Activity page, it remains a disabled text field for input consistency.

**How to test:**

1. Navigate to the Final Review page.
2. Under Report Information > Emission, you should now see the CAS Registry Number displayed as plain text for the selected Gas Type.

![image](https://github.com/user-attachments/assets/d283d53c-bc4a-49cd-bd01-98e28a22340d)
