### PR TITLE
chore: verify ownership of sub-account in BCCR

### DIFF
--- a/bc_obps/compliance/dataclass.py
+++ b/bc_obps/compliance/dataclass.py
@@ -56,7 +56,7 @@ class BCCRAccountResponseDetails:
 
     entity_id: str
     organization_classification_id: str
-    type_of_account_holder: str
+    type_of_account_holder: Optional[str]
     trading_name: str
 
 

--- a/bc_obps/compliance/service/bc_carbon_registry/schema.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/schema.py
@@ -82,9 +82,9 @@ class AccountDetailEntity(BaseModel):
     mainContactName: Optional[str] = None  # "Kelly Konrad"
     accountTypeName: Optional[str] = None  # "General Participant"
     accountTypeId: Optional[NonNegativeInt] = None  # 10
-    type_of_account_holder: str  # "Corporation"
-    # Below fields are also part of the response, but we are not interested in them for now
-    # masterAccountId: Optional[PositiveInt] = None  # 102000000001000
+    type_of_account_holder: Optional[str] = None  # "Corporation"
+    masterAccountId: Optional[PositiveInt] = None  # 102000000001000 - Needed for ownership validation
+    # Below fields are also part of the response, but we are not interested in them for now except masterAccountId
     # masterAccountName: Optional[str] = None  # "British Columbia Government Account"
     # billingContactEmail: Optional[str] = None  # "someone.email@gov.bc.ca"
     # auxiliaries: Optional[Any] = None  # None

--- a/bc_obps/compliance/tests/api/_bccr/_accounts/test_account_id.py
+++ b/bc_obps/compliance/tests/api/_bccr/_accounts/test_account_id.py
@@ -10,6 +10,7 @@ COMPLIANCE_REPORT_VERSION_ID = 1
 BCCR_SERVICE_PATH = (
     "compliance.service.bc_carbon_registry.account_service.BCCarbonRegistryAccountService.get_account_details"
 )
+VALIDATE_OWNERSHIP_PATH = "compliance.service.bc_carbon_registry.account_service.BCCarbonRegistryAccountService.validate_holding_account_ownership"
 VALIDATE_PERMISSION_PATH = 'common.permissions.validate_all'
 
 
@@ -27,9 +28,10 @@ class TestAccountIdEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoid data
             kwargs={"account_id": account_id, "compliance_report_version_id": compliance_report_version_id},
         )
 
+    @patch(VALIDATE_OWNERSHIP_PATH)
     @patch(BCCR_SERVICE_PATH)
     @patch(VALIDATE_PERMISSION_PATH)
-    def test_successful_account_details_retrieval(self, mock_permission, mock_service):
+    def test_successful_account_details_retrieval(self, mock_permission, mock_service, mock_ownership):
         # Arrange
         mock_permission.return_value = True
         mock_service.return_value = BCCRAccountResponseDetails(
@@ -38,10 +40,17 @@ class TestAccountIdEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoid data
             type_of_account_holder="Corporation",
             trading_name="Test Account Inc.",
         )
+        mock_ownership.return_value = True  # Valid ownership
+
         # Act
         response = self.client.get(self._get_endpoint_url(VALID_ACCOUNT_ID, COMPLIANCE_REPORT_VERSION_ID))
+
         # Assert
         mock_service.assert_called_once_with(account_id=VALID_ACCOUNT_ID)
+        mock_ownership.assert_called_once_with(
+            holding_account_id=VALID_ACCOUNT_ID,
+            compliance_report_version_id=COMPLIANCE_REPORT_VERSION_ID,
+        )
         assert response.status_code == 200
         assert response.json() == {"bccr_trading_name": "Test Account Inc."}
 
@@ -80,3 +89,59 @@ class TestAccountIdEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoid data
         assert response.json() == {
             "message": "The system cannot connect to the external application. Please try again later. If the problem persists, contact GHGRegulator@gov.bc.ca for help."
         }
+
+    @patch(VALIDATE_OWNERSHIP_PATH)
+    @patch(BCCR_SERVICE_PATH)
+    @patch(VALIDATE_PERMISSION_PATH)
+    def test_invalid_account_ownership(self, mock_permission, mock_service, mock_ownership):
+        # Arrange
+        mock_permission.return_value = True
+        mock_service.return_value = BCCRAccountResponseDetails(
+            entity_id="123",
+            organization_classification_id="456",
+            type_of_account_holder="Corporation",
+            trading_name="Test Account Inc.",
+        )
+        mock_ownership.return_value = False  # Invalid ownership
+
+        # Act
+        response = self.client.get(self._get_endpoint_url(VALID_ACCOUNT_ID, COMPLIANCE_REPORT_VERSION_ID))
+
+        # Assert
+        mock_service.assert_called_once_with(account_id=VALID_ACCOUNT_ID)
+        mock_ownership.assert_called_once_with(
+            holding_account_id=VALID_ACCOUNT_ID,
+            compliance_report_version_id=COMPLIANCE_REPORT_VERSION_ID,
+        )
+        assert response.status_code == 400
+        assert response.json() == {
+            "message": "The provided holding account does not own the compliance sub-account for this operation."
+        }
+
+    @patch(VALIDATE_OWNERSHIP_PATH)
+    @patch(BCCR_SERVICE_PATH)
+    @patch(VALIDATE_PERMISSION_PATH)
+    def test_account_details_with_null_type_of_account_holder(self, mock_permission, mock_service, mock_ownership):
+        # Arrange - Test schema change where type_of_account_holder can be null
+        mock_permission.return_value = True
+        mock_service.return_value = BCCRAccountResponseDetails(
+            entity_id="123",
+            organization_classification_id="456",
+            type_of_account_holder=None,  # Null value should be handled gracefully
+            trading_name="Test Account Inc.",
+        )
+        mock_ownership.return_value = True  # Valid ownership
+
+        # Act
+        response = self.client.get(self._get_endpoint_url(VALID_ACCOUNT_ID, COMPLIANCE_REPORT_VERSION_ID))
+
+        # Assert
+        mock_service.assert_called_once_with(account_id=VALID_ACCOUNT_ID)
+        mock_ownership.assert_called_once_with(
+            holding_account_id=VALID_ACCOUNT_ID,
+            compliance_report_version_id=COMPLIANCE_REPORT_VERSION_ID,
+        )
+        assert response.status_code == 200
+        assert response.json() == {
+            "bccr_trading_name": "Test Account Inc."
+        }  # Should still work with null type_of_account_holder

