### PR TITLE
265 fix outstanding balance calculation

### DIFF
--- a/bc_obps/compliance/service/bc_carbon_registry/apply_compliance_units_service.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/apply_compliance_units_service.py
@@ -147,7 +147,7 @@ class ApplyComplianceUnitsService:
         if response.get("success"):
             ComplianceAdjustmentService.create_adjustment(
                 compliance_report_version_id=compliance_report_version_id,
-                adjustment_total=Decimal(payload["total_equivalent_value"]),
+                adjustment_total=-Decimal(payload["total_equivalent_value"]),
             )
 
     @classmethod

--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_apply_compliance_units_service.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_apply_compliance_units_service.py
@@ -282,6 +282,10 @@ class TestApplyComplianceUnitsService:
         assert unit2["new_quantity"] == 75
         assert unit2["id"] == "unit-2"
 
+        # Verify adjustment creation
+        assert mock_create_adjustment.call_args.kwargs["compliance_report_version_id"] == compliance_report_version.id
+        assert mock_create_adjustment.call_args.kwargs['adjustment_total'] == -80
+
     @patch(APPLY_COMPLIANCE_UNITS_BCCR_ACCOUNT_SERVICE_PATH)
     @patch(COMPLIANCE_CREATE_ADJUSTMENT_PATH)
     def test_apply_compliance_units_filters_zero_quantities(self, mock_create_adjustment, mock_bccr_service):


### PR DESCRIPTION
https://github.com/bcgov/cas-compliance/issues/265

This PR:
- put a negative in front of the adjustment value in the apply compliance unit service (if we're applying units, the balance is always going to go down)
- pytest to check that the apply service is called with a negative number