### PR TITLE
chore: reporter does not see delete contact button

### DIFF
--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -71,7 +71,7 @@ export default function ContactForm({
         onCancel={() => setModalOpen(false)}
         onConfirm={handleArchiveContact}
         confirmText="Delete Contact"
-        cancelText={hasPlacesAssigned ? "Cancel" : "Back"}
+        cancelText={hasPlacesAssigned ? "Back" : "Cancel"}
         showConfirmButton={!hasPlacesAssigned}
         isSubmitting={isSubmitting}
       >

--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import SingleStepTaskListForm from "@bciers/components/form/SingleStepTaskListForm";
 import { ContactFormData } from "./types";
-import { FormMode } from "@bciers/utils/src/enums";
+import { FormMode, FrontEndRoles } from "@bciers/utils/src/enums";
 import { contactsUiSchema } from "@/administration/app/data/jsonSchema/contact";
 import Link from "next/link";
 import SimpleModal from "@bciers/components/modal/SimpleModal";
@@ -91,7 +91,9 @@ export default function ContactForm({
         inlineMessage={
           isCreatingState && !role.includes("cas") && <NewOperationMessage />
         }
-        showDeleteButton={!isCreatingState && !role.includes("cas")}
+        showDeleteButton={
+          !isCreatingState && role === FrontEndRoles.INDUSTRY_USER_ADMIN
+        }
         handleDelete={handleClickDelete}
         deleteButtonText="Delete Contact"
         onSubmit={async (data: { formData?: any }) => {

--- a/bciers/apps/administration/app/components/contacts/ContactForm.tsx
+++ b/bciers/apps/administration/app/components/contacts/ContactForm.tsx
@@ -76,7 +76,7 @@ export default function ContactForm({
         isSubmitting={isSubmitting}
       >
         {hasPlacesAssigned
-          ? "Before you can delete this contact, please replace them in the places they are assigned with another contact first."
+          ? "Before you can delete this contact, please remove them from the places they are assigned. If you are the only one assigned, you must replace them with another contact in the assigned place."
           : "Please confirm that you would like to delete this contact."}
       </SimpleModal>
       <SingleStepTaskListForm

--- a/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
@@ -523,7 +523,7 @@ describe("ContactForm component", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          /Before you can delete this contact, please replace them in the places they are assigned with another contact first/i,
+          /Before you can delete this contact, please remove them from the places they are assigned. If you are the only one assigned, you must replace them with another contact in the assigned place./i,
         ),
       ).toBeVisible();
     });

--- a/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
@@ -154,7 +154,7 @@ describe("ContactForm component", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("loads existing readonly contact form data for an external user", async () => {
+  it("loads existing readonly contact form data for an external admin user", async () => {
     useSessionRole.mockReturnValue("industry_user_admin");
     const readOnlyContactSchema = createContactSchema(contactsSchema, false);
     const { container } = render(
@@ -562,5 +562,14 @@ describe("ContactForm component", () => {
 
     await userEvent.click(modalDeleteButton);
     expect(archiveContact).toHaveBeenCalledWith("123");
+  });
+
+  it("does not allow deletion if industry user is a reporter", async () => {
+    vi.clearAllMocks();
+    useSessionRole.mockReturnValue("industry_user");
+    const deleteButton = screen.queryByRole("button", {
+      name: /delete contact/i,
+    });
+    expect(deleteButton).not.toBeInTheDocument();
   });
 });

--- a/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
@@ -527,7 +527,7 @@ describe("ContactForm component", () => {
         ),
       ).toBeVisible();
     });
-    expect(screen.getByRole("button", { name: /cancel/i })).toBeVisible();
+    expect(screen.getByRole("button", { name: /back/i })).toBeVisible();
   });
 
   it("allows deletion of contact if they are not assigned anywhere", async () => {
@@ -553,7 +553,9 @@ describe("ContactForm component", () => {
       ),
     ).toBeVisible();
 
-    expect(within(modal).getByRole("button", { name: /back/i })).toBeVisible();
+    expect(
+      within(modal).getByRole("button", { name: /cancel/i }),
+    ).toBeVisible();
 
     const modalDeleteButton = within(modal).getByRole("button", {
       name: /delete contact/i,


### PR DESCRIPTION
card #1606 

This PR is a follow up to the main PR to address this part:
- removes the "Delete Contact" button for reporters