### PR TITLE
Chore/185 fetch compliance reports via timeline operations

### DIFF
--- a/bc_obps/compliance/service/compliance_dashboard_service.py
+++ b/bc_obps/compliance/service/compliance_dashboard_service.py
@@ -48,6 +48,9 @@ class ComplianceDashboardService:
             )
         )
 
+        for version in compliance_report_versions:
+            version.outstanding_balance = ComplianceReportVersionService.calculate_outstanding_balance(version)  # type: ignore[attr-defined]
+
         return compliance_report_versions
 
     @classmethod

--- a/bc_obps/compliance/service/compliance_dashboard_service.py
+++ b/bc_obps/compliance/service/compliance_dashboard_service.py
@@ -4,10 +4,11 @@ from django.db.models import QuerySet
 from compliance.models import ComplianceReportVersion, ElicensingPayment
 from service.data_access_service.user_service import UserDataAccessService
 from service.data_access_service.operation_service import OperationDataAccessService
-from registration.models import Operation, UserOperator
+from registration.models import Operation
 from typing import Optional
 from compliance.service.elicensing.elicensing_data_refresh_service import ElicensingDataRefreshService
 from compliance.dataclass import PaymentDataWithFreshnessFlag
+from service.user_operator_service import UserOperatorService
 
 
 class ComplianceDashboardService:
@@ -31,7 +32,9 @@ class ComplianceDashboardService:
         # Get all compliance report versions for the filtered operations
         compliance_report_versions = ComplianceReportVersion.objects.filter(
             compliance_report__report__operation_id__in=operations,
-            compliance_report__report__operator=UserOperator.objects.get(user_id=user_guid).operator,
+            compliance_report__report__operator=UserOperatorService.get_current_user_approved_user_operator_or_raise(
+                user
+            ).operator,
         ).select_related(
             'compliance_report__report__operation',
             'compliance_report__compliance_period',

--- a/bc_obps/compliance/service/compliance_dashboard_service.py
+++ b/bc_obps/compliance/service/compliance_dashboard_service.py
@@ -4,7 +4,7 @@ from django.db.models import QuerySet
 from compliance.models import ComplianceReportVersion, ElicensingPayment
 from service.data_access_service.user_service import UserDataAccessService
 from service.data_access_service.operation_service import OperationDataAccessService
-from registration.models import Operation
+from registration.models import Operation, UserOperator
 from typing import Optional
 from compliance.service.elicensing.elicensing_data_refresh_service import ElicensingDataRefreshService
 from compliance.dataclass import PaymentDataWithFreshnessFlag
@@ -30,7 +30,8 @@ class ComplianceDashboardService:
 
         # Get all compliance report versions for the filtered operations
         compliance_report_versions = ComplianceReportVersion.objects.filter(
-            compliance_report__report__operation_id__in=operations
+            compliance_report__report__operation_id__in=operations,
+            compliance_report__report__operator=UserOperator.objects.get(user_id=user_guid).operator,
         ).select_related(
             'compliance_report__report__operation',
             'compliance_report__compliance_period',

--- a/bc_obps/compliance/service/compliance_dashboard_service.py
+++ b/bc_obps/compliance/service/compliance_dashboard_service.py
@@ -4,7 +4,7 @@ from django.db.models import QuerySet
 from compliance.models import ComplianceReportVersion, ElicensingPayment
 from service.data_access_service.user_service import UserDataAccessService
 from service.data_access_service.operation_service import OperationDataAccessService
-from registration.models.operation import Operation
+from registration.models import Operation
 from typing import Optional
 from compliance.service.elicensing.elicensing_data_refresh_service import ElicensingDataRefreshService
 from compliance.dataclass import PaymentDataWithFreshnessFlag
@@ -37,9 +37,12 @@ class ComplianceDashboardService:
             'compliance_earned_credit',
         )
 
-        # Calculate and attach the outstanding balance to each compliance_report_version
-        for version in compliance_report_versions:
-            version.outstanding_balance = ComplianceReportVersionService.calculate_outstanding_balance(version)  # type: ignore[attr-defined]
+        compliance_report_versions = (
+            compliance_report_versions
+            | ComplianceReportVersionService.get_compliance_report_versions_for_previously_owned_operations(
+                user_guid=user_guid
+            )
+        )
 
         return compliance_report_versions
 

--- a/bc_obps/compliance/service/compliance_report_version_service.py
+++ b/bc_obps/compliance/service/compliance_report_version_service.py
@@ -183,5 +183,5 @@ class ComplianceReportVersionService:
                 'compliance_report__compliance_period',
                 'compliance_earned_credits',
             )
