### PR TITLE
fix: let operation name in compliance summary grid take from reporting rather than admin

### DIFF
--- a/bc_obps/compliance/schema/compliance_report_version.py
+++ b/bc_obps/compliance/schema/compliance_report_version.py
@@ -6,7 +6,7 @@ from registration.models import Operation
 
 # report aliases
 OPERATOR_NAME_ALIAS = "compliance_report.report.operator.legal_name"
-OPERATION_NAME_ALIAS = "compliance_report.report.operation.name"
+OPERATION_NAME_ALIAS = "report_compliance_summary.report_version.report_operation.operation_name"
 OPERATION_BCGHG_ID_ALIAS = "compliance_report.report.operation.bcghg_id.id"
 
 # reporting_year aliases

--- a/bc_obps/compliance/tests/api/_compliance_report_versions/test_compliance_report_version_id.py
+++ b/bc_obps/compliance/tests/api/_compliance_report_versions/test_compliance_report_version_id.py
@@ -16,6 +16,7 @@ class TestComplianceReportVersionEndpoint(CommonTestSetup):
             report_compliance_summary__excess_emissions=Decimal("50.0000"),
             report_compliance_summary__credited_emissions=Decimal("25.0000"),
             status="Obligation not met",
+            report_compliance_summary__report_version__report_operation__operation_name="Test Operation",
         )
         mock_get_version.return_value = compliance_report_version
 
@@ -37,7 +38,10 @@ class TestComplianceReportVersionEndpoint(CommonTestSetup):
         # Verify the response data
         assert response_data["id"] == compliance_report_version.id
         assert response_data["status"] == compliance_report_version.status
-        assert response_data["operation_name"] == compliance_report_version.compliance_report.report.operation.name
+        assert (
+            response_data["operation_name"]
+            == compliance_report_version.report_compliance_summary.report_version.report_operation.operation_name
+        )
         assert (
             response_data["reporting_year"]
             == compliance_report_version.compliance_report.compliance_period.end_date.year

--- a/bc_obps/compliance/tests/api/test_compliance_report_versions.py
+++ b/bc_obps/compliance/tests/api/test_compliance_report_versions.py
@@ -11,11 +11,17 @@ class TestComplianceReportVersionsEndpoint(CommonTestSetup):
     )
     def test_get_compliance_report_versions_list_success(self, mock_get_versions):
         # Arrange
-        version1 = make_recipe('compliance.tests.utils.compliance_report_version')
+        version1 = make_recipe(
+            'compliance.tests.utils.compliance_report_version',
+            report_compliance_summary__report_version__report_operation__operation_name="Test Operation1",
+        )
         version1.report_compliance_summary.excess_emissions = Decimal("50.0000")
         version1.report_compliance_summary.save()
 
-        version2 = make_recipe('compliance.tests.utils.compliance_report_version')
+        version2 = make_recipe(
+            'compliance.tests.utils.compliance_report_version',
+            report_compliance_summary__report_version__report_operation__operation_name="Test Operation2",
+        )
         version2.report_compliance_summary.excess_emissions = Decimal("75.0000")
         version2.report_compliance_summary.save()
 
@@ -45,13 +51,19 @@ class TestComplianceReportVersionsEndpoint(CommonTestSetup):
         # Verify first version
         assert items[0]["id"] == version1.id
         assert items[0]["status"] == version1.status
-        assert items[0]["operation_name"] == version1.compliance_report.report.operation.name
+        assert (
+            items[0]["operation_name"]
+            == version1.report_compliance_summary.report_version.report_operation.operation_name
+        )
         assert items[0]["reporting_year"] == version1.compliance_report.compliance_period.end_date.year
         assert Decimal(items[0]["excess_emissions"]) == Decimal("50.0000")
 
         # Verify second version
         assert items[1]["id"] == version2.id
         assert items[1]["status"] == version2.status
-        assert items[1]["operation_name"] == version2.compliance_report.report.operation.name
+        assert (
+            items[1]["operation_name"]
+            == version2.report_compliance_summary.report_version.report_operation.operation_name
+        )
         assert items[1]["reporting_year"] == version2.compliance_report.compliance_period.end_date.year
         assert Decimal(items[1]["excess_emissions"]) == Decimal("75.0000")


### PR DESCRIPTION
https://github.com/bcgov/cas-compliance/issues/173