### PR TITLE
224 - use operator mailing instead of physical address on invoices

### DIFF
--- a/bc_obps/compliance/service/compliance_invoice_service.py
+++ b/bc_obps/compliance/service/compliance_invoice_service.py
@@ -73,7 +73,7 @@ class ComplianceInvoiceService:
         # Operator → Address
 
         operator_address_line1, operator_address_line2 = ComplianceInvoiceService.format_operator_address(
-            operator.physical_address
+            operator.mailing_address
         )
 
         invoice_number = invoice.invoice_number

--- a/bc_obps/registration/fixtures/mock/address.json
+++ b/bc_obps/registration/fixtures/mock/address.json
@@ -3,10 +3,10 @@
     "model": "registration.address",
     "pk": 1,
     "fields": {
-      "street_address": "123 Main St",
-      "municipality": "Cityville",
-      "province": "ON",
-      "postal_code": "A1B 2C3"
+      "street_address": "568 Wonky St",
+      "municipality": "Villaville",
+      "province": "BC",
+      "postal_code": "H0H 0H0"
     }
   },
   {


### PR DESCRIPTION
card: https://github.com/bcgov/cas-compliance/issues/224

This PR:
- uses operator.mailing_address instead of physical address in the invoice service
- there was a duplicate address in the fixtures which made it harder to see which address was being used, so I updated the fixtures to be unique