### PR TITLE
feat: 161 transfer compliance units

### DIFF
--- a/bc_obps/common/tests/endpoints/auth/constants.py
+++ b/bc_obps/common/tests/endpoints/auth/constants.py
@@ -350,6 +350,14 @@ ENDPOINTS = {
                 "compliance_report_version_id": MOCK_INT,
             },
         },
+        {
+            "method": "post",
+            "endpoint_name": "apply_compliance_units",
+            "kwargs": {
+                "account_id": MOCK_UUID,
+                "compliance_report_version_id": MOCK_INT,
+            },
+        },
     ],
     "all_roles": [
         {"method": "get", "endpoint_name": "get_reporting_year"},

--- a/bc_obps/compliance/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/compliance_units.py
+++ b/bc_obps/compliance/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/compliance_units.py
@@ -1,10 +1,10 @@
 from dataclasses import asdict
 from ninja.types import DictStrAny
 from compliance.api.router import router
-from typing import Literal, Tuple
+from typing import Dict, Literal, Tuple
 from django.http import HttpRequest
 from common.permissions import authorize
-from compliance.schema.apply_compliance_units import ApplyComplianceUnitsOut
+from compliance.schema.apply_compliance_units import ApplyComplianceUnitsIn, ApplyComplianceUnitsOut
 from compliance.service.apply_compliance_units_service import ApplyComplianceUnitsService
 from compliance.service.bc_carbon_registry.schema import FifteenDigitString
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -26,3 +26,20 @@ def get_apply_compliance_units_page_data(
         account_id=account_id, compliance_report_version_id=compliance_report_version_id
     )
     return 200, asdict(apply_compliance_units_page_data)
+
+
+@router.post(
+    "/bccr/accounts/{account_id}/compliance-report-versions/{compliance_report_version_id}/compliance-units",
+    response={200: Dict[str, bool], custom_codes_4xx: Message},
+    tags=COMPLIANCE,
+    description="Apply compliance units to a BCCR compliance account.",
+    auth=authorize("approved_industry_user"),
+)
+def apply_compliance_units(
+    request: HttpRequest,
+    account_id: FifteenDigitString,
+    compliance_report_version_id: int,
+    payload: ApplyComplianceUnitsIn,
+) -> Tuple[Literal[200], DictStrAny]:
+    ApplyComplianceUnitsService.apply_compliance_units(account_id=account_id, payload=payload.model_dump())
+    return 200, {"success": True}

--- a/bc_obps/compliance/dataclass.py
+++ b/bc_obps/compliance/dataclass.py
@@ -14,6 +14,7 @@ class BCCRUnit:
     serial_number: Optional[str]
     vintage_year: Optional[int]
     quantity_available: Optional[str]
+    quantity_to_be_applied: int = 0  # Default to 0, will be passed to the frontend to populate the input field
 
 
 @dataclass
@@ -56,3 +57,20 @@ class PaymentDataWithFreshnessFlag:
 class RefreshWrapperReturn:
     data_is_fresh: bool
     invoice: ElicensingInvoice
+
+@dataclass
+class MixedUnit:
+    """Data model for a unit in the mixed unit list for BCCR transfer"""
+
+    account_id: str
+    serial_no: str
+    new_quantity: int
+    id: str
+
+
+@dataclass
+class TransferComplianceUnitsPayload:
+    """Data model for the BCCR transfer compliance units API payload"""
+
+    destination_account_id: str
+    mixedUnitList: List[MixedUnit]

--- a/bc_obps/compliance/dataclass.py
+++ b/bc_obps/compliance/dataclass.py
@@ -58,6 +58,7 @@ class RefreshWrapperReturn:
     data_is_fresh: bool
     invoice: ElicensingInvoice
 
+
 @dataclass
 class MixedUnit:
     """Data model for a unit in the mixed unit list for BCCR transfer"""

--- a/bc_obps/compliance/dataclass.py
+++ b/bc_obps/compliance/dataclass.py
@@ -9,7 +9,7 @@ from compliance.models import ElicensingPayment, ElicensingInvoice
 class BCCRUnit:
     """Data model for BC Carbon Registry Unit information"""
 
-    id: Optional[int]
+    id: Optional[str]
     type: Optional[str]
     serial_number: Optional[str]
     vintage_year: Optional[int]

--- a/bc_obps/compliance/schema/apply_compliance_units.py
+++ b/bc_obps/compliance/schema/apply_compliance_units.py
@@ -1,19 +1,27 @@
 from decimal import Decimal
 from typing import Optional, List
+from compliance.service.bc_carbon_registry.schema import FifteenDigitString
 from ninja import Schema
 
 
 class BCCRUnit(Schema):
-    id: int
+    id: str
     type: str
     serial_number: str
     vintage_year: int
     quantity_available: int
+    quantity_to_be_applied: Optional[int] = None
 
 
 class ApplyComplianceUnitsOut(Schema):
     bccr_trading_name: Optional[str] = None
-    bccr_compliance_account_id: Optional[int] = None
+    bccr_compliance_account_id: Optional[str] = None
     charge_rate: Optional[Decimal] = None
     outstanding_balance: Optional[str] = None
+    bccr_units: List[BCCRUnit] = []
+
+
+class ApplyComplianceUnitsIn(Schema):
+    bccr_holding_account_id: FifteenDigitString
+    bccr_compliance_account_id: FifteenDigitString
     bccr_units: List[BCCRUnit] = []

--- a/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
@@ -22,6 +22,8 @@ from compliance.service.bc_carbon_registry.schema import (
     SearchFilterWrapper,
 )
 from requests.exceptions import Timeout, ConnectionError, HTTPError, RequestException
+from compliance.service.bc_carbon_registry.utils import log_error_message
+
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +147,7 @@ class BCCarbonRegistryAPIClient:
             logger.error("Invalid response from %s: %s", url, str(e), exc_info=True)
             raise BCCarbonRegistryError(f"Invalid response format: {str(e)}", endpoint=url) from e
         except Exception as e:
+            log_error_message(e)  # If BCCR API returns a valid error response, this will log it
             logger.error("Request to %s failed: %s", url, str(e), exc_info=True)
             raise BCCarbonRegistryError(f"Request failed: {str(e)}", endpoint=url) from e
 

--- a/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_service.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_service.py
@@ -89,8 +89,9 @@ class BCCarbonRegistryService:
         new_compliance_account = new_compliance_account_response_dict.get(
             "entity", {}
         )  # passing empty dict to avoid KeyError
+        entity_id = new_compliance_account.get("id")
         return BCCRComplianceAccountResponseDetails(
-            master_account_name=new_compliance_account.get("parent_name"), entity_id=new_compliance_account.get("id")
+            master_account_name=new_compliance_account.get("parent_name"), entity_id=str(entity_id) if entity_id else None
         )
 
     def get_or_create_compliance_account(
@@ -110,9 +111,10 @@ class BCCarbonRegistryService:
         existing_compliance_account = self._get_first_entity(compliance_account)
 
         if existing_compliance_account:
+            entity_id = existing_compliance_account.get("entityId")
             return BCCRComplianceAccountResponseDetails(
                 master_account_name=existing_compliance_account.get("masterAccountName"),
-                entity_id=existing_compliance_account.get("entityId"),
+                entity_id=str(entity_id) if entity_id else None,
             )
 
         return self.create_compliance_account(

--- a/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_service.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_service.py
@@ -91,7 +91,8 @@ class BCCarbonRegistryService:
         )  # passing empty dict to avoid KeyError
         entity_id = new_compliance_account.get("id")
         return BCCRComplianceAccountResponseDetails(
-            master_account_name=new_compliance_account.get("parent_name"), entity_id=str(entity_id) if entity_id else None
+            master_account_name=new_compliance_account.get("parent_name"),
+            entity_id=str(entity_id) if entity_id else None,
         )
 
     def get_or_create_compliance_account(

--- a/bc_obps/compliance/service/bc_carbon_registry/utils.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/utils.py
@@ -1,0 +1,52 @@
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def log_error_message(exception: Exception) -> None:
+    """
+    Log error message from an exception object if it exists.
+
+    Args:
+        exception: The exception object to extract and log error message from
+    """
+    try:
+        if not hasattr(exception, 'response'):
+            logger.debug("Exception has no response attribute")
+            return
+
+        response = getattr(exception, 'response', None)
+        if not response:
+            logger.debug("Exception response is empty")
+            return
+
+        if not hasattr(response, '_content'):
+            logger.debug("Response has no _content attribute")
+            return
+
+        content = getattr(response, '_content', None)
+        if not content:
+            logger.debug("Response _content is empty")
+            return
+
+        # Parse the JSON
+        error_data = json.loads(content)
+
+        if not isinstance(error_data, list) or not error_data:
+            logger.debug("Response does not contain a valid error array")
+            return
+
+        first_error = error_data[0]
+        if not isinstance(first_error, dict):
+            logger.debug("First error item is not a dictionary")
+            return
+
+        error_message = first_error.get('errorMessage')
+        if error_message:
+            logger.error("Error message from response: %s", error_message)
+        else:
+            logger.debug("No errorMessage found in response")
+
+    except (json.JSONDecodeError, AttributeError, IndexError, KeyError) as e:
+        logger.debug("Error parsing exception response: %s", str(e))

--- a/bc_obps/compliance/tests/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/test_compliance_units.py
+++ b/bc_obps/compliance/tests/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/test_compliance_units.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 from django.test import SimpleTestCase, override_settings, Client
 from decimal import Decimal
-from compliance.service.bc_carbon_registry.exceptions import BCCarbonRegistryError
 from registration.utils import custom_reverse_lazy
 from compliance.dataclass import BCCRUnit, ComplianceUnitsPageData
 
@@ -12,6 +11,9 @@ APPLY_COMPLIANCE_UNITS_SERVICE_PATH = (
     "compliance.service.apply_compliance_units_service.ApplyComplianceUnitsService.get_apply_compliance_units_page_data"
 )
 PERMISSION_CHECK_PATH = "common.permissions.check_permission_for_role"
+APPLY_COMPLIANCE_UNITS_SERVICE_APPLY_PATH = (
+    "compliance.service.apply_compliance_units_service.ApplyComplianceUnitsService.apply_compliance_units"
+)
 
 
 @override_settings(MIDDLEWARE=[])  # Disable middleware to prevent database queries
@@ -104,20 +106,6 @@ class TestComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoi
 
     @patch(APPLY_COMPLIANCE_UNITS_SERVICE_PATH)
     @patch(PERMISSION_CHECK_PATH)
-    def test_service_error_handling(self, mock_permission, mock_service):
-        # Arrange
-        mock_permission.return_value = True
-        mock_service.side_effect = BCCarbonRegistryError("Service error")
-        # Act
-        response = self.client.get(self._get_endpoint_url(VALID_ACCOUNT_ID, VALID_COMPLIANCE_REPORT_VERSION_ID))
-        # Assert
-        assert response.status_code == 400
-        assert response.json() == {
-            "message": "The system cannot connect to the external application. Please try again later. If the problem persists, contact GHGRegulator@gov.bc.ca for help."
-        }
-
-    @patch(APPLY_COMPLIANCE_UNITS_SERVICE_PATH)
-    @patch(PERMISSION_CHECK_PATH)
     def test_no_compliance_units(self, mock_permission, mock_service):
         # Arrange
         mock_permission.return_value = True
@@ -140,3 +128,149 @@ class TestComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoi
         assert response_data["charge_rate"] == "40.00"
         assert response_data["outstanding_balance"] == "16000"
         assert response_data["bccr_units"] == []
+
+
+@override_settings(MIDDLEWARE=[])  # Disable middleware to prevent database queries
+class TestApplyComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoid database access
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.client = Client()
+
+    @staticmethod
+    def _get_endpoint_url(account_id, compliance_report_version_id):
+        return custom_reverse_lazy(
+            "apply_compliance_units",
+            kwargs={"account_id": account_id, "compliance_report_version_id": compliance_report_version_id},
+        )
+
+    @patch(APPLY_COMPLIANCE_UNITS_SERVICE_APPLY_PATH)
+    @patch(PERMISSION_CHECK_PATH)
+    def test_apply_compliance_units_success(self, mock_permission, mock_apply_compliance_units):
+        # Arrange
+        mock_permission.return_value = True
+        mock_apply_compliance_units.return_value = None
+
+        # Create test data
+        test_units = [
+            {
+                "id": "1",
+                "type": "Earned Credits",
+                "serial_number": "BCE-2023-0001",
+                "vintage_year": 2023,
+                "quantity_available": 100,
+                "quantity_to_be_applied": 50,
+            },
+            {
+                "id": "2",
+                "type": "Offset Units",
+                "serial_number": "BCO-2023-0001",
+                "vintage_year": 2023,
+                "quantity_available": 200,
+                "quantity_to_be_applied": 75,
+            },
+        ]
+
+        payload = {
+            "bccr_holding_account_id": VALID_ACCOUNT_ID,
+            "bccr_compliance_account_id": "987654321098765",
+            "bccr_units": test_units,
+        }
+
+        # Act
+        response = self.client.post(
+            self._get_endpoint_url(VALID_ACCOUNT_ID, VALID_COMPLIANCE_REPORT_VERSION_ID),
+            data=payload,
+            content_type="application/json",
+        )
+
+        # Assert
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["success"] is True
+
+        # Verify service was called with correct parameters
+        mock_apply_compliance_units.assert_called_once_with(
+            account_id=VALID_ACCOUNT_ID,
+            payload=payload,
+        )
+
+    @patch(APPLY_COMPLIANCE_UNITS_SERVICE_APPLY_PATH)
+    @patch(PERMISSION_CHECK_PATH)
+    def test_apply_compliance_units_with_units_having_zero_quantity(self, mock_permission, mock_apply_compliance_units):
+        # Arrange
+        mock_permission.return_value = True
+        mock_apply_compliance_units.return_value = None
+
+        test_units = [
+            {
+                "id": "1",
+                "type": "Earned Credits",
+                "serial_number": "BCE-2023-0001",
+                "vintage_year": 2023,
+                "quantity_available": 100,
+                "quantity_to_be_applied": 1,
+            },
+            {
+                "id": "2",
+                "type": "Offset Units",
+                "serial_number": "BCO-2023-0001",
+                "vintage_year": 2023,
+                "quantity_available": 200,
+                "quantity_to_be_applied": 0,
+            },
+            {
+                "id": "3",
+                "type": "Offset Units",
+                "serial_number": "BCO-2023-0002",
+                "vintage_year": 2023,
+                "quantity_available": 10,
+                "quantity_to_be_applied": None,
+            },
+        ]
+
+        payload = {
+            "bccr_holding_account_id": VALID_ACCOUNT_ID,
+            "bccr_compliance_account_id": "987654321098765",
+            "bccr_units": test_units,
+        }
+
+        # Act
+        response = self.client.post(
+            self._get_endpoint_url(VALID_ACCOUNT_ID, VALID_COMPLIANCE_REPORT_VERSION_ID),
+            data=payload,
+            content_type="application/json",
+        )
+
+        # Assert
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["success"] is True
+
+        # Verify service was called with units having zero/None quantities
+        mock_apply_compliance_units.assert_called_once_with(
+            account_id=VALID_ACCOUNT_ID,
+            payload=payload,
+        )
+
+    @patch(PERMISSION_CHECK_PATH)
+    def test_apply_compliance_units_invalid_account_id_format(self, mock_permission):
+        # Arrange
+        mock_permission.return_value = True
+        invalid_account_id = "123"  # Not 15 digits
+
+        payload = {
+            "bccr_holding_account_id": invalid_account_id,
+            "bccr_compliance_account_id": "987654321098765",
+            "bccr_units": [],
+        }
+
+        # Act
+        response = self.client.post(
+            self._get_endpoint_url(invalid_account_id, VALID_COMPLIANCE_REPORT_VERSION_ID),
+            data=payload,
+            content_type="application/json",
+        )
+
+        # Assert
+        assert response.status_code == 422  # Validation error

--- a/bc_obps/compliance/tests/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/test_compliance_units.py
+++ b/bc_obps/compliance/tests/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/test_compliance_units.py
@@ -42,7 +42,7 @@ class TestComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoi
             outstanding_balance="16000",
             bccr_units=[
                 BCCRUnit(
-                    id=1,
+                    id="1",
                     type="Earned Credits",
                     serial_number="BCE-2023-0001",
                     vintage_year=2023,
@@ -58,7 +58,7 @@ class TestComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoi
         assert response.status_code == 200
         response_data = response.json()
         assert response_data["bccr_trading_name"] == "Test Company"
-        assert response_data["bccr_compliance_account_id"] == int(VALID_ACCOUNT_ID)
+        assert response_data["bccr_compliance_account_id"] == VALID_ACCOUNT_ID
         assert response_data["charge_rate"] == "40.00"
         assert response_data["outstanding_balance"] == "16000"
         assert len(response_data["bccr_units"]) == 1
@@ -124,7 +124,7 @@ class TestComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoi
         assert response.status_code == 200
         response_data = response.json()
         assert response_data["bccr_trading_name"] == "Test Company"
-        assert response_data["bccr_compliance_account_id"] == int(VALID_ACCOUNT_ID)
+        assert response_data["bccr_compliance_account_id"] == VALID_ACCOUNT_ID
         assert response_data["charge_rate"] == "40.00"
         assert response_data["outstanding_balance"] == "16000"
         assert response_data["bccr_units"] == []

--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_utils.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_utils.py
@@ -1,0 +1,233 @@
+import json
+import logging
+from unittest.mock import Mock, patch
+from django.test import SimpleTestCase
+from compliance.service.bc_carbon_registry.utils import log_error_message
+
+
+class TestLogErrorMessage(SimpleTestCase):
+    def setUp(self):
+        self.logger = logging.getLogger('compliance.service.bc_carbon_registry.utils')
+        self.logger.setLevel(logging.DEBUG)
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_valid_error_response(self, mock_logger):
+        """Test logging when exception has valid error response."""
+        # Create mock response with error content
+        mock_response = Mock()
+        mock_response._content = json.dumps([{'errorMessage': 'Test error message'}]).encode('utf-8')
+
+        # Create mock exception with response
+        mock_exception = Mock()
+        mock_exception.response = mock_response
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify error was logged
+        mock_logger.error.assert_called_once_with("Error message from response: %s", "Test error message")
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_no_response_attribute(self, mock_logger):
+        """Test logging when exception has no response attribute."""
+        # Create mock exception without response
+        mock_exception = Mock()
+        del mock_exception.response
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify debug was logged
+        mock_logger.debug.assert_called_with("Exception has no response attribute")
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_empty_response(self, mock_logger):
+        """Test logging when exception has empty response."""
+        # Create mock exception with empty response
+        mock_exception = Mock()
+        mock_exception.response = None
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify debug was logged
+        mock_logger.debug.assert_called_with("Exception response is empty")
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_response_no_content(self, mock_logger):
+        """Test logging when response has no _content attribute."""
+        # Create mock response without _content
+        mock_response = Mock()
+        del mock_response._content
+
+        # Create mock exception with response
+        mock_exception = Mock()
+        mock_exception.response = mock_response
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify debug was logged
+        mock_logger.debug.assert_called_with("Response has no _content attribute")
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_empty_content(self, mock_logger):
+        """Test logging when response has empty content."""
+        # Create mock response with empty content
+        mock_response = Mock()
+        mock_response._content = None
+
+        # Create mock exception with response
+        mock_exception = Mock()
+        mock_exception.response = mock_response
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify debug was logged
+        mock_logger.debug.assert_called_with("Response _content is empty")
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_invalid_json(self, mock_logger):
+        """Test logging when response content is invalid JSON."""
+        # Create mock response with invalid JSON
+        mock_response = Mock()
+        mock_response._content = b"invalid json content"
+
+        # Create mock exception with response
+        mock_exception = Mock()
+        mock_exception.response = mock_response
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify debug was logged for JSON decode error
+        mock_logger.debug.assert_called_with(
+            "Error parsing exception response: %s", "Expecting value: line 1 column 1 (char 0)"
+        )
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_non_list_response(self, mock_logger):
+        """Test logging when response is not a list."""
+        # Create mock response with non-list JSON
+        mock_response = Mock()
+        mock_response._content = json.dumps({"key": "value"}).encode('utf-8')
+
+        # Create mock exception with response
+        mock_exception = Mock()
+        mock_exception.response = mock_response
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify debug was logged
+        mock_logger.debug.assert_called_with("Response does not contain a valid error array")
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_empty_list_response(self, mock_logger):
+        """Test logging when response is an empty list."""
+        # Create mock response with empty list
+        mock_response = Mock()
+        mock_response._content = json.dumps([]).encode('utf-8')
+
+        # Create mock exception with response
+        mock_exception = Mock()
+        mock_exception.response = mock_response
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify debug was logged
+        mock_logger.debug.assert_called_with("Response does not contain a valid error array")
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_non_dict_first_item(self, mock_logger):
+        """Test logging when first item in response is not a dictionary."""
+        # Create mock response with non-dict first item
+        mock_response = Mock()
+        mock_response._content = json.dumps(["not a dict"]).encode('utf-8')
+
+        # Create mock exception with response
+        mock_exception = Mock()
+        mock_exception.response = mock_response
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify debug was logged
+        mock_logger.debug.assert_called_with("First error item is not a dictionary")
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_no_error_message_key(self, mock_logger):
+        """Test logging when error item has no errorMessage key."""
+        # Create mock response with dict but no errorMessage
+        mock_response = Mock()
+        mock_response._content = json.dumps([{"otherKey": "value"}]).encode('utf-8')
+
+        # Create mock exception with response
+        mock_exception = Mock()
+        mock_exception.response = mock_response
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify debug was logged
+        mock_logger.debug.assert_called_with("No errorMessage found in response")
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_empty_error_message(self, mock_logger):
+        """Test logging when errorMessage is empty."""
+        # Create mock response with empty errorMessage
+        mock_response = Mock()
+        mock_response._content = json.dumps([{"errorMessage": ""}]).encode('utf-8')
+
+        # Create mock exception with response
+        mock_exception = Mock()
+        mock_exception.response = mock_response
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify debug was logged
+        mock_logger.debug.assert_called_with("No errorMessage found in response")
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_multiple_errors(self, mock_logger):
+        """Test logging when response has multiple errors (should log first one)."""
+        # Create mock response with multiple errors
+        mock_response = Mock()
+        mock_response._content = json.dumps([{"errorMessage": "First error"}, {"errorMessage": "Second error"}]).encode(
+            'utf-8'
+        )
+
+        # Create mock exception with response
+        mock_exception = Mock()
+        mock_exception.response = mock_response
+
+        # Call the function
+        log_error_message(mock_exception)
+
+        # Verify only first error was logged
+        mock_logger.error.assert_called_once_with("Error message from response: %s", "First error")
+
+    @patch('compliance.service.bc_carbon_registry.utils.logger')
+    def test_log_error_message_with_real_exception(self, mock_logger):
+        """Test logging with a real exception object."""
+
+        # Create a real exception-like object
+        class CustomException(Exception):
+            def __init__(self, response):
+                self.response = response
+
+        # Create mock response
+        mock_response = Mock()
+        mock_response._content = json.dumps([{'errorMessage': 'Real exception error'}]).encode('utf-8')
+
+        # Create real exception
+        exception = CustomException(mock_response)
+
+        # Call the function
+        log_error_message(exception)
+
+        # Verify error was logged
+        mock_logger.error.assert_called_once_with("Error message from response: %s", "Real exception error")

--- a/bc_obps/compliance/tests/service/test_apply_compliance_units_service.py
+++ b/bc_obps/compliance/tests/service/test_apply_compliance_units_service.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import patch, Mock
 from model_bakery import baker
+from common.exceptions import UserError
 from compliance.service.apply_compliance_units_service import ApplyComplianceUnitsService
 from compliance.dataclass import BCCRUnit, ComplianceUnitsPageData
 from registration.models.operation import Operation
@@ -151,3 +152,192 @@ class TestApplyComplianceUnitsService:
         mock_bccr_service.get_or_create_compliance_account.assert_not_called()
         mock_bccr_service.client.list_all_units.assert_not_called()
         mock_compliance_charge_rate_service.get_rate_for_year.assert_not_called()
+
+    def test_validate_quantity_limits_success(self):
+        # Arrange
+        units = [
+            {
+                "serial_number": "BCE-2023-0001",
+                "quantity_available": 100,
+                "quantity_to_be_applied": 50,
+            },
+            {
+                "serial_number": "BCO-2023-0001",
+                "quantity_available": 200,
+                "quantity_to_be_applied": 200,  # Equal is allowed
+            },
+            {
+                "serial_number": "BCE-2023-0002",
+                "quantity_available": 75,
+                "quantity_to_be_applied": 0,  # Zero is allowed
+            },
+        ]
+
+        # Act & Assert - should not raise any exception
+        ApplyComplianceUnitsService._validate_quantity_limits(units)
+
+    def test_validate_quantity_limits_exceeds_available(self):
+        # Arrange
+        units = [
+            {
+                "serial_number": "BCE-2023-0001",
+                "quantity_available": 100,
+                "quantity_to_be_applied": 150,  # Exceeds available
+            }
+        ]
+
+        # Act & Assert
+        with pytest.raises(UserError, match="Quantity to be applied exceeds available quantity for unit BCE-2023-0001"):
+            ApplyComplianceUnitsService._validate_quantity_limits(units)
+
+    @patch('compliance.service.apply_compliance_units_service.bccr_service')
+    def test_apply_compliance_units_success(self, mock_bccr_service):
+        # Arrange
+        account_id = "123"
+        payload = {
+            "bccr_compliance_account_id": "456",
+            "bccr_units": [
+                {
+                    "id": "unit-1",
+                    "serial_number": "BCE-2023-0001",
+                    "quantity_available": 100,
+                    "quantity_to_be_applied": 50,
+                },
+                {
+                    "id": "unit-2",
+                    "serial_number": "BCO-2023-0001",
+                    "quantity_available": 200,
+                    "quantity_to_be_applied": 75,
+                },
+            ],
+        }
+
+        # Act
+        ApplyComplianceUnitsService.apply_compliance_units(account_id, payload)
+
+        # Assert
+        mock_bccr_service.client.transfer_compliance_units.assert_called_once()
+        call_args = mock_bccr_service.client.transfer_compliance_units.call_args[0][0]
+
+        # Verify the transfer payload structure
+        assert call_args["destination_account_id"] == "456"
+        assert len(call_args["mixedUnitList"]) == 2
+
+        # Verify first unit
+        unit1 = call_args["mixedUnitList"][0]
+        assert unit1["account_id"] == "123"
+        assert unit1["serial_no"] == "BCE-2023-0001"
+        assert unit1["new_quantity"] == 50
+        assert unit1["id"] == "unit-1"
+
+        # Verify second unit
+        unit2 = call_args["mixedUnitList"][1]
+        assert unit2["account_id"] == "123"
+        assert unit2["serial_no"] == "BCO-2023-0001"
+        assert unit2["new_quantity"] == 75
+        assert unit2["id"] == "unit-2"
+
+    @patch('compliance.service.apply_compliance_units_service.bccr_service')
+    def test_apply_compliance_units_filters_zero_quantities(self, mock_bccr_service):
+        # Arrange
+        account_id = "123"
+        payload = {
+            "bccr_compliance_account_id": "456",
+            "bccr_units": [
+                {
+                    "id": "unit-1",
+                    "serial_number": "BCE-2023-0001",
+                    "quantity_available": 100,
+                    "quantity_to_be_applied": 50,
+                },
+                {
+                    "id": "unit-2",
+                    "serial_number": "BCO-2023-0001",
+                    "quantity_available": 200,
+                    "quantity_to_be_applied": 0,  # Should be filtered out
+                },
+                {
+                    "id": "unit-3",
+                    "serial_number": "BCE-2023-0002",
+                    "quantity_available": 150,
+                    "quantity_to_be_applied": -10,  # Should be filtered out
+                },
+                {
+                    "id": "unit-4",
+                    "serial_number": "BCO-2023-0002",
+                    "quantity_available": 300,
+                    "quantity_to_be_applied": 25,
+                },
+            ],
+        }
+
+        # Act
+        ApplyComplianceUnitsService.apply_compliance_units(account_id, payload)
+
+        # Assert
+        mock_bccr_service.client.transfer_compliance_units.assert_called_once()
+        call_args = mock_bccr_service.client.transfer_compliance_units.call_args[0][0]
+
+        # Should only include units with positive quantities
+        assert len(call_args["mixedUnitList"]) == 2
+
+        # Verify only the units with positive quantities are included
+        serial_numbers = [unit["serial_no"] for unit in call_args["mixedUnitList"]]
+        assert "BCE-2023-0001" in serial_numbers
+        assert "BCO-2023-0002" in serial_numbers
+        assert "BCO-2023-0001" not in serial_numbers
+        assert "BCE-2023-0002" not in serial_numbers
+
+    @patch('compliance.service.apply_compliance_units_service.bccr_service')
+    def test_apply_compliance_units_validation_error(self, mock_bccr_service):
+        # Arrange
+        account_id = "123"
+        payload = {
+            "bccr_compliance_account_id": "456",
+            "bccr_units": [
+                {
+                    "id": "unit-1",
+                    "serial_number": "BCE-2023-0001",
+                    "quantity_available": 100,
+                    "quantity_to_be_applied": 150,  # Exceeds available
+                }
+            ],
+        }
+
+        # Act & Assert
+        with pytest.raises(UserError, match="Quantity to be applied exceeds available quantity for unit BCE-2023-0001"):
+            ApplyComplianceUnitsService.apply_compliance_units(account_id, payload)
+
+        # Verify that the transfer was not called due to validation error
+        mock_bccr_service.client.transfer_compliance_units.assert_not_called()
+
+    @patch('compliance.service.apply_compliance_units_service.bccr_service')
+    def test_apply_compliance_units_all_zero_quantities(self, mock_bccr_service):
+        # Arrange
+        account_id = "123"
+        payload = {
+            "bccr_compliance_account_id": "456",
+            "bccr_units": [
+                {
+                    "id": "unit-1",
+                    "serial_number": "BCE-2023-0001",
+                    "quantity_available": 100,
+                    "quantity_to_be_applied": 0,
+                },
+                {
+                    "id": "unit-2",
+                    "serial_number": "BCO-2023-0001",
+                    "quantity_available": 200,
+                    "quantity_to_be_applied": 0,
+                },
+            ],
+        }
+
+        # Act
+        ApplyComplianceUnitsService.apply_compliance_units(account_id, payload)
+
+        # Assert
+        mock_bccr_service.client.transfer_compliance_units.assert_called_once()
+        call_args = mock_bccr_service.client.transfer_compliance_units.call_args[0][0]
+        assert call_args["destination_account_id"] == "456"
+        assert call_args["mixedUnitList"] == []

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/review-compliance-summary/ComplianceSummaryReviewPage.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/review-compliance-summary/ComplianceSummaryReviewPage.tsx
@@ -18,19 +18,8 @@ export default async function ComplianceSummaryReviewPage({
     complianceUnits: {
       complianceSummaryId,
       gridData: {
-        rows: [
-          {
-            id: 1,
-            type: "-",
-            serialNumber: "-",
-            vintageYear: "-",
-            quantityApplied: "-",
-            equivalentEmissionReduced: "-",
-            equivalentValue: "-",
-            status: "-",
-          },
-        ],
-        row_count: 1,
+        rows: [],
+        row_count: 0,
       },
     },
     monetaryPayments: {

--- a/bciers/apps/compliance/src/app/data/jsonSchema/manageObligation/applyComplianceUnitsSchema.tsx
+++ b/bciers/apps/compliance/src/app/data/jsonSchema/manageObligation/applyComplianceUnitsSchema.tsx
@@ -57,7 +57,7 @@ export const applyComplianceUnitsSchema: RJSFSchema = {
                   type: { type: "string" },
                   serial_number: { type: "string" },
                   vintage_year: { type: "number" },
-                  quantity_available: { type: "string" },
+                  quantity_available: { type: "number" },
                   quantity_to_be_applied: { type: "number" },
                 },
               },

--- a/bciers/apps/compliance/src/app/widgets/ApplyComplianceUnitsWidget.tsx
+++ b/bciers/apps/compliance/src/app/widgets/ApplyComplianceUnitsWidget.tsx
@@ -55,11 +55,10 @@ const ApplyComplianceUnitsWidget = ({
 
   return (
     <div className="w-full">
-      {
-        !isSubmitted && COMPLIANCE_LIMIT_MESSAGES[
+      {!isSubmitted &&
+        COMPLIANCE_LIMIT_MESSAGES[
           complianceLimitStatus as ComplianceLimitStatus
-        ]
-      }
+        ]}
       <DataGrid
         columns={columns}
         initialData={{ rows: localUnits, row_count: localUnits.length }}

--- a/bciers/apps/compliance/src/app/widgets/ApplyComplianceUnitsWidget.tsx
+++ b/bciers/apps/compliance/src/app/widgets/ApplyComplianceUnitsWidget.tsx
@@ -36,7 +36,7 @@ const ApplyComplianceUnitsWidget = ({
   formContext,
   readonly,
 }: WidgetProps) => {
-  const { chargeRate, complianceLimitStatus } = formContext;
+  const { chargeRate, complianceLimitStatus, isSubmitted } = formContext;
   const [localUnits, setLocalUnits] = useState<BccrUnit[]>(value);
 
   const handleUnitUpdate = (updatedUnit: BccrUnit) => {
@@ -56,7 +56,7 @@ const ApplyComplianceUnitsWidget = ({
   return (
     <div className="w-full">
       {
-        COMPLIANCE_LIMIT_MESSAGES[
+        !isSubmitted && COMPLIANCE_LIMIT_MESSAGES[
           complianceLimitStatus as ComplianceLimitStatus
         ]
       }

--- a/bciers/apps/compliance/src/tests/components/widgets/ApplyComplianceUnitsWidget.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/widgets/ApplyComplianceUnitsWidget.test.tsx
@@ -4,6 +4,7 @@ import ApplyComplianceUnitsWidget from "@/compliance/src/app/widgets/ApplyCompli
 import { BccrUnit } from "@/compliance/src/app/types";
 import { useSearchParams } from "@bciers/testConfig/mocks";
 import { fireEvent } from "@testing-library/react";
+import { ComplianceLimitStatus } from "@/compliance/src/app/components/compliance-summary/manage-obligation/apply-compliance-units/ApplyComplianceUnitsComponent";
 
 useSearchParams.mockReturnValue({
   get: vi.fn(),
@@ -38,7 +39,8 @@ const defaultProps = {
   value: mockUnits,
   formContext: {
     chargeRate: 40,
-    complianceLimitStatus: "BELOW" as const,
+    complianceLimitStatus: "BELOW" as ComplianceLimitStatus,
+    isSubmitted: false,
   },
 } as unknown as WidgetProps;
 
@@ -95,12 +97,13 @@ describe("ApplyComplianceUnitsWidget", () => {
     expect(secondRow.getByText("$0.00")).toBeVisible();
   });
 
-  it("shows compliance limit message when status is EXCEEDS", () => {
+  it("shows compliance limit message when status is EXCEEDS and not submitted", () => {
     const props = {
       ...defaultProps,
       formContext: {
         ...defaultProps.formContext,
-        complianceLimitStatus: "EXCEEDS" as const,
+        complianceLimitStatus: "EXCEEDS" as ComplianceLimitStatus,
+        isSubmitted: false,
       },
     };
 
@@ -113,12 +116,13 @@ describe("ApplyComplianceUnitsWidget", () => {
     ).toBeVisible();
   });
 
-  it("shows compliance limit message when status is EQUALS", () => {
+  it("shows compliance limit message when status is EQUALS and not submitted", () => {
     const props = {
       ...defaultProps,
       formContext: {
         ...defaultProps.formContext,
-        complianceLimitStatus: "EQUALS" as const,
+        complianceLimitStatus: "EQUALS" as ComplianceLimitStatus,
+        isSubmitted: false,
       },
     };
 
@@ -131,8 +135,41 @@ describe("ApplyComplianceUnitsWidget", () => {
     ).toBeVisible();
   });
 
+  it("does not show compliance limit message when status is EQUALS but form is submitted", () => {
+    const props = {
+      ...defaultProps,
+      formContext: {
+        ...defaultProps.formContext,
+        complianceLimitStatus: "EQUALS" as ComplianceLimitStatus,
+        isSubmitted: true,
+      },
+    };
+
+    render(<ApplyComplianceUnitsWidget {...props} />);
+
+    expect(
+      screen.queryByText(
+        /the compliance units \(earned credits, offset units\) you selected below have reached 50% of the compliance obligation\. the remaining balance must be met with monetary payment\(s\)\./i,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not show compliance limit message when status is BELOW", () => {
     render(<ApplyComplianceUnitsWidget {...defaultProps} />);
+
+    expect(screen.queryByText(/compliance obligation/)).not.toBeInTheDocument();
+  });
+
+  it("does not show compliance limit message when status is BELOW and form is submitted", () => {
+    const props = {
+      ...defaultProps,
+      formContext: {
+        ...defaultProps.formContext,
+        isSubmitted: true,
+      },
+    };
+
+    render(<ApplyComplianceUnitsWidget {...props} />);
 
     expect(screen.queryByText(/compliance obligation/)).not.toBeInTheDocument();
   });


### PR DESCRIPTION
[ISSUE 161](https://github.com/bcgov/cas-compliance/issues/161)


**Changes:**

- **New Endpoint for Compliance Unit Transfer**
  - Added a POST API endpoint to apply (transfer) compliance units between BCCR accounts.
  - Updated test constants and endpoint registration to include the new endpoint.

- **Data Model Enhancements**
  - Introduced new dataclasses for transfer payloads and mixed units.

- **Service and Business Logic**
  - Implemented service method for applying (transferring) compliance units, with:
    - Quantity limit validation (cannot apply more than available).
    - Construction of transfer payloads for downstream API.

- **API Client and Utility Improvements**
  - Added a utility function (`log_error_message`) to extract and log detailed error messages from failed BCCR API responses.


🧪 **To Test:**

- Log in as `bc-cas-dev`
- Submit the `Compliance SFO - Obligation Not Met` report
- Navigate to the Compliance Summaries data grid
- Click the Manage Obligation link for the relevant entry
- Click the Apply Compliance Units button
- Enter a correct number to view your compliance account ID and available units
- Select some units and click the Apply button to transfer the selected units from the holding account to the compliance account.
- **NOTE**: Adjusting outstanding balance and calling eLicensing is not part of this PR.(Will be handled in https://github.com/bcgov/cas-compliance/issues/190)