### PR TITLE
feat: Reports stay with Operator who submitted them, even after Transfer

### DIFF
--- a/bc_obps/registration/tests/utils/baker_recipes.py
+++ b/bc_obps/registration/tests/utils/baker_recipes.py
@@ -123,6 +123,7 @@ user_operator = Recipe(
 approved_user_operator = Recipe(
     UserOperator,
     status=UserOperator.Statuses.APPROVED,
+    role=UserOperator.Roles.ADMIN,
     operator=foreign_key(operator_for_approved_user_operator),
     user=foreign_key(industry_operator_user),
 )

--- a/bc_obps/reporting/api/report_operation.py
+++ b/bc_obps/reporting/api/report_operation.py
@@ -20,6 +20,10 @@ from ..schema.report_operation import (
 )
 from ..service.report_operation_service import ReportOperationService
 
+"""
+GET methods
+"""
+
 
 @router.get(
     "/report-version/{version_id}/report-operation-data",
@@ -30,6 +34,22 @@ from ..service.report_operation_service import ReportOperationService
 )
 def get_report_operation_data(request: HttpRequest, version_id: int) -> dict:
     return ReportOperationService.get_report_operation_data_by_version_id(version_id)
+
+
+@router.get(
+    "/report-version/{version_id}/report-operation",
+    response={200: ReportOperationSchemaOut, custom_codes_4xx: Message},
+    tags=EMISSIONS_REPORT_TAGS,
+    description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
+    auth=approved_authorized_roles_report_version_composite_auth,
+)
+def get_report_operation_by_version_id(request: HttpRequest, version_id: int) -> dict:
+    return ReportOperationService.get_report_operation_by_version_id(version_id)
+
+
+"""
+PATCH methods
+"""
 
 
 @router.patch(
@@ -44,15 +64,9 @@ def get_update_report(request: HttpRequest, version_id: int) -> tuple[Literal[20
     return 200, report_operation
 
 
-@router.get(
-    "/report-version/{version_id}/report-operation",
-    response={200: ReportOperationSchemaOut, custom_codes_4xx: Message},
-    tags=EMISSIONS_REPORT_TAGS,
-    description="""Takes version_id (primary key of Report_Version model) and returns its report_operation object.""",
-    auth=approved_authorized_roles_report_version_composite_auth,
-)
-def get_report_operation_by_version_id(request: HttpRequest, version_id: int) -> dict:
-    return ReportOperationService.get_report_operation_by_version_id(version_id)
+"""
+POST methods
+"""
 
 
 @router.post(

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -129,10 +129,6 @@ class ReportingDashboardService:
             .distinct()  # this prevents duplication in cases where the operation has had multiple owners
         )
 
-        # Filter results for operator if user is external - they should only see results for their own operator
-        if (op := user_operator) is not None:
-            queryset = queryset.filter(operator_id=op.operator_id)
-
         sort_fields = cls._get_sort_fields(sort_field, sort_order)
 
         return filters.filter(queryset).order_by(*sort_fields)

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -118,6 +118,7 @@ class ReportingDashboardService:
                 # we have different statuses on the frontend than in the db, so we need to create a custom sort key
                 report_status_sort_key=cls.report_status_sort_key,
             )
+            .distinct() # this prevents duplication in cases where the operation has had multiple owners
         )
 
         sort_fields = cls._get_sort_fields(sort_field, sort_order)

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -112,6 +112,8 @@ class ReportingDashboardService:
                 # we have different statuses on the frontend than in the db, so we need to create a custom sort key
                 report_status_sort_key=cls.report_status_sort_key,
             )
+            # need to ensure distinct() because the annotation above can produce duplicates when there's multiple reports for an operation
+            .distinct()
         )
 
         # FIXME - duplicated variable sort_fields - figure out which one to use

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -92,7 +92,7 @@ class ReportingDashboardService:
         current_operations = OperationDataAccessService.get_all_current_operations_for_user(user)
         # need to fetch previously owned operations in case reports were filed for them already or if they need to
         # create a new report version for an operation they once owned.
