### PR TITLE
chore: fix bandit dependencies in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,7 @@ repos:
     rev: "1.7.5"
     hooks:
       - id: bandit
+        additional_dependencies: [pbr]
         args: ["-c", "bc_obps/bandit.yaml"]
 
   - repo: https://github.com/zricethezav/gitleaks


### PR DESCRIPTION
This PR:
- adds additional dependencies to bandit in pre-commit to get past pbr error, e.g. https://github.com/bcgov/cas-registration/actions/runs/17213663266/job/48837263110?pr=3709