### PR TITLE
chore: correct calculation for earned credit cap limit

### DIFF
--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_apply_compliance_units_service.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_apply_compliance_units_service.py
@@ -418,7 +418,9 @@ class TestApplyComplianceUnitsService:
         mock_refresh_data.return_value = mock_refresh_result
 
         # Act
-        result = ApplyComplianceUnitsService._get_total_adjustments_for_report_version(1)
+        result = ApplyComplianceUnitsService._get_total_adjustments_for_report_version_by_reason(
+            1, 'Compliance Units Applied'
+        )
 
         # Assert
         assert result == Decimal("0")
@@ -435,7 +437,9 @@ class TestApplyComplianceUnitsService:
         mock_adjustments_manager.filter.return_value.aggregate.return_value = {"total": None}
 
         # Act
-        result = ApplyComplianceUnitsService._get_total_adjustments_for_report_version(1)
+        result = ApplyComplianceUnitsService._get_total_adjustments_for_report_version_by_reason(
+            1, 'Compliance Units Applied'
+        )
 
         # Assert: fallback to zero when no line items or aggregate is None
         assert result == Decimal("0")


### PR DESCRIPTION
Fixes an issue with how the earned credit limit/cap was being calculated.

The issue:
When an adjustment is made via a supplementary report. It should be considered when calculating the 50% limit, but not count against the cap remaining (adjustments made when applying credits should lower the cap remaining, not supplementary adjustments).

The fix:
Updated the get adjustments function to differentiate between those two adjustment types and fetch them in the appropriate places in the function logic.