### PR TITLE
Feat 124 display voided invoice

### DIFF
--- a/bc_obps/compliance/dataclass.py
+++ b/bc_obps/compliance/dataclass.py
@@ -118,6 +118,7 @@ class ComplianceInvoiceContext:
     invoice_date: str
     invoice_due_date: str
     invoice_printed_date: str
+    invoice_is_void: bool
     operator_name: str
     operator_address_line1: str
     operator_address_line2: str

--- a/bc_obps/compliance/service/compliance_invoice_service.py
+++ b/bc_obps/compliance/service/compliance_invoice_service.py
@@ -110,6 +110,10 @@ class ComplianceInvoiceService:
             invoice = refresh_result.invoice
             invoice_number = invoice.invoice_number
             invoice_due_date = invoice.due_date.strftime("%b %-d, %Y") if invoice.due_date else "—"
+            invoice_is_void = (
+                invoice.is_void
+                and compliance_report_version.status == ComplianceReportVersion.ComplianceStatus.OBLIGATION_FULLY_MET
+            )
 
             # Build invoice biling items and amounts due
             amount_due, billing_items = cls.calculate_invoice_amount_due(invoice)
@@ -122,6 +126,7 @@ class ComplianceInvoiceService:
                 invoice_date=invoice_date,
                 invoice_due_date=invoice_due_date,
                 invoice_printed_date=invoice_printed_date,
+                invoice_is_void=invoice_is_void,
                 operator_name=operator_name,
                 operator_address_line1=operator_address_line1,
                 operator_address_line2=operator_address_line2,

--- a/bc_obps/compliance/templates/invoice.html
+++ b/bc_obps/compliance/templates/invoice.html
@@ -171,10 +171,25 @@
         margin: 0;
         font-weight: bold;
       }
+      /* Watermark styles */
+      .watermark {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%) rotate(-45deg);
+        font-size: 150px;
+        font-weight: bold;
+        color: #313132;
+        opacity: 0.1;
+        text-transform: uppercase;
+      }
     </style>
   </head>
 
   <body>
+    {% if invoice_is_void %}
+    <div class="watermark">VOID</div>
+    {% endif %}
     <div class="container">
       <div class="header-section">
         <img

--- a/bc_obps/compliance/templates/invoice.html
+++ b/bc_obps/compliance/templates/invoice.html
@@ -55,13 +55,6 @@
       h6 {
         margin: 0;
       }
-
-      .invoice-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        margin-bottom: 50px;
-      }
       .invoice-header p {
         margin: 0;
       }