-        previous_operations = OperationDataAccessService.get_all_previously_owned_operations_for_user_operator(user)
+        previous_operations = OperationDataAccessService.get_all_previously_owned_operations_for_operator(user, user.user_operators.first().operator_id)
 
         all_operations = current_operations | previous_operations
 

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -88,7 +88,7 @@ class ReportingDashboardService:
         current_operations = OperationDataAccessService.get_all_current_operations_for_user(user)
         # need to fetch previously owned operations in case reports were filed for them already or if they need to
         # create a new report version for an operation they once owned.
-        if user.user_operators.first():
+        if user.user_operators.exists():
             previous_operations = OperationDataAccessService.get_previously_owned_operations_for_operator(
                 user, user.user_operators.first().operator_id, reporting_year
             )

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -92,7 +92,7 @@ class ReportingDashboardService:
         current_operations = OperationDataAccessService.get_all_current_operations_for_user(user)
         # need to fetch previously owned operations in case reports were filed for them already or if they need to
         # create a new report version for an operation they once owned.
-        if user.user_operators.first().exists():
+        if user.user_operators.exists():
             previous_operations = OperationDataAccessService.get_all_previously_owned_operations_for_operator(
                 user, user.user_operators.first().operator_id
             )

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -577,7 +577,7 @@ class TestReportingDashboardService:
         # assert original_user can see transferred operation in their reporting dashboard for reporting year 2024
         assert operation.id in list(queryset_2024.values_list("id", flat=True))
         # assert the created report appears in the queryset
-        assert report_r1v1_id in list(queryset_2024.values_list("report_id", flat=True))
+        assert report_version1.report.id in list(queryset_2024.values_list("report_id", flat=True))
         # assert original_user doesn't get results for operations from other operators
         assert queryset_2024.count() == 1
         assert queryset_2025.count() == 1
@@ -588,7 +588,7 @@ class TestReportingDashboardService:
         assert operation.id not in list(queryset_2026.values_list("id", flat=True))
 
         # assert new_user doesn't see the report in their dashboard for 2024 (they didn't own it then)
-        assert report_r1v1_id not in list(queryset_2024_new_user.values_list("report_id", flat=True))
+        assert report_version1.report.id not in list(queryset_2024_new_user.values_list("report_id", flat=True))
         # assert new_user does see the operation in their dashboard for 2025
         assert operation.id in list(queryset_2025_new_user.values_list("id", flat=True))
         # assert new_user doesn't get results for operations from other operators

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -465,3 +465,6 @@ class TestReportingDashboardService:
             (testing_version[1], operation2.name, last_year),
             (testing_version[2], operation2.name, current_year),
         ]
+    def test_report_retrieval_after_transfer(self):
+        # TODO
+        pass

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -3,6 +3,9 @@ import pytest
 from registration.models.operation import Operation
 from model_bakery.baker import make_recipe
 from reporting.models.report_operation import ReportOperation
+from registration.models.user import User
+from registration.models.app_role import AppRole
+from registration.models.user_operator import UserOperator
 from registration.tests.utils.bakers import operation_baker, operator_baker, user_baker, user_operator_baker
 from reporting.service.reporting_dashboard_service import ReportingDashboardService
 from reporting.tests.utils.bakers import report_version_baker, reporting_year_baker
@@ -14,6 +17,7 @@ from reporting.schema.dashboard import (
     ReportingDashboardReportFilterSchema,
     ReportsPeriod,
 )
+from model_bakery import baker
 
 
 @pytest.mark.django_db
@@ -27,7 +31,16 @@ class TestReportingDashboardService:
         mock_get_by_guid: MagicMock | AsyncMock,
         mock_get_all_current_operations_for_user: MagicMock | AsyncMock,
     ):
-        user_operator = user_operator_baker()
+        user = baker.make(User, app_role=AppRole.objects.get(role_name="industry_user"))
+        operator = operator_baker()
+        user_operator = user_operator_baker(
+            {
+                "user": user,
+                "operator": operator,
+                "status": UserOperator.Statuses.APPROVED,
+                "role": UserOperator.Roles.ADMIN,
+            }
+        )
         mock_get_by_guid.return_value = user_operator.user
         mock_get_all_operations_for_user.side_effect = lambda user: Operation.objects.all()
 
