### PR TITLE
Remove Growthbook clientKey from values.yaml

### DIFF
--- a/helm/cas-bciers/values-dev.yaml
+++ b/helm/cas-bciers/values-dev.yaml
@@ -117,9 +117,6 @@ dashboardFrontend:
     keycloakAuthUrl: https://dev.loginproxy.gov.bc.ca/auth
     siteminderAuthUrl: https://logontest7.gov.bc.ca
 
-growthbook:
-  clientKey: sdk-YMBcx9KglRDGzGTE
-
 download-dags:
   airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca
 

--- a/helm/cas-bciers/values-prod.yaml
+++ b/helm/cas-bciers/values-prod.yaml
@@ -143,9 +143,6 @@ dashboardFrontend:
     maxReplicas: 4
     targetCPUUtilizationPercentage: 80
 
-growthbook:
-  clientKey: sdk-9Vyna67jpIYdjMa
-
 download-dags:
   airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca
 

--- a/helm/cas-bciers/values-test.yaml
+++ b/helm/cas-bciers/values-test.yaml
@@ -116,9 +116,6 @@ dashboardFrontend:
       cpu: 60m
       memory: 128Mi
 
-growthbook:
-  clientKey: sdk-9Vyna67jpIYdjMa
-
 download-dags:
   airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca
 


### PR DESCRIPTION
Context: github alerted us to a potential password leak in our repo regarding our clientKey for Growthbook. Our clientKey isn't actually confidential, but since we're not using growthbook at the moment, I'm removing it from our yaml files anyway (but it hasn't been totally scrubbed from our repo, it will still appear in previous commits). 

A copy of our clientKey has been saved into our team 1Password for reference just in case.

-----

chore: removed growthbook clientKey from values.yaml for dev, test, and prod