### PR TITLE
chore: add route for "View Details" link `review-obligation-summary`

### DIFF
--- a/bciers/apps/compliance/src/app/bceidbusiness/industry_user/compliance-summaries/[compliance_report_version_id]/(met-obligation)/review-obligation-summary/page.tsx
+++ b/bciers/apps/compliance/src/app/bceidbusiness/industry_user/compliance-summaries/[compliance_report_version_id]/(met-obligation)/review-obligation-summary/page.tsx
@@ -1,0 +1,4 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import Page from "@/compliance/src/app/components/compliance-summary/met-obligation/review-compliance-summary/ComplianceSummaryReviewPage";
+
+export default defaultPageFactory(Page);

--- a/bciers/apps/compliance/src/app/bceidbusiness/industry_user_admin/compliance-summaries/[compliance_report_version_id]/(met-obligation)/review-obligation-summary/page.tsx
+++ b/bciers/apps/compliance/src/app/bceidbusiness/industry_user_admin/compliance-summaries/[compliance_report_version_id]/(met-obligation)/review-obligation-summary/page.tsx
@@ -1,0 +1,4 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import Page from "@/compliance/src/app/components/compliance-summary/met-obligation/review-compliance-summary/ComplianceSummaryReviewPage";
+
+export default defaultPageFactory(Page);

--- a/bciers/apps/compliance/src/app/components/compliance-summary/met-obligation/review-compliance-summary/ComplianceSummaryReviewComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/met-obligation/review-compliance-summary/ComplianceSummaryReviewComponent.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import FormBase from "@bciers/components/form/FormBase";
+import ComplianceStepButtons from "@/compliance/src/app/components/ComplianceStepButtons";
+import { ComplianceSummaryReviewPageData } from "@/compliance/src/app/types";
+import {
+  complianceSummaryReviewSchema,
+  complianceSummaryReviewUiSchema,
+} from "@/compliance/src/app/data/jsonSchema/metObligation/complianceSummaryReviewSchema";
+
+interface Props {
+  data: ComplianceSummaryReviewPageData;
+}
+
+const ComplianceSummaryReviewComponent = ({ data }: Props) => {
+  const backUrl = "/compliance-summaries";
+
+  return (
+    <FormBase
+      schema={complianceSummaryReviewSchema(data.reporting_year)}
+      uiSchema={complianceSummaryReviewUiSchema()}
+      formData={data}
+      className="w-full"
+    >
+      <ComplianceStepButtons backUrl={backUrl} className="mt-44" />
+    </FormBase>
+  );
+};
+
+export default ComplianceSummaryReviewComponent;