@@ -69,6 +82,8 @@ class TestReportingDashboardService:
             user_operator.user.user_guid, 5091, sort_field, sort_order, filters
         ).values()
         result_list = list(result)
+
+        breakpoint()
 
         assert len(result_list) == 3
 
@@ -260,7 +275,16 @@ class TestReportingDashboardService:
     ):
 
         # SETUP
-        user_operator = user_operator_baker()
+        user = baker.make(User, app_role=AppRole.objects.get(role_name="industry_user"))
+        operator = operator_baker()
+        user_operator = user_operator_baker(
+            {
+                "user": user,
+                "operator": operator,
+                "status": UserOperator.Statuses.APPROVED,
+                "role": UserOperator.Roles.ADMIN,
+            }
+        )
         mock_get_by_guid.return_value = user_operator.user
         mock_get_all_operations_for_user.side_effect = lambda user: Operation.objects.all()
 

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -6,7 +6,7 @@ from reporting.models.report_operation import ReportOperation
 from registration.models.user import User
 from registration.models.app_role import AppRole
 from registration.models.user_operator import UserOperator
-from registration.tests.utils.bakers import operation_baker, operator_baker, user_baker, user_operator_baker
+from registration.tests.utils.bakers import operation_baker, operator_baker, user_operator_baker
 from reporting.service.reporting_dashboard_service import ReportingDashboardService
 from reporting.tests.utils.bakers import report_version_baker, reporting_year_baker
 from service.report_service import ReportService
@@ -46,7 +46,6 @@ class TestReportingDashboardService:
 
         year = reporting_year_baker(reporting_year=5091)
         operations = operation_baker(operator_id=user_operator.operator.id, _quantity=5)
-
 
         # Change operation names so alphabetical sorting produces consistent results
         operations[0].name = "a"
@@ -114,7 +113,9 @@ class TestReportingDashboardService:
         assert op2_result["report_version_id"] is None
         assert op2_result["report_status"] is None
 
-    @patch("service.data_access_service.operation_service.OperationDataAccessService.get_all_current_operations_for_user")
+    @patch(
+        "service.data_access_service.operation_service.OperationDataAccessService.get_all_current_operations_for_user"
+    )
     @patch("service.data_access_service.user_service.UserDataAccessService.get_by_guid")
     def test_get_past_reports_for_reporting_dashboard(
         self,
@@ -329,7 +330,11 @@ class TestReportingDashboardService:
         # ASSERTIONS FOR FILTERING
         # Frontend status are Draft, Draft Supplementary, Not Started, Submitted
         draft_filter_result = ReportingDashboardService.get_operations_for_reporting_dashboard(
-            user_operator.user.user_guid, 5091, sort_field, sort_order, ReportingDashboardOperationFilterSchema(report_status="draft")
+            user_operator.user.user_guid,
+            5091,
+            sort_field,
+            sort_order,
+            ReportingDashboardOperationFilterSchema(report_status="draft"),
         ).values()
         assert list(draft_filter_result.values_list('report_status', 'report_version_id')) == [
             ('Draft', latest_r0_revision.id),
@@ -337,18 +342,30 @@ class TestReportingDashboardService:
         ]
 
         draft_supplementary_filter_result = ReportingDashboardService.get_operations_for_reporting_dashboard(
-            user_operator.user.user_guid, 5091, sort_field, sort_order, ReportingDashboardOperationFilterSchema(report_status="sup")
+            user_operator.user.user_guid,
+            5091,
+            sort_field,
+            sort_order,
+            ReportingDashboardOperationFilterSchema(report_status="sup"),
         ).values()
         assert len(draft_supplementary_filter_result) == 1
 
         submitted_filter_result = ReportingDashboardService.get_operations_for_reporting_dashboard(
-            user_operator.user.user_guid, 5091, sort_field, sort_order, ReportingDashboardOperationFilterSchema(report_status="sub")
+            user_operator.user.user_guid,
+            5091,
+            sort_field,
+            sort_order,
+            ReportingDashboardOperationFilterSchema(report_status="sub"),
         ).values()
         # submitted reports don't show if there's a supplementary report, so we should only see the one for r2
         assert len(submitted_filter_result) == 1
 
         not_started_filter_result = ReportingDashboardService.get_operations_for_reporting_dashboard(
-            user_operator.user.user_guid, 5091, sort_field, sort_order, ReportingDashboardOperationFilterSchema(report_status="not")
+            user_operator.user.user_guid,
+            5091,
+            sort_field,
+            sort_order,
+            ReportingDashboardOperationFilterSchema(report_status="not"),
         ).values()
         assert len(not_started_filter_result) == 1
 

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -42,7 +42,7 @@ class TestReportingDashboardService:
             }
         )
         mock_get_by_guid.return_value = user_operator.user
