### PR TITLE
Internal Annual Reports grid

### DIFF
--- a/bc_obps/common/tests/endpoints/auth/constants.py
+++ b/bc_obps/common/tests/endpoints/auth/constants.py
@@ -513,7 +513,7 @@ ENDPOINTS = {
         },
         {"method": "get", "endpoint_name": "build_form_schema"},
         {"method": "get", "endpoint_name": "get_dashboard_operations_list"},
-        {"method": "get", "endpoint_name": "get_dashboard_past_reports_list"},
+        {"method": "get", "endpoint_name": "get_dashboard_reports_list"},
         {
             "method": "get",
             "endpoint_name": "get_facility_report_form_data",

--- a/bc_obps/common/tests/endpoints/auth/constants.py
+++ b/bc_obps/common/tests/endpoints/auth/constants.py
@@ -51,16 +51,6 @@ ENDPOINTS = {
             "endpoint_name": "get_initial_activity_data",
             "kwargs": {"version_id": MOCK_INT, "facility_id": MOCK_UUID},
         },
-        {
-            "method": "get",
-            "endpoint_name": "get_report_history",
-            "kwargs": {"report_id": MOCK_INT},
-        },
-        {
-            "method": "get",
-            "endpoint_name": "get_report_operation",
-            "kwargs": {"report_id": MOCK_INT},
-        },
         {"method": "get", "endpoint_name": "validate_user_reporting_access"},
         {
             "method": "get",
@@ -538,6 +528,16 @@ ENDPOINTS = {
             "method": "get",
             "endpoint_name": "get_facility_report_by_version_id",
             "kwargs": {"version_id": MOCK_INT},
+        },
+        {
+            "method": "get",
+            "endpoint_name": "get_report_history",
+            "kwargs": {"report_id": MOCK_INT},
+        },
+        {
+            "method": "get",
+            "endpoint_name": "get_report_operation",
+            "kwargs": {"report_id": MOCK_INT},
         },
         {
             "method": "put",

--- a/bc_obps/reporting/api/report_history.py
+++ b/bc_obps/reporting/api/report_history.py
@@ -21,7 +21,7 @@ from ..service.report_history_dashboard_service import ReportingHistoryDashboard
     response={200: List[ReportHistoryResponse], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Returns json object with current reporting year and due date.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_authorized_roles"),
 )
 @paginate(PageNumberPagination, page_size=PAGE_SIZE)
 def get_report_history(request: HttpRequest, report_id: int) -> QuerySet[ReportVersion]:
@@ -34,7 +34,7 @@ def get_report_history(request: HttpRequest, report_id: int) -> QuerySet[ReportV
     response={200: ReportOperationResponse, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Returns the operation details given report.""",
-    auth=authorize("approved_industry_user"),
+    auth=authorize("approved_authorized_roles"),
 )
 def get_report_operation(request: HttpRequest, report_id: int) -> Tuple[int, Operation]:
     operation = Report.objects.select_related('operation').get(id=report_id).operation

--- a/bc_obps/reporting/api/reporting_dashboard.py
+++ b/bc_obps/reporting/api/reporting_dashboard.py
@@ -48,10 +48,10 @@ def get_dashboard_operations_list(
 
 
 @router.get(
-    "/past-reports",
+    "/reports",
     response={200: List[ReportingDashboardReportOut], custom_codes_4xx: Message},
     tags=DASHBOARD_TAGS,
-    description="""Returns a list of past reports for the current user. Returns all reports for the operator excluding the current reporting year""",
+    description="""Returns a list of reports for the current user.""",
     auth=authorize("approved_authorized_roles"),
 )
 @paginate(PageNumberPagination)
@@ -61,9 +61,15 @@ def get_dashboard_past_reports_list(
     sort_field: Optional[str] = "reporting_year",
     sort_order: Optional[Literal["desc", "asc"]] = "desc",
     paginate_result: bool = Query(True, description="Whether to paginate the results"),
+    get_past_reports: Optional[bool] = Query(None),
 ) -> QuerySet[Report]:
     user_guid: UUID = get_current_user_guid(request)
     reporting_year: int = ReportingYearService.get_current_reporting_year().reporting_year
-    return ReportingDashboardService.get_past_reports_for_reporting_dashboard(
-        user_guid, reporting_year, sort_field=sort_field, sort_order=sort_order, filters=filters
+    return ReportingDashboardService.get_reports_for_reporting_dashboard(
+        user_guid,
+        reporting_year,
+        get_past_reports=get_past_reports,
+        sort_field=sort_field,
+        sort_order=sort_order,
+        filters=filters,
     )

--- a/bc_obps/reporting/api/reporting_dashboard.py
+++ b/bc_obps/reporting/api/reporting_dashboard.py
@@ -55,7 +55,7 @@ def get_dashboard_operations_list(
     auth=authorize("approved_authorized_roles"),
 )
 @paginate(PageNumberPagination)
-def get_dashboard_past_reports_list(
+def get_dashboard_reports_list(
     request: HttpRequest,
     filters: ReportingDashboardOperationFilterSchema = Query(...),
     sort_field: Optional[str] = "reporting_year",

--- a/bc_obps/reporting/api/reporting_dashboard.py
+++ b/bc_obps/reporting/api/reporting_dashboard.py
@@ -15,6 +15,7 @@ from reporting.schema.dashboard import (
     ReportingDashboardOperationFilterSchema,
     ReportingDashboardOperationOut,
     ReportingDashboardReportOut,
+    ReportsPeriod,
 )
 from reporting.service.reporting_dashboard_service import ReportingDashboardService
 from service.error_service.custom_codes_4xx import custom_codes_4xx
@@ -61,14 +62,14 @@ def get_dashboard_reports_list(
     sort_field: Optional[str] = "reporting_year",
     sort_order: Optional[Literal["desc", "asc"]] = "desc",
     paginate_result: bool = Query(True, description="Whether to paginate the results"),
-    get_past_reports: Optional[bool] = Query(None),
+    reports_period: ReportsPeriod = ReportsPeriod.ALL,
 ) -> QuerySet[Report]:
     user_guid: UUID = get_current_user_guid(request)
     reporting_year: int = ReportingYearService.get_current_reporting_year().reporting_year
     return ReportingDashboardService.get_reports_for_reporting_dashboard(
         user_guid,
         reporting_year,
-        get_past_reports=get_past_reports,
+        reports_period=reports_period,
         sort_field=sort_field,
         sort_order=sort_order,
         filters=filters,

--- a/bc_obps/reporting/api/reporting_dashboard.py
+++ b/bc_obps/reporting/api/reporting_dashboard.py
@@ -51,7 +51,7 @@ def get_dashboard_operations_list(
     "/reports",
     response={200: List[ReportingDashboardReportOut], custom_codes_4xx: Message},
     tags=DASHBOARD_TAGS,
-    description="""Returns a list of reports for the current user.""",
+    description="""Returns a list of reports for the current user. Can return reports for current year, past years, or both.""",
     auth=authorize("approved_authorized_roles"),
 )
 @paginate(PageNumberPagination)

--- a/bc_obps/reporting/schema/dashboard.py
+++ b/bc_obps/reporting/schema/dashboard.py
@@ -47,6 +47,8 @@ class ReportingDashboardOperationFilterSchema(FilterSchema):
     operation_name: Optional[str] = Field(None, json_schema_extra={'q': 'operation_name__icontains'})
     report_status: Optional[str] = Field(None, json_schema_extra={'q': 'report_status__icontains'})
     reporting_year: Optional[int] = Field(None, json_schema_extra={'q': 'report__reporting_year'})
+    report_version_id: Optional[int] = Field(None, json_schema_extra={'q': 'report_version_id'})
+    report_updated_at: Optional[datetime] = Field(None, json_schema_extra={'q': 'report_updated_at__date'})
 
     def filter_report_status(self, value: str) -> Q:
         """

--- a/bc_obps/reporting/schema/dashboard.py
+++ b/bc_obps/reporting/schema/dashboard.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import Enum
 import re
 from typing import Optional
 from uuid import UUID
@@ -69,3 +70,9 @@ class ReportingDashboardOperationFilterSchema(FilterSchema):
         filters |= Q(report_status__icontains=value)
 
         return filters
+
+
+class ReportsPeriod(str, Enum):
+    ALL = "all"
+    PAST = "past"
+    CURRENT = "current"

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -10,7 +10,7 @@ from reporting.models.report_version import ReportVersion
 from service.data_access_service.operation_service import OperationDataAccessService
 from service.data_access_service.user_service import UserDataAccessService
 from typing import Optional
-from reporting.schema.dashboard import ReportingDashboardOperationFilterSchema
+from reporting.schema.dashboard import ReportingDashboardOperationFilterSchema, ReportsPeriod
 from service.user_operator_service import UserOperatorService
 
 
@@ -110,9 +110,7 @@ class ReportingDashboardService:
         cls,
         user_guid: UUID,
         current_reporting_year: int,
-        get_past_reports: Optional[
-            bool
-        ] = None,  # if True, fetch past reports. If False, fetch current year reports. If None, fetch all reports.
+        reports_period: ReportsPeriod = ReportsPeriod.ALL,
         sort_field: Optional[str] = None,
         sort_order: Optional[str] = None,
         filters: ReportingDashboardOperationFilterSchema = Query(...),
@@ -157,12 +155,11 @@ class ReportingDashboardService:
                 report_status_sort_key=cls.report_status_sort_key,
             )
 
-        if get_past_reports is not None:
-            if get_past_reports:
-                queryset = queryset.exclude(reporting_year=current_reporting_year)
-            else:
-                queryset = queryset.filter(reporting_year=current_reporting_year)
-        # else get_past_report is None, so we fetch all reports
+        if reports_period == ReportsPeriod.CURRENT:
+            queryset = queryset.filter(reporting_year=current_reporting_year)
+        elif reports_period == ReportsPeriod.PAST:
+            queryset = queryset.exclude(reporting_year=current_reporting_year)
+        # else reports_period == ALL, so we fetch all reports
 
         sort_fields = cls._get_sort_fields(sort_field, sort_order)
 

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -111,8 +111,8 @@ class ReportingDashboardService:
         user_guid: UUID,
         current_reporting_year: int,
         reports_period: ReportsPeriod = ReportsPeriod.ALL,
-        sort_field: Optional[str] = None,
-        sort_order: Optional[str] = None,
+        sort_field: Optional[str] = "reporting_year",
+        sort_order: Optional[str] = "asc",
         filters: ReportingDashboardOperationFilterSchema = Query(...),
     ) -> QuerySet[Report]:
         """
@@ -123,10 +123,6 @@ class ReportingDashboardService:
         user = UserDataAccessService.get_by_guid(user_guid)
         is_internal = "cas_" in user.app_role_id
 
-        queryset = Report.objects.all().annotate(
-            report_id=F("id"),
-            first_report_version_id=cls.first_report_version_subquery.values("id")[:1],
-        )
         if is_internal:
             queryset = Report.objects.filter(report_versions__is_latest_submitted=True).annotate(
                 report_id=F("id"),

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -56,8 +56,8 @@ class ReportingDashboardService:
         cls,
         user_guid: UUID,
         reporting_year: int,
-        sort_field: Optional[str] = None,
-        sort_order: Optional[str] = None,
+        sort_field: Optional[str] = "id",
+        sort_order: Optional[str] = "asc",
         filters: ReportingDashboardOperationFilterSchema = Query(...),
     ) -> QuerySet[Operation]:
         """

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -118,7 +118,9 @@ class ReportingDashboardService:
         filters: ReportingDashboardOperationFilterSchema = Query(...),
     ) -> QuerySet[Report]:
         """
-        Fetches all past reports for the user, and annotates it with the associated operation data required for the API call
+        Fetches reports, and annotates it with the associated operation data required for the API call
+        If external user, only fetch reports for their operator
+
         """
         user = UserDataAccessService.get_by_guid(user_guid)
         is_internal = "cas_" in user.app_role_id

--- a/bc_obps/reporting/tests/api/test_reporting_dashboard_endpoints.py
+++ b/bc_obps/reporting/tests/api/test_reporting_dashboard_endpoints.py
@@ -60,7 +60,7 @@ class TestReportingDashboardEndpoints(CommonTestSetup):
             assert item['report_status'] is None
 
     @patch(
-        "reporting.service.reporting_dashboard_service.ReportingDashboardService.get_past_reports_for_reporting_dashboard"
+        "reporting.service.reporting_dashboard_service.ReportingDashboardService.get_reports_for_reporting_dashboard"
     )
     @patch("common.api.utils.get_current_user_guid")
     @patch("service.reporting_year_service.ReportingYearService.get_current_reporting_year")

--- a/bc_obps/reporting/tests/api/test_reporting_dashboard_endpoints.py
+++ b/bc_obps/reporting/tests/api/test_reporting_dashboard_endpoints.py
@@ -71,7 +71,7 @@ class TestReportingDashboardEndpoints(CommonTestSetup):
         mock_get_past_reports: MagicMock | AsyncMock,
     ):
 
-        endpoint_under_test = custom_reverse_lazy("get_dashboard_past_reports_list")
+        endpoint_under_test = custom_reverse_lazy("get_dashboard_reports_list")
         operator = operator_baker()
         TestUtils.authorize_current_user_as_operator_user(self, operator=operator)
         operations = operation_baker(operator_id=operator.id, _quantity=3)

--- a/bc_obps/reporting/tests/api/test_reporting_dashboard_endpoints.py
+++ b/bc_obps/reporting/tests/api/test_reporting_dashboard_endpoints.py
@@ -64,7 +64,7 @@ class TestReportingDashboardEndpoints(CommonTestSetup):
     )
     @patch("common.api.utils.get_current_user_guid")
     @patch("service.reporting_year_service.ReportingYearService.get_current_reporting_year")
