### PR TITLE
304 - internal declined note is conditional

### DIFF
--- a/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/internal/track-status-of-issuance/InternalIssuanceStatusDeclinedNote.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/internal/track-status-of-issuance/InternalIssuanceStatusDeclinedNote.tsx
@@ -1,12 +1,21 @@
 import AlertNote from "@bciers/components/form/components/AlertNote";
 import { AlertIcon } from "@bciers/components/icons";
+import { AnalystSuggestion } from "@bciers/utils/src/enums";
 
-export const InternalIssuanceStatusDeclinedNote = () => {
+type Props = {
+  formContext: {
+    analystSuggestion: AnalystSuggestion;
+  };
+};
+
+export const InternalIssuanceStatusDeclinedNote = ({
+  formContext: { analystSuggestion },
+}: Props) => {
   return (
     <AlertNote icon={<AlertIcon width="20" height="20" />}>
-      Please contact the operator to clarify the supplementary report
-      requirement in the previous step. This request has been declined
-      automatically.
+      {analystSuggestion === AnalystSuggestion.REQUIRING_SUPPLEMENTARY_REPORT
+        ? "Please contact the operator to clarify the supplementary report requirement in the previous step. This request has been declined automatically."
+        : "The issuance request is declined. The earned credits will not be issued to the holding account as identified below in B.C. Carbon Registry (BCCR)."}
     </AlertNote>
   );
 };

--- a/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/internal/track-status-of-issuance/InternalTrackStatusOfIssuanceComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/internal/track-status-of-issuance/InternalTrackStatusOfIssuanceComponent.tsx
@@ -33,6 +33,7 @@ export default function InternalTrackStatusOfIssuanceComponent({
       uiSchema={internalTrackStatusOfIssuanceUiSchema}
       formData={data}
       className="w-full"
+      formContext={{ analystSuggestion: data.analyst_suggestion }}
     >
       <ComplianceStepButtons
         key="form-buttons"

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/request-issuance/internal/track-status-of-issuance/InternalIssuanceStatusDeclinedNote.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/request-issuance/internal/track-status-of-issuance/InternalIssuanceStatusDeclinedNote.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { InternalIssuanceStatusDeclinedNote } from "@/compliance/src/app/components/compliance-summary/request-issuance/internal/track-status-of-issuance/InternalIssuanceStatusDeclinedNote";
+import { AnalystSuggestion } from "@bciers/utils/src/enums";
 
 vi.mock("@bciers/components/icons/AlertIcon", () => ({
   __esModule: true,
@@ -11,8 +12,14 @@ vi.mock("@bciers/components/icons/AlertIcon", () => ({
 }));
 
 describe("InternalIssuanceStatusDeclinedNote", () => {
-  it("displays the correct text content", () => {
-    render(<InternalIssuanceStatusDeclinedNote />);
+  it("displays the correct text content when the issuance is declined because an analyst requests a supplmentary report", () => {
+    render(
+      <InternalIssuanceStatusDeclinedNote
+        formContext={{
+          analystSuggestion: AnalystSuggestion.REQUIRING_SUPPLEMENTARY_REPORT,
+        }}
+      />,
+    );
 
     const declinedNoteTextPatterns = [
       /Please contact the operator to clarify/i,
@@ -25,8 +32,31 @@ describe("InternalIssuanceStatusDeclinedNote", () => {
     }
   });
 
+  it("displays the correct text content when the issuance is declined by the director", () => {
+    render(
+      <InternalIssuanceStatusDeclinedNote
+        formContext={{ analystSuggestion: AnalystSuggestion.READY_TO_APPROVE }}
+      />,
+    );
+
+    const declinedNoteTextPatterns = [
+      /The issuance request is declined/i,
+      /The earned credits will not be issued/i,
+      /to the holding account/i,
+      /as identified below in B\.C\. Carbon Registry \(BCCR\)/i,
+    ];
+
+    for (const textPattern of declinedNoteTextPatterns) {
+      expect(screen.getByText(textPattern)).toBeVisible();
+    }
+  });
+
   it("displays the AlertIcon with correct props", () => {
-    render(<InternalIssuanceStatusDeclinedNote />);
+    render(
+      <InternalIssuanceStatusDeclinedNote
+        formContext={{ analystSuggestion: AnalystSuggestion.READY_TO_APPROVE }}
+      />,
+    );
 
     const alertIcon = screen.getByTestId("alert-icon");
     expect(alertIcon).toBeVisible();


### PR DESCRIPTION
card: https://github.com/bcgov/cas-compliance/issues/304

This PR:
- the wording of internal declined note on the track status of issuance page is conditional based on how the declined happened (analyst requested supp report vs. director declined). This PR adds that conditionality
- update vitests