### PR TITLE
fix: update CAS_PENDING role to include UPDATE operation

### DIFF
--- a/bc_obps/registration/models/rls_configs/user.py
+++ b/bc_obps/registration/models/rls_configs/user.py
@@ -10,6 +10,6 @@ class Rls:
         RlsRoles.CAS_ADMIN: [RlsOperations.SELECT, RlsOperations.INSERT, RlsOperations.UPDATE],
         RlsRoles.CAS_ANALYST: [RlsOperations.SELECT, RlsOperations.INSERT, RlsOperations.UPDATE],
         RlsRoles.CAS_VIEW_ONLY: [RlsOperations.SELECT, RlsOperations.INSERT, RlsOperations.UPDATE],
-        RlsRoles.CAS_PENDING: [RlsOperations.SELECT, RlsOperations.INSERT],
+        RlsRoles.CAS_PENDING: [RlsOperations.SELECT, RlsOperations.INSERT, RlsOperations.UPDATE],
     }
     grants = generate_rls_grants(role_grants_mapping, RegistrationTableNames.USER)


### PR DESCRIPTION
Related Sentry Error: https://government-of-british-columbia.sentry.io/issues/6711187992/?environment=production&project=4506624068026368&query=is%3Aunresolved&referrer=issue-stream&stream_index=0