### PR TITLE
Delete contacts 1606

### DIFF
--- a/bc_obps/common/tests/endpoints/auth/constants.py
+++ b/bc_obps/common/tests/endpoints/auth/constants.py
@@ -433,6 +433,7 @@ ENDPOINTS = {
             "method": "get",
             "endpoint_name": "get_current_user_operator_access_requests",
         },
+        {"method": "patch", "endpoint_name": "archive_contact", "kwargs": {"contact_id": MOCK_UUID}},
     ],
     "authorized_irc_user": [
         {"method": "get", "endpoint_name": "list_operators"},

--- a/bc_obps/registration/api/_contacts/contact_id.py
+++ b/bc_obps/registration/api/_contacts/contact_id.py
@@ -9,6 +9,7 @@ from registration.api.router import router
 from service.contact_service import ContactService
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from registration.schema import ContactWithPlacesAssigned
+from ninja.types import DictStrAny
 
 
 @router.get(
@@ -33,3 +34,15 @@ def get_contact(request: HttpRequest, contact_id: int) -> Tuple[Literal[200], Op
 )
 def update_contact(request: HttpRequest, contact_id: int, payload: ContactIn) -> Tuple[Literal[200], Contact]:
     return 200, ContactService.update_contact(get_current_user_guid(request), contact_id, payload)
+
+
+@router.patch(
+    "/contacts/{contact_id}",
+    response={200: DictStrAny, custom_codes_4xx: Message},
+    tags=CONTACT_TAGS,
+    description="""Archives a contact by its ID. The user must be authorized to perform this action.""",
+    auth=authorize("approved_industry_admin_user"),
+)
+def archive_contact(request: HttpRequest, contact_id: int) -> Tuple[Literal[200], DictStrAny]:
+    ContactService.archive_contact(get_current_user_guid(request), contact_id)
+    return 200, {"success": True}

--- a/bc_obps/registration/api/contacts.py
+++ b/bc_obps/registration/api/contacts.py
@@ -12,6 +12,7 @@ from registration.api.router import router
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from ninja import Query
 from django.db.models import QuerySet
+from ninja.types import DictStrAny
 
 
 @router.get(
@@ -44,3 +45,15 @@ def list_contacts(
 )
 def create_contact(request: HttpRequest, payload: ContactIn) -> Tuple[Literal[201], Contact]:
     return 201, ContactService.create_contact(get_current_user_guid(request), payload)
+
+
+@router.patch(
+    "/contacts/{contact_id}",
+    response={200: DictStrAny, custom_codes_4xx: Message},
+    tags=CONTACT_TAGS,
+    description="""Archives a contact by its ID. The user must be authorized to perform this action.""",
+    auth=authorize("approved_industry_admin_user"),
+)
+def archive_contact(request: HttpRequest, contact_id: int) -> Tuple[Literal[200], DictStrAny]:
+    ContactService.archive_contact(get_current_user_guid(request), contact_id)
+    return 200, {"success": True}

--- a/bc_obps/registration/api/contacts.py
+++ b/bc_obps/registration/api/contacts.py
@@ -12,7 +12,6 @@ from registration.api.router import router
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from ninja import Query
 from django.db.models import QuerySet
-from ninja.types import DictStrAny
 
 
 @router.get(
@@ -45,15 +44,3 @@ def list_contacts(
 )
 def create_contact(request: HttpRequest, payload: ContactIn) -> Tuple[Literal[201], Contact]:
     return 201, ContactService.create_contact(get_current_user_guid(request), payload)
-
-
-@router.patch(
-    "/contacts/{contact_id}",
-    response={200: DictStrAny, custom_codes_4xx: Message},
-    tags=CONTACT_TAGS,
-    description="""Archives a contact by its ID. The user must be authorized to perform this action.""",
-    auth=authorize("approved_industry_admin_user"),
-)
-def archive_contact(request: HttpRequest, contact_id: int) -> Tuple[Literal[200], DictStrAny]:
-    ContactService.archive_contact(get_current_user_guid(request), contact_id)
-    return 200, {"success": True}

--- a/bc_obps/registration/fixtures/mock/contact.json
+++ b/bc_obps/registration/fixtures/mock/contact.json
@@ -272,7 +272,7 @@
       "last_name": "Industry User",
       "position_title": "Manager",
       "address": 17,
-      "email": "email@email.com",
+      "email": "bc-cas-dev@email.com",
       "phone_number": "+16044011249",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051"
     }

--- a/bc_obps/registration/fixtures/mock/contact.json
+++ b/bc_obps/registration/fixtures/mock/contact.json
@@ -262,5 +262,33 @@
       "phone_number": "+16044011249",
       "operator_id": "4a792f0f-cf9d-48c8-9a95-f504c5f84b12"
     }
+  },
+  {
+    "model": "registration.contact",
+    "pk": 20,
+    "fields": {
+      "business_role": "Operation Representative",
+      "first_name": "bc-cas-dev",
+      "last_name": "Industry User",
+      "position_title": "Manager",
+      "address": 17,
+      "email": "email@email.com",
+      "phone_number": "+16044011249",
+      "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051"
+    }
+  },
+  {
+    "model": "registration.contact",
+    "pk": 21,
+    "fields": {
+      "business_role": "Operation Representative",
+      "first_name": "bc-cas-dev-secondary",
+      "last_name": "Industry User",
+      "position_title": "Manager",
+      "address": 17,
+      "email": "email2@email.com",
+      "phone_number": "+16044011249",
+      "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051"
+    }
   }
 ]

