### PR TITLE
Feat/247 supplementary report decreases earned credits

### DIFF
--- a/bc_obps/compliance/service/supplementary_version_service.py
+++ b/bc_obps/compliance/service/supplementary_version_service.py
@@ -1,4 +1,3 @@
-from compliance.models.compliance_earned_credit import ComplianceEarnedCredit
 from compliance.service.elicensing.elicensing_obligation_service import ElicensingObligationService
 from reporting.models import ReportVersion, ReportComplianceSummary
 from compliance.models import ComplianceReport, ComplianceEarnedCredit


### PR DESCRIPTION
Issue: https://github.com/bcgov/cas-compliance/issues/247

Supplmentary scenario where a report decreases the earned credits from the original report:

To test:
- Submit the earned credits report
- Create a supplementary report and edit it so that the earned credits decreases (increase emissions)
- Check that the amount in the earned_credit record has been updated with the decreased amount of credits