-        mock_get_all_operations_for_user.side_effect = lambda user: Operation.objects.all()
+        mock_get_all_current_operations_for_user.side_effect = lambda user: Operation.objects.all()
 
         year = reporting_year_baker(reporting_year=5091)
         operations = operation_baker(operator_id=user_operator.operator.id, _quantity=5)
@@ -111,9 +111,6 @@ class TestReportingDashboardService:
         assert op2_result["report_version_id"] is None
         assert op2_result["report_status"] is None
 
-    @patch(
-        "service.data_access_service.operation_service.OperationDataAccessService.get_all_current_operations_for_user"
-    )
     @patch("service.data_access_service.user_service.UserDataAccessService.get_by_guid")
     def test_get_past_reports_for_reporting_dashboard(
         self,
@@ -285,7 +282,7 @@ class TestReportingDashboardService:
             }
         )
         mock_get_by_guid.return_value = user_operator.user
-        mock_get_all_operations_for_user.side_effect = lambda user: Operation.objects.all()
+        mock_get_all_current_operations_for_user.side_effect = lambda user: Operation.objects.all()
 
         year = reporting_year_baker(reporting_year=5091)
         operations = operation_baker(operator_id=user_operator.operator.id, _quantity=4)

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -82,8 +82,6 @@ class TestReportingDashboardService:
         ).values()
         result_list = list(result)
 
-        breakpoint()
-
         assert len(result_list) == 3
 
         # Create dictionaries for easy lookup by operation ID

--- a/bc_obps/service/data_access_service/operation_service.py
+++ b/bc_obps/service/data_access_service/operation_service.py
@@ -109,7 +109,6 @@ class OperationDataAccessService:
             # to be implemented later
             return
         else:
-            user_operator = UserOperatorService.get_current_user_approved_user_operator_or_raise(user)
             operator = Operator.objects.get(id=operator_id)
             # Check if the user has access to the specified operator
             if not operator.user_has_access(user.user_guid):
@@ -118,7 +117,7 @@ class OperationDataAccessService:
 
             return (
                 Operation.objects.filter(
-                    designated_operators__operator_id=user_operator.operator_id,
+                    designated_operators__operator_id=operator_id,
                     designated_operators__end_date__isnull=False,
                 )
                 .select_related("operator", "bc_obps_regulated_operation")

--- a/bc_obps/service/data_access_service/operation_service.py
+++ b/bc_obps/service/data_access_service/operation_service.py
@@ -4,7 +4,6 @@ from registration.models import Operation, User, RegulatedProduct, Activity, Ope
 from ninja.types import DictStrAny
 from django.db.models import QuerySet, Q
 from service.user_operator_service import UserOperatorService
-from registration.constants import UNAUTHORIZED_MESSAGE
 
 
 class OperationDataAccessService:
@@ -114,8 +113,8 @@ class OperationDataAccessService:
         operator = Operator.objects.get(id=operator_id)
         # Check if the user has access to the specified operator
         if not operator.user_has_access(user.user_guid):
-            # Raise an exception if access is denied
-            raise Exception(UNAUTHORIZED_MESSAGE)
+            print("user doesn't have access to operator")
+            return Operation.objects.none()
         filters = Q(designated_operators__operator_id=operator_id) & Q(designated_operators__end_date__isnull=False)
         if reporting_year is not None:
             filters &= Q(designated_operators__end_date__year__gte=reporting_year)

--- a/bc_obps/service/data_access_service/operation_service.py
+++ b/bc_obps/service/data_access_service/operation_service.py
@@ -98,3 +98,26 @@ class OperationDataAccessService:
             .filter(operator_id=user_operator.operator_id)
             .only("id", "name", "submission_date", "status", "operator__legal_name", "bc_obps_regulated_operation__id")
         )