--- a/bc_obps/compliance/tests/service/test_invoice_template.py
+++ b/bc_obps/compliance/tests/service/test_invoice_template.py
@@ -1,0 +1,138 @@
+from django.template.loader import render_to_string
+from django.test import SimpleTestCase
+from compliance.dataclass import ComplianceInvoiceContext
+
+
+class TestInvoiceTemplate(SimpleTestCase):
+    def setUp(self):
+        self.base_context = ComplianceInvoiceContext(
+            invoice_number="INV-2025-001",
+            invoice_date="Jan 15, 2025",
+            invoice_due_date="Feb 15, 2025",
+            invoice_printed_date="Jan 15, 2025",
+            invoice_is_void=False,
+            operator_name="Test Operator Ltd.",
+            operator_address_line1="123 Test Street",
+            operator_address_line2="Vancouver, BC V6B 1A1",
+            operation_name="Test Operation",
+            compliance_obligation_year=2024,
+            compliance_obligation_id="25-0001-1",
+            compliance_obligation="1,000 tonnes CO2e",
+            compliance_obligation_charge_rate="$2.00 per tonne",
+            compliance_obligation_equivalent_amount="$2,000.00",
+            billing_items=[{"date": "Jan 15, 2025", "description": "Compliance Fee", "amount": "$2,000.00"}],
+            total_amount_due="$2,000.00",
+            logo_base64="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+        )
+
+    def test_invoice_template_renders_with_all_required_variables(self):
+        context = self.base_context.__dict__
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertIn("<!doctype html>", rendered_html)
+        self.assertIn("<title>Compliance Invoice</title>", rendered_html)
+        self.assertIn("Ministry of Energy and Climate Solutions", rendered_html)
+        self.assertIn("Invoice", rendered_html)
+
+    def test_invoice_template_includes_all_operator_information(self):
+        context = self.base_context.__dict__
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertIn("Operator Business Address", rendered_html)
+        self.assertIn("Test Operator Ltd.", rendered_html)
+        self.assertIn("123 Test Street", rendered_html)
+        self.assertIn("Vancouver, BC V6B 1A1", rendered_html)
+        self.assertIn("Test Operation", rendered_html)
+
+    def test_invoice_template_includes_all_invoice_details(self):
+        context = self.base_context.__dict__
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertIn("INV-2025-001", rendered_html)
+        self.assertIn("Jan 15, 2025", rendered_html)
+        self.assertIn("Feb 15, 2025", rendered_html)
+        self.assertIn("25-0001-1", rendered_html)
+        self.assertIn("2024 Compliance Obligation", rendered_html)
+        self.assertIn("1,000 tonnes CO2e", rendered_html)
+        self.assertIn("$2.00 per tonne", rendered_html)
+        self.assertIn("$2,000.00", rendered_html)
+
+    def test_invoice_template_includes_billing_items(self):
+        context = self.base_context.__dict__
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertIn("Fees and Adjustments", rendered_html)
+        self.assertIn("Date", rendered_html)
+        self.assertIn("Description", rendered_html)
+        self.assertIn("Amount", rendered_html)
+        self.assertIn("Compliance Fee", rendered_html)
+        self.assertIn("$2,000.00", rendered_html)
+        self.assertIn("Amount Due:", rendered_html)
+
+    def test_invoice_template_with_void_invoice(self):
+        context = self.base_context.__dict__.copy()
+        context['invoice_is_void'] = True
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertIn("VOID", rendered_html)
+        self.assertIn("watermark", rendered_html)
+
+    def test_invoice_template_without_void_invoice(self):
+        context = self.base_context.__dict__.copy()
+        context['invoice_is_void'] = False
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertNotIn("VOID", rendered_html)
+
+    def test_invoice_template_with_multiple_billing_items(self):
+        context = self.base_context.__dict__.copy()
+        context['billing_items'] = [
+            {"date": "Jan 15, 2025", "description": "Compliance Fee", "amount": "$2,000.00"},
+            {"date": "Jan 20, 2025", "description": "Late Payment Penalty", "amount": "$100.00"},
+            {"date": "Jan 25, 2025", "description": "Payment Credit", "amount": "-$500.00"},
+        ]
+        context['total_amount_due'] = "$1,600.00"
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertIn("Compliance Fee", rendered_html)
+        self.assertIn("Late Payment Penalty", rendered_html)
+        self.assertIn("Payment Credit", rendered_html)
+        self.assertIn("$2,000.00", rendered_html)
+        self.assertIn("$100.00", rendered_html)
+        self.assertIn("-$500.00", rendered_html)
+        self.assertIn("$1,600.00", rendered_html)
+
+    def test_invoice_template_with_empty_billing_items(self):
+        context = self.base_context.__dict__.copy()
+        context['billing_items'] = []
+        context['total_amount_due'] = "$0.00"
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertIn("<!doctype html>", rendered_html)
+        self.assertIn("Fees and Adjustments", rendered_html)
+        self.assertIn("Amount Due:", rendered_html)
+        self.assertIn("$0.00", rendered_html)
+
+    def test_invoice_template_includes_logo(self):
+        context = self.base_context.__dict__
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertIn("data:image/png;base64,", rendered_html)
+        self.assertIn("CleanBC Logo", rendered_html)
+
+    def test_invoice_template_css_styles_present(self):
+        context = self.base_context.__dict__
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertIn("font-family: \"Inter\"", rendered_html)
+        self.assertIn("company-logo", rendered_html)
+        self.assertIn("ministry-title", rendered_html)
+        self.assertIn("invoice-title", rendered_html)
+        self.assertIn("fees-container", rendered_html)
+        self.assertIn("watermark", rendered_html)
+
+    def test_invoice_template_page_setup(self):
+        context = self.base_context.__dict__
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertIn("@page", rendered_html)
+        self.assertIn("size: A4 landscape", rendered_html)
+        self.assertIn("@bottom-left", rendered_html)
+        self.assertIn("@bottom-center", rendered_html)
+        self.assertIn("@bottom-right", rendered_html)
+        self.assertIn("Clean Growth Branch", rendered_html)
+
+    def test_invoice_template_font_loading(self):
+        context = self.base_context.__dict__
+        rendered_html = render_to_string('invoice.html', context)
+        self.assertIn("fonts.googleapis.com", rendered_html)
+        self.assertIn("Inter", rendered_html)

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/download-payment-instructions/PaymentInstructionsDownloadComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/download-payment-instructions/PaymentInstructionsDownloadComponent.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { FormBase } from "@bciers/components/form";
-import ComplianceStepButtons from "../../../ComplianceStepButtons";
+import ComplianceStepButtons from "@/compliance/src/app/components/ComplianceStepButtons";
 import {
   createDownloadPaymentInstructionsSchema,
   downloadPaymentInstructionsUiSchema,
@@ -10,16 +10,16 @@ import {
 import FormAlerts from "@bciers/components/form/FormAlerts";
 
 interface Props {
-  readonly complianceReportVersionId: number;
-  readonly invoiceID: string;
+  complianceReportVersionId: number;
+  invoiceID: string;
 }
 
 export default function PaymentInstructionsDownloadComponent({
   complianceReportVersionId,
   invoiceID,
-}: Props) {
-  const backUrl = `/compliance-summaries/${complianceReportVersionId}/manage-obligation/review-compliance-summary`;
-  const saveAndContinueUrl = `/compliance-summaries/${complianceReportVersionId}/manage-obligation/pay-obligation-track-payments`;
+}: Readonly<Props>) {
+  const backUrl = `/compliance-summaries/${complianceReportVersionId}/manage-obligation-review-summary`;
+  const saveAndContinueUrl = `/compliance-summaries/${complianceReportVersionId}/pay-obligation-track-payments`;
   const [errors, setErrors] = useState<string[]>([]);
   const [isGeneratingDownload, setIsGeneratingDownload] = useState(false);
   const instructionFormData = {

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.tsx
@@ -17,7 +17,7 @@ export function ObligationTrackPaymentsComponent({
   data,
   complianceReportVersionId,
 }: Props) {
-  const backUrl = `/compliance-summaries/${complianceReportVersionId}/manage-obligation-review-summary`;
+  const backUrl = `/compliance-summaries/${complianceReportVersionId}/download-payment-instructions`;
   const saveAndContinueUrl = `/compliance-summaries/${complianceReportVersionId}/review-penalty-summary`;
 
   return (

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.test.tsx
@@ -93,7 +93,7 @@ describe("ObligationTrackPaymentsComponent", () => {
 
     expect(screen.getByTestId("back-button")).toHaveAttribute(
       "data-url",
-      "/compliance-summaries/123/manage-obligation-review-summary",
+      "/compliance-summaries/123/download-payment-instructions",
     );
     expect(screen.getByTestId("continue-button")).toHaveAttribute(
       "data-url",
@@ -118,32 +118,7 @@ describe("ObligationTrackPaymentsComponent", () => {
     expect(backButton).toBeVisible();
     expect(backButton).toHaveAttribute(
       "data-url",
-      "/compliance-summaries/123/manage-obligation-review-summary",
-    );
-
-    const continueButton = screen.getByTestId("continue-button");
-    expect(continueButton).toBeVisible();
-    expect(continueButton).not.toHaveAttribute("data-url");
-  });
-
-  it("does not set continueUrl when outstanding_balance is not 0", () => {
-    const dataWithBalance = {
-      ...mockData,
-      outstanding_balance: 100,
-    };
-
-    render(
-      <ObligationTrackPaymentsComponent
-        data={dataWithBalance}
-        complianceReportVersionId={123}
-      />,
-    );
-
-    const backButton = screen.getByTestId("back-button");
-    expect(backButton).toBeVisible();
-    expect(backButton).toHaveAttribute(
-      "data-url",
-      "/compliance-summaries/123/manage-obligation-review-summary",
+      "/compliance-summaries/123/download-payment-instructions",
     );
 
     const continueButton = screen.getByTestId("continue-button");


### PR DESCRIPTION
[ISSUE 124](https://github.com/bcgov/cas-compliance/issues/124)
[ISSUE 272](https://github.com/bcgov/cas-compliance/issues/272)


## Overview
This PR implements the display of voided invoices with a visual watermark to clearly indicate their voided status.

## Changes

### Invoice Service Logic
- **File**: `bc_obps/compliance/service/compliance_invoice_service.py`
- Enhanced `generate_invoice_pdf` method to detect voided invoices
- Added logic to determine `invoice_is_void` based on invoice's `is_void` status and compliance report version status being `OBLIGATION_FULLY_MET`

### Invoice Template Enhancement
- **File**: `bc_obps/compliance/templates/invoice.html`
- Added CSS styles for watermark display with 45-degree rotation and low opacity
- Added conditional watermark rendering when `invoice_is_void` is true

## Bug Fix: Issue 272
**Issue**: [272](https://github.com/bcgov/cas-compliance/issues/272) - Navigation flow issues in compliance components


## 🧪 Testing:
- Log in as bc-cas-dev
- Navigate to Submit Annual Report(s)
- Submit a report for `Compliance SFO - Obligation not met`
- In the database, update the newly created `ComplianceReportVersion` status to `OBLIGATION_FULLY_MET`
- In the database, set the `is_void` field in the related `ElicensingInvoice` record to True
- Return to the main dashboard
- Under the Compliance tile, click My Compliance
- Click Manage Obligation for the operation
- Click the Generate Compliance Invoice button