--- a/bc_obps/registration/fixtures/mock/user.json
+++ b/bc_obps/registration/fixtures/mock/user.json
@@ -36,7 +36,7 @@
       "first_name": "bc-cas-dev-secondary",
       "last_name": "Industry User",
       "position_title": "Code Monkey",
-      "email": "email@email.com",
+      "email": "email2@email.com",
       "phone_number": "+16044015432",
       "app_role": "industry_user"
     }

--- a/bc_obps/registration/fixtures/mock/user.json
+++ b/bc_obps/registration/fixtures/mock/user.json
@@ -22,7 +22,7 @@
       "first_name": "bc-cas-dev",
       "last_name": "Industry User",
       "position_title": "Code Monkey",
-      "email": "email@email.com",
+      "email": "bc-cas-dev@email.com",
       "phone_number": "+16044015432",
       "app_role": "industry_user"
     }

--- a/bc_obps/registration/tests/endpoints/test_contacts.py
+++ b/bc_obps/registration/tests/endpoints/test_contacts.py
@@ -4,6 +4,7 @@ from registration.tests.utils.bakers import contact_baker, operator_baker
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.utils import custom_reverse_lazy
 from model_bakery.recipe import seq
+from model_bakery import baker
 from itertools import cycle
 
 
@@ -157,3 +158,36 @@ class TestContactsEndpoint(CommonTestSetup):
         assert created_contact.address.street_address == mock_contact.get(
             'street_address'
         )  # confirm that an address was created(even with only street_address)
+
+    # PATCH
+    def test_patch_archive_contact(self):
+        contact = baker.make_recipe(
+            "registration.tests.utils.contact",
+        )
+        TestUtils.authorize_current_user_as_operator_user(self, contact.operator)
+        patch_response = TestUtils.mock_patch_with_auth_role(
+            self,
+            "industry_user",
+            self.content_type,
+            {},
+            custom_reverse_lazy("archive_contact", kwargs={"contact_id": contact.id}),
+        )
+        assert patch_response.status_code == 200
+        response_json = patch_response.json()
+        assert response_json.get("success") is True
+        contact.refresh_from_db()
+        assert contact.archived_at is not None
+
+    def test_patch_archive_contact_fail(self):
+        contact = baker.make_recipe(
+            "registration.tests.utils.contact",
+        )
+        TestUtils.authorize_current_user_as_operator_user(self, contact.operator)
+        patch_response = TestUtils.mock_patch_with_auth_role(
+            self,
+            "industry_user",
+            self.content_type,
+            {},
+            custom_reverse_lazy("archive_contact", kwargs={"contact_id": 999}),
+        )
+        assert patch_response.status_code == 401

--- a/bc_obps/registration/tests/endpoints/test_contacts.py
+++ b/bc_obps/registration/tests/endpoints/test_contacts.py
@@ -179,15 +179,15 @@ class TestContactsEndpoint(CommonTestSetup):
         assert contact.archived_at is not None
 
     def test_patch_archive_contact_fail(self):
-        contact = baker.make_recipe(
+        random_contact = baker.make_recipe(
             "registration.tests.utils.contact",
         )
-        TestUtils.authorize_current_user_as_operator_user(self, contact.operator)
+        TestUtils.authorize_current_user_as_operator_user(self, baker.make_recipe("registration.tests.utils.operator"))
         patch_response = TestUtils.mock_patch_with_auth_role(
             self,
             "industry_user",
             self.content_type,
             {},
-            custom_reverse_lazy("archive_contact", kwargs={"contact_id": 999}),
+            custom_reverse_lazy("archive_contact", kwargs={"contact_id": random_contact.id}),
         )
         assert patch_response.status_code == 401

--- a/bc_obps/service/contact_service.py
+++ b/bc_obps/service/contact_service.py
@@ -177,3 +177,10 @@ class ContactService:
                 else f"The email '{email}' is in use by another contact. Please use a different email address."
             )
             raise UserError(message)
+
+    @classmethod
+    def archive_contact(cls, user_guid: UUID, contact_id: int) -> None:
+        """Archives a contact if the user has appropriate permissions."""
+        contact = cls.get_if_authorized(user_guid, contact_id)
+        if contact is not None:
+            contact.set_archive(user_guid)