-            all_historical_report_versions.union(historical_report_versions)
+            all_historical_report_versions = all_historical_report_versions.union(historical_report_versions)
         return all_historical_report_versions

--- a/bc_obps/compliance/service/compliance_report_version_service.py
+++ b/bc_obps/compliance/service/compliance_report_version_service.py
@@ -184,4 +184,4 @@ class ComplianceReportVersionService:
                 'compliance_earned_credits',
             )
             all_historical_report_versions.union(historical_report_versions)
-        return historical_report_versions
+        return all_historical_report_versions

--- a/bc_obps/compliance/service/compliance_report_version_service.py
+++ b/bc_obps/compliance/service/compliance_report_version_service.py
@@ -181,7 +181,7 @@ class ComplianceReportVersionService:
             ).select_related(
                 'compliance_report__report__operation',
                 'compliance_report__compliance_period',
-                'compliance_earned_credits',
+                'compliance_earned_credit',
             )
             all_historical_report_versions = all_historical_report_versions.union(historical_report_versions)
         return all_historical_report_versions

--- a/bc_obps/compliance/service/compliance_report_version_service.py
+++ b/bc_obps/compliance/service/compliance_report_version_service.py
@@ -174,11 +174,14 @@ class ComplianceReportVersionService:
             )
         )
 
+        if not previously_owned_operations:
+            return ComplianceReportVersion.objects.none()
+
         query = Q()
         for operation_ownership in previously_owned_operations:
             query |= (
                 Q(compliance_report__report__operation_id=operation_ownership.operation_id)
-                & Q(compliance_report__compliance_period__end_date__lt=operation_ownership.end_date)
+                & Q(compliance_report__compliance_period__end_date__lte=operation_ownership.end_date)
                 & Q(compliance_report__compliance_period__end_date__gte=operation_ownership.start_date)
             )
 

--- a/bc_obps/compliance/service/compliance_report_version_service.py
+++ b/bc_obps/compliance/service/compliance_report_version_service.py
@@ -181,7 +181,7 @@ class ComplianceReportVersionService:
         for operation_ownership in previously_owned_operations:
             query |= (
                 Q(compliance_report__report__operation_id=operation_ownership.operation_id)
-                & Q(compliance_report__compliance_period__end_date__lte=operation_ownership.end_date)
+                & Q(compliance_report__compliance_period__end_date__lt=operation_ownership.end_date)
                 & Q(compliance_report__compliance_period__end_date__gte=operation_ownership.start_date)
             )
 

--- a/bc_obps/compliance/service/compliance_report_version_service.py
+++ b/bc_obps/compliance/service/compliance_report_version_service.py
@@ -178,7 +178,7 @@ class ComplianceReportVersionService:
         for operation_ownership in previously_owned_operations:
             query |= (
                 Q(compliance_report__report__operation_id=operation_ownership.operation_id)
-                & Q(compliance_report__compliance_period__start_date__lte=operation_ownership.end_date)
+                & Q(compliance_report__compliance_period__end_date__lt=operation_ownership.end_date)
                 & Q(compliance_report__compliance_period__end_date__gte=operation_ownership.start_date)
             )
 

--- a/bc_obps/compliance/tests/service/test_compliance_dashboard_service.py
+++ b/bc_obps/compliance/tests/service/test_compliance_dashboard_service.py
@@ -4,6 +4,8 @@ import pytest
 from model_bakery.baker import make_recipe
 from compliance.service.elicensing.elicensing_data_refresh_service import RefreshWrapperReturn
 from compliance.service.compliance_dashboard_service import ComplianceDashboardService