+
+    @classmethod
+    def get_all_previously_owned_operations_for_user_operator(cls, user: User) -> QuerySet[Operation]:
+        """
+        Returns all operations that were previously owned by the user's operator.
+        """
+        if user.is_irc_user():
+            # to be implemented later
+            return
+        else:
+            user_operator = UserOperatorService.get_current_user_approved_user_operator_or_raise(user)
+
+            return (
+                Operation.objects.filter(
+                    designated_operators__operator_id=user_operator.operator_id,
+                    designated_operators__end_date__isnull=False,
+                )
+                .select_related("operator", "bc_obps_regulated_operation")
+                .exclude(status__in=[Operation.Statuses.NOT_STARTED, Operation.Statuses.DRAFT])
+                .only(
+                    "id", "name", "submission_date", "status", "operator__legal_name", "bc_obps_regulated_operation__id"
+                )
+            )

--- a/bc_obps/service/data_access_service/report_service.py
+++ b/bc_obps/service/data_access_service/report_service.py
@@ -10,3 +10,15 @@ class ReportDataAccessService:
             .filter(operation__id=operation_id, reporting_year=reporting_year)
             .first()
         )
+    
+    @classmethod
+    def get_all_reports_for_operator(cls, operator_id: UUID, reporting_year: int = 2024) -> list[Report]:
+        """
+        Fetches all reports filed by the operator, regardless of current ownership of the operation.
+        """
+        return (
+            Report.objects.filter(operation__operator_id=operator_id)
+            .prefetch_related("operation")
+            .filter(reporting_year=reporting_year)
+            .order_by("-reporting_year")
+        )

--- a/bc_obps/service/data_access_service/report_service.py
+++ b/bc_obps/service/data_access_service/report_service.py
@@ -10,15 +10,3 @@ class ReportDataAccessService:
             .filter(operation__id=operation_id, reporting_year=reporting_year)
             .first()
         )
-    
-    @classmethod
-    def get_all_reports_for_operator(cls, operator_id: UUID, reporting_year: int = 2024) -> list[Report]:
-        """
-        Fetches all reports filed by the operator, regardless of current ownership of the operation.
-        """
-        return (
-            Report.objects.filter(operation__operator_id=operator_id)
-            .prefetch_related("operation")
-            .filter(reporting_year=reporting_year)
-            .order_by("-reporting_year")
-        )

