### PR TITLE
chore: 303 update compliance access status logic

### DIFF
--- a/bc_obps/compliance/service/user_compliance_access_service.py
+++ b/bc_obps/compliance/service/user_compliance_access_service.py
@@ -36,8 +36,8 @@ class UserComplianceAccessService:
         # Get the operator associated with the current user
         operator = UserDataAccessService.get_operator_by_user(user_guid)
 
-        # Check if the operator has a registered operation
-        if not OperationDataAccessService.check_current_users_registered_operation(operator.id):
+        # Check if the operator has a registered regulated operation
+        if not OperationDataAccessService.check_current_users_registered_regulated_operation(operator.id):
             return UserStatusEnum.INVALID.value
 
         # If a compliance report version ID is provided, check if it belongs to this operator

--- a/bc_obps/compliance/tests/service/test_user_compliance_access_service.py
+++ b/bc_obps/compliance/tests/service/test_user_compliance_access_service.py
@@ -20,7 +20,9 @@ DASHBOARD_SERVICE_PATH = f"{BASE_PATH}.ComplianceDashboardService"
 
 # Method paths to patch
 GET_OPERATOR_BY_USER_PATH = f"{USER_DATA_ACCESS_PATH}.get_operator_by_user"
-CHECK_REGISTERED_OPERATION_PATH = f"{OPERATION_DATA_ACCESS_PATH}.check_current_users_registered_operation"
+CHECK_REGISTERED_REGULATED_OPERATION_PATH = (
+    f"{OPERATION_DATA_ACCESS_PATH}.check_current_users_registered_regulated_operation"
+)
 GET_REPORT_VERSION_BY_ID_PATH = f"{DASHBOARD_SERVICE_PATH}.get_compliance_report_version_by_id"
 
 OPERATOR_GUID = uuid4()
@@ -41,7 +43,7 @@ def mock_user_data_access():
 
 @pytest.fixture
 def mock_operation_data_access():
-    with patch(CHECK_REGISTERED_OPERATION_PATH) as mock:
+    with patch(CHECK_REGISTERED_REGULATED_OPERATION_PATH) as mock:
         mock.return_value = True
         yield mock
 


### PR DESCRIPTION
Addresses: 
[303](https://github.com/bcgov/cas-compliance/issues/303)

### 🚀 Impact:
- Follow up to [Compliance Tile for EIO and Reporting Only](https://github.com/bcgov/cas-compliance/issues/143) - updated `user_compliance_access_service` get user compliance access status for registered _regulated_ operations

## 🔬 Local Testing:  

### **Test Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  
2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  


### **Test: Restrict access to `Compliance` app routes to users with registered _regulated_  operation**  

#### **Steps:**  
1. Sign in to Keycloak using `bc-cas-dev-secondary`  
3. Navigate to urls:
- http://localhost:3000/compliance
- http://localhost:3000/compliance/compliance-summaries

**Expected results:**  
- Route is NOT permitted (no registered operation)
- Redirection to to Dashboard
- Administration tile has link `Select an Operator`   
<img width="1633" height="848" alt="image" src="https://github.com/user-attachments/assets/e3f2609a-ded1-4ff0-841b-a6644490e2a6" />

---

4. Click link `Administration\Select an Operator`  
5. Click link `Add Operator`  
6. Complete required fields  
7. Click button `Submit`  

**Expected results:**  
- Form submits and creates a new approved operator with an approved admin user operator  
<img width="1627" height="680" alt="image" src="https://github.com/user-attachments/assets/28deb19f-1acb-4d65-92f7-89ab4c5d9306" />

---

8. Navigate to urls:
- http://localhost:3000/compliance
- http://localhost:3000/compliance/compliance-summaries

**Expected results:**  
- Route is NOT permitted (no registered _regulated_  operation)
- Redirection to Dashboard
- Registration tile has link `Register an Operation`   

<img width="1552" height="660" alt="image" src="https://github.com/user-attachments/assets/9596d77e-c65d-4443-add2-e167f6aa3efa" />

---

9. Click link `Registration\Register an Operation` 
10. Select `The purpose of this registration is to register as a:*` as `Electricity Import Operation` or Reporting only
11. Complete the operation registration flow and click `Submit`
**Expected results:**  
- Operation is registered
- Operation is NOT _regulated_

---
12. Navigate to url:
- http://localhost:3000/compliance
**Expected results:**  
- Route is NOT permitted (has registered but NOT _regulated_  operation)
- Redirection to Dashboard
<img width="1574" height="664" alt="image" src="https://github.com/user-attachments/assets/2be3d2fb-122e-48ad-8ba1-2852f7d4d5bb" />

---
13.Click link `Registration\Register an Operation` 
14. Select `The purpose of this registration is to register as a:*` as `OBPS Regulated Operation`
15. Complete the operation registration flow and click `Submit`
**Expected results:**  
- Operation is registered
- Operation is _regulated_

---
16. Navigate to url:
- http://localhost:3000/compliance/compliance-summaries
**Expected results:**  
- Route is permitted (has registered  _regulated_ operation)
- Compliance summaries grid displays
- Grid has no compliance summaries displayed
<img width="1573" height="741" alt="image" src="https://github.com/user-attachments/assets/b7b36aa2-aea1-472f-aa56-6fa6820b6290" />

---
