### PR TITLE
173 operation name should be derived from reporting

### DIFF
--- a/bc_obps/compliance/service/compliance_invoice_service.py
+++ b/bc_obps/compliance/service/compliance_invoice_service.py
@@ -60,7 +60,6 @@ class ComplianceInvoiceService:
             operation: Operation = ComplianceReportVersionService.get_operation_by_compliance_report_version(
                 compliance_report_version_id
             )
-            operation_name = operation.name
 
             # Get operator information
             # Operation → Operator
@@ -84,6 +83,11 @@ class ComplianceInvoiceService:
             # ComplianceObligation  → ComplianceReportVersion
             compliance_report_version: ComplianceReportVersion = compliance_obligation.compliance_report_version
             fee_amount_dollars = compliance_obligation.fee_amount_dollars
+
+            # Get operation name from report operation
+            operation_name = (
+                compliance_report_version.report_compliance_summary.report_version.report_operation.operation_name
+            )
 
             # Get excess_emissions from
             # ComplianceReportVersion → ReportComplianceSummary

--- a/bc_obps/compliance/tests/service/test_compliance_invoice_service.py
+++ b/bc_obps/compliance/tests/service/test_compliance_invoice_service.py
@@ -17,6 +17,7 @@ class TestComplianceInvoiceService:
 
         self.compliance_report_version = make_recipe(
             "compliance.tests.utils.compliance_report_version",
+            report_compliance_summary__report_version__report_operation__operation_name="test",
         )
 
         self.obligation = make_recipe(

--- a/bciers/apps/compliance/src/app/components/layout/CompliancePageHeading.tsx
+++ b/bciers/apps/compliance/src/app/components/layout/CompliancePageHeading.tsx
@@ -1,16 +1,14 @@
 import { HasComplianceReportVersion } from "../../types";
-import getOperationByComplianceReportVersionId from "../../utils/getOperationByComplianceReportVersionId";
+import { getComplianceSummary } from "../../utils/getComplianceSummary";
 
 export const CompliancePageHeading = async ({
   compliance_report_version_id: complianceReportVersionId,
 }: Readonly<HasComplianceReportVersion>) => {
-  const operation = await getOperationByComplianceReportVersionId(
-    complianceReportVersionId,
-  );
+  const operation = await getComplianceSummary(complianceReportVersionId);
   return (
     <div className="container mx-auto pb-4">
       <h2 className="text-2xl font-bold mb-4 text-bc-bg-blue">
-        {operation.name}
+        {operation.operation_name}
       </h2>
     </div>
   );

--- a/bciers/apps/compliance/src/tests/components/layout/CompliancePageHeading.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/layout/CompliancePageHeading.test.tsx
@@ -1,13 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import { CompliancePageHeading } from "@/compliance/src/app/components/layout/CompliancePageHeading";
 
-// Mock the getOperationByComplianceReportVersionId function
-vi.mock(
-  "@/compliance/src/app/utils/getOperationByComplianceReportVersionId",
-  () => ({
-    default: vi.fn().mockResolvedValue({ name: "Operation ABC" }),
-  }),
-);
+// Mock the getComplianceSummary function
+vi.mock("@/compliance/src/app/utils/getComplianceSummary", () => ({
+  getComplianceSummary: vi
+    .fn()
+    .mockResolvedValue({ operation_name: "Operation ABC" }),
+}));
 
 const mockComplianceReportVersionId = 123;
 


### PR DESCRIPTION
Part 2 of ticket [173](https://github.com/bcgov/cas-compliance/issues/173)

This changes the operation name to be pulled from reporting in the:
- Compliance obligation review page
- Compliance invoice

To Test:
- continue a report with obligation not met
- change the name
- go to compliance and manage obligation of the compliance report
- report name in title should be new name

- click generate invoice
- invoice should contain edited operation name as well