### PR TITLE
date format update mmm dd, yyyy

### DIFF
--- a/bciers/apps/administration/tests/components/facilities/FacilityForm.test.tsx
+++ b/bciers/apps/administration/tests/components/facilities/FacilityForm.test.tsx
@@ -460,7 +460,7 @@ describe("FacilityForm component", () => {
     );
     expect(
       container.querySelector("#root_section1_starting_date"),
-    ).toHaveTextContent("2024-07-11");
+    ).toHaveTextContent("Jul 11, 2024");
     expect(
       container.querySelector("#root_section2_street_address"),
     ).toHaveTextContent("adf");
@@ -510,7 +510,7 @@ describe("FacilityForm component", () => {
     );
     expect(
       container.querySelector("#root_section1_starting_date"),
-    ).toHaveTextContent("2024-07-11");
+    ).toHaveTextContent("Jul 11, 2024");
     expect(
       container.querySelector("#root_section1_street_address"),
     ).toHaveTextContent("adf");

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.test.tsx
@@ -80,7 +80,7 @@ describe("ObligationTrackPaymentsComponent", () => {
     expect(screen.getByText("Payment 1")).toBeVisible();
 
     // Check the payment received date from mockData
-    expect(screen.getByText("2025-12-06")).toBeVisible();
+    expect(screen.getByText("Dec 06, 2025")).toBeVisible();
   });
 
   it("renders step buttons with correct URLs when outstanding_balance is 0", () => {

--- a/bciers/apps/registration/tests/components/transfers/TransferDetailForm.test.tsx
+++ b/bciers/apps/registration/tests/components/transfers/TransferDetailForm.test.tsx
@@ -179,7 +179,7 @@ describe("The TransferDetailForm component", () => {
       "what is being transferred?",
       "operation 1",
       "effective date of transfer",
-      "2022-12-31",
+      "Dec 31, 2022",
     ];
     checkFormFieldsAndLabels(formFieldsAndLabels);
     checkButtons();
@@ -200,7 +200,7 @@ describe("The TransferDetailForm component", () => {
       "name 1 - \\(11, 22\\), name 2 - \\(33, 44\\)",
       "new operation",
       "effective date of transfer",
-      "2022-12-31",
+      "Dec 31, 2022",
     ];
 
     checkFormFieldsAndLabels(formFieldsAndLabels);

--- a/bciers/libs/components/src/form/widgets/readOnly/ReadOnlyDateWidget.test.tsx
+++ b/bciers/libs/components/src/form/widgets/readOnly/ReadOnlyDateWidget.test.tsx
@@ -35,7 +35,7 @@ describe("RJSF ReadOnlyWidget", () => {
 
     const dateWidget = container.querySelector("#root_dateWidgetTestField");
     expect(dateWidget).toBeVisible();
-    expect(dateWidget).toHaveTextContent("2024-07-05");
+    expect(dateWidget).toHaveTextContent("Jul 05, 2024");
   });
 
   it("should be empty when no value is provided", () => {

--- a/bciers/libs/components/src/form/widgets/readOnly/ReadOnlyDateWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/readOnly/ReadOnlyDateWidget.tsx
@@ -3,7 +3,7 @@ import dayjs from "dayjs";
 
 const formatDate = (value: string) => {
   if (typeof value === "string" && dayjs(value).isValid()) {
-    return dayjs(value).format("YYYY-MM-DD");
+    return dayjs(value).format("MMM DD, YYYY");
   }
   return null;
 };


### PR DESCRIPTION
[278](https://github.com/bcgov/cas-compliance/issues/278)

- **fix: change date widget format to Mon DD, YYYY**
- **test: update test for datewidget to display in mmm dd, yyyy format**

*** this PR also changes anything related to the date widget:
- transfer detail form
- facility form

**To Test:**

- sign off on a report with an obligation
- navigate to pay obligation page
- payment received date should be in the format Mon DD, YYYY

<img width="537" height="508" alt="Screenshot 2025-08-11 at 5 06 55 PM" src="https://github.com/user-attachments/assets/44f65950-3587-4372-a926-82f16bbc1d92" />