--- a/bciers/apps/compliance/src/app/components/compliance-summary/met-obligation/review-compliance-summary/ComplianceSummaryReviewPage.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/met-obligation/review-compliance-summary/ComplianceSummaryReviewPage.tsx
@@ -1,0 +1,41 @@
+import CompliancePageLayout from "@/compliance/src/app/components/layout/CompliancePageLayout";
+import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
+import {
+  ComplianceSummaryReviewPageData,
+  HasComplianceReportVersion,
+} from "@/compliance/src/app/types";
+import { fetchComplianceSummaryReviewPageData } from "@/compliance/src/app/utils/fetchComplianceSummaryReviewPageData";
+
+import ComplianceSummaryReviewComponent from "./ComplianceSummaryReviewComponent";
+
+export default async function ComplianceSummaryReviewPage({
+  compliance_report_version_id: complianceReportVersionId,
+}: Readonly<HasComplianceReportVersion>) {
+  const data: ComplianceSummaryReviewPageData =
+    await fetchComplianceSummaryReviewPageData(complianceReportVersionId);
+
+  const taskListElements: TaskListElement[] = [
+    {
+      type: "Section",
+      title: `${data.reporting_year} Compliance Summary`,
+      isExpanded: true,
+      elements: [
+        {
+          type: "Page" as const,
+          title: `Review ${data.reporting_year} Obligation Summary`,
+          link: `/compliance-summaries/${complianceReportVersionId}/review-obligation-summary`,
+          isActive: true,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <CompliancePageLayout
+      complianceReportVersionId={complianceReportVersionId}
+      taskListElements={taskListElements}
+    >
+      <ComplianceSummaryReviewComponent data={data} />
+    </CompliancePageLayout>
+  );
+}

--- a/bciers/apps/compliance/src/app/data/jsonSchema/metObligation/complianceSummaryReviewSchema.tsx
+++ b/bciers/apps/compliance/src/app/data/jsonSchema/metObligation/complianceSummaryReviewSchema.tsx
@@ -1,0 +1,73 @@
+import { RJSFSchema, UiSchema } from "@rjsf/utils";
+import FieldTemplate from "@bciers/components/form/fields/FieldTemplate";
+import {
+  readOnlyObjectField,
+  readOnlyStringField,
+  tco2eUiConfig,
+  headerUiConfig,
+  commonReadOnlyOptions,
+} from "@/compliance/src/app/data/jsonSchema/helpers";
+
+export const complianceSummaryReviewSchema = (
+  reportingYear: number,
+): RJSFSchema => ({
+  type: "object",
+  title: `Review ${reportingYear} Obligation Summary`,
+  properties: {
+    // Summary Section
+    summary_header: readOnlyObjectField(`From ${reportingYear} Report`),
+    emissions_attributable_for_compliance: readOnlyStringField(
+      "Emissions Attributable for Compliance:",
+    ),
+    emissions_limit: readOnlyStringField("Emissions Limit:"),
+    excess_emissions: readOnlyStringField("Excess Emissions:"),
+    // Obligation Section
+    obligation_header: readOnlyObjectField(
+      `${reportingYear} Compliance Obligation`,
+    ),
+    obligation_id: readOnlyStringField("Obligation ID:"),
+    compliance_charge_rate: readOnlyStringField(
+      `${reportingYear} Compliance Charge Rate:`,
+    ),
+    equivalent_value: readOnlyStringField("Equivalent Value:"),
+    // Outstanding Compliance Obligation Section
+    outstanding_obligation_header: readOnlyObjectField(
+      "Outstanding Compliance Obligation",
+    ),
+    outstanding_balance_tco2e: readOnlyStringField("Outstanding Balance:"),
+    outstanding_balance_equivalent_value:
+      readOnlyStringField("Equivalent Value:"),
+  },
+});
+
+export const complianceSummaryReviewUiSchema = (): UiSchema => ({
+  "ui:FieldTemplate": FieldTemplate,
+  "ui:classNames": "form-heading-label",
+
+  // Summary Section
+  summary_header: headerUiConfig,
+  emissions_attributable_for_compliance: tco2eUiConfig,
+  emissions_limit: tco2eUiConfig,
+  excess_emissions: tco2eUiConfig,
+  // Obligation Section
+  obligation_header: headerUiConfig,
+  obligation_id: commonReadOnlyOptions,
+  compliance_charge_rate: {
+    ...commonReadOnlyOptions,
+    "ui:options": {
+      prefix: "$",
+      suffix: "/tCO2e",
+    },
+  },
+  equivalent_value: {
+    ...commonReadOnlyOptions,
+    "ui:widget": "ReadOnlyCurrencyWidget",
+  },
+  // Outstanding Compliance Obligation Section
+  outstanding_obligation_header: headerUiConfig,
+  outstanding_balance_tco2e: tco2eUiConfig,
+  outstanding_balance_equivalent_value: {
+    ...commonReadOnlyOptions,
+    "ui:widget": "ReadOnlyCurrencyWidget",
+  },
+});

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/met-obligation/review-obligation-summary/ComplianceSummaryReviewComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/met-obligation/review-obligation-summary/ComplianceSummaryReviewComponent.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useRouter, useSessionRole } from "@bciers/testConfig/mocks";
+import ComplianceSummaryReviewComponent from "@/compliance/src/app/components/compliance-summary/met-obligation/review-compliance-summary/ComplianceSummaryReviewComponent";
+
+// Mock the router
+const mockRouterPush = vi.fn();
+useRouter.mockReturnValue({
+  query: {},
+  push: mockRouterPush,
+});
+
+const mockData = {
+  id: 1,
+  operation_name: "Test Operation",
+  reporting_year: 2024,
+  compliance_charge_rate: 80.0,
+  excess_emissions: 0,
+  emissions_limit: "90.0",
+  obligation_id: "test-obligation-id",
+  outstanding_balance: 0.0,
+  equivalent_value: 0.0,
+  status: "Obligation fully met",
+  outstanding_balance_equivalent_value: 0.0,
+};
+
+describe("ComplianceSummaryReviewComponent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionRole.mockReturnValue("industry_user");
+  });
+
+  it("renders the form with correct schema fields and headers", () => {
+    render(<ComplianceSummaryReviewComponent data={mockData} />);
+
+    // Check form title
+    expect(screen.getByText("Review 2024 Obligation Summary")).toBeVisible();
+  });
+
+  it("renders back button with correct urls", () => {
+    render(<ComplianceSummaryReviewComponent data={mockData} />);
+
+    // Check button text and states
+    const backButton = screen.getByRole("button", { name: "Back" });
+    expect(backButton).toBeVisible();
+    expect(backButton).not.toBeDisabled();
+
+    const continueButton = screen.queryByRole("button", { name: "Continue" });
+    expect(continueButton).toBeNull();
+
+    // Verify router push is called with correct URLs when buttons are clicked
+    fireEvent.click(backButton);
+    expect(mockRouterPush).toHaveBeenCalledWith("/compliance-summaries");
+  });
+});

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/met-obligation/review-obligation-summary/ComplianceSummaryReviewPage.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/met-obligation/review-obligation-summary/ComplianceSummaryReviewPage.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import ComplianceSummaryReviewPage from "@/compliance/src/app/components/compliance-summary/met-obligation/review-compliance-summary/ComplianceSummaryReviewPage";
+
+// Mocks
+vi.mock(
+  "@/compliance/src/app/utils/fetchComplianceSummaryReviewPageData",
+  () => ({
+    fetchComplianceSummaryReviewPageData: vi.fn(),
+  }),
+);
+
+vi.mock("@/compliance/src/app/components/layout/CompliancePageLayout", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>Mock Layout {children}</div>
+  ),
+}));
+
+vi.mock(
+  "@/compliance/src/app/components/compliance-summary/met-obligation/review-obligation-summary/ComplianceSummaryReviewComponent",
+  () => ({
+    __esModule: true,
+    ComplianceSummaryReviewComponent: ({
+      complianceReportVersionId,
+      data,
+    }: any) => (
+      <div>
+        Mock Review Component - {complianceReportVersionId} -{" "}
+        {data.operation_name}
+      </div>
+    ),
+  }),
+);
+
+import { fetchComplianceSummaryReviewPageData } from "@/compliance/src/app/utils/fetchComplianceSummaryReviewPageData";
+
+describe("ComplianceSummaryReviewPage (Met Obligation)", () => {
+  const mockComplianceReportVersionId = 123;
+  const mockData = {
+    id: 1,
+    operation_name: "Test Operation",
+    reporting_year: 2024,
+    compliance_charge_rate: 80.0,
+    excess_emissions: 0,
+    emissions_limit: "90.0",
+    obligation_id: "test-obligation-id",
+    outstanding_balance: 0.0,
+    equivalent_value: 0.0,
+    status: "Obligation fully met",
+    outstanding_balance_equivalent_value: 0.0,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (fetchComplianceSummaryReviewPageData as vi.Mock).mockResolvedValue(
+      mockData,
+    );
+  });
+
+  it("fetches data, generates task list, and renders layout with review component", async () => {
+    render(
+      await ComplianceSummaryReviewPage({
+        compliance_report_version_id: mockComplianceReportVersionId,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Mock Layout")).toBeInTheDocument();
+      expect(
+        screen.getByText("Review 2024 Obligation Summary"),
+      ).toBeInTheDocument();
+    });
+
+    expect(fetchComplianceSummaryReviewPageData).toHaveBeenCalledWith(
+      mockComplianceReportVersionId,
+    );
+  });
+});


