### PR TITLE
Potential fix for code scanning alert no. 145: Use of externally-controlled format string

### DIFF
--- a/bciers/libs/actions/src/actions.ts
+++ b/bciers/libs/actions/src/actions.ts
@@ -116,7 +116,7 @@ export async function actionHandler(
         Sentry.captureException(error as Error);
         if (error instanceof Error) {
           // eslint-disable-next-line no-console
-          console.error(`An error occurred while fetching ${endpoint}:`, error);
+          console.error("An error occurred while fetching %s:", endpoint, error);
           if (error.message === ENDPOINT_NOT_ALLOWED_ERROR) {
             return {
               error: `Your session has timed out. Please log in again at https://industrialemissions.gov.bc.ca/onboarding to continue.`,

--- a/bciers/libs/actions/src/actions.ts
+++ b/bciers/libs/actions/src/actions.ts
@@ -116,7 +116,11 @@ export async function actionHandler(
         Sentry.captureException(error as Error);
         if (error instanceof Error) {
           // eslint-disable-next-line no-console
-          console.error("An error occurred while fetching %s:", endpoint, error);
+          console.error(
+            "An error occurred while fetching %s:",
+            endpoint,
+            error,
+          );
           if (error.message === ENDPOINT_NOT_ALLOWED_ERROR) {
             return {
               error: `Your session has timed out. Please log in again at https://industrialemissions.gov.bc.ca/onboarding to continue.`,

--- a/bciers/libs/utils/src/actions.test.ts
+++ b/bciers/libs/utils/src/actions.test.ts
@@ -106,7 +106,8 @@ describe("actionHandler function", () => {
 
     expect(consoleMock).toHaveBeenCalledOnce();
     expect(consoleMock).toHaveBeenLastCalledWith(
-      "An error occurred while fetching /endpoint:",
+      "An error occurred while fetching %s:",
+      "/endpoint",
       expect.any(Error),
     );
 
@@ -184,7 +185,8 @@ describe("actionHandler function", () => {
 
     expect(consoleMock).toHaveBeenCalledOnce();
     expect(consoleMock).toHaveBeenLastCalledWith(
-      "An error occurred while fetching /endpoint:",
+      "An error occurred while fetching %s:",
+      "/endpoint",
       expect.any(Error),
     );
 


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/cas-registration/security/code-scanning/145](https://github.com/bcgov/cas-registration/security/code-scanning/145)

To fix the issue, we need to sanitize the `endpoint` parameter before using it in the error message. A simple and effective approach is to ensure that the `endpoint` value is safely escaped or explicitly converted to a string using a `%s` specifier in the log message. This prevents any unintended behavior caused by malicious input. Additionally, we should validate the `endpoint` value to ensure it conforms to expected patterns (e.g., a valid URL or path).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