--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
@@ -46,6 +46,7 @@ BASE_ACCOUNT_RESPONSE = {
             "accountTypeName": "Test Account Type",
             "accountTypeId": 10,
             "type_of_account_holder": "Test Type",
+            "masterAccountId": None,
         }
     ],
 }
@@ -172,6 +173,7 @@ def assert_account_keys(entities):
             "accountTypeName",
             "accountTypeId",
             "type_of_account_holder",
+            "masterAccountId",
         ]
     )
 
@@ -425,6 +427,7 @@ class TestBCCarbonRegistryAPIClient:
                         "accountTypeName": "Test Account Type 2",
                         "accountTypeId": 20,
                         "type_of_account_holder": "Test Type 2",
+                        "masterAccountId": None,
                     },
                 ],
             },
@@ -719,7 +722,7 @@ class TestBCCarbonRegistryAPIClient:
                 "entities": [
                     {
                         **BASE_ACCOUNT_RESPONSE["entities"][0],
-                        "masterAccountId": MOCK_FIFTEEN_DIGIT_STRING,
+                        "masterAccountId": MOCK_FIFTEEN_DIGIT_INT,
                         "masterAccountName": "Test Holding Account",
                         "entityId": 123456789012345,
                     }
@@ -734,7 +737,7 @@ class TestBCCarbonRegistryAPIClient:
         # Assert
         assert result["totalEntities"] == 1
         assert len(result["entities"]) == 1
-        assert result["entities"][0]["masterAccountId"] == MOCK_FIFTEEN_DIGIT_STRING
+        assert result["entities"][0]["masterAccountId"] == MOCK_FIFTEEN_DIGIT_INT
         assert result["entities"][0]["masterAccountName"] == "Test Holding Account"
         assert result["entities"][0]["entityId"] == 123456789012345
         mock_request.assert_called_once_with(

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/apply-compliance-units/ApplyComplianceUnitsComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/apply-compliance-units/ApplyComplianceUnitsComponent.tsx
@@ -218,8 +218,13 @@ export default function ApplyComplianceUnitsComponent({
 
   // Check if we should show the Submit button (when trading name is received)
   const shouldShowSubmitButton = useMemo(() => {
-    return status === "idle" || status === "submitting";
-  }, [status]);
+    const data = formData as ApplyComplianceUnitsFormData;
+    // Only show submit button if we have a valid trading name and appropriate status
+    return (
+      (status === "idle" || status === "submitting") &&
+      !!data?.bccr_trading_name
+    );
+  }, [status, formData]);
 
   // Check if Submit button should be enabled (when checkbox is checked)
   const canSubmit = useMemo(() => {


### PR DESCRIPTION
## Overview
Fixes ticket https://github.com/bcgov/cas-compliance/issues/226 by implementing proper ownership validation for BCCR Holding Account IDs in the "Apply Compliance Units" functionality. Previously, users could enter any BCCR Holding Account ID and apply units even if they didn't own the associated compliance sub-account, leading to units being deducted but not properly reflected in BCIERS or BCCR.

## Changes Made

### Backend
- **Added `validate_holding_account_ownership()` method** in `BCCarbonRegistryAccountService`
  - Validates that a holding account owns the compliance sub-account for a given operation
  - Handles both existing sub-accounts (via `masterAccountId` comparison) and new operations (via compliance account lookup)
- **Integrated ownership validation** into `ApplyComplianceUnitsService`:
- **Schema updates**: Made `type_of_account_holder` optional in Pydantic schema and dataclass to handle BCCR API responses

### Frontend
- **Updated submit button logic** to only display when valid trading name exists

## Testing
- Log in as bc-cas-dev
- Navigate to Submit Annual Report(s)
- Submit a report for Compliance SFO - Obligation not met
- Go back to the main dashboard
- Click My Compliance under the Compliance tile
- Click Manage Obligation for the operation
- Click Apply Compliance Units
- Enter an invalid BCCR Holding Account ID (103200000028730)
- Check that error is showing like account is not found
- Enter a correct BCCR Holding Account ID (103200000028731 )
- Apply some units
- Click Apply
- Once successful, click Back - verify that the applied units are visible in the grid