--- a/bciers/apps/reporting/src/app/components/operations/cells/ActionCell.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/cells/ActionCell.tsx
@@ -16,28 +16,32 @@ const ActionCell = (params: GridRenderCellParams) => {
   const router = useRouter();
   const operationId = params.row.operation_id;
   const [responseError, setResponseError] = React.useState<string | null>(null);
+  const operationName = params?.row.operation_name;
   const [hasClicked, setHasClicked] = React.useState<boolean>(false);
   const [modalOpen, setModalOpen] = React.useState(false);
   const [modalErrorMessage, setModalErrorMessage] = React.useState("");
 
   // Create a new report
-  const handleStartReport = async (reportingYear: number): Promise<string | undefined> => {
+  const handleStartReport = async (
+    reportingYear: number,
+  ): Promise<string | undefined> => {
     try {
       const response = await createReport(operationId, reportingYear);
       if (response?.error) {
         setModalErrorMessage(
-          `We couldn't create a report for operation ID '${operationId}' and reporting year ${reportingYear}: ${response?.error}`,
+          `We couldn't create a report for operation '${operationName}' and reporting year ${reportingYear}: ${response?.error}`,
         );
         setModalOpen(true);
         return;
       }
       return response;
     } catch (error) {
-      setModalErrorMessage("An unexpected error occurred while creating the report.");
+      setModalErrorMessage(
+        "An unexpected error occurred while creating the report.",
+      );
       setModalOpen(true);
     }
   };
-
 
   // Create a new report version
   const handleNewDraftVersion = async (): Promise<string | undefined> => {
@@ -52,7 +56,9 @@ const ActionCell = (params: GridRenderCellParams) => {
       }
       return response;
     } catch (error) {
-      setModalErrorMessage("An unexpected error occurred while creating a new draft version of the report.");
+      setModalErrorMessage(
+        "An unexpected error occurred while creating a new draft version of the report.",
+      );
       setModalOpen(true);
     }
   };
@@ -95,34 +101,33 @@ const ActionCell = (params: GridRenderCellParams) => {
 
   return (
     <>
-    <SimpleModal
-      open={modalOpen}
-      title="Error Creating Report"
-      onCancel={() => setModalOpen(false)}
-      onConfirm={() => setModalOpen(false)}
-      confirmText="OK"
-      cancelText="Close"
-    >
-      {modalErrorMessage}
-    </SimpleModal>
-    <Button
-      sx={{
-        width: 120,
-        height: 40,
-        borderRadius: "5px",
-        border: `1px solid ${BC_GOV_LINKS_COLOR}`,
-        cursor: buttonDisabled ? "not-allowed" : "pointer",
-      }}
-      color="primary"
-      disabled={buttonDisabled}
-      onClick={async () => {
-        setHasClicked(true);
-        await buttonAction();
-        setHasClicked(false);
-      }}
-    >
-      {buttonText}
-    </Button>
+      <SimpleModal
+        open={modalOpen}
+        title="Error Creating Report"
+        onCancel={() => setModalOpen(false)}
+        onConfirm={() => setModalOpen(false)}
+        showConfirmButton={false}
+      >
+        {modalErrorMessage}
+      </SimpleModal>
+      <Button
+        sx={{
+          width: 120,
+          height: 40,
+          borderRadius: "5px",
+          border: `1px solid ${BC_GOV_LINKS_COLOR}`,
+          cursor: buttonDisabled ? "not-allowed" : "pointer",
+        }}
+        color="primary"
+        disabled={buttonDisabled}
+        onClick={async () => {
+          setHasClicked(true);
+          await buttonAction();
+          setHasClicked(false);
+        }}
+      >
+        {buttonText}
+      </Button>
     </>
   );
 };


### PR DESCRIPTION
### Changes Made:

- reporting dashboard service pulls both current operations and previously owned operations for the external user's operator
- added filter on reporting dashboard to ensure that only reports created by the user's operator are displayed in the grid
- added modal to display error message when Operator B tried to create a new report for an operation when previous owner Operator A already created a report for the same operation and reporting_year

### Recommended Testing Steps

1. sign in with your own Business BCeID, or use bc-cas-dev-secondary. Create a new operator for this user. Then log out
2. sign in with your IDIR. Delete the existing pending transfer for "Bangles SFO" (operator Bravo Technologies). Create a new transfer for "Bangles SFO" to transfer to the operator created in Step 1, with date of transfer effective immediately. Log out.
3. sign in with the `bc-cas-dev` Business BCeID (operator is Bravo Technologies). Confirm that "Bangles SFO" operation no longer appears in your Administration dashboard, but it should still appear in your Reporting dashboard and you should still be able to view the report that was submitted for it. Log out.
4. sign in again with the BCeID used in Step 1. Confirm that "Bangles SFO" operation now appears in your Administration dashboard. Then go to Reporting dashboard and confirm that the operation appears there too, but that you don't have the option to view the report submitted for it by Bravo. Click the "Start" button to try to create a new report for Bangles SFO -you should see a modal popup with an error message saying that a report already exists for that operation and reporting year.