+from compliance.models import ComplianceReportVersion
+from registration.models import Operation
 
 
 class TestComplianceDashboardService(TestCase):
@@ -31,3 +33,33 @@ class TestComplianceDashboardService(TestCase):
         assert returned_data.data_is_fresh == True  # noqa: E712
         assert returned_data.data.first() == payment_1
         assert returned_data.data.last() == payment_2
+
+    @pytest.mark.django_db
+    @patch(
+        'compliance.service.compliance_report_version_service.ComplianceReportVersionService.get_compliance_report_versions_for_previously_owned_operations'
+    )
+    def test_get_compliance_report_versions_for_dashboard(self, mock_previously_owned):
+        user_operator = make_recipe('registration.tests.utils.approved_user_operator')
+
+        operation = make_recipe(
+            'registration.tests.utils.operation', operator=user_operator.operator, status=Operation.Statuses.REGISTERED
+        )
+
+        report = make_recipe('reporting.tests.utils.report', operator=user_operator.operator, operation=operation)
+        compliance_report = make_recipe('compliance.tests.utils.compliance_report', report=report)
+        compliance_report_version = make_recipe(
+            'compliance.tests.utils.compliance_report_version', compliance_report=compliance_report
+        )
+        previous_compliance_report_version = make_recipe('compliance.tests.utils.compliance_report_version')
+        mock_previously_owned.return_value = ComplianceReportVersion.objects.filter(
+            id=previous_compliance_report_version.id
+        )
+
+        result = ComplianceDashboardService.get_compliance_report_versions_for_dashboard(
+            user_guid=user_operator.user.user_guid
+        )
+
+        # Returns the union of reports for currently owned operations & reports for previously owned operations
+        assert result.count() == 2
+        assert result.first() == compliance_report_version
+        assert result.last() == previous_compliance_report_version

--- a/bc_obps/compliance/tests/service/test_compliance_report_version_service.py
+++ b/bc_obps/compliance/tests/service/test_compliance_report_version_service.py
@@ -71,7 +71,7 @@ class TestComplianceReportVersionService:
     def test_get_compliance_report_versions_for_previously_owned_operations(self):
         # Arrange
         operator = baker.make_recipe('registration.tests.utils.operator')
-        user_operator = baker.make_recipe('registration.tests.utils.user_operator', operator=operator)
+        user_operator = baker.make_recipe('registration.tests.utils.approved_user_operator', operator=operator)
         baker.make_recipe(
             'compliance.tests.utils.compliance_period',
             id=2025,
@@ -108,8 +108,24 @@ class TestComplianceReportVersionService:
             'compliance.tests.utils.compliance_report_version', compliance_report=xferred_compliance_report
         )
 
+        xferred_operation_2 = baker.make_recipe(
+            'registration.tests.utils.operation_designated_operator_timeline',
+            operation=baker.make_recipe('registration.tests.utils.operation', status=Operation.Statuses.REGISTERED),
+            start_date="2024-01-01 01:46:20.789146",
+            end_date="2026-02-27 01:46:20.789146",
+            operator=operator,
+        )
+
+        xferred_emissions_report_2 = baker.make_recipe(
+            'reporting.tests.utils.report', reporting_year_id=2025, operation=xferred_operation_2.operation
+        )
+
+        xferred_compliance_report_2 = baker.make_recipe(
+            'compliance.tests.utils.compliance_report', compliance_period_id=2025, report=xferred_emissions_report_2
+        )
+
         xferred_compliance_report_version_2 = baker.make_recipe(
-            'compliance.tests.utils.compliance_report_version', compliance_report=xferred_compliance_report
+            'compliance.tests.utils.compliance_report_version', compliance_report=xferred_compliance_report_2
         )
 
         # OUT OF BOUNDS REPORTS

--- a/bc_obps/service/data_access_service/operation_designated_operator_timeline_service.py
+++ b/bc_obps/service/data_access_service/operation_designated_operator_timeline_service.py
@@ -83,3 +83,13 @@ class OperationDesignatedOperatorTimelineDataAccessService:
             # Industry users can only see operations associated with their own operator
             user_operator = UserOperatorService.get_current_user_approved_user_operator_or_raise(user)
             return queryset.filter(operator_id=user_operator.operator_id, end_date__isnull=True)
