### PR TITLE
3125 backend error wording

### DIFF
--- a/bciers/libs/components/src/error/ErrorBoundary.tsx
+++ b/bciers/libs/components/src/error/ErrorBoundary.tsx
@@ -3,48 +3,11 @@ import * as Sentry from "@sentry/nextjs";
 import { ghgRegulatorEmail } from "@bciers/utils/src/urls";
 
 import { Alert, AlertTitle } from "@mui/material";
+import ErrorBox from "./ErrorBox";
 
 interface Props {
   error: Error & { digest?: string };
 }
 export default function ErrorBoundary({ error }: Props) {
-  const [eventId, setEventId] = useState<string | null>(null);
-  useEffect(() => {
-    if (error) {
-      try {
-        // Attempt to log the error to Sentry
-        const id = Sentry.captureException(error);
-        setEventId(id); // Store Sentry event ID
-      } catch (sentryError) {
-        // If there's an error logging to Sentry, log it to the console
-        // eslint-disable-next-line no-console
-        console.error("Error logging to Sentry:", sentryError);
-      }
-    }
-  }, [error]);
-
-  return (
-    <div className="flex flex-col items-center text-bc-gov-links-color">
-      <h2>Something went wrong...</h2>
-      <Alert
-        severity="error"
-        sx={{
-          width: "100%",
-          maxWidth: "600px",
-          marginBottom: "1rem",
-        }}
-      >
-        <AlertTitle>
-          <strong>Error</strong>
-        </AlertTitle>
-        <p>An internal server error has occured.</p>
-        <p>
-          Please refresh the page. If the problem persists, contact{" "}
-          <a href={ghgRegulatorEmail}>ghgregulator@gov.bc.ca</a> for help and
-          include the reference code:{" "}
-          <strong>{eventId ? eventId : "No reference code available"}</strong>
-        </p>
-      </Alert>
-    </div>
-  );
+  return <ErrorBox error={error} />;
 }

--- a/bciers/libs/components/src/error/ErrorBoundary.tsx
+++ b/bciers/libs/components/src/error/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import * as Sentry from "@sentry/nextjs";
+import { ghgRegulatorEmail } from "@bciers/utils/src/urls";
 
 import { Alert, AlertTitle } from "@mui/material";
 
@@ -38,15 +39,11 @@ export default function ErrorBoundary({ error }: Props) {
         </AlertTitle>
         <p>An internal server error has occured.</p>
         <p>
-          Please try refreshing the page or contact support if the problem
-          persists.
+          Please refresh the page. If the problem persists, contact{" "}
+          <a href={ghgRegulatorEmail}>ghgregulator@gov.bc.ca</a> for help and
+          include the reference code:{" "}
+          <strong>{eventId ? eventId : "No reference code available"}</strong>
         </p>
-        <p>If reporting this issue, mention that the error has been logged.</p>
-        {eventId && (
-          <p>
-            Reference Code: <strong>{eventId}</strong>
-          </p>
-        )}
       </Alert>
     </div>
   );

--- a/bciers/libs/components/src/error/ErrorBox.tsx
+++ b/bciers/libs/components/src/error/ErrorBox.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { useEffect, useState } from "react";
+import * as Sentry from "@sentry/nextjs";
+import { ghgRegulatorEmail } from "@bciers/utils/src/urls";
+
+import { Alert, AlertTitle } from "@mui/material";
+
+interface Props {
+  error?: Error & { digest?: string };
+}
+export default function ErrorBox({ error }: Props) {
+  const [eventId, setEventId] = useState<string | null>(null);
+  useEffect(() => {
+    if (error) {
+      try {
+        // Attempt to log the error to Sentry
+        const id = Sentry.captureException(error);
+        setEventId(id); // Store Sentry event ID
+      } catch (sentryError) {
+        // If there's an error logging to Sentry, log it to the console
+        // eslint-disable-next-line no-console
+        console.error("Error logging to Sentry:", sentryError);
+      }
+    }
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center text-bc-gov-links-color">
+      <h2>Something went wrong...</h2>
+      <Alert
+        severity="error"
+        sx={{
+          width: "100%",
+          maxWidth: "600px",
+          marginBottom: "1rem",
+        }}
+      >
+        <AlertTitle>
+          <strong>Error</strong>
+        </AlertTitle>
+        <p>An internal server error has occured.</p>
+        <p>
+          Please refresh the page. If the problem persists, contact{" "}
+          <a href={ghgRegulatorEmail}>ghgregulator@gov.bc.ca</a> for help and
+          include the reference code:{" "}
+          <strong>{eventId ? eventId : "pending"}</strong>
+        </p>
+      </Alert>
+    </div>
+  );
+}


### PR DESCRIPTION
card: https://github.com/bcgov/cas-registration/issues/3125

The card asks for the backend errors to be handled by the same message as the ErrorBoundary, so this PR:
- creates a new component with the bulk of the ErrorBoundary component that's reusable across client/server components (ErrorBoundary only catches render errors in client component, not fetch ones in server components)