### PR TITLE
chore: 206 replace hardcoded outstanding_balance

### DIFF
--- a/bc_obps/compliance/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/compliance_units.py
+++ b/bc_obps/compliance/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/compliance_units.py
@@ -21,11 +21,14 @@ from compliance.constants import COMPLIANCE
 )
 def get_apply_compliance_units_page_data(
     request: HttpRequest, account_id: FifteenDigitString, compliance_report_version_id: int
-) -> Tuple[Literal[200], DictStrAny]:
+) -> Tuple[Literal[200], ApplyComplianceUnitsOut]:
     apply_compliance_units_page_data = ApplyComplianceUnitsService.get_apply_compliance_units_page_data(
         account_id=account_id, compliance_report_version_id=compliance_report_version_id
     )
-    return 200, asdict(apply_compliance_units_page_data)
+
+    response = ApplyComplianceUnitsOut(**asdict(apply_compliance_units_page_data))
+
+    return 200, response
 
 
 @router.post(

--- a/bc_obps/compliance/dataclass.py
+++ b/bc_obps/compliance/dataclass.py
@@ -44,7 +44,7 @@ class ComplianceUnitsPageData:
     bccr_trading_name: Optional[str]
     bccr_compliance_account_id: Optional[str]
     charge_rate: Optional[Decimal]
-    outstanding_balance: Optional[str]
+    outstanding_balance: Optional[Decimal]
     bccr_units: List[BCCRUnit]
 
 

--- a/bc_obps/compliance/schema/apply_compliance_units.py
+++ b/bc_obps/compliance/schema/apply_compliance_units.py
@@ -32,7 +32,7 @@ class ApplyComplianceUnitsOut(Schema):
     bccr_trading_name: Optional[str] = None
     bccr_compliance_account_id: Optional[str] = None
     charge_rate: Optional[Decimal] = None
-    outstanding_balance: Optional[str] = None
+    outstanding_balance: Optional[Decimal] = None
     bccr_units: List[BCCRUnit] = []
 
 

--- a/bc_obps/compliance/service/bc_carbon_registry/apply_compliance_units_service.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/apply_compliance_units_service.py
@@ -5,6 +5,7 @@ from compliance.dataclass import ComplianceUnitsPageData, BCCRUnit, TransferComp
 from compliance.service.bc_carbon_registry.account_service import BCCarbonRegistryAccountService
 from compliance.service.compliance_charge_rate_service import ComplianceChargeRateService
 from compliance.service.compliance_report_version_service import ComplianceReportVersionService
+from compliance.service.compliance_obligation_service import ComplianceObligationService
 from decimal import Decimal
 
 bccr_account_service = BCCarbonRegistryAccountService()
@@ -83,12 +84,16 @@ class ApplyComplianceUnitsService:
         )
         bccr_units = bccr_account_service.client.list_all_units(account_id=account_id)
 
+        obligation_data = ComplianceObligationService.get_obligation_data_by_report_version(
+            compliance_report_version_id
+        )
+        outstanding_balance = obligation_data.equivalent_value
+
         return ComplianceUnitsPageData(
             bccr_trading_name=bccr_compliance_account.master_account_name,
             bccr_compliance_account_id=bccr_compliance_account.entity_id,
             charge_rate=ComplianceChargeRateService.get_rate_for_year(compliance_report.report.reporting_year),
-            # TODO: This value is hardcoded for now, We need to implement the logic to fetch the actual outstanding balance in ticket #193
-            outstanding_balance="16000",
+            outstanding_balance=outstanding_balance,
             bccr_units=cls._format_bccr_units_for_grid_display(bccr_units.get("entities", [])),
         )
 

--- a/bc_obps/compliance/tests/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/test_compliance_units.py
+++ b/bc_obps/compliance/tests/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/test_compliance_units.py
@@ -35,7 +35,7 @@ class TestComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoi
             bccr_trading_name="Test Company",
             bccr_compliance_account_id=VALID_ACCOUNT_ID,
             charge_rate=Decimal("40.00"),
-            outstanding_balance="16000",
+            outstanding_balance=Decimal("30000.00"),
             bccr_units=[
                 BCCRUnit(
                     id="1",
@@ -55,8 +55,8 @@ class TestComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoi
         response_data = response.json()
         assert response_data["bccr_trading_name"] == "Test Company"
         assert response_data["bccr_compliance_account_id"] == VALID_ACCOUNT_ID
-        assert response_data["charge_rate"] == "40.00"
-        assert response_data["outstanding_balance"] == "16000"
+        assert Decimal(response_data["charge_rate"]) == Decimal("40.00")
+        assert Decimal(response_data["outstanding_balance"]) == Decimal("30000.00")
         assert len(response_data["bccr_units"]) == 1
         assert response_data["bccr_units"][0]["type"] == "Earned Credits"
         assert response_data["bccr_units"][0]["serial_number"] == "BCE-2023-0001"
@@ -109,7 +109,7 @@ class TestComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoi
             bccr_trading_name="Test Company",
             bccr_compliance_account_id=VALID_ACCOUNT_ID,
             charge_rate=Decimal("40.00"),
-            outstanding_balance="16000",
+            outstanding_balance=Decimal("25000.00"),
             bccr_units=[],
         )
 
@@ -121,8 +121,8 @@ class TestComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoi
         response_data = response.json()
         assert response_data["bccr_trading_name"] == "Test Company"
         assert response_data["bccr_compliance_account_id"] == VALID_ACCOUNT_ID
-        assert response_data["charge_rate"] == "40.00"
-        assert response_data["outstanding_balance"] == "16000"
+        assert Decimal(response_data["charge_rate"]) == Decimal("40.00")
+        assert Decimal(response_data["outstanding_balance"]) == Decimal("25000.00")
         assert response_data["bccr_units"] == []
 
 

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.test.tsx
@@ -50,7 +50,7 @@ vi.mock(
 
 const mockData = {
   reporting_year: "2024",
-  outstanding_balance: "0.0000 tCO2e",
+  outstanding_balance: 0.0,
   equivalent_value: "$0.00",
   payments: [
     {


### PR DESCRIPTION
**[ISSUE 206](https://github.com/bcgov/cas-compliance/issues/206)**

## 🎯 **Overview**
Replace hardcoded outstanding balance in `apply_compliance_units_service` with dynamic value sourced from `ElicensingInvoice` model via the compliance obligation relationship chain.

---

## 🔧 **Backend Changes**

### **Service Layer Updates**
- **`ApplyComplianceUnitsService.get_apply_compliance_units_page_data()`** - Enhanced method to dynamically fetch outstanding balance:
  - Replaced hardcoded `outstanding_balance="16000"` with dynamic lookup
  - Leverages existing `ComplianceObligationService.get_obligation_data_by_report_version()` method for robust data retrieval
  - Service method includes elicensing data refresh before accessing invoice data

---

## 🧪 **Testing**

1. Log in as `bc-cas-dev`
2. Submit the **Bugle SFO - Registered** with excess emissions
1. Navigate to **Compliance Summaries** data grid
2. Click **"Manage Obligation"** link for the relevant entry
3. Click "Apply Compliance Units" button
5. Enter a **valid BCCR account number** to display your Compliance Trading Name
6. Check "Outstanding Balance after Applying Compliance Units" text box -> it should display actual outstanding balance in $$ instead of hardcoded $16000