+
+    @classmethod
+    def get_previously_owned_operations_by_operator(
+        cls, operator_id: UUID
+    ) -> QuerySet[OperationDesignatedOperatorTimeline]:
+        """
+        Gets a list of operations & the dates that they were previously owned by an operator.
+        """
+
+        OperationDesignatedOperatorTimeline.objects.filter(operator_id=operator_id, end_date__isnull=False)

--- a/bc_obps/service/data_access_service/operation_designated_operator_timeline_service.py
+++ b/bc_obps/service/data_access_service/operation_designated_operator_timeline_service.py
@@ -92,4 +92,4 @@ class OperationDesignatedOperatorTimelineDataAccessService:
         Gets a list of operations & the dates that they were previously owned by an operator.
         """
 
-        OperationDesignatedOperatorTimeline.objects.filter(operator_id=operator_id, end_date__isnull=False)
+        return OperationDesignatedOperatorTimeline.objects.filter(operator_id=operator_id, end_date__isnull=False)

--- a/bc_obps/service/tests/data_access_service/test_data_access_operation_designated_operator_timeline.py
+++ b/bc_obps/service/tests/data_access_service/test_data_access_operation_designated_operator_timeline.py
@@ -95,17 +95,16 @@ class TestDataAccessOperationDesignatedOperatorTimelineService:
         assert timeline.count() == 21
 
     @staticmethod
-    def get_previously_owned_operations_by_operator():
+    def test_get_previously_owned_operations_by_operator():
 
         operator = baker.make_recipe('registration.tests.utils.operator')
 
         # transferred operation
-        baker.make_recipe(
+        xferred_operation = baker.make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
-            operation=baker.make_recipe(
-                'registration.tests.utils.operation', status=Operation.Statuses.REGISTERED, operator=operator
-            ),
+            operation=baker.make_recipe('registration.tests.utils.operation', status=Operation.Statuses.REGISTERED),
             end_date="2024-02-27 01:46:20.789146+00:00",
+            operator=operator,
         )
 
         # active operation - should not be returned
@@ -121,4 +120,4 @@ class TestDataAccessOperationDesignatedOperatorTimelineService:
             operator_id=operator.id
         )
         assert result.count() == 1
-        assert result.first().end_date == "2024-02-27 01:46:20.789146+00:00"
+        assert result.first().operation == xferred_operation.operation

--- a/bc_obps/service/tests/data_access_service/test_data_access_operation_designated_operator_timeline.py
+++ b/bc_obps/service/tests/data_access_service/test_data_access_operation_designated_operator_timeline.py
@@ -93,3 +93,32 @@ class TestDataAccessOperationDesignatedOperatorTimelineService:
         )
 
         assert timeline.count() == 21
+
+    @staticmethod
+    def get_previously_owned_operations_by_operator():
+
+        operator = baker.make_recipe('registration.tests.utils.operator')
+
+        # transferred operation
+        baker.make_recipe(
+            'registration.tests.utils.operation_designated_operator_timeline',
+            operation=baker.make_recipe(
+                'registration.tests.utils.operation', status=Operation.Statuses.REGISTERED, operator=operator
+            ),
+            end_date="2024-02-27 01:46:20.789146+00:00",
+        )
+
+        # active operation - should not be returned
+        baker.make_recipe(
+            'registration.tests.utils.operation_designated_operator_timeline',
+            operation=baker.make_recipe(
+                'registration.tests.utils.operation', status=Operation.Statuses.REGISTERED, operator=operator
+            ),
+            end_date=None,
+        )
+
+        result = OperationDesignatedOperatorTimelineDataAccessService.get_previously_owned_operations_by_operator(
+            operator_id=operator.id
+        )
+        assert result.count() == 1
+        assert result.first().end_date == "2024-02-27 01:46:20.789146+00:00"


### PR DESCRIPTION
Added some functions that check the timeline table for operations that were previously owned by an operator & retrieves any compliance report versions that the user should see because of that relationship.

Nothing in the UI can test this currently, but happy to go over the functions & tests with someone as part of the review