### PR TITLE
chore: update compliance_period prod fixtures to be correct

### DIFF
--- a/bc_obps/compliance/fixtures/production/compliance_periods.json
+++ b/bc_obps/compliance/fixtures/production/compliance_periods.json
@@ -5,21 +5,9 @@
     "fields": {
       "created_at": "2024-01-01T00:00:00Z",
       "updated_at": "2024-01-01T00:00:00Z",
-      "start_date": "2023-01-01",
-      "end_date": "2023-12-31",
-      "compliance_deadline": "2024-06-30",
-      "reporting_year": 2023
-    }
-  },
-  {
-    "model": "compliance.complianceperiod",
-    "pk": 2,
-    "fields": {
-      "created_at": "2024-01-01T00:00:00Z",
-      "updated_at": "2024-01-01T00:00:00Z",
       "start_date": "2024-01-01",
       "end_date": "2024-12-31",
-      "compliance_deadline": "2025-06-30",
+      "compliance_deadline": "2025-11-30",
       "reporting_year": 2024
     }
   }


### PR DESCRIPTION
Updates the fixtures in the production directory to be correct:
- removes the compliance period for reporting year 2023
- updates the deadline date to nov 30 2025 for reporting year 2024