### PR TITLE
chore: update selectors to avoid backend collision

### DIFF
--- a/helm/cas-bciers/templates/NetworkPolicy/backendPostgresIngress.yaml
+++ b/helm/cas-bciers/templates/NetworkPolicy/backendPostgresIngress.yaml
@@ -17,3 +17,11 @@ spec:
         matchLabels:
           app.kubernetes.io/name: {{ include "cas-bciers.fullname" . }}
           component: backend
+    - podSelector:
+        matchLabels:
+          release: {{ include "cas-bciers.fullname" . }}
+          component: backend-check-document-file-status
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: {{ include "cas-bciers.fullname" . }}
+          component: backend-check-document-file-status

--- a/helm/cas-bciers/templates/backend/check-file-status-deployment.yaml
+++ b/helm/cas-bciers/templates/backend/check-file-status-deployment.yaml
@@ -9,12 +9,12 @@ spec:
   selector:
     matchLabels:
 {{- include "cas-bciers.selectorLabels" . | nindent 6 }}
-      component: backend
+      component: backend-check-document-file-status
   template:
     metadata:
       labels:
 {{- include "cas-bciers.selectorLabels" . | nindent 8 }}
-        component: backend
+        component: backend-check-document-file-status
     spec:
       restartPolicy: Always
       serviceAccountName: deployer


### PR DESCRIPTION
Fixes configuration of new file check deployment to be selectable independent from the backend. Adds additional network selectors so that the pod can properly access postgres.