### PR TITLE
239 excess emissions value

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -10,7 +10,7 @@ sonar.python.version=3.12
 # Path is relative to the sonar-project.properties file. Defaults to .
 sonar.sources=.
 
-sonar.exclusions=**/Makefile, **/migrations/**, **/bciers/apps/registration/tests/**, **/bc_obps/reporting/tests/models/program_configuration_tests/**,
+sonar.exclusions=**/Makefile, **/migrations/**, **/bciers/apps/registration/tests/**, **/bc_obps/reporting/tests/models/program_configuration_tests/**, **/bc_obps/compliance/tests/**
 
 # Ignore duplication scanning for registration part 2 (will be removed once part 2 is merged into part 1)
 # Adding Compliance as well for its middleware and middleware testing

--- a/bc_obps/compliance/service/compliance_dashboard_service.py
+++ b/bc_obps/compliance/service/compliance_dashboard_service.py
@@ -101,8 +101,13 @@ class ComplianceDashboardService:
 
             summary = compliance_report_version.report_compliance_summary
             if summary and summary.excess_emissions is not None:
+                if compliance_report_version.is_supplementary:
+                    summary.excess_emissions = max(
+                        compliance_report_version.excess_emissions_delta_from_previous or 0, 0
+                    )
                 compliance_report_version.equivalent_value = summary.excess_emissions * charge_rate  # type: ignore[attr-defined]
 
+                compliance_report_version.save()
             obligation = getattr(compliance_report_version, "obligation", None)
             if (
                 obligation

--- a/bc_obps/compliance/tests/service/test_compliance_dashboard_service.py
+++ b/bc_obps/compliance/tests/service/test_compliance_dashboard_service.py
@@ -305,7 +305,135 @@ class TestComplianceDashboardService(TestCase):
         # Assert
         assert result is not None
         assert result.id == version.id
+        assert result.report_compliance_summary.excess_emissions == Decimal(4.0)
+
         assert result.compliance_charge_rate == Decimal("25.00")
         assert result.equivalent_value == Decimal("100.00")  # 4.0 * 25.0
         # assert result.outstanding_balance_tco2e == Decimal("2.0")
         # assert result.outstanding_balance_equivalent_value == Decimal("50.0")  # 2.0 * 25.0
+
+    @patch(
+        "compliance.service.compliance_dashboard_service.ComplianceReportVersionService.calculate_outstanding_balance_tco2e"
+    )
+    @patch("compliance.service.compliance_dashboard_service.ComplianceChargeRateService.get_rate_for_year")
+    @patch(
+        "compliance.service.elicensing.elicensing_data_refresh_service.ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id"
+    )
+    def test_get_compliance_report_version_by_id_supplementary_excess_emissions_are_are_greater(
+        self,
+        mock_refresh_data,
+        mock_get_rate,
+        mock_calculate_tco2e,
+    ):
+        # Setup user and operator
+        user_operator = make_recipe("registration.tests.utils.approved_user_operator")
+        operator = user_operator.operator
+        user_guid = user_operator.user.user_guid
+
+        # Mock values
+        mock_get_rate.return_value = Decimal("25.00")
+        mock_calculate_tco2e.return_value = Decimal("2.0")
+
+        # Report chain
+        operation = make_recipe("registration.tests.utils.operation", operator=operator)
+        report = make_recipe("reporting.tests.utils.report", operator=operator, operation=operation)
+        compliance_report = make_recipe("compliance.tests.utils.compliance_report", report=report)
+
+        # Invoice and obligation
+        invoice = make_recipe("compliance.tests.utils.elicensing_invoice", outstanding_balance=Decimal("2.0"))
+        obligation = make_recipe("compliance.tests.utils.compliance_obligation", elicensing_invoice=invoice)
+
+        # Compliance report versions
+        # version 1
+        make_recipe(
+            "compliance.tests.utils.compliance_report_version",
+            compliance_report=compliance_report,
+            obligation=obligation,
+            report_compliance_summary__excess_emissions=Decimal("4.0"),
+        )
+        version_2 = make_recipe(
+            "compliance.tests.utils.compliance_report_version",
+            compliance_report=compliance_report,
+            obligation=obligation,
+            report_compliance_summary__excess_emissions=Decimal("4.0"),
+            excess_emissions_delta_from_previous=Decimal("7.0"),
+            is_supplementary=True,
+        )
+
+        mock_refresh_data.return_value = RefreshWrapperReturn(data_is_fresh=True, invoice=invoice)
+
+        # Act
+        result = ComplianceDashboardService.get_compliance_report_version_by_id(
+            user_guid=user_guid,
+            compliance_report_version_id=version_2.id,
+        )
+
+        # Assert
+        assert result is not None
+        assert result.id == version_2.id
+        # check we're using the report_version.excess_emissions_delta_from_previous instead of report_compliance_summary.excess_emissions for supplementary reports
+        assert result.report_compliance_summary.excess_emissions == Decimal(7.0)
+        assert result.equivalent_value == Decimal("175.00")  # 7.0 * 25.0
+
+    @patch(
+        "compliance.service.compliance_dashboard_service.ComplianceReportVersionService.calculate_outstanding_balance_tco2e"
+    )
+    @patch("compliance.service.compliance_dashboard_service.ComplianceChargeRateService.get_rate_for_year")
+    @patch(
+        "compliance.service.elicensing.elicensing_data_refresh_service.ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id"
+    )
+    def test_get_compliance_report_version_by_id_supplementary_excess_emissions_are_are_less(
+        self,
+        mock_refresh_data,
+        mock_get_rate,
+        mock_calculate_tco2e,
+    ):
+        # Setup user and operator
+        user_operator = make_recipe("registration.tests.utils.approved_user_operator")
+        operator = user_operator.operator
+        user_guid = user_operator.user.user_guid
+
+        # Mock values
+        mock_get_rate.return_value = Decimal("25.00")
+        mock_calculate_tco2e.return_value = Decimal("2.0")
+
+        # Report chain
+        operation = make_recipe("registration.tests.utils.operation", operator=operator)
+        report = make_recipe("reporting.tests.utils.report", operator=operator, operation=operation)
+        compliance_report = make_recipe("compliance.tests.utils.compliance_report", report=report)
+
+        # Invoice and obligation
+        invoice = make_recipe("compliance.tests.utils.elicensing_invoice", outstanding_balance=Decimal("2.0"))
+        obligation = make_recipe("compliance.tests.utils.compliance_obligation", elicensing_invoice=invoice)
+
+        # Compliance report versions
+        # version 1
+        make_recipe(
+            "compliance.tests.utils.compliance_report_version",
+            compliance_report=compliance_report,
+            obligation=obligation,
+            report_compliance_summary__excess_emissions=Decimal("4.0"),
+        )
+        version_2 = make_recipe(
+            "compliance.tests.utils.compliance_report_version",
+            compliance_report=compliance_report,
+            obligation=obligation,
+            report_compliance_summary__excess_emissions=Decimal("4.0"),
+            excess_emissions_delta_from_previous=Decimal("-5.0"),
+            is_supplementary=True,
+        )
+
+        mock_refresh_data.return_value = RefreshWrapperReturn(data_is_fresh=True, invoice=invoice)
+
+        # Act
+        result = ComplianceDashboardService.get_compliance_report_version_by_id(
+            user_guid=user_guid,
+            compliance_report_version_id=version_2.id,
+        )
+
+        # Assert
+        assert result is not None
+        assert result.id == version_2.id
+        # check we're using the report_version.excess_emissions_delta_from_previous instead of report_compliance_summary.excess_emissions for supplementary reports
+        assert result.report_compliance_summary.excess_emissions == Decimal(0)
+        assert result.equivalent_value == Decimal(0)  # 0 * 25.0


### PR DESCRIPTION
card: https://github.com/bcgov/cas-compliance/issues/239

This PR:
- adds a condition to show the excess emissions delta for supplementary reports (vs. the excess emissions of the original report) on the compliance summary page
- pytests for ^

Notes:
- sonar fails are on duplication in tests; if the reviewer agrees, I'll dismiss
- I didn't do the DC about changing the ninja schema because I don't think I need to--I'm still using the excess_emissions alias

To test:
- create a supplementary report with higher emissions than the original report. You should see a new row in the summaries grid with the new excess emissions and equivalent value in its grid and on its summary page
- currently, nothing's built to handle supplementary reports with lower emissions, so the only way to test that case is with the pytests