### PR DESCRIPTION
Addresses [300](https://github.com/bcgov/cas-compliance/issues/300)


### 🚀 Impact:
- Added to the `bceidbusiness` folder `review-obligation-summary` routes in `industry_user` and `industry_user_admin`.


###  📝 Notes:
- TO DO: Refine the `review-obligation-summary` route page data displayed- [301](https://github.com/bcgov/cas-compliance/issues/301)
- TO DO: Refine the `review-obligation-summary` page and component tests- [301](https://github.com/bcgov/cas-compliance/issues/301)


## 🔬 Local Testing:  

### **Test Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  
2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  




### **Test: "View Details" link to `review-obligation-summary`**  

#### **Steps:**  

1.  UPDATE erc.compliance_report_version SET status='Obligation fully met'  WHERE id=2;
2. Navigate to [http://localhost:3000](http://localhost:3000)  
3. Click the **"Log in with Business BCeID"** button
4. Log in using `bc-cas-dev`
5. Navigate to http://localhost:3000/compliance/compliance-summaries
6. Click `Compliance SFO - Obligation not met` action "View Details"
**Expected Results**
- Route to `Review Obligation Summary`
<img width="1715" height="934" alt="image" src="https://github.com/user-attachments/assets/84bcaa77-b61b-45cb-82e7-1d1b12f2aa5b" />
