### PR TITLE
Chore/292 routing rules for penalty status

### DIFF
--- a/bciers/apps/compliance/src/middlewares/constants.ts
+++ b/bciers/apps/compliance/src/middlewares/constants.ts
@@ -35,13 +35,20 @@ export const joinCompliancePath = (...segs: (string | number | undefined)[]) =>
 export enum AppRoutes {
   ONBOARDING = "onboarding",
   REVIEW_COMPLIANCE_SUMMARIES = "compliance-summaries",
+  MO_REVIEW_SUMMARY = "review-compliance-obligation-report",
   MO_APPLY_COMPLIANCE_UNITS = "apply-compliance-units",
+  MO_DOWNLOAD_PAYMENT_INSTRUCTIONS = "download-payment-instructions",
+  MO_PAY_OBLIGATION_TRACK_PAYMENTS = "pay-obligation-track-payments",
+  MO_REVIEW_PENALTY_SUMMARY = "review-penalty-summary",
+  MO_DOWNLOAD_PENALTY_PAYMENT_INSTRUCTIONS = "download-payment-penalty-instructions",
+  MO_PAY_PENALTY_TRACK_PAYMENTS = "pay-penalty-track-payments",
   NO_REVIEW_SUMMARY = "review-summary",
   RI_EARNED_CREDITS = "request-issuance-of-earned-credits",
   RI_REVIEW_SUMMARY = "request-issuance-review-summary",
   RI_REVIEW_SUMMARY_CREDITS = "review-credits-issuance-request",
   RI_TRACK_STATUS = "track-status-of-issuance",
   REVIEW_BY_DIRECTOR = "review-by-director",
+  REVIEW_PENALTY_SUMMARY = "review-penalty-summary",
 }
 
 export type ComplianceStatus =
@@ -50,19 +57,27 @@ export type ComplianceStatus =
   | ComplianceSummaryStatus;
 
 // App routes restricted to compliance report version status "No obligation or earned credits"
-export const routesNoObligation = ["review-summary"];
+export const routesNoObligation = [AppRoutes.NO_REVIEW_SUMMARY];
 
 // App routes restricted to compliance report version status "Obligation not met"
 export const routesObligation = [
-  "apply-compliance-units",
-  "download-payment-instructions",
-  "review-compliance-obligation-report",
-  "pay-obligation-track-payments",
+  AppRoutes.MO_REVIEW_SUMMARY,
+  AppRoutes.MO_APPLY_COMPLIANCE_UNITS,
+  AppRoutes.MO_DOWNLOAD_PAYMENT_INSTRUCTIONS,
+  AppRoutes.MO_PAY_OBLIGATION_TRACK_PAYMENTS,
+  AppRoutes.MO_REVIEW_PENALTY_SUMMARY,
+  AppRoutes.MO_DOWNLOAD_PENALTY_PAYMENT_INSTRUCTIONS,
+  AppRoutes.MO_PAY_PENALTY_TRACK_PAYMENTS,
+];
+export const routesObligationPenalty = [
+  AppRoutes.MO_REVIEW_PENALTY_SUMMARY,
+  AppRoutes.MO_DOWNLOAD_PENALTY_PAYMENT_INSTRUCTIONS,
+  AppRoutes.MO_PAY_PENALTY_TRACK_PAYMENTS,
 ];
 
 // App routes restricted to compliance report version status "Earned credits"
 export const routesEarnedCredits = [
-  "request-issuance-of-earned-credits",
-  "request-issuance-review-summary",
-  "track-status-of-issuance",
+  AppRoutes.RI_EARNED_CREDITS,
+  AppRoutes.RI_REVIEW_SUMMARY,
+  AppRoutes.RI_TRACK_STATUS,
 ];


### PR DESCRIPTION
Addresses: 
[292](https://github.com/bcgov/cas-compliance/issues/292)


### 🚀 Impact:
- Gating routes under (manage-obligation)\(automatic-overdue-penalty) based on obligation outstanding balance and `penalty_status`

---

## 🔬 Local Testing:  

### **Tests Set-Up:**  

1. Start the API server:  
   ```sh
   cd bc_obps
   make reset_db
   make run
   ```  
2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  
3. Navigate to [http://localhost:3000](http://localhost:3000)  
4. Click the **"Log in with Business BCeID"** button
5. Log in using `bc-cas-dev`


##### Submit report `Compliance SFO - Obligation not met`
1. Navigate to reports http://localhost:3000/reporting/reports
2.  For report `Compliance SFO - Obligation not met`, click `Continue`
3.  Navigate to `/sign-off`
4. Complete the form
5. Click `Submit`


### **Test: Penalty Routes Gating**  

#### **Steps:**  
1. Navigate to compliance http://localhost:3000/compliance/compliance-summaries
2. For compliance report version `Compliance SFO - Obligation not met`, click `Manage Obligation`
**Expected results:**  
- Route task list does not display the links for penalty routes

<img width="1508" height="709" alt="image" src="https://github.com/user-attachments/assets/6289a398-b119-4436-aead-705a056b7dec" />

4. Navigate to compliance report version urls:
http://localhost:3000/compliance/compliance-summaries/2/apply-compliance-units
http://localhost:3000/compliance/compliance-summaries/2/review-compliance-obligation-report
http://localhost:3000/compliance/compliance-summaries/2/download-payment-instructions
http://localhost:3000/compliance/compliance-summaries/2/pay-obligation-track-payments
**Expected results:**  
- Routes are permitted

5. Navigate to urls:
- http://localhost:3000/compliance/compliance-summaries/2/review-penalty-summary
- http://localhost:3000/compliance/compliance-summaries/2/download-payment-penalty-instructions
- http://localhost:3000/compliance/compliance-summaries/2/pay-penalty-track-payments
**Expected results:**  
- Routes are not permitted, redirect to summaries grid

6. From terminal command, update the outstanding balance and penalty status
```
psql -d registration

UPDATE erc.elicensing_invoice
SET outstanding_balance = 0,
    invoice_fee_balance = 0,
    invoice_interest_balance = 0
WHERE id = 1;

UPDATE erc.compliance_obligation
SET penalty_status='PAID'
WHERE compliance_report_version_id=2;
```
7. Navigate to http://localhost:3000/compliance/compliance-summaries/2/review-compliance-obligation-report
**Expected results:**  
- Route task list does display the links for penalty routes
<img width="1508" height="709" alt="image" src="https://github.com/user-attachments/assets/406181af-b046-4ca7-a52d-13483c1b758d" />

8. Navigate to urls:
- http://localhost:3000/compliance/compliance-summaries/2/review-penalty-summary
- http://localhost:3000/compliance/compliance-summaries/2/download-payment-penalty-instructions
- http://localhost:3000/compliance/compliance-summaries/2/pay-penalty-track-payments
**Expected results:**  
- Routes are permitted 
- ❗Note: You will encounter errors on certain routes since the compliance report version -> penalty hierarchy has not been fully set up for the components (just setup for the routing)

9. Navigate to compliance report version urls:
http://localhost:3000/compliance/compliance-summaries/2/apply-compliance-units
http://localhost:3000/compliance/compliance-summaries/2/review-compliance-obligation-report
http://localhost:3000/compliance/compliance-summaries/2/download-payment-instructions
http://localhost:3000/compliance/compliance-summaries/2/pay-obligation-track-payments
**Expected results:**  
- Routes are permitted