--- a/bciers/apps/administration-e2e/playwright.config.ts
+++ b/bciers/apps/administration-e2e/playwright.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from "@playwright/test";
 import playwrightBaseConfig from "../../playwright.config.base";
 
-export default defineConfig({
+const config = {
   ...playwrightBaseConfig,
-});
+};
+
+if (process.env.E2E_TIMEOUT) {
+  config.expect = {
+    timeout: Number(process.env.E2E_TIMEOUT),
+  };
+}
+
+export default defineConfig(config);

--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -60,6 +60,7 @@ export default function ContactForm({
       return;
     }
     router.push("/contacts?from_deletion=true");
+    return;
   };
 
   const hasPlacesAssigned =

--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -49,10 +49,7 @@ export default function ContactForm({
 
   const handleArchiveContact = async () => {
     setIsSubmitting(true);
-    const response = await archiveContact(
-      params.contactId as string,
-      "/contacts",
-    );
+    const response = await archiveContact(params.contactId as string);
     if (response?.error) {
       setError(response.error as any);
       setModalOpen(false);

--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import SingleStepTaskListForm from "@bciers/components/form/SingleStepTaskListForm";
-import { actionHandler } from "@bciers/actions";
 import { ContactFormData } from "./types";
 import { FormMode } from "@bciers/utils/src/enums";
 import { contactsUiSchema } from "@/administration/app/data/jsonSchema/contact";
-import { useSessionRole } from "@bciers/utils/src/sessionUtils";
 import Link from "next/link";
+import SimpleModal from "@bciers/components/modal/SimpleModal";
+import { archiveContact } from "@bciers/actions/api";
+import { useParams, useRouter } from "next/navigation";
+import { useSessionRole } from "@bciers/utils/src/sessionUtils";
+import { actionHandler } from "@bciers/actions";
 
 interface Props {
   schema: any;
@@ -37,65 +39,109 @@ export default function ContactForm({
   const [isCreatingState, setIsCreatingState] = useState(isCreating);
   const [key, setKey] = useState(Math.random());
   const role = useSessionRole();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const params = useParams();
+
+  const handleClickDelete = () => {
+    setModalOpen(true);
+  };
+
+  const handleArchiveContact = async () => {
+    setIsSubmitting(true);
+    const response = await archiveContact(
+      params.contactId as string,
+      "/contacts",
+    );
+    if (response?.error) {
+      setError(response.error as any);
+      setModalOpen(false);
+      setIsSubmitting(false);
+      return;
+    }
+    router.push("/contacts?from_deletion=true");
+  };
+
+  const hasPlacesAssigned =
+    formData.places_assigned && formData.places_assigned.length > 0;
 
   return (
-    <SingleStepTaskListForm
-      key={key}
-      error={error}
-      schema={schema}
-      uiSchema={contactsUiSchema}
-      formData={formState}
-      formContext={{ userRole: role }}
-      mode={isCreatingState ? FormMode.CREATE : FormMode.READ_ONLY}
-      allowEdit={allowEdit}
-      inlineMessage={
-        isCreatingState && !role.includes("cas") && <NewOperationMessage />
-      }
-      onSubmit={async (data: { formData?: any }) => {
-        setError(undefined);
-        const updatedFormData = { ...formState, ...data.formData };
-        setFormState(updatedFormData);
-
-        const method = isCreatingState ? "POST" : "PUT";
-        const endpoint = isCreatingState
-          ? "registration/contacts"
-          : `registration/contacts/${formState.id}`;
-        const pathToRevalidate = isCreatingState
-          ? "/contacts"
-          : `/contacts/${formState.id}`;
-        const body = {
-          ...data.formData,
-        };
-
-        const response = await actionHandler(
-          endpoint,
-          method,
-          pathToRevalidate,
-          {
-            body: JSON.stringify(body),
-          },
-        );
-
-        if (response.error) {
-          setError(response.error);
-          return { error: response.error };
+    <>
+      <SimpleModal
+        title="Confirmation"
+        open={modalOpen}
+        onCancel={() => setModalOpen(false)}
+        onConfirm={handleArchiveContact}
+        confirmText="Delete Contact"
+        cancelText={hasPlacesAssigned ? "Cancel" : "Back"}
+        showConfirmButton={!hasPlacesAssigned}
+        isSubmitting={isSubmitting}
+      >
+        {hasPlacesAssigned
+          ? "Before you can delete this contact, please replace them in the places they are assigned with another contact first."
+          : "Please confirm that you would like to delete this contact."}
+      </SimpleModal>
+      <SingleStepTaskListForm
+        key={key}
+        error={error}
+        schema={schema}
+        uiSchema={contactsUiSchema}
+        formData={formState}
+        formContext={{ userRole: role }}
+        mode={isCreatingState ? FormMode.CREATE : FormMode.READ_ONLY}
+        allowEdit={allowEdit}
+        inlineMessage={
+          isCreatingState && !role.includes("cas") && <NewOperationMessage />
         }
+        showDeleteButton={!isCreatingState && !role.includes("cas")}
+        handleDelete={handleClickDelete}
+        deleteButtonText="Delete Contact"
+        onSubmit={async (data: { formData?: any }) => {
+          setError(undefined);
+          const updatedFormData = { ...formState, ...data.formData };
+          setFormState(updatedFormData);
 
-        if (isCreatingState) {
-          setIsCreatingState(false);
-          setFormState((prevState) => ({
-            ...prevState,
-            id: response.id,
-          }));
-        } else {
-          setKey(Math.random());
-        }
-        const replaceUrl = `/contacts/${
-          method === "POST" ? response.id : formState.id
-        }?contacts_title=${response.first_name} ${response.last_name}`;
-        router.replace(replaceUrl);
-      }}
-      onCancel={() => router.replace("/contacts")}
-    />
+          const method = isCreatingState ? "POST" : "PUT";
+          const endpoint = isCreatingState
+            ? "registration/contacts"
+            : `registration/contacts/${formState.id}`;
+          const pathToRevalidate = isCreatingState
+            ? "/contacts"
+            : `/contacts/${formState.id}`;
+          const body = {
+            ...data.formData,
+          };
+
+          const response = await actionHandler(
+            endpoint,
+            method,
+            pathToRevalidate,
+            {
+              body: JSON.stringify(body),
+            },
+          );
+
+          if (response.error) {
+            setError(response.error);
+            return { error: response.error };
+          }
+
+          if (isCreatingState) {
+            setIsCreatingState(false);
+            setFormState((prevState) => ({
+              ...prevState,
+              id: response.id,
+            }));
+          } else {
+            setKey(Math.random());
+          }
+          const replaceUrl = `/contacts/${
+            method === "POST" ? response.id : formState.id
+          }?contacts_title=${response.first_name} ${response.last_name}`;
+          router.replace(replaceUrl);
+        }}
+        onCancel={() => router.replace("/contacts")}
+      />
+    </>
   );
 }

--- a/bciers/apps/administration/app/components/contacts/ContactsDataGrid.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactsDataGrid.tsx
@@ -30,7 +30,9 @@ const ContactsDataGrid = ({
   };
 }) => {
   const searchParams = useSearchParams();
-  const isRedirectedFromDeletion = searchParams.get("from_deletion") as string;
+  const isRedirectedFromDeletion = Boolean(
+    searchParams.get("from_deletion") ?? false,
+  );
   const [isSnackbarOpen, setIsSnackbarOpen] = useState(
     isRedirectedFromDeletion,
   );

--- a/bciers/apps/administration/app/components/contacts/ContactsDataGrid.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactsDataGrid.tsx
@@ -9,6 +9,8 @@ import fetchContactsPageData from "./fetchContactsPageData";
 import contactColumns from "../datagrid/models/contacts/contactColumns";
 import contactGroupColumns from "../datagrid/models/contacts/contactGroupColumns";
 import { GridRenderCellParams } from "@mui/x-data-grid";
+import SnackBar from "@bciers/components/form/components/SnackBar";
+import { useSearchParams } from "next/navigation";
 
 const ContactsActionCell = ActionCellFactory({
   generateHref: (params: GridRenderCellParams) => {
@@ -27,6 +29,12 @@ const ContactsDataGrid = ({
     row_count: number;
   };
 }) => {
+  const searchParams = useSearchParams();
+  const isRedirectedFromDeletion = searchParams.get("from_deletion") as string;
+  const [isSnackbarOpen, setIsSnackbarOpen] = useState(
+    isRedirectedFromDeletion,
+  );
+
   const [lastFocusedField, setLastFocusedField] = useState<string | null>(null);
 
   const SearchCell = useMemo(
@@ -52,14 +60,21 @@ const ContactsDataGrid = ({
     return row.id + operator;
   }
   return (
-    <DataGrid
-      columns={columns}
-      columnGroupModel={columnGroup}
-      fetchPageData={fetchContactsPageData}
-      paginationMode="server"
-      initialData={initialData}
-      getRowId={getRowId}
-    />
+    <>
+      <DataGrid
+        columns={columns}
+        columnGroupModel={columnGroup}
+        fetchPageData={fetchContactsPageData}
+        paginationMode="server"
+        initialData={initialData}
+        getRowId={getRowId}
+      />
+      <SnackBar
+        isSnackbarOpen={isSnackbarOpen}
+        message={"Contact deleted"}
+        setIsSnackbarOpen={setIsSnackbarOpen}
+      />
+    </>
   );
 };
 

--- a/bciers/apps/administration/app/components/contacts/types.ts
+++ b/bciers/apps/administration/app/components/contacts/types.ts
@@ -32,6 +32,11 @@ export interface ContactFormData {
   municipality?: string;
   province?: string;
   postal_code?: string;
+  places_assigned?: {
+    operation_id: UUID;
+    operation_name: string;
+    role_name: string;
+  }[];
 }
 
 export interface UserOperatorUser {

--- a/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
@@ -561,6 +561,6 @@ describe("ContactForm component", () => {
     expect(modalDeleteButton).toBeVisible();
 
     await userEvent.click(modalDeleteButton);
-    expect(archiveContact).toHaveBeenCalledWith("123", "/contacts");
+    expect(archiveContact).toHaveBeenCalledWith("123");
   });
 });

--- a/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
@@ -520,7 +520,6 @@ describe("ContactForm component", () => {
     });
     expect(deleteButton).toBeVisible(); //  delete button on the contact form
     await userEvent.click(deleteButton);
-    // brianna maybe a waitfor
     await waitFor(() => {
       expect(
         screen.getByText(
@@ -545,7 +544,6 @@ describe("ContactForm component", () => {
     });
     expect(deleteButton).toBeVisible(); //  delete button on the contact form
     await userEvent.click(deleteButton);
-    // brianna maybe a waitfor
     const modal = screen.getByRole("dialog");
     expect(modal).toBeVisible();
 

--- a/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
@@ -1,9 +1,12 @@
-import { render, screen, act, waitFor } from "@testing-library/react";
+import { render, screen, act, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   actionHandler,
+  archiveContact,
   useRouter,
   useSessionRole,
+  useSearchParams,
+  useParams,
 } from "@bciers/testConfig/mocks";
 import {
   contactsSchema,
@@ -14,9 +17,15 @@ import { createContactSchema } from "apps/administration/app/components/contacts
 import { FrontendMessages } from "@bciers/utils/src/enums";
 
 const mockReplace = vi.fn();
+const mockRouterPush = vi.fn();
 useRouter.mockReturnValue({
   query: {},
   replace: mockReplace,
+  push: mockRouterPush,
+});
+useSearchParams.mockReturnValue({ from_deletion: true });
+useParams.mockReturnValue({
+  contactId: "123",
 });
 
 const contactFormData = {
@@ -140,8 +149,12 @@ describe("ContactForm component", () => {
     // Buttons
     expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
     expect(screen.getByRole("button", { name: /back/i })).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: /delete contact/i }),
+    ).not.toBeInTheDocument();
   });
-  it("loads existing readonly contact form data for an internal user", async () => {
+
+  it("loads existing readonly contact form data for an external user", async () => {
     useSessionRole.mockReturnValue("industry_user_admin");
     const readOnlyContactSchema = createContactSchema(contactsSchema, false);
     const { container } = render(
@@ -151,8 +164,6 @@ describe("ContactForm component", () => {
         isCreating={false}
       />,
     );
-
-    checkInlineMessage(false);
 
     expect(
       container.querySelector("#root_section1_first_name"),
@@ -198,7 +209,32 @@ describe("ContactForm component", () => {
     ).toHaveTextContent("A1B 2C3");
 
     expect(screen.getByRole("button", { name: /edit/i })).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: /delete contact/i }),
+    ).toBeVisible();
   });
+  it("renders the form for an internal user", async () => {
+    useSessionRole.mockReturnValue("cas_admin");
+    const readOnlyContactSchema = createContactSchema(contactsSchema, false);
+    render(
+      <ContactForm
+        schema={readOnlyContactSchema}
+        formData={contactFormData}
+        isCreating={false}
+        allowEdit={false}
+      />,
+    );
+
+    checkInlineMessage(false);
+
+    expect(
+      screen.queryByRole("button", { name: /edit/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /delete contact/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not allow new contact form submission if there are validation errors (empty form data)", async () => {
     render(
       <ContactForm
@@ -213,6 +249,7 @@ describe("ContactForm component", () => {
     });
     expect(screen.getAllByText(/^.* is required/i)).toHaveLength(9);
   });
+
   it(
     "fills the mandatory form fields, creates new contact, and redirects on success",
     {
@@ -468,5 +505,64 @@ describe("ContactForm component", () => {
     expect(
       screen.queryByRole("button", { name: /remove item/i }),
     ).not.toBeInTheDocument();
+  });
+  it("does not allow deletion of contact if the contact is asssigned to places", async () => {
+    const readOnlyContactSchema = createContactSchema(contactsSchema, false);
+    render(
+      <ContactForm
+        schema={readOnlyContactSchema}
+        formData={contactFormData}
+        allowEdit
+      />,
+    );
+    const deleteButton = screen.getByRole("button", {
+      name: /delete contact/i,
+    });
+    expect(deleteButton).toBeVisible(); //  delete button on the contact form
+    await userEvent.click(deleteButton);
+    // brianna maybe a waitfor
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /Before you can delete this contact, please replace them in the places they are assigned with another contact first/i,
+        ),
+      ).toBeVisible();
+    });
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeVisible();
+  });
+
+  it("allows deletion of contact if they are not assigned anywhere", async () => {
+    const readOnlyContactSchema = createContactSchema(contactsSchema, false);
+    render(
+      <ContactForm
+        schema={readOnlyContactSchema}
+        formData={{ ...contactFormData, places_assigned: [] }}
+        allowEdit
+      />,
+    );
+    const deleteButton = screen.getByRole("button", {
+      name: /delete contact/i,
+    });
+    expect(deleteButton).toBeVisible(); //  delete button on the contact form
+    await userEvent.click(deleteButton);
+    // brianna maybe a waitfor
+    const modal = screen.getByRole("dialog");
+    expect(modal).toBeVisible();
+
+    expect(
+      within(modal).getByText(
+        /Please confirm that you would like to delete this contact./i,
+      ),
+    ).toBeVisible();
+
+    expect(within(modal).getByRole("button", { name: /back/i })).toBeVisible();
+
+    const modalDeleteButton = within(modal).getByRole("button", {
+      name: /delete contact/i,
+    });
+    expect(modalDeleteButton).toBeVisible();
+
+    await userEvent.click(modalDeleteButton);
+    expect(archiveContact).toHaveBeenCalledWith("123", "/contacts");
   });
 });

--- a/bciers/apps/administration/tests/components/contacts/ContactPage.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactPage.test.tsx
@@ -67,6 +67,9 @@ describe("Contact component", () => {
         "Once added, this new contact can be selected wherever needed or applicable.",
       ),
     ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /delete contact/i }),
+    ).not.toBeInTheDocument();
   });
   it("renders the Contact component in readonly mode(Contact details)", async () => {
     getContact.mockReturnValueOnce(contactFormData);
@@ -80,6 +83,9 @@ describe("Contact component", () => {
     // Note component
     expect(
       screen.getByText("View or update information of this contact here."),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /delete contact/i }),
     ).toBeVisible();
   });
 });

--- a/bciers/apps/administration/tests/components/contacts/ContactsDataGrid.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactsDataGrid.test.tsx
@@ -13,8 +13,9 @@ import extractParams from "@bciers/testConfig/helpers/extractParams";
 
 const mockReplace = vi.spyOn(global.history, "replaceState");
 
+const mockGetSearchParams = vi.fn();
 useSearchParams.mockReturnValue({
-  get: vi.fn(),
+  get: mockGetSearchParams,
 } as QueryParams);
 
 const mockExternalResponse = {
@@ -222,5 +223,25 @@ describe("ContactsDataGrid component", () => {
         "john",
       );
     });
+  });
+  it("shows the snackbar when being redirected from a contact deletion", async () => {
+    mockGetSearchParams.mockReturnValue({ from_deletion: true });
+    render(
+      <ContactsDataGrid
+        isExternalUser={true}
+        initialData={mockInternalResponse}
+      />,
+    );
+    expect(screen.getByText("Contact deleted")).toBeVisible();
+  });
+  it("does not show the snackbar if not redirected from a contact deletion", async () => {
+    mockGetSearchParams.mockReturnValue(undefined);
+    render(
+      <ContactsDataGrid
+        isExternalUser={true}
+        initialData={mockInternalResponse}
+      />,
+    );
+    expect(screen.queryByText("Contact deleted")).not.toBeInTheDocument();
   });
 });

--- a/bciers/apps/compliance-e2e/playwright.config.ts
+++ b/bciers/apps/compliance-e2e/playwright.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from "@playwright/test";
 import playwrightBaseConfig from "../../playwright.config.base";
 
-export default defineConfig({
+const config = {
   ...playwrightBaseConfig,
-});
+};
+
+if (process.env.E2E_TIMEOUT) {
+  config.expect = {
+    timeout: Number(process.env.E2E_TIMEOUT),
+  };
+}
+
+export default defineConfig(config);

--- a/bciers/apps/dashboard-e2e/playwright.config.ts
+++ b/bciers/apps/dashboard-e2e/playwright.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from "@playwright/test";
 import playwrightBaseConfig from "../../playwright.config.base";
 
-export default defineConfig({
+const config = {
   ...playwrightBaseConfig,
-});
+};
+
+if (process.env.E2E_TIMEOUT) {
+  config.expect = {
+    timeout: Number(process.env.E2E_TIMEOUT),
+  };
+}
+
+export default defineConfig(config);

--- a/bciers/apps/registration-e2e/playwright.config.ts
+++ b/bciers/apps/registration-e2e/playwright.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from "@playwright/test";
 import playwrightBaseConfig from "../../playwright.config.base";
 
-export default defineConfig({
+const config = {
   ...playwrightBaseConfig,
-});
+};
+
+if (process.env.E2E_TIMEOUT) {
+  config.expect = {
+    timeout: Number(process.env.E2E_TIMEOUT),
+  };
+}
+
+export default defineConfig(config);

--- a/bciers/apps/reporting-e2e/playwright.config.ts
+++ b/bciers/apps/reporting-e2e/playwright.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from "@playwright/test";
 import playwrightBaseConfig from "../../playwright.config.base";
 
-export default defineConfig({
+const config = {
   ...playwrightBaseConfig,
-});
+};
+
+if (process.env.E2E_TIMEOUT) {
+  config.expect = {
+    timeout: Number(process.env.E2E_TIMEOUT),
+  };
+}
+
+export default defineConfig(config);

--- a/bciers/libs/actions/src/api/archiveContact.ts
+++ b/bciers/libs/actions/src/api/archiveContact.ts
@@ -1,0 +1,13 @@
+import { actionHandler } from "@bciers/actions";
+
+// 🛠️ Function to fetch a contact by id
+export default async function archiveContact(
+  id: string,
+  pathToRevalidate: string = "",
+) {
+  return actionHandler(
+    `registration/contacts/${id}`,
+    "PATCH",
+    pathToRevalidate,
+  );
+}

--- a/bciers/libs/actions/src/api/index.ts
+++ b/bciers/libs/actions/src/api/index.ts
@@ -11,6 +11,7 @@ export { default as getRegistrationPurposes } from "./getRegistrationPurposes";
 export { default as getOptedInOperationDetail } from "./getOptedInOperationDetail";
 export { default as getOperationRegistration } from "./getOperationRegistration";
 export { default as getContact } from "./getContact";
+export { default as archiveContact } from "./archiveContact";
 export { default as getContacts } from "./getContacts";
 export { default as getOperationRepresentatives } from "./getOperationRepresentatives";
 export { default as getProductionData } from "./getProductionData";

--- a/bciers/libs/components/src/form/SingleStepTaskListForm.tsx
+++ b/bciers/libs/components/src/form/SingleStepTaskListForm.tsx
@@ -2,6 +2,7 @@
 
 import { createRef, useState } from "react";
 import { Alert, Button } from "@mui/material";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import { IChangeEvent } from "@rjsf/core";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import FormBase from "@bciers/components/form/FormBase";
@@ -13,6 +14,7 @@ import {
 import { FormMode, FrontendMessages } from "@bciers/utils/src/enums";
 import SnackBar from "@bciers/components/form/components/SnackBar";
 import SubmitButton from "@bciers/components/button/SubmitButton";
+import { BC_GOV_SEMANTICS_RED } from "@bciers/styles";
 
 interface SingleStepTaskListFormProps {
   disabled?: boolean;
@@ -29,6 +31,9 @@ interface SingleStepTaskListFormProps {
   formContext?: { [key: string]: any };
   showTasklist?: boolean;
   showCancelOrBackButton?: boolean;
+  showDeleteButton?: boolean;
+  handleDelete?: () => void;
+  deleteButtonText?: string;
   customButtonSection?: React.ReactNode;
 }
 
@@ -38,6 +43,7 @@ const SingleStepTaskListForm = ({
   onChange,
   onCancel,
   onSubmit,
+  handleDelete,
   schema,
   uiSchema,
   error,
@@ -47,6 +53,8 @@ const SingleStepTaskListForm = ({
   formContext,
   showTasklist = true,
   showCancelOrBackButton = true,
+  showDeleteButton = false,
+  deleteButtonText = "Delete",
   customButtonSection,
 }: SingleStepTaskListFormProps) => {
   const hasFormData = Object.keys(rawFormData).length > 0;
@@ -128,43 +136,57 @@ const SingleStepTaskListForm = ({
           <div className="min-h-6">
             {error && <Alert severity="error">{error}</Alert>}
           </div>
-          {customButtonSection || (
-            <div className="w-full flex justify-start mt-8">
-              {showCancelOrBackButton && (
-                <Button
-                  className="mr-4"
-                  variant="outlined"
-                  type="button"
-                  onClick={onCancel}
-                >
-                  {modeState === FormMode.EDIT ? "Cancel" : "Back"}
-                </Button>
-              )}
-              {allowEdit && (
-                <>
-                  {isDisabled ? (
-                    <Button
-                      variant="contained"
-                      onClick={() => {
-                        setIsDisabled(false);
-                        setIsSnackbarOpen(false);
-                        setModeState(FormMode.EDIT);
-                      }}
-                    >
-                      Edit
-                    </Button>
-                  ) : (
-                    <SubmitButton
-                      disabled={isSubmitting}
-                      isSubmitting={isSubmitting}
-                    >
-                      Save
-                    </SubmitButton>
-                  )}
-                </>
-              )}
-            </div>
-          )}
+          <div className="w-full flex justify-between items-center mt-8">
+            {customButtonSection || (
+              <div className="flex items-center">
+                {showCancelOrBackButton && (
+                  <Button
+                    className="mr-4"
+                    variant="outlined"
+                    type="button"
+                    onClick={onCancel}
+                  >
+                    {modeState === FormMode.EDIT ? "Cancel" : "Back"}
+                  </Button>
+                )}
+                {allowEdit && (
+                  <>
+                    {isDisabled ? (
+                      <Button
+                        variant="contained"
+                        onClick={() => {
+                          setIsDisabled(false);
+                          setIsSnackbarOpen(false);
+                          setModeState(FormMode.EDIT);
+                        }}
+                      >
+                        Edit
+                      </Button>
+                    ) : (
+                      <SubmitButton
+                        disabled={isSubmitting}
+                        isSubmitting={isSubmitting}
+                      >
+                        Save
+                      </SubmitButton>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+
+            {showDeleteButton && (
+              <Button
+                variant="outlined"
+                color="error"
+                style={{ color: BC_GOV_SEMANTICS_RED }}
+                startIcon={<DeleteOutlineIcon />}
+                onClick={handleDelete}
+              >
+                {deleteButtonText}
+              </Button>
+            )}
+          </div>
         </FormBase>
       </div>
     </div>

--- a/bciers/libs/components/src/modal/SimpleModal.tsx
+++ b/bciers/libs/components/src/modal/SimpleModal.tsx
@@ -10,6 +10,7 @@ interface Props extends React.PropsWithChildren {
   onConfirm: () => void;
   confirmText?: string;
   cancelText?: string;
+  showConfirmButton?: boolean;
   textComponentType?: "p" | "span" | "div";
   dialogContentClassName?: string;
   isSubmitting?: boolean;
@@ -22,6 +23,7 @@ const SimpleModal: React.FC<Props> = ({
   onConfirm,
   confirmText = "Confirm",
   cancelText = "Cancel",
+  showConfirmButton = true,
   textComponentType = "p",
   children,
   dialogContentClassName,
@@ -39,9 +41,11 @@ const SimpleModal: React.FC<Props> = ({
         <Button variant="outlined" color="primary" onClick={onCancel}>
           {cancelText}
         </Button>
-        <SubmitButton isSubmitting={isSubmitting} onClick={onConfirm}>
-          {confirmText}
-        </SubmitButton>
+        {showConfirmButton && (
+          <SubmitButton isSubmitting={isSubmitting} onClick={onConfirm}>
+            {confirmText}
+          </SubmitButton>
+        )}
       </DialogActions>
     </Modal>
   );

--- a/bciers/libs/testConfig/src/global.tsx
+++ b/bciers/libs/testConfig/src/global.tsx
@@ -31,6 +31,7 @@ import {
   useContext,
   captureException,
   signIn,
+  archiveContact,
 } from "./mocks";
 import createFetchMock from "vitest-fetch-mock";
 
@@ -88,6 +89,10 @@ vi.mock("@bciers/utils/src/sessionUtils", () => ({
 vi.mock("@bciers/actions", () => ({
   actionHandler,
   getToken,
+}));
+
+vi.mock("libs/actions/src/api/archiveContact", () => ({
+  default: archiveContact,
 }));
 
 vi.mock("libs/actions/src/api/getOperation", () => ({

--- a/bciers/libs/testConfig/src/mocks.ts
+++ b/bciers/libs/testConfig/src/mocks.ts
@@ -52,6 +52,7 @@ const getFacility = vi.fn();
 const getCurrentUsersOperations = vi.fn();
 const handleInternalAccessRequest = vi.fn();
 const captureException = vi.fn();
+const archiveContact = vi.fn();
 
 export {
   actionHandler,
@@ -84,4 +85,5 @@ export {
   useContext,
   captureException,
   signIn,
+  archiveContact,
 };


### PR DESCRIPTION
card: https://github.com/bcgov/cas-registration/issues/1606

This PR:
- adds a delete button and conditional props to the SingleStepTasklist (currently the contact form is the only one with a delete button, but it looks like it's needed for https://github.com/bcgov/cas-registration/issues/3482 too, and it was clearer to add to that component vs. trying to wrestle it into ContactForm)
- modal when the delete button is clicked; text and buttons in the modal conditional on whether or not the contact is assigned places
- endpoint to archive contact
- snackbar on grid
- added bc-cas-dev and bc-cas-dev-secondary as contacts (more representative of real app; every user should have a contact record too unless someone later deletes it)
- pytests
- vitests
- added an env variable so we can make the playwright timer longer in local (PB: the default timeout on await somestuff.click() is 5s and is too little for nextjs to compile the page)
- some of the happo diffs are real because we now have a delete button