### PR TITLE
remove 'Not applicable' allocation methodology for SFOs

### DIFF
--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -24,6 +24,7 @@ interface Props {
   isPulpAndPaper: boolean;
   overlappingIndustrialProcessEmissions: number;
   facilityType: string;
+  operationType?: string;
 }
 
 interface FormData {
@@ -145,7 +146,20 @@ export default function FacilityEmissionAllocationForm({
   navigationInformation,
   isPulpAndPaper,
   overlappingIndustrialProcessEmissions,
+  operationType,
 }: Props) {
+  // filter allocation_methodology enum
+  const getFilteredSchema = () => {
+    const schema = JSON.parse(JSON.stringify(emissionAllocationSchema));
+    if (operationType === "Single Facility Operation") {
+      const enums = schema.properties.allocation_methodology.enum;
+      schema.properties.allocation_methodology.enum = enums.filter(
+        (methodology: string) => methodology !== "Not Applicable",
+      );
+    }
+    return schema;
+  };
+
   // Using the useState hook to initialize the form data with initialData values
   const [formData, setFormData] = useState<any>(() => ({
     allocation_methodology: initialData.allocation_methodology,
@@ -337,7 +351,7 @@ export default function FacilityEmissionAllocationForm({
       initialStep={navigationInformation.headerStepIndex}
       steps={navigationInformation.headerSteps}
       taskListElements={navigationInformation.taskList}
-      schema={emissionAllocationSchema}
+      schema={getFilteredSchema()}
       uiSchema={emissionAllocationUiSchema}
       formData={formData}
       submitButtonDisabled={submitButtonDisabled}

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationPage.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationPage.tsx
@@ -59,6 +59,7 @@ export default async function FacilityEmissionAllocationPage({
         overlappingIndustrialProcessEmissions
       }
       facilityType={facilityType}
+      operationType={tasklistData?.operationType}
     />
   );
 }

--- a/bciers/apps/reporting/src/tests/components/facility/FacilityEmissionAllocationForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/facility/FacilityEmissionAllocationForm.test.tsx
@@ -229,14 +229,14 @@ describe("FacilityEmissionAllocationForm component", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("back");
   });
 
-  it("renders a Not Applicable option for methodology if report type is small or medium", async () => {
+  it("renders a Not Applicable option for methodology", async () => {
     render(
       <FacilityEmissionAllocationForm
         version_id={config.mockVersionId}
         facility_id={config.mockFacilityId}
         orderedActivities={[]}
         initialData={mockInitialData}
-        facilityType={"Small Aggregate"}
+        facilityType={""}
         navigationInformation={{
           taskList: [],
           continueUrl: "",
@@ -255,5 +255,33 @@ describe("FacilityEmissionAllocationForm component", () => {
     const methodology = screen.getAllByText(/Not Applicable/i)[0];
     expect(methodology).toBeInTheDocument();
     expect(methodology).toBeVisible();
+  });
+
+  it("does not render a Not Applicable option for methodology if operation type is SFO", async () => {
+    render(
+      <FacilityEmissionAllocationForm
+        version_id={config.mockVersionId}
+        facility_id={config.mockFacilityId}
+        orderedActivities={[]}
+        initialData={mockInitialData}
+        facilityType=""
+        navigationInformation={{
+          taskList: [],
+          continueUrl: "",
+          backUrl: "",
+          headerSteps: [],
+          headerStepIndex: 0,
+        }}
+        isPulpAndPaper={false}
+        overlappingIndustrialProcessEmissions={0}
+        operationType="Single Facility Operation"
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("combobox", { name: /root_allocation_methodology/i }),
+    );
+    const methodology = screen.queryAllByText(/Not Applicable/i)[0];
+    expect(methodology).toBeUndefined();
   });
 });


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/719

#### What I did
 - if operation is an SFO, filter the schema to remove "Not Applicable" from the enums of methodology options.

#### To test
1. Run the project and log in as bc-cas-dev
2. Start or continue a report for an OBPS regulated operation that is an SFO (eg. Bugle SFO)
3. Progress through the report to the allocation-of-emissions page
4. Click the Methodology dropdown selector
   - Expect to see: 'Not Applicable' is NOT an option.
5. [Optional] Pick an LFO and progress through the report for any facility. Get to the allocation-of-emissions page and see that 'Not Applicable' IS still a methodology option (as expected).