### PR TITLE
fix: invoice amount should properly handle adjustments

### DIFF
--- a/bc_obps/compliance/service/compliance_invoice_service.py
+++ b/bc_obps/compliance/service/compliance_invoice_service.py
@@ -210,7 +210,7 @@ class ComplianceInvoiceService:
             billing_items.extend(adjustments_billing_items)
             total_adjustments += adjustments_total
 
-        amount_due = (total_fee - total_payments - total_adjustments).quantize(Decimal("0.01"))
+        amount_due = (total_fee - total_payments + total_adjustments).quantize(Decimal("0.01"))
         return amount_due, billing_items
 
     @staticmethod

--- a/bc_obps/compliance/tests/service/test_compliance_invoice_service.py
+++ b/bc_obps/compliance/tests/service/test_compliance_invoice_service.py
@@ -101,14 +101,14 @@ class TestComplianceInvoiceService:
             (
                 Decimal("300.00"),
                 [],
-                [{"amount": Decimal("50.00"), "date": datetime(2025, 6, 12).date(), "description": "Rebate"}],
+                [{"amount": Decimal("-50.00"), "date": datetime(2025, 6, 12).date(), "description": "Rebate"}],
                 Decimal("250.00"),
                 2,
             ),
             (
                 Decimal("300.00"),
                 [{"amount": Decimal("100.00"), "date": datetime(2025, 6, 10).date(), "description": "Partial Payment"}],
-                [{"amount": Decimal("25.00"), "date": datetime(2025, 6, 12).date(), "description": "Rebate"}],
+                [{"amount": Decimal("-25.00"), "date": datetime(2025, 6, 12).date(), "description": "Rebate"}],
                 Decimal("175.00"),
                 3,
             ),


### PR DESCRIPTION
[ISSUE 269](https://github.com/bcgov/cas-compliance/issues/269)
Follow-up to (https://github.com/bcgov/cas-compliance/issues/265)

🐞 Bug Fix: Incorrect Amount Due Calculation When Generating Compliance Invoice
Overview
Resolved an issue where, after an industry user applied compliance units to an obligation, the Generate Compliance Invoice action would incorrectly calculate a higher "Amount Due"—adding the value of applied compliance units on top of the original obligation amount, instead of properly subtracting it.

🔧 Fix Summary
- Updated invoice calculation logic:
- Ensured amount due is correctly reduced by the value of applied compliance units
- Reviewed and updated relevant service/function responsible for the calculation before invoice generation
- Added regression checks to confirm calculation is correct after changes
- Verified fix against test case scenarios provided in documentation

🧪 Testing Steps
- Log in as an industry user
- Submit report "Compliance SFO - Obligation not met"
- Apply compliance units to a compliance obligation
- Click Generate Compliance Invoice
- Verify: The "Amount Due" correctly reflects the original obligation amount minus the value of applied compliance units
- Cross-reference result with expected behavior in [test document](https://buttoninc-my.sharepoint.com/:w:/g/personal/francesca_button_is/EUiqNwlgi3hGok8_4Qodco4BFoesi7-h72sGLt2DlzLD3A?e=ceVw1E&nav=eyJoIjoiOTgyOTU4MDIyIn0%3D)

🖥️ Screenshots / Evidence
[0cb2c168-ff46-442f-9506-ad273d0cdbe9.pdf](https://github.com/user-attachments/files/21533956/0cb2c168-ff46-442f-9506-ad273d0cdbe9.pdf)