-    def test_returns_past_report_data_as_provided_by_the_service(
+    def test_returns_report_data_as_provided_by_the_service(
         self,
         mock_get_current_year: MagicMock | AsyncMock,
         mock_get_current_user: MagicMock | AsyncMock,

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -144,8 +144,8 @@ class TestReportingDashboardService:
         rep3_op2_report = rep3_op2_latest_version.report
         rep3_report_operation = ReportOperation.objects.get(report_version=rep3_op2_latest_version)
 
-        result = ReportingDashboardService.get_past_reports_for_reporting_dashboard(
-            uo.user.user_guid, current_year, sort_field, sort_order, filters
+        result = ReportingDashboardService.get_reports_for_reporting_dashboard(
+            uo.user.user_guid, current_year, True, sort_field, sort_order, filters
         ).values()
         result_list = list(result)
         assert len(result_list) == 3

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -9,7 +9,7 @@ from reporting.tests.utils.bakers import report_version_baker, reporting_year_ba
 from service.report_service import ReportService
 from reporting.models.report_version import ReportVersion
 from typing import Optional
-from reporting.schema.dashboard import ReportingDashboardOperationFilterSchema
+from reporting.schema.dashboard import ReportingDashboardOperationFilterSchema, ReportsPeriod
 
 
 @pytest.mark.django_db
@@ -145,7 +145,7 @@ class TestReportingDashboardService:
         rep3_report_operation = ReportOperation.objects.get(report_version=rep3_op2_latest_version)
 
         result = ReportingDashboardService.get_reports_for_reporting_dashboard(
-            uo.user.user_guid, current_year, True, sort_field, sort_order, filters
+            uo.user.user_guid, current_year, ReportsPeriod.PAST, sort_field, sort_order, filters
         ).values()
         result_list = list(result)
         assert len(result_list) == 3

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user/reports/previous-years/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user/reports/previous-years/page.tsx
@@ -2,16 +2,12 @@ import { generateMetadata } from "@bciers/components/layout/RootLayout";
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 import PastReportsPage from "@reporting/src/app/components/operations/PastReportsPage";
 import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
-import { PastReportsSearchParams } from "@reporting/src/app/components/operations/types";
+import { ReportSearchParams } from "@reporting/src/app/components/operations/types";
 
 const title = "Reports";
 export const metadata = generateMetadata(title);
 
-function ReportsPage({
-  searchParams,
-}: {
-  searchParams: PastReportsSearchParams;
-}) {
+function ReportsPage({ searchParams }: { searchParams: ReportSearchParams }) {
   return (
     <ReportsBasePage activeTab={1}>
       <div className="flex flex-col">

--- a/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/reports/previous-years/page.tsx
+++ b/bciers/apps/reporting/src/app/bceidbusiness/industry_user_admin/reports/previous-years/page.tsx
@@ -2,16 +2,12 @@ import { generateMetadata } from "@bciers/components/layout/RootLayout";
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 import PastReportsPage from "@reporting/src/app/components/operations/PastReportsPage";
 import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
-import { PastReportsSearchParams } from "@reporting/src/app/components/operations/types";
+import { ReportSearchParams } from "@reporting/src/app/components/operations/types";
 
 const title = "Reports";
 export const metadata = generateMetadata(title);
 
-function ReportsPage({
-  searchParams,
-}: {
-  searchParams: PastReportsSearchParams;
-}) {
+function ReportsPage({ searchParams }: { searchParams: ReportSearchParams }) {
   return (
     <ReportsBasePage activeTab={1}>
       <div className="flex flex-col">

--- a/bciers/apps/reporting/src/app/components/attachments/attachmentsList/AttachmentsListPage.tsx
+++ b/bciers/apps/reporting/src/app/components/attachments/attachmentsList/AttachmentsListPage.tsx
@@ -19,12 +19,7 @@ interface Props {
 const AttachmentsListPage: React.FC<Props> = async ({ searchParams }) => {
   const data = await getAttachmentsList(searchParams);
 
-  return (
-    <div>
-      <h1>Report Attachments</h1>
-      <AttachmentsListGrid initialData={data} />
-    </div>
-  );
+  return <AttachmentsListGrid initialData={data} />;
 };
 
 export default AttachmentsListPage;

--- a/bciers/apps/reporting/src/app/components/datagrid/models/annualReports/annualReportsColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/annualReports/annualReportsColumns.tsx
@@ -17,14 +17,14 @@ const AnnualReportColumns = (): GridColDef[] => {
       flex: 1,
     },
     {
-      field: "report_updated_at",
-      headerName: "Date of submission",
-      renderCell: UpdatedAtCell,
+      field: "report_version_id",
+      headerName: "Report Version ID",
       width: 180,
     },
     {
-      field: "report_version_id",
-      headerName: "Report Version ID",
+      field: "report_updated_at",
+      headerName: "Date of submission",
+      renderCell: UpdatedAtCell,
       width: 180,
     },
     {

--- a/bciers/apps/reporting/src/app/components/datagrid/models/annualReports/annualReportsColumns.tsx
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/annualReports/annualReportsColumns.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
+import formatTimestamp from "@bciers/utils/src/formatTimestamp";
+import ViewReportCell from "../../../operations/cells/ViewReportCell";
+import ViewReportHistoryCell from "../../../operations/cells/ViewReportHistoryCell";
+
+const UpdatedAtCell = ({ value }: GridRenderCellParams) =>
+  formatTimestamp(value);
+
+const AnnualReportColumns = (): GridColDef[] => {
+  const columns: GridColDef[] = [
+    {
+      field: "operation_name",
+      headerName: "Operation",
+      width: 500,
+      flex: 1,
+    },
+    {
+      field: "report_updated_at",
+      headerName: "Date of submission",
+      renderCell: UpdatedAtCell,
+      width: 180,
+    },
+    {
+      field: "report_version_id",
+      headerName: "Report Version ID",
+      width: 180,
+    },
+    {
+      field: "report",
+      headerName: "Reports",
+      renderCell: ViewReportCell,
+      sortable: false,
+      width: 240,
+    },
+    {
+      field: "history",
+      headerName: "Report History",
+      renderCell: ViewReportHistoryCell,
+      sortable: false,
+      width: 240,
+    },
+  ];
+
+  return columns;
+};
+
+export default AnnualReportColumns;

--- a/bciers/apps/reporting/src/app/components/datagrid/models/annualReports/annualReportsGroupColumns.ts
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/annualReports/annualReportsGroupColumns.ts
@@ -1,0 +1,22 @@
+import EmptyGroupCell from "@bciers/components/datagrid/cells/EmptyGroupCell";
+import createColumnGroup from "@bciers/components/datagrid/createColumnGrid";
+import {
+  GridColumnGroupHeaderParams,
+  GridColumnGroupingModel,
+} from "@mui/x-data-grid";
+
+const annualReportGroupColumns = (
+  SearchCell: (params: GridColumnGroupHeaderParams) => JSX.Element,
+) => {
+  const columnGroupModel = [
+    createColumnGroup("operation_name", "Operation", SearchCell),
+    createColumnGroup("report_version_id", "Report Version ID", SearchCell),
+    createColumnGroup("report_updated_at", "Date of submission", SearchCell),
+
+    createColumnGroup("report", "Report", EmptyGroupCell),
+    createColumnGroup("history", "Report History", EmptyGroupCell),
+  ] as GridColumnGroupingModel;
+  return columnGroupModel;
+};
+
+export default annualReportGroupColumns;

--- a/bciers/apps/reporting/src/app/components/datagrid/models/annualReports/annualReportsGroupColumns.ts
+++ b/bciers/apps/reporting/src/app/components/datagrid/models/annualReports/annualReportsGroupColumns.ts
@@ -11,7 +11,11 @@ const annualReportGroupColumns = (
   const columnGroupModel = [
     createColumnGroup("operation_name", "Operation", SearchCell),
     createColumnGroup("report_version_id", "Report Version ID", SearchCell),
-    createColumnGroup("report_updated_at", "Date of submission", SearchCell),
+    createColumnGroup(
+      "report_updated_at",
+      "Date of submission",
+      EmptyGroupCell,
+    ),
 
     createColumnGroup("report", "Report", EmptyGroupCell),
     createColumnGroup("history", "Report History", EmptyGroupCell),

--- a/bciers/apps/reporting/src/app/components/operations/PastReports.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/PastReports.tsx
@@ -1,11 +1,11 @@
 import { fetchPastReportsPageData } from "./fetchPastReportsPageData";
 import PastReportsDataGrid from "./PastReportsDataGrid";
-import { ReportRow, PastReportsSearchParams } from "./types";
+import { ReportRow, ReportSearchParams } from "./types";
 
 export default async function PastReports({
   searchParams,
 }: {
-  searchParams: PastReportsSearchParams;
+  searchParams: ReportSearchParams;
 }) {
   const pastReports: { rows: ReportRow[]; row_count: number } =
     await fetchPastReportsPageData(searchParams);

--- a/bciers/apps/reporting/src/app/components/operations/PastReports.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/PastReports.tsx
@@ -1,13 +1,13 @@
 import { fetchPastReportsPageData } from "./fetchPastReportsPageData";
 import PastReportsDataGrid from "./PastReportsDataGrid";
-import { PastReportsRow, PastReportsSearchParams } from "./types";
+import { ReportRow, PastReportsSearchParams } from "./types";
 
 export default async function PastReports({
   searchParams,
 }: {
   searchParams: PastReportsSearchParams;
 }) {
-  const pastReports: { rows: PastReportsRow[]; row_count: number } =
+  const pastReports: { rows: ReportRow[]; row_count: number } =
     await fetchPastReportsPageData(searchParams);
   if (!pastReports) {
     return <div>No past reports data in database.</div>;

--- a/bciers/apps/reporting/src/app/components/operations/PastReportsDataGrid.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/PastReportsDataGrid.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import DataGrid from "@bciers/components/datagrid/DataGrid";
 import HeaderSearchCell from "@bciers/components/datagrid/cells/HeaderSearchCell";
-import { PastReportsRow } from "./types";
+import { ReportRow } from "./types";
 import pastReportsColumns from "../datagrid/models/pastReports/pastReportsColumns";
 import pastReportsGroupColumns from "../datagrid/models/pastReports/pastReportsGroupColumns";
 import { fetchPastReportsPageData } from "./fetchPastReportsPageData";
@@ -12,7 +12,7 @@ const PastReportsDataGrid = ({
   initialData,
 }: {
   initialData: {
-    rows: PastReportsRow[];
+    rows: ReportRow[];
     row_count: number;
   };
 }) => {

--- a/bciers/apps/reporting/src/app/components/operations/PastReportsPage.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/PastReportsPage.tsx
@@ -1,10 +1,10 @@
 import PastReports from "./PastReports";
-import { PastReportsSearchParams } from "./types";
+import { ReportSearchParams } from "./types";
 
 export default async function PastReportsPage({
   searchParams,
 }: {
-  searchParams: PastReportsSearchParams;
+  searchParams: ReportSearchParams;
 }) {
   return <PastReports searchParams={searchParams} />;
 }

--- a/bciers/apps/reporting/src/app/components/operations/ReportsBasePage.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/ReportsBasePage.tsx
@@ -21,13 +21,15 @@ export default async function ReportsBasePage({
 
   const tabs = userRole.includes("industry_")
     ? [
+        //tabs for external users
         { label: "View annual report(s)", href: "/reports/current-reports" },
         { label: "View past reports", href: "/reports/previous-years" },
       ]
     : [
+        //tabs for internal users
         { label: "View annual reports", href: "/reports/current-reports" },
         { label: "View past reports", href: "/reports/previous-years" },
-        { label: "Download Report Attachments", href: "/reports/attachments" },
+        { label: "Download report attachments", href: "/reports/attachments" },
       ];
   const CURRENT_REPORTS_TAB_INDEX = 0;
   const PAST_REPORTS_TAB_INDEX = 1;

--- a/bciers/apps/reporting/src/app/components/operations/ReportsBasePage.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/ReportsBasePage.tsx
@@ -1,4 +1,5 @@
 import { Tabs } from "@bciers/components/tabs/Tabs";
+import { getSessionRole } from "@bciers/utils/src/sessionUtils";
 import { ReactNode } from "react";
 import { getReportingYear } from "../../utils/getReportingYear";
 import dayjs from "dayjs";

--- a/bciers/apps/reporting/src/app/components/operations/ReportsBasePage.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/ReportsBasePage.tsx
@@ -13,15 +13,23 @@ export default async function ReportsBasePage({
   activeTab,
   children,
 }: Readonly<ReportsBasePageProps>) {
+  const userRole = await getSessionRole();
+
+  const reportingYearObj = await getReportingYear();
+  const reportDueDate = reportingYearObj.report_due_date;
+  const reportDueYearOnly = dayjs(reportDueDate).year();
+
+  const currentReportsTabTitle = `View annual report${
+    //render the (s) for external users as they may only have one operation
+    userRole.includes("industry_") ? "(s)" : "s"
+  }`;
+
   const tabs = [
-    { label: "View annual reports", href: "/reports/current-reports" },
+    { label: currentReportsTabTitle, href: "/reports/current-reports" },
     { label: "View past reports", href: "/reports/previous-years" },
   ];
   const CURRENT_REPORTS_TAB_INDEX = 0;
   const PREVIOUS_REPORTS_TAB_INDEX = 1;
-  const reportingYearObj = await getReportingYear();
-  const reportDueDate = reportingYearObj.report_due_date;
-  const reportDueyearOnly = dayjs(reportDueDate).year();
   const pageTitle =
     activeTab === CURRENT_REPORTS_TAB_INDEX
       ? `Reporting year ${reportingYearObj.reporting_year}`
@@ -33,9 +41,11 @@ export default async function ReportsBasePage({
         {activeTab === CURRENT_REPORTS_TAB_INDEX && (
           <div className="flex justify-between items-center">
             <h2 className="text-2xl font-bold">{pageTitle}</h2>
-            <h3 className="text-bc-text text-right">
-              Reports due May 31, {reportDueyearOnly}
-            </h3>
+            {userRole.includes("industry_") && (
+              <h3 className="text-bc-text text-right">
+                Reports due May 31, {reportDueYearOnly}
+              </h3>
+            )}
           </div>
         )}
         {activeTab === PREVIOUS_REPORTS_TAB_INDEX && (

--- a/bciers/apps/reporting/src/app/components/operations/ReportsBasePage.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/ReportsBasePage.tsx
@@ -19,21 +19,34 @@ export default async function ReportsBasePage({
   const reportDueDate = reportingYearObj.report_due_date;
   const reportDueYearOnly = dayjs(reportDueDate).year();
 
-  const currentReportsTabTitle = `View annual report${
-    //render the (s) for external users as they may only have one operation
-    userRole.includes("industry_") ? "(s)" : "s"
-  }`;
-
-  const tabs = [
-    { label: currentReportsTabTitle, href: "/reports/current-reports" },
-    { label: "View past reports", href: "/reports/previous-years" },
-  ];
+  const tabs = userRole.includes("industry_")
+    ? [
+        { label: "View annual report(s)", href: "/reports/current-reports" },
+        { label: "View past reports", href: "/reports/previous-years" },
+      ]
+    : [
+        { label: "View annual reports", href: "/reports/current-reports" },
+        { label: "View past reports", href: "/reports/previous-years" },
+        { label: "Download Report Attachments", href: "/reports/attachments" },
+      ];
   const CURRENT_REPORTS_TAB_INDEX = 0;
-  const PREVIOUS_REPORTS_TAB_INDEX = 1;
-  const pageTitle =
-    activeTab === CURRENT_REPORTS_TAB_INDEX
-      ? `Reporting year ${reportingYearObj.reporting_year}`
-      : "Past Reports";
+  const PAST_REPORTS_TAB_INDEX = 1;
+  const ATTACHMENTS_TAB_INDEX = 2;
+
+  let pageTitle = "";
+  switch (activeTab) {
+    case CURRENT_REPORTS_TAB_INDEX:
+      pageTitle = `Reporting year ${reportingYearObj.reporting_year}`;
+      break;
+    case PAST_REPORTS_TAB_INDEX:
+      pageTitle = "Past Reports";
+      break;
+    case ATTACHMENTS_TAB_INDEX:
+      pageTitle = "Download Report Attachments";
+      break;
+    default:
+      pageTitle = "Reports";
+  }
 
   return (
     <div className="py-4">
@@ -48,7 +61,7 @@ export default async function ReportsBasePage({
             )}
           </div>
         )}
-        {activeTab === PREVIOUS_REPORTS_TAB_INDEX && (
+        {activeTab !== CURRENT_REPORTS_TAB_INDEX && (
           <h2 className="text-2xl font-bold">{pageTitle}</h2>
         )}
         <Tabs

--- a/bciers/apps/reporting/src/app/components/operations/annualReports.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/annualReports.tsx
@@ -1,0 +1,21 @@
+import AnnualReportsDataGrid from "./annualReportsDataGrid";
+import { fetchAnnualReportsPageData } from "./fetchAnnualReportsPageData";
+import { AnnualReportRow, ReportSearchParams } from "./types";
+
+export default async function PastReports({
+  searchParams,
+}: {
+  searchParams: ReportSearchParams;
+}) {
+  const reports: { rows: AnnualReportRow[]; row_count: number } =
+    await fetchAnnualReportsPageData(searchParams);
+  if (!reports) {
+    return <div>No reports data in database for the current year.</div>;
+  }
+  // Render the DataGrid component
+  return (
+    <div className="mt-5">
+      <AnnualReportsDataGrid initialData={reports} />
+    </div>
+  );
+}

--- a/bciers/apps/reporting/src/app/components/operations/annualReports.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/annualReports.tsx
@@ -1,13 +1,13 @@
 import AnnualReportsDataGrid from "./annualReportsDataGrid";
 import { fetchAnnualReportsPageData } from "./fetchAnnualReportsPageData";
-import { AnnualReportRow, ReportSearchParams } from "./types";
+import { ReportRow, ReportSearchParams } from "./types";
 
 export default async function PastReports({
   searchParams,
 }: {
   searchParams: ReportSearchParams;
 }) {
-  const reports: { rows: AnnualReportRow[]; row_count: number } =
+  const reports: { rows: ReportRow[]; row_count: number } =
     await fetchAnnualReportsPageData(searchParams);
   if (!reports) {
     return <div>No reports data in database for the current year.</div>;

--- a/bciers/apps/reporting/src/app/components/operations/annualReportsDataGrid.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/annualReportsDataGrid.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import DataGrid from "@bciers/components/datagrid/DataGrid";
 import HeaderSearchCell from "@bciers/components/datagrid/cells/HeaderSearchCell";
-import { AnnualReportRow } from "./types";
+import { ReportRow } from "./types";
 import annualReportsColumns from "../datagrid/models/annualReports/annualReportsColumns";
 import annualReportsGroupColumns from "../datagrid/models/annualReports/annualReportsGroupColumns";
 import { fetchAnnualReportsPageData } from "./fetchAnnualReportsPageData";
@@ -12,7 +12,7 @@ const AnnualReportsDataGrid = ({
   initialData,
 }: {
   initialData: {
-    rows: AnnualReportRow[];
+    rows: ReportRow[];
     row_count: number;
   };
 }) => {

--- a/bciers/apps/reporting/src/app/components/operations/annualReportsDataGrid.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/annualReportsDataGrid.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import DataGrid from "@bciers/components/datagrid/DataGrid";
+import HeaderSearchCell from "@bciers/components/datagrid/cells/HeaderSearchCell";
+import { AnnualReportRow } from "./types";
+import annualReportsColumns from "../datagrid/models/annualReports/annualReportsColumns";
+import annualReportsGroupColumns from "../datagrid/models/annualReports/annualReportsGroupColumns";
+import { fetchAnnualReportsPageData } from "./fetchAnnualReportsPageData";
+
+const AnnualReportsDataGrid = ({
+  initialData,
+}: {
+  initialData: {
+    rows: AnnualReportRow[];
+    row_count: number;
+  };
+}) => {
+  const [lastFocusedField, setLastFocusedField] = useState<string | null>(null);
+
+  const SearchCell = useMemo(
+    () => HeaderSearchCell({ lastFocusedField, setLastFocusedField }),
+    [lastFocusedField, setLastFocusedField],
+  );
+
+  const columns = annualReportsColumns();
+
+  const columnGroup = useMemo(
+    () => annualReportsGroupColumns(SearchCell),
+    [SearchCell],
+  );
+
+  // Create a key based on the initialData that will change when the data changes.
+  const gridKey = useMemo(() => JSON.stringify(initialData), [initialData]);
+
+  return (
+    <DataGrid
+      key={gridKey} // This forces a remount when initialData changes.
+      columns={columns}
+      columnGroupModel={columnGroup}
+      fetchPageData={fetchAnnualReportsPageData}
+      paginationMode="server"
+      initialData={initialData}
+    />
+  );
+};
+
+export default AnnualReportsDataGrid;

--- a/bciers/apps/reporting/src/app/components/operations/annualReportsPage.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/annualReportsPage.tsx
@@ -1,6 +1,4 @@
-import { getReportingYear } from "@reporting/src/app/utils/getReportingYear";
 import { ReportSearchParams } from "apps/reporting/src/app/components/operations/types";
-import dayjs from "dayjs";
 import AnnualReports from "./annualReports";
 
 export default async function AnnualReportsPage({
@@ -8,21 +6,5 @@ export default async function AnnualReportsPage({
 }: {
   searchParams: ReportSearchParams;
 }) {
-  const reportingYearObj = await getReportingYear();
-  const reportDueDate = reportingYearObj.report_due_date;
-  const dueDateYearOnly = dayjs(reportDueDate).year();
-
-  return (
-    <>
-      <div className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold">
-          Reporting year {reportingYearObj.reporting_year}
-        </h2>
-        <h3 className="text-bc-text text-right">
-          Reports due May 31, {dueDateYearOnly}
-        </h3>
-      </div>
-      <AnnualReports searchParams={searchParams} />
-    </>
-  );
+  return <AnnualReports searchParams={searchParams} />;
 }

--- a/bciers/apps/reporting/src/app/components/operations/annualReportsPage.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/annualReportsPage.tsx
@@ -1,0 +1,28 @@
+import { getReportingYear } from "@reporting/src/app/utils/getReportingYear";
+import { ReportSearchParams } from "apps/reporting/src/app/components/operations/types";
+import dayjs from "dayjs";
+import AnnualReports from "./annualReports";
+
+export default async function AnnualReportsPage({
+  searchParams,
+}: {
+  searchParams: ReportSearchParams;
+}) {
+  const reportingYearObj = await getReportingYear();
+  const reportDueDate = reportingYearObj.report_due_date;
+  const dueDateYearOnly = dayjs(reportDueDate).year();
+
+  return (
+    <>
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">
+          Reporting year {reportingYearObj.reporting_year}
+        </h2>
+        <h3 className="text-bc-text text-right">
+          Reports due May 31, {dueDateYearOnly}
+        </h3>
+      </div>
+      <AnnualReports searchParams={searchParams} />
+    </>
+  );
+}

--- a/bciers/apps/reporting/src/app/components/operations/cells/ViewReportCell.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/cells/ViewReportCell.tsx
@@ -1,0 +1,31 @@
+import { BC_GOV_LINKS_COLOR } from "@bciers/styles";
+import Button from "@mui/material/Button";
+import { GridRenderCellParams } from "@mui/x-data-grid";
+import { useRouter } from "next/navigation";
+import React from "react";
+
+const ViewReportCell = (params: GridRenderCellParams) => {
+  const reportVersionId = params?.row?.report_version_id;
+
+  const router = useRouter();
+  const handleClick = async () => {
+    router.push(`${reportVersionId}`);
+  };
+
+  return (
+    <Button
+      sx={{
+        width: 180,
+        height: 40,
+        borderRadius: "5px",
+        border: `1px solid ${BC_GOV_LINKS_COLOR}`,
+      }}
+      color="primary"
+      onClick={handleClick}
+    >
+      View Report
+    </Button>
+  );
+};
+
+export default ViewReportCell;

--- a/bciers/apps/reporting/src/app/components/operations/cells/ViewReportHistoryCell.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/cells/ViewReportHistoryCell.tsx
@@ -1,0 +1,31 @@
+import { BC_GOV_LINKS_COLOR } from "@bciers/styles";
+import Button from "@mui/material/Button";
+import { GridRenderCellParams } from "@mui/x-data-grid";
+import { useRouter } from "next/navigation";
+import React from "react";
+
+const ViewReportHistoryCell = (params: GridRenderCellParams) => {
+  const reportId = params?.row?.report_id;
+
+  const router = useRouter();
+  const handleClick = async () => {
+    router.push(`report-history/${reportId}`);
+  };
+
+  return (
+    <Button
+      sx={{
+        width: 180,
+        height: 40,
+        borderRadius: "5px",
+        border: `1px solid ${BC_GOV_LINKS_COLOR}`,
+      }}
+      color="primary"
+      onClick={handleClick}
+    >
+      View Report History
+    </Button>
+  );
+};
+
+export default ViewReportHistoryCell;

--- a/bciers/apps/reporting/src/app/components/operations/fetchAnnualReportsPageData.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/fetchAnnualReportsPageData.tsx
@@ -8,7 +8,7 @@ export const fetchAnnualReportsPageData = async (
 ) => {
   const queryParams = buildQueryParams({
     ...searchParams,
-    get_past_reports: false,
+    reports_period: "current",
   });
   // fetch data from server
   const pageData = await actionHandler(

--- a/bciers/apps/reporting/src/app/components/operations/fetchAnnualReportsPageData.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/fetchAnnualReportsPageData.tsx
@@ -1,14 +1,14 @@
 import { actionHandler } from "@bciers/actions";
 import buildQueryParams from "@bciers/utils/src/buildQueryParams";
-import { PastReportsSearchParams } from "./types";
+import { ReportSearchParams } from "./types";
 
-// 🛠️ Function to fetch past reports
-export const fetchPastReportsPageData = async (
-  searchParams: PastReportsSearchParams,
+// 🛠️ Function to fetch annual reports
+export const fetchAnnualReportsPageData = async (
+  searchParams: ReportSearchParams,
 ) => {
   const queryParams = buildQueryParams({
     ...searchParams,
-    get_past_reports: true,
+    get_past_reports: false,
   });
   // fetch data from server
   const pageData = await actionHandler(

--- a/bciers/apps/reporting/src/app/components/operations/fetchPastReportsPageData.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/fetchPastReportsPageData.tsx
@@ -8,7 +8,7 @@ export const fetchPastReportsPageData = async (
 ) => {
   const queryParams = buildQueryParams({
     ...searchParams,
-    get_past_reports: true,
+    reports_period: "past",
   });
   // fetch data from server
   const pageData = await actionHandler(

--- a/bciers/apps/reporting/src/app/components/operations/fetchPastReportsPageData.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/fetchPastReportsPageData.tsx
@@ -1,10 +1,10 @@
 import { actionHandler } from "@bciers/actions";
 import buildQueryParams from "@bciers/utils/src/buildQueryParams";
-import { PastReportsSearchParams } from "./types";
+import { ReportSearchParams } from "./types";
 
 // 🛠️ Function to fetch past reports
 export const fetchPastReportsPageData = async (
-  searchParams: PastReportsSearchParams,
+  searchParams: ReportSearchParams,
 ) => {
   const queryParams = buildQueryParams({
     ...searchParams,

--- a/bciers/apps/reporting/src/app/components/operations/types.ts
+++ b/bciers/apps/reporting/src/app/components/operations/types.ts
@@ -46,7 +46,7 @@ export interface PastReportsSearchParams {
   report_status?: string;
 }
 
-export interface PastReportsRow {
+export interface ReportRow {
   id: number;
   reporting_year: number;
   operation_name: string;
@@ -63,12 +63,4 @@ export interface ReportSearchParams {
   page?: number;
   sort_field?: string;
   sort_order?: string;
-}
-
-export interface AnnualReportRow {
-  id: number;
-  reporting_year: number;
-  operation_name: string;
-  operator: string; // TODO: Verify if operator field is needed
-  report_version_id: number;
 }

--- a/bciers/apps/reporting/src/app/components/operations/types.ts
+++ b/bciers/apps/reporting/src/app/components/operations/types.ts
@@ -50,7 +50,25 @@ export interface PastReportsRow {
   id: number;
   reporting_year: number;
   operation_name: string;
-  operator: string;
+  operator?: string;
   report_version_id: number;
-  report_status: string;
+  report_status?: string;
+}
+
+export interface ReportSearchParams {
+  [key: string]: string | number | undefined;
+  reporting_year?: number;
+  operation_name?: string;
+  report_version_id?: number;
+  page?: number;
+  sort_field?: string;
+  sort_order?: string;
+}
+
+export interface AnnualReportRow {
+  id: number;
+  reporting_year: number;
+  operation_name: string;
+  operator: string; // TODO: Verify if operator field is needed
+  report_version_id: number;
 }

--- a/bciers/apps/reporting/src/app/components/operations/types.ts
+++ b/bciers/apps/reporting/src/app/components/operations/types.ts
@@ -36,16 +36,6 @@ export interface ContactRow {
   email: string;
 }
 
-export interface PastReportsSearchParams {
-  [key: string]: string | number | undefined;
-  reporting_year?: number;
-  operation_name?: string;
-  page?: number;
-  sort_field?: string;
-  sort_order?: string;
-  report_status?: string;
-}
-
 export interface ReportRow {
   id: number;
   reporting_year: number;

--- a/bciers/apps/reporting/src/app/idir/cas_admin/reports/[version_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_admin/reports/[version_id]/page.tsx
@@ -1,0 +1,5 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+
+export default defaultPageFactory(() => (
+  <div>View-only Report page is under development</div>
+));

--- a/bciers/apps/reporting/src/app/idir/cas_admin/reports/[version_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_admin/reports/[version_id]/page.tsx
@@ -1,5 +1,13 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 
 export default defaultPageFactory(() => (
-  <div>View-only Report page is under development</div>
+  <div className="flex flex-col items-center justify-center py-12">
+    <h2 className="text-2xl font-bold mb-4 text-bc-bg-blue">View Report</h2>
+    <p className="text-bc-text text-lg mb-2">
+      This feature is <b>coming soon</b>.
+    </p>
+    <p className="text-bc-text text-center max-w-xl">
+      You’ll be able to view a read-only version of the report here.
+    </p>
+  </div>
 ));

--- a/bciers/apps/reporting/src/app/idir/cas_admin/reports/attachments/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_admin/reports/attachments/page.tsx
@@ -1,4 +1,19 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 import AttachmentsListPage from "@reporting/src/app/components/attachments/attachmentsList/AttachmentsListPage";
+import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
+import { AttachmentsSearchParams } from "@reporting/src/app/utils/getAttachmentsList";
 
-export default defaultPageFactory(AttachmentsListPage);
+function ReportsPage({
+  searchParams,
+}: {
+  searchParams: AttachmentsSearchParams;
+}) {
+  return (
+    <ReportsBasePage activeTab={2}>
+      <div className="flex flex-col">
+        <AttachmentsListPage searchParams={searchParams || {}} />
+      </div>
+    </ReportsBasePage>
+  );
+}
+export default defaultPageFactory(ReportsPage);

--- a/bciers/apps/reporting/src/app/idir/cas_admin/reports/current-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_admin/reports/current-reports/page.tsx
@@ -1,0 +1,23 @@
+import { generateMetadata } from "@bciers/components/layout/RootLayout";
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import AnnualReportsPage from "@reporting/src/app/components/operations/annualReportsPage";
+import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
+import { OperationsSearchParams } from "@reporting/src/app/components/operations/types";
+
+const title = "Reports";
+export const metadata = generateMetadata(title);
+
+function ReportsPage({
+  searchParams,
+}: {
+  searchParams: OperationsSearchParams;
+}) {
+  return (
+    <ReportsBasePage activeTab={0}>
+      <div className="flex flex-col">
+        <AnnualReportsPage searchParams={searchParams || {}} />
+      </div>
+    </ReportsBasePage>
+  );
+}
+export default defaultPageFactory(ReportsPage);

--- a/bciers/apps/reporting/src/app/idir/cas_admin/reports/current-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_admin/reports/current-reports/page.tsx
@@ -2,16 +2,12 @@ import { generateMetadata } from "@bciers/components/layout/RootLayout";
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 import AnnualReportsPage from "@reporting/src/app/components/operations/annualReportsPage";
 import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
-import { OperationsSearchParams } from "@reporting/src/app/components/operations/types";
+import { ReportSearchParams } from "@reporting/src/app/components/operations/types";
 
 const title = "Reports";
 export const metadata = generateMetadata(title);
 
-function ReportsPage({
-  searchParams,
-}: {
-  searchParams: OperationsSearchParams;
-}) {
+function ReportsPage({ searchParams }: { searchParams: ReportSearchParams }) {
   return (
     <ReportsBasePage activeTab={0}>
       <div className="flex flex-col">

--- a/bciers/apps/reporting/src/app/idir/cas_admin/reports/past-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_admin/reports/past-reports/page.tsx
@@ -1,0 +1,5 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+
+export default defaultPageFactory(() => (
+  <div>Past Reports page is under development</div>
+));

--- a/bciers/apps/reporting/src/app/idir/cas_admin/reports/past-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_admin/reports/past-reports/page.tsx
@@ -1,5 +1,0 @@
-import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
-
-export default defaultPageFactory(() => (
-  <div>Past Reports page is under development</div>
-));

--- a/bciers/apps/reporting/src/app/idir/cas_admin/reports/previous-years/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_admin/reports/previous-years/page.tsx
@@ -1,0 +1,22 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
+
+function ReportsPage() {
+  return (
+    <ReportsBasePage activeTab={1}>
+      <div className="flex flex-col items-center justify-center py-12">
+        <h2 className="text-2xl font-bold mb-4 text-bc-bg-blue">
+          Previous Years Reports
+        </h2>
+        <p className="text-bc-text text-lg mb-2">
+          This feature is <b>coming soon</b>.
+        </p>
+        <p className="text-bc-text text-center max-w-xl">
+          You’ll be able to view reports from previous reporting years here.
+        </p>
+      </div>
+    </ReportsBasePage>
+  );
+}
+
+export default defaultPageFactory(ReportsPage);

--- a/bciers/apps/reporting/src/app/idir/cas_admin/reports/report-history/[report_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_admin/reports/report-history/[report_id]/page.tsx
@@ -1,0 +1,4 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import Page from "@reporting/src/app/components/reportHistory/ReportHistoryPage";
+
+export default defaultPageFactory(Page);

--- a/bciers/apps/reporting/src/app/idir/cas_admin/reports/report-history/[report_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_admin/reports/report-history/[report_id]/page.tsx
@@ -1,4 +1,5 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
-import Page from "@reporting/src/app/components/reportHistory/ReportHistoryPage";
 
-export default defaultPageFactory(Page);
+export default defaultPageFactory(() => (
+  <div>Internal Report History page is under development</div>
+));

--- a/bciers/apps/reporting/src/app/idir/cas_admin/reports/report-history/[report_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_admin/reports/report-history/[report_id]/page.tsx
@@ -1,5 +1,15 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 
 export default defaultPageFactory(() => (
-  <div>Internal Report History page is under development</div>
+  <div className="flex flex-col items-center justify-center py-12">
+    <h2 className="text-2xl font-bold mb-4 text-bc-bg-blue">
+      View Report History
+    </h2>
+    <p className="text-bc-text text-lg mb-2">
+      This feature is <b>coming soon</b>.
+    </p>
+    <p className="text-bc-text text-center max-w-xl">
+      You’ll be able to view the history of report versions for this report.
+    </p>
+  </div>
 ));

--- a/bciers/apps/reporting/src/app/idir/cas_analyst/reports/[version_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_analyst/reports/[version_id]/page.tsx
@@ -1,0 +1,5 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+
+export default defaultPageFactory(() => (
+  <div>View-only Report page is under development</div>
+));

--- a/bciers/apps/reporting/src/app/idir/cas_analyst/reports/[version_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_analyst/reports/[version_id]/page.tsx
@@ -1,5 +1,13 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 
 export default defaultPageFactory(() => (
-  <div>View-only Report page is under development</div>
+  <div className="flex flex-col items-center justify-center py-12">
+    <h2 className="text-2xl font-bold mb-4 text-bc-bg-blue">View Report</h2>
+    <p className="text-bc-text text-lg mb-2">
+      This feature is <b>coming soon</b>.
+    </p>
+    <p className="text-bc-text text-center max-w-xl">
+      You’ll be able to view a read-only version of the report here.
+    </p>
+  </div>
 ));

--- a/bciers/apps/reporting/src/app/idir/cas_analyst/reports/attachments/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_analyst/reports/attachments/page.tsx
@@ -1,4 +1,19 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 import AttachmentsListPage from "@reporting/src/app/components/attachments/attachmentsList/AttachmentsListPage";
+import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
+import { AttachmentsSearchParams } from "@reporting/src/app/utils/getAttachmentsList";
 
-export default defaultPageFactory(AttachmentsListPage);
+function ReportsPage({
+  searchParams,
+}: {
+  searchParams: AttachmentsSearchParams;
+}) {
+  return (
+    <ReportsBasePage activeTab={2}>
+      <div className="flex flex-col">
+        <AttachmentsListPage searchParams={searchParams || {}} />
+      </div>
+    </ReportsBasePage>
+  );
+}
+export default defaultPageFactory(ReportsPage);

--- a/bciers/apps/reporting/src/app/idir/cas_analyst/reports/current-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_analyst/reports/current-reports/page.tsx
@@ -1,0 +1,23 @@
+import { generateMetadata } from "@bciers/components/layout/RootLayout";
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import AnnualReportsPage from "@reporting/src/app/components/operations/annualReportsPage";
+import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
+import { OperationsSearchParams } from "@reporting/src/app/components/operations/types";
+
+const title = "Reports";
+export const metadata = generateMetadata(title);
+
+function ReportsPage({
+  searchParams,
+}: {
+  searchParams: OperationsSearchParams;
+}) {
+  return (
+    <ReportsBasePage activeTab={0}>
+      <div className="flex flex-col">
+        <AnnualReportsPage searchParams={searchParams || {}} />
+      </div>
+    </ReportsBasePage>
+  );
+}
+export default defaultPageFactory(ReportsPage);

--- a/bciers/apps/reporting/src/app/idir/cas_analyst/reports/current-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_analyst/reports/current-reports/page.tsx
@@ -2,16 +2,12 @@ import { generateMetadata } from "@bciers/components/layout/RootLayout";
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 import AnnualReportsPage from "@reporting/src/app/components/operations/annualReportsPage";
 import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
-import { OperationsSearchParams } from "@reporting/src/app/components/operations/types";
+import { ReportSearchParams } from "@reporting/src/app/components/operations/types";
 
 const title = "Reports";
 export const metadata = generateMetadata(title);
 
-function ReportsPage({
-  searchParams,
-}: {
-  searchParams: OperationsSearchParams;
-}) {
+function ReportsPage({ searchParams }: { searchParams: ReportSearchParams }) {
   return (
     <ReportsBasePage activeTab={0}>
       <div className="flex flex-col">

--- a/bciers/apps/reporting/src/app/idir/cas_analyst/reports/past-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_analyst/reports/past-reports/page.tsx
@@ -1,0 +1,5 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+
+export default defaultPageFactory(() => (
+  <div>Past Reports page is under development</div>
+));

--- a/bciers/apps/reporting/src/app/idir/cas_analyst/reports/past-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_analyst/reports/past-reports/page.tsx
@@ -1,5 +1,0 @@
-import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
-
-export default defaultPageFactory(() => (
-  <div>Past Reports page is under development</div>
-));

--- a/bciers/apps/reporting/src/app/idir/cas_analyst/reports/previous-years/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_analyst/reports/previous-years/page.tsx
@@ -1,0 +1,22 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
+
+function ReportsPage() {
+  return (
+    <ReportsBasePage activeTab={1}>
+      <div className="flex flex-col items-center justify-center py-12">
+        <h2 className="text-2xl font-bold mb-4 text-bc-bg-blue">
+          Previous Years Reports
+        </h2>
+        <p className="text-bc-text text-lg mb-2">
+          This feature is <b>coming soon</b>.
+        </p>
+        <p className="text-bc-text text-center max-w-xl">
+          You’ll be able to view reports from previous reporting years here.
+        </p>
+      </div>
+    </ReportsBasePage>
+  );
+}
+
+export default defaultPageFactory(ReportsPage);

--- a/bciers/apps/reporting/src/app/idir/cas_analyst/reports/report-history/[report_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_analyst/reports/report-history/[report_id]/page.tsx
@@ -1,0 +1,4 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import Page from "@reporting/src/app/components/reportHistory/ReportHistoryPage";
+
+export default defaultPageFactory(Page);

--- a/bciers/apps/reporting/src/app/idir/cas_analyst/reports/report-history/[report_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_analyst/reports/report-history/[report_id]/page.tsx
@@ -1,4 +1,5 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
-import Page from "@reporting/src/app/components/reportHistory/ReportHistoryPage";
 
-export default defaultPageFactory(Page);
+export default defaultPageFactory(() => (
+  <div>Internal Report History page is under development</div>
+));

--- a/bciers/apps/reporting/src/app/idir/cas_analyst/reports/report-history/[report_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_analyst/reports/report-history/[report_id]/page.tsx
@@ -1,5 +1,15 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 
 export default defaultPageFactory(() => (
-  <div>Internal Report History page is under development</div>
+  <div className="flex flex-col items-center justify-center py-12">
+    <h2 className="text-2xl font-bold mb-4 text-bc-bg-blue">
+      View Report History
+    </h2>
+    <p className="text-bc-text text-lg mb-2">
+      This feature is <b>coming soon</b>.
+    </p>
+    <p className="text-bc-text text-center max-w-xl">
+      You’ll be able to view the history of report versions for this report.
+    </p>
+  </div>
 ));

--- a/bciers/apps/reporting/src/app/idir/cas_director/reports/[version_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_director/reports/[version_id]/page.tsx
@@ -1,0 +1,5 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+
+export default defaultPageFactory(() => (
+  <div>View-only Report page is under development</div>
+));

--- a/bciers/apps/reporting/src/app/idir/cas_director/reports/[version_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_director/reports/[version_id]/page.tsx
@@ -1,5 +1,13 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 
 export default defaultPageFactory(() => (
-  <div>View-only Report page is under development</div>
+  <div className="flex flex-col items-center justify-center py-12">
+    <h2 className="text-2xl font-bold mb-4 text-bc-bg-blue">View Report</h2>
+    <p className="text-bc-text text-lg mb-2">
+      This feature is <b>coming soon</b>.
+    </p>
+    <p className="text-bc-text text-center max-w-xl">
+      You’ll be able to view a read-only version of the report here.
+    </p>
+  </div>
 ));

--- a/bciers/apps/reporting/src/app/idir/cas_director/reports/attachments/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_director/reports/attachments/page.tsx
@@ -1,4 +1,19 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 import AttachmentsListPage from "@reporting/src/app/components/attachments/attachmentsList/AttachmentsListPage";
+import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
+import { AttachmentsSearchParams } from "@reporting/src/app/utils/getAttachmentsList";
 
-export default defaultPageFactory(AttachmentsListPage);
+function ReportsPage({
+  searchParams,
+}: {
+  searchParams: AttachmentsSearchParams;
+}) {
+  return (
+    <ReportsBasePage activeTab={2}>
+      <div className="flex flex-col">
+        <AttachmentsListPage searchParams={searchParams || {}} />
+      </div>
+    </ReportsBasePage>
+  );
+}
+export default defaultPageFactory(ReportsPage);

--- a/bciers/apps/reporting/src/app/idir/cas_director/reports/current-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_director/reports/current-reports/page.tsx
@@ -1,0 +1,23 @@
+import { generateMetadata } from "@bciers/components/layout/RootLayout";
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import AnnualReportsPage from "@reporting/src/app/components/operations/annualReportsPage";
+import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
+import { OperationsSearchParams } from "@reporting/src/app/components/operations/types";
+
+const title = "Reports";
+export const metadata = generateMetadata(title);
+
+function ReportsPage({
+  searchParams,
+}: {
+  searchParams: OperationsSearchParams;
+}) {
+  return (
+    <ReportsBasePage activeTab={0}>
+      <div className="flex flex-col">
+        <AnnualReportsPage searchParams={searchParams || {}} />
+      </div>
+    </ReportsBasePage>
+  );
+}
+export default defaultPageFactory(ReportsPage);

--- a/bciers/apps/reporting/src/app/idir/cas_director/reports/current-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_director/reports/current-reports/page.tsx
@@ -2,16 +2,12 @@ import { generateMetadata } from "@bciers/components/layout/RootLayout";
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 import AnnualReportsPage from "@reporting/src/app/components/operations/annualReportsPage";
 import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
-import { OperationsSearchParams } from "@reporting/src/app/components/operations/types";
+import { ReportSearchParams } from "@reporting/src/app/components/operations/types";
 
 const title = "Reports";
 export const metadata = generateMetadata(title);
 
-function ReportsPage({
-  searchParams,
-}: {
-  searchParams: OperationsSearchParams;
-}) {
+function ReportsPage({ searchParams }: { searchParams: ReportSearchParams }) {
   return (
     <ReportsBasePage activeTab={0}>
       <div className="flex flex-col">

--- a/bciers/apps/reporting/src/app/idir/cas_director/reports/past-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_director/reports/past-reports/page.tsx
@@ -1,0 +1,5 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+
+export default defaultPageFactory(() => (
+  <div>Past Reports page is under development</div>
+));

--- a/bciers/apps/reporting/src/app/idir/cas_director/reports/past-reports/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_director/reports/past-reports/page.tsx
@@ -1,5 +1,0 @@
-import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
-
-export default defaultPageFactory(() => (
-  <div>Past Reports page is under development</div>
-));

--- a/bciers/apps/reporting/src/app/idir/cas_director/reports/previous-years/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_director/reports/previous-years/page.tsx
@@ -1,0 +1,22 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
+
+function ReportsPage() {
+  return (
+    <ReportsBasePage activeTab={1}>
+      <div className="flex flex-col items-center justify-center py-12">
+        <h2 className="text-2xl font-bold mb-4 text-bc-bg-blue">
+          Previous Years Reports
+        </h2>
+        <p className="text-bc-text text-lg mb-2">
+          This feature is <b>coming soon</b>.
+        </p>
+        <p className="text-bc-text text-center max-w-xl">
+          You’ll be able to view reports from previous reporting years here.
+        </p>
+      </div>
+    </ReportsBasePage>
+  );
+}
+
+export default defaultPageFactory(ReportsPage);

--- a/bciers/apps/reporting/src/app/idir/cas_director/reports/report-history/[report_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_director/reports/report-history/[report_id]/page.tsx
@@ -1,0 +1,4 @@
+import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
+import Page from "@reporting/src/app/components/reportHistory/ReportHistoryPage";
+
+export default defaultPageFactory(Page);

--- a/bciers/apps/reporting/src/app/idir/cas_director/reports/report-history/[report_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_director/reports/report-history/[report_id]/page.tsx
@@ -1,4 +1,5 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
-import Page from "@reporting/src/app/components/reportHistory/ReportHistoryPage";
 
-export default defaultPageFactory(Page);
+export default defaultPageFactory(() => (
+  <div>Internal Report History page is under development</div>
+));

--- a/bciers/apps/reporting/src/app/idir/cas_director/reports/report-history/[report_id]/page.tsx
+++ b/bciers/apps/reporting/src/app/idir/cas_director/reports/report-history/[report_id]/page.tsx
@@ -1,5 +1,15 @@
 import defaultPageFactory from "@bciers/components/nextPageFactory/defaultPageFactory";
 
 export default defaultPageFactory(() => (
-  <div>Internal Report History page is under development</div>
+  <div className="flex flex-col items-center justify-center py-12">
+    <h2 className="text-2xl font-bold mb-4 text-bc-bg-blue">
+      View Report History
+    </h2>
+    <p className="text-bc-text text-lg mb-2">
+      This feature is <b>coming soon</b>.
+    </p>
+    <p className="text-bc-text text-center max-w-xl">
+      You’ll be able to view the history of report versions for this report.
+    </p>
+  </div>
 ));

--- a/bciers/apps/reporting/src/tests/components/dataGrid/model/annualReports/annualReportsColumns.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/dataGrid/model/annualReports/annualReportsColumns.test.tsx
@@ -1,0 +1,102 @@
+import { describe, vi } from "vitest";
+import { GridColDef } from "@mui/x-data-grid";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRouter } from "@bciers/testConfig/mocks";
+import formatTimestamp from "@bciers/utils/src/formatTimestamp";
+import annualReportsColumns from "@reporting/src/app/components/datagrid/models/annualReports/annualReportsColumns";
+
+vi.mock("@bciers/utils/src/formatTimestamp", () => ({
+  default: vi.fn((value) => `Formatted(${value})`),
+}));
+
+const mockPush = vi.fn();
+useRouter.mockReturnValue({
+  push: mockPush,
+});
+
+describe("annualReportsColumns function", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an array of column definitions", () => {
+    const columns: GridColDef[] = annualReportsColumns();
+
+    expect(columns).toHaveLength(5);
+
+    expect(columns[0].field).toBe("operation_name");
+    expect(columns[0].headerName).toBe("Operation");
+    expect(columns[0].width).toBe(500);
+
+    expect(columns[1].field).toBe("report_version_id");
+    expect(columns[1].headerName).toBe("Report Version ID");
+    expect(columns[1].width).toBe(180);
+
+    expect(columns[2].field).toBe("report_updated_at");
+    expect(columns[2].headerName).toBe("Date of submission");
+    expect(columns[2].width).toBe(180);
+
+    expect(columns[3].field).toBe("report");
+    expect(columns[3].headerName).toBe("Reports");
+    expect(columns[3].width).toBe(240);
+
+    expect(columns[4].field).toBe("history");
+    expect(columns[4].headerName).toBe("Report History");
+    expect(columns[4].width).toBe(240);
+  });
+
+  it("renders a formatted timestamp in UpdatedAtCell", () => {
+    const columns = annualReportsColumns();
+    const params = {
+      row: { report_status: "Submitted" },
+      value: "2024-03-01T12:00:00Z",
+    };
+
+    expect(columns[2].renderCell(params)).toBe(
+      formatTimestamp("2024-03-01T12:00:00Z"),
+    );
+  });
+
+  it("navigates to the view report page when clicking the View Report button", async () => {
+    const columns = annualReportsColumns();
+    const row = {
+      report_version_id: 123,
+    };
+    const params = { row, value: row.report_version_id };
+
+    function WrapperComponent() {
+      const cell = columns[3].renderCell;
+
+      return <div>{cell(params)}</div>;
+    }
+
+    const user = userEvent.setup();
+    render(<WrapperComponent />);
+    const button = screen.getByText("View Report");
+    await user.click(button);
+
+    expect(mockPush).toHaveBeenCalledWith("123");
+  });
+
+  it("navigates to the report history page when clicking the View Report History button", async () => {
+    const columns = annualReportsColumns();
+    const row = {
+      report_id: 456,
+    };
+    const params = { row, value: row.report_id };
+
+    function WrapperComponent() {
+      const cell = columns[4].renderCell;
+
+      return <div>{cell(params)}</div>;
+    }
+
+    const user = userEvent.setup();
+    render(<WrapperComponent />);
+    const button = screen.getByText("View Report History");
+    await user.click(button);
+
+    expect(mockPush).toHaveBeenCalledWith("report-history/456");
+  });
+});


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/666

### Changes
- Created AnnualReports page for internal users
- refactored ReportsBasePage to display different tabs based on user role
- refactored get_past_reports_for_reporting_dashboard -> get_past_reports_for_reporting_dashboard
   - this function now takes an argument to return either past, current, or all reports
   - this function will now return user operator approved reports for external users, and submitted reports by all operators for internal users.
 - added placeholder pages for the internal "View Reports" and "Report History" pages and "Past reports" tab
 - Added the "download report attachments" page to a tab on the reports grid page

**NOTE** The wireframe for this page shows a search field for 'Date of Submission' but that is not being implemented at this time.

### Testing
Things I can think of that should be tested:
1. Check that only reports that have a Submitted version show on the Annual reports page
   - Banana and Bangles are the reports submitted in the fixtures. As an external user, submit another report to see a new report added to the annual reports grid
2. Check that the 'View Report' and 'View Report History' links work
   - they only direct to placeholder pages at the moment
3. Check that the grid search and sort functions work as expected
4. Check that the reporting dashboard links all work