### PR TITLE
Fix/airflow dag params

### DIFF
--- a/dags/bc_obps_test_migrations.py
+++ b/dags/bc_obps_test_migrations.py
@@ -64,7 +64,7 @@ postgres_helm_install = KubernetesJobOperator(
     namespace="{{ params.destination_namespace }}",
     service_account_name=SERVICE_ACCOUNT_NAME,
     image=K8S_IMAGE,
-    env_vars={"HOME": "/tmp"},
+    env_vars={"HOME": "/tmp"},  # nosec B108
     cmds=["bash", "-c"],
     arguments=[
         "helm repo add cas-registration https://bcgov.github.io/cas-registration/ && "
@@ -109,7 +109,7 @@ backend_helm_install = KubernetesJobOperator(
     namespace="{{ params.destination_namespace }}",
     service_account_name=SERVICE_ACCOUNT_NAME,
     image=K8S_IMAGE,
-    env_vars={"HOME": "/tmp"},
+    env_vars={"HOME": "/tmp"},  # nosec B108
     cmds=["bash", "-c"],
     arguments=[
         "helm repo add cas-registration https://bcgov.github.io/cas-registration/ && "

--- a/dags/bc_obps_test_migrations.py
+++ b/dags/bc_obps_test_migrations.py
@@ -2,6 +2,7 @@ from dag_configuration import default_dag_args
 from trigger_k8s_cronjob import trigger_k8s_cronjob
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.operators.python_operator import PythonOperator
+from airflow.models.param import Param
 from datetime import datetime, timedelta
 from airflow import DAG
 import os
@@ -12,6 +13,7 @@ TWO_DAYS_AGO = datetime.now() - timedelta(days=2)
 TEST_MIGRATIONS_DAG_NAME = "cas_bciers_test_migrations"
 K8S_IMAGE = "alpine/k8s:1.29.15"
 SERVICE_ACCOUNT_NAME = "airflow-deployer"
+bciers_namespace = os.getenv("BCIERS_NAMESPACE")
 
 default_args = {**default_dag_args, "start_date": TWO_DAYS_AGO}
 
@@ -21,10 +23,26 @@ test_migrations_dag = DAG(
     schedule_interval=None,
     catchup=False,
     params={
-        "destination_namespace": "abc123-test",
-        "source_namespace": "abc123-prod",
-        "backend_chart_tag": "latest",
-        "helm_options": "--atomic --wait-for-jobs --timeout 2400s",
+        "destination_namespace": Param(
+            bciers_namespace,
+            type="string",
+            description="The namespace to deploy the test charts into. This will ONLY work if the environment matches this Airflow instance.",
+        ),
+        "source_namespace": Param(
+            bciers_namespace,
+            type="string",
+            description="The namespace to use as the source of backups. Generally, this should be '-prod'.",
+        ),
+        "backend_chart_tag": Param(
+            "latest",
+            type="string",
+            description="The built image tag to pull within the backend chart (not the chart tag).",
+        ),
+        "helm_options": Param(
+            "--atomic --wait-for-jobs --timeout 2400s",
+            type="string",
+            description="Helm install options, shouldn't need to be changed.",
+        ),
     },
 )
 

--- a/dags/bc_obps_test_migrations.py
+++ b/dags/bc_obps_test_migrations.py
@@ -64,6 +64,7 @@ postgres_helm_install = KubernetesJobOperator(
     namespace="{{ params.destination_namespace }}",
     service_account_name=SERVICE_ACCOUNT_NAME,
     image=K8S_IMAGE,
+    env_vars={"HOME": "/tmp"},
     cmds=["bash", "-c"],
     arguments=[
         "helm repo add cas-registration https://bcgov.github.io/cas-registration/ && "
@@ -108,6 +109,7 @@ backend_helm_install = KubernetesJobOperator(
     namespace="{{ params.destination_namespace }}",
     service_account_name=SERVICE_ACCOUNT_NAME,
     image=K8S_IMAGE,
+    env_vars={"HOME": "/tmp"},
     cmds=["bash", "-c"],
     arguments=[
         "helm repo add cas-registration https://bcgov.github.io/cas-registration/ && "

--- a/docs/devops/release.md
+++ b/docs/devops/release.md
@@ -17,7 +17,7 @@ When you're ready to make a release, apply the following steps:
 1. post in the Teams developers channel that you're doing a release and there's a merge halt on
 1. go into the github settings and turn off merging to develop so no one can merge by accident if they miss the merge halt post. (Optional, but this ensures no other changes are made to the `develop` branch while the release is in progress. Release PRs can't be rebased (see note below), so if someone does merge something in, you have to restart the release.)
 1. on `develop`, check migrations against prod data:
-   1. go to the cas-airflow-dev frontend and trigger the `cas_bciers_test_migrations` dag. You will need the source (where the database backup originates from, likely `abc123-prod`) and target (where to deploy the tests, likely (`abc123-test`)) namespaces, as well as the git hash of the commit you want to test (used by `BACKEND_CHART_TAG`).
+   1. go to the cas-airflow-test frontend and trigger the `cas_bciers_test_migrations` dag. You will need the source (where the database backup originates from, likely `abc123-prod`) and target (where to deploy the tests, (`abc123-test`)) namespaces, as well as the git hash of the commit with a backend image built that you want to test (used by `BACKEND_CHART_TAG`).
    1. Ensure the dag completes successfully. If any steps fail, the helm charts remain deployed in the target namespace for later inspection. If there are any problems with the migrations, create a branch, fix, and merge the fix before continuing.
 1. create a `chore/release` branch and create the upstream
 1. reset database with `make reset_db` (from `cas-registration/bc_obps`) for proper creation of migration files


### PR DESCRIPTION
Addresses problems with the Airflow test dag created in #3478. The dag needs to _deploy into the same environment as the airflow instance_. This updates defaults, adds documentation and fixes the release process docs.