### PR TITLE
268 request issuance button

### DIFF
--- a/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/request-issuance-of-earned-credits/RequestIssuanceOfEarnedCreditsComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/request-issuance-of-earned-credits/RequestIssuanceOfEarnedCreditsComponent.tsx
@@ -81,7 +81,6 @@ const RequestIssuanceOfEarnedCreditsComponent = ({
       setErrors([response.error || "Failed to submit request"]);
       setIsSubmitting(false); // we only set isSubmitting to false if there was an error so that the button will remain disabled if user tries to submit again
     }
-    setIsSubmitting(false);
   };
 
   return (
@@ -107,7 +106,7 @@ const RequestIssuanceOfEarnedCreditsComponent = ({
         <FormAlerts errors={errors} />
         <ComplianceStepButtons backUrl={backUrl} className="mt-4">
           <SubmitButton isSubmitting={isSubmitting} disabled={!canSubmit}>
-            Requests Issuance of Earned Credits
+            Request Issuance of Earned Credits
           </SubmitButton>
         </ComplianceStepButtons>
       </div>

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/request-issuance/request-issuance-of-earned-credits/RequestIssuanceOfEarnedCreditsComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/request-issuance/request-issuance-of-earned-credits/RequestIssuanceOfEarnedCreditsComponent.test.tsx
@@ -56,8 +56,9 @@ describe("RequestIssuanceOfEarnedCreditsComponent", () => {
     );
 
     expect(
-      screen.getByText("Request Issuance of Earned Credits"),
-    ).toBeVisible();
+      screen.getAllByText("Request Issuance of Earned Credits"),
+    ).toHaveLength(2);
+
     expect(
       screen.getByText("B.C. Carbon Registry (BCCR) Account Information"),
     ).toBeVisible();
@@ -128,7 +129,7 @@ describe("RequestIssuanceOfEarnedCreditsComponent", () => {
 
     const backButton = screen.getByRole("button", { name: "Back" });
     const continueButton = screen.getByRole("button", {
-      name: "Requests Issuance of Earned Credits",
+      name: "Request Issuance of Earned Credits",
     });
 
     // Should be enabled after valid account
@@ -140,7 +141,7 @@ describe("RequestIssuanceOfEarnedCreditsComponent", () => {
 
     // Should be disabled with invalid account
     const disabledContinueButton = screen.getByRole("button", {
-      name: "Requests Issuance of Earned Credits",
+      name: "Request Issuance of Earned Credits",
     });
     expect(disabledContinueButton).toBeDisabled();
   });
@@ -156,7 +157,7 @@ describe("RequestIssuanceOfEarnedCreditsComponent", () => {
     );
 
     const continueButton = screen.getByRole("button", {
-      name: "Requests Issuance of Earned Credits",
+      name: "Request Issuance of Earned Credits",
     });
     fireEvent.click(continueButton);
 
@@ -208,7 +209,7 @@ describe("RequestIssuanceOfEarnedCreditsComponent", () => {
     await setupValidAccount();
 
     const continueButton = screen.getByRole("button", {
-      name: "Requests Issuance of Earned Credits",
+      name: "Request Issuance of Earned Credits",
     });
     fireEvent.click(continueButton);
 
@@ -225,7 +226,7 @@ describe("RequestIssuanceOfEarnedCreditsComponent", () => {
     await setupValidAccount();
 
     const continueButton = screen.getByRole("button", {
-      name: "Requests Issuance of Earned Credits",
+      name: "Request Issuance of Earned Credits",
     });
     fireEvent.click(continueButton);
 
@@ -245,7 +246,7 @@ describe("RequestIssuanceOfEarnedCreditsComponent", () => {
     await setupValidAccount();
 
     const continueButton = screen.getByRole("button", {
-      name: "Requests Issuance of Earned Credits",
+      name: "Request Issuance of Earned Credits",
     });
     fireEvent.click(continueButton);
 
@@ -282,7 +283,7 @@ describe("RequestIssuanceOfEarnedCreditsComponent", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("button", {
-          name: "Requests Issuance of Earned Credits",
+          name: "Request Issuance of Earned Credits",
         }),
       ).toBeDisabled();
     });


### PR DESCRIPTION
card: https://github.com/bcgov/cas-compliance/issues/268

The button already correctly stays disabled during form submission (`const isDisabled = disabled || isSubmitting;` in the button component, and we have a vitest and manual testing to confirm). The reason it looks broken is because it takes a second for the redirect to take effect, so there's a moment where the button is renabled because the submission is complete but the redirect isn't. To fix it, I moved `setIsSubmitting(false) into the error condition so that the button doesn't get renabled if the submission was successful. This pattern appears in some of the other compliance components.

Also fixed the typo in the button text.