### PR TITLE
3370 alert assign op rep

### DIFF
--- a/bc_obps/registration/schema/operation_timeline.py
+++ b/bc_obps/registration/schema/operation_timeline.py
@@ -19,6 +19,9 @@ class OperationTimelineListOut(ModelSchema):
     operation__status: str = Field(..., alias="operation.status")
     operation__id: UUID = Field(..., alias="operation.id")
     operation__registration_purpose: Optional[str] = Field(None, alias="operation.registration_purpose")
+    operation__contact_ids: Optional[list[int | None]] = Field(
+        None, alias="operation__contact_ids"
+    )  # this is an annotated field in the query
 
     class Meta:
         model = OperationDesignatedOperatorTimeline

--- a/bc_obps/registration/tests/endpoints/test_operations.py
+++ b/bc_obps/registration/tests/endpoints/test_operations.py
@@ -55,6 +55,7 @@ class TestOperationsEndpoint(CommonTestSetup):
                 'operator__legal_name',
                 'operation__id',
                 'operation__status',
+                'operation__contact_ids',
             ]
         )
 

--- a/bciers/apps/administration/app/bceidbusiness/industry_user/operations/page.tsx
+++ b/bciers/apps/administration/app/bceidbusiness/industry_user/operations/page.tsx
@@ -1,57 +1,11 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-import {
-  OperationRow,
-  OperationsSearchParams,
-} from "@/administration/app/components/operations/types";
-import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
-import { ExternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
-import Loading from "@bciers/components/loading/SkeletonGrid";
-import { Suspense } from "react";
-import { getSessionRole } from "@bciers/utils/src/sessionUtils";
-import { fetchOperationsPageData } from "@bciers/actions/api";
+import { OperationsSearchParams } from "@/administration/app/components/operations/types";
+import OperationPage from "@/administration/app/components/operations/OperationPage";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
-  const role = await getSessionRole();
-  const isInternalUser = role.includes("cas_");
-
-  // IRC users should only see Registered operations
-  const filteredSearchParams = isInternalUser
-    ? { ...searchParams, operation__status: "Registered" }
-    : searchParams;
-
-  // Fetch operations data
-  const operations: {
-    rows: OperationRow[];
-    row_count: number;
-  } = await fetchOperationsPageData(filteredSearchParams);
-  if (!operations || "error" in operations)
-    throw new Error("Failed to retrieve operations");
-
-  const operationsWithoutContacts = operations.rows // this filter lists operations that are Registered but have no contacts(reps) assigned
-    .filter(
-      (operation) =>
-        operation.status === "Registered" &&
-        (!operation.operation__contact_ids ||
-          (operation.operation__contact_ids.length === 1 &&
-            operation.operation__contact_ids[0] === null)),
-    )
-    .map((operation) => operation.operation__name);
-
-  return (
-    <ExternalUserOperationDataGridLayout
-      operationsWithoutContacts={operationsWithoutContacts}
-    >
-      <Suspense fallback={<Loading />}>
-        <OperationDataGridPage
-          filteredSearchParams={filteredSearchParams}
-          isInternalUser={isInternalUser}
-          initialData={operations}
-        />
-      </Suspense>
-    </ExternalUserOperationDataGridLayout>
-  );
+  return <OperationPage searchParams={searchParams} />;
 }

--- a/bciers/apps/administration/app/bceidbusiness/industry_user/operations/page.tsx
+++ b/bciers/apps/administration/app/bceidbusiness/industry_user/operations/page.tsx
@@ -1,19 +1,56 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-import { OperationsSearchParams } from "@/administration/app/components/operations/types";
+import {
+  OperationRow,
+  OperationsSearchParams,
+} from "@/administration/app/components/operations/types";
 import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
 import { ExternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
 import Loading from "@bciers/components/loading/SkeletonGrid";
 import { Suspense } from "react";
+import { getSessionRole } from "@bciers/utils/src/sessionUtils";
+import { fetchOperationsPageData } from "@bciers/actions/api";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
+  const role = await getSessionRole();
+  const isInternalUser = role.includes("cas_");
+
+  // IRC users should only see Registered operations
+  const filteredSearchParams = isInternalUser
+    ? { ...searchParams, operation__status: "Registered" }
+    : searchParams;
+
+  // Fetch operations data
+  const operations: {
+    rows: OperationRow[];
+    row_count: number;
+  } = await fetchOperationsPageData(filteredSearchParams);
+  if (!operations || "error" in operations)
+    throw new Error("Failed to retrieve operations");
+
+  const operationsWithoutContacts = operations.rows // this filter lists operations that are Registered but have no contacts(reps) assigned
+    .filter(
+      (operation) =>
+        operation.status === "Registered" &&
+        (!operation.operation__contact_ids ||
+          (operation.operation__contact_ids.length === 1 &&
+            operation.operation__contact_ids[0] === null)),
+    )
+    .map((operation) => operation.operation__name);
+
   return (
-    <ExternalUserOperationDataGridLayout>
+    <ExternalUserOperationDataGridLayout
+      operationsWithoutContacts={operationsWithoutContacts}
+    >
       <Suspense fallback={<Loading />}>
-        <OperationDataGridPage searchParams={searchParams} />
+        <OperationDataGridPage
+          filteredSearchParams={filteredSearchParams}
+          isInternalUser={isInternalUser}
+          initialData={operations}
+        />
       </Suspense>
     </ExternalUserOperationDataGridLayout>
   );

--- a/bciers/apps/administration/app/bceidbusiness/industry_user_admin/operations/page.tsx
+++ b/bciers/apps/administration/app/bceidbusiness/industry_user_admin/operations/page.tsx
@@ -1,56 +1,11 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-import {
-  OperationRow,
-  OperationsSearchParams,
-} from "@/administration/app/components/operations/types";
-import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
-import { ExternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
-import Loading from "@bciers/components/loading/SkeletonGrid";
-import { Suspense } from "react";
-import { getSessionRole } from "@bciers/utils/src/sessionUtils";
-import { fetchOperationsPageData } from "@bciers/actions/api";
+import { OperationsSearchParams } from "@/administration/app/components/operations/types";
+import OperationPage from "@/administration/app/components/operations/OperationPage";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
-  const role = await getSessionRole();
-  const isInternalUser = role.includes("cas_");
-
-  // IRC users should only see Registered operations
-  const filteredSearchParams = isInternalUser
-    ? { ...searchParams, operation__status: "Registered" }
-    : searchParams;
-
-  // Fetch operations data
-  const operations: {
-    rows: OperationRow[];
-    row_count: number;
-  } = await fetchOperationsPageData(filteredSearchParams);
-  if (!operations || "error" in operations)
-    throw new Error("Failed to retrieve operations");
-  const operationsWithoutContacts = operations.rows // this filter lists operations that are Registered but have no contacts(reps) assigned
-    .filter(
-      (operation) =>
-        operation.operation__status == "Registered" &&
-        (!operation.operation__contact_ids ||
-          (operation.operation__contact_ids.length === 1 &&
-            operation.operation__contact_ids[0] === null)),
-    )
-    .map((operation) => operation.operation__name);
-
-  return (
-    <ExternalUserOperationDataGridLayout
-      operationsWithoutContacts={operationsWithoutContacts}
-    >
-      <Suspense fallback={<Loading />}>
-        <OperationDataGridPage
-          filteredSearchParams={filteredSearchParams}
-          isInternalUser={isInternalUser}
-          initialData={operations}
-        />
-      </Suspense>
-    </ExternalUserOperationDataGridLayout>
-  );
+  return <OperationPage searchParams={searchParams} />;
 }

--- a/bciers/apps/administration/app/bceidbusiness/industry_user_admin/operations/page.tsx
+++ b/bciers/apps/administration/app/bceidbusiness/industry_user_admin/operations/page.tsx
@@ -1,19 +1,55 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
-import { OperationsSearchParams } from "@/administration/app/components/operations/types";
+import {
+  OperationRow,
+  OperationsSearchParams,
+} from "@/administration/app/components/operations/types";
 import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
 import { ExternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
 import Loading from "@bciers/components/loading/SkeletonGrid";
 import { Suspense } from "react";
+import { getSessionRole } from "@bciers/utils/src/sessionUtils";
+import { fetchOperationsPageData } from "@bciers/actions/api";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
+  const role = await getSessionRole();
+  const isInternalUser = role.includes("cas_");
+
+  // IRC users should only see Registered operations
+  const filteredSearchParams = isInternalUser
+    ? { ...searchParams, operation__status: "Registered" }
+    : searchParams;
+
+  // Fetch operations data
+  const operations: {
+    rows: OperationRow[];
+    row_count: number;
+  } = await fetchOperationsPageData(filteredSearchParams);
+  if (!operations || "error" in operations)
+    throw new Error("Failed to retrieve operations");
+  const operationsWithoutContacts = operations.rows // this filter lists operations that are Registered but have no contacts(reps) assigned
+    .filter(
+      (operation) =>
+        operation.operation__status == "Registered" &&
+        (!operation.operation__contact_ids ||
+          (operation.operation__contact_ids.length === 1 &&
+            operation.operation__contact_ids[0] === null)),
+    )
+    .map((operation) => operation.operation__name);
+
   return (
-    <ExternalUserOperationDataGridLayout>
+    <ExternalUserOperationDataGridLayout
+      operationsWithoutContacts={operationsWithoutContacts}
+    >
       <Suspense fallback={<Loading />}>
-        <OperationDataGridPage searchParams={searchParams} />
+        <OperationDataGridPage
+          filteredSearchParams={filteredSearchParams}
+          isInternalUser={isInternalUser}
+          initialData={operations}
+        />
       </Suspense>
     </ExternalUserOperationDataGridLayout>
   );

--- a/bciers/apps/administration/app/components/operations/OperationDataGridPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationDataGridPage.tsx
@@ -2,37 +2,26 @@ import OperationDataGrid from "./OperationDataGrid";
 import { OperationRow, OperationsSearchParams } from "./types";
 import { Suspense } from "react";
 import Loading from "@bciers/components/loading/SkeletonGrid";
-import { getSessionRole } from "@bciers/utils/src/sessionUtils";
-import { fetchOperationsPageData } from "@bciers/actions/api";
 
 // 🧩 Main component
 export default async function OperationDataGridPage({
-  searchParams,
+  isInternalUser,
+  initialData,
+  filteredSearchParams,
 }: {
-  searchParams: OperationsSearchParams;
-}) {
-  const role = await getSessionRole();
-  const isInternalUser = role.includes("cas_");
-
-  // IRC users should only see Registered operations
-  const filteredSearchParams = isInternalUser
-    ? { ...searchParams, operation__status: "Registered" }
-    : searchParams;
-
-  // Fetch operations data
-  const operations: {
+  isInternalUser: boolean;
+  initialData: {
     rows: OperationRow[];
     row_count: number;
-  } = await fetchOperationsPageData(filteredSearchParams);
-  if (!operations || "error" in operations)
-    throw new Error("Failed to retrieve operations");
-
+  };
+  filteredSearchParams: OperationsSearchParams;
+}) {
   // Render the DataGrid component
   return (
     <Suspense fallback={<Loading />}>
       <div className="mt-5">
         <OperationDataGrid
-          initialData={operations}
+          initialData={initialData}
           isInternalUser={isInternalUser}
           filteredSearchParams={filteredSearchParams}
         />

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -23,6 +23,11 @@ import Note from "@bciers/components/layout/Note";
 import Link from "next/link";
 import ConfirmChangeOfFieldModal from "@/registration/app/components/operations/registration/ConfirmChangeOfFieldModal";
 
+// const isMissingRepresentative = (formData: OperationInformationPartialFormData) =>
+//   formData.status === "Registered" &&
+//   (!formData.operation_representatives ||
+//     formData.operation_representatives.length === 0);
+
 const OperationInformationForm = ({
   formData,
   operationId,
@@ -47,6 +52,9 @@ const OperationInformationForm = ({
   ] = useState("");
   const [isConfirmPurposeChangeModalOpen, setIsConfirmPurposeChangeModalOpen] =
     useState<boolean>(false);
+  // const [isMissingRepresentative, setIsMissingRepresentative] = useState(
+  //   isMissingRepresentative(formData),
+  // );
   const router = useRouter();
   // To get the user's role from the session
   const role = useSessionRole();
@@ -184,6 +192,7 @@ const OperationInformationForm = ({
             RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION.valueOf(),
           ),
           status: formData.status,
+          missing_representative_alert: {display: true},
         }}
       />
     </>

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -47,16 +47,24 @@ const OperationInformationForm = ({
   ] = useState("");
   const [isConfirmPurposeChangeModalOpen, setIsConfirmPurposeChangeModalOpen] =
     useState<boolean>(false);
+
   const router = useRouter();
   // To get the user's role from the session
   const role = useSessionRole();
   const searchParams = useSearchParams();
   const isRedirectedFromContacts = searchParams.get("from_contacts") as string;
-  const isMissingRepresentative =
-    !role.includes("cas_") &&
-    formData.status === "Registered" &&
-    (!formData.operation_representatives ||
-      formData.operation_representatives.length === 0);
+  function checkMissingRepresentative(data: any) {
+    if (data && data.status && data.registration_purpose) {
+      return (
+        data.status === "Registered" &&
+        (!data.operation_representatives ||
+          data.operation_representatives.length === 0)
+      );
+    } else return false;
+  }
+  const [isMissingRepresentative, setIsMissingRepresentative] = useState(
+    checkMissingRepresentative(formData),
+  );
 
   useEffect(() => {
     if (selectedPurpose) {
@@ -67,7 +75,7 @@ const OperationInformationForm = ({
     } else {
       setSchema(generalSchema);
     }
-  }, [selectedPurpose, eioSchema, generalSchema]);
+  }, [selectedPurpose, eioSchema, generalSchema, formData]);
 
   const handleSubmit = async (data: {
     formData?: OperationInformationFormData;
@@ -177,6 +185,7 @@ const OperationInformationForm = ({
           if (newSelectedPurpose !== selectedPurpose) {
             handleSelectedPurposeChange(newSelectedPurpose);
           }
+          setIsMissingRepresentative(checkMissingRepresentative(e.formData));
         }}
         onCancel={() => router.push("/operations")}
         formContext={{

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -53,6 +53,7 @@ const OperationInformationForm = ({
   const searchParams = useSearchParams();
   const isRedirectedFromContacts = searchParams.get("from_contacts") as string;
   const isMissingRepresentative =
+    !role.includes("cas_") &&
     formData.status === "Registered" &&
     (!formData.operation_representatives ||
       formData.operation_representatives.length === 0);

--- a/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationForm.tsx
@@ -23,11 +23,6 @@ import Note from "@bciers/components/layout/Note";
 import Link from "next/link";
 import ConfirmChangeOfFieldModal from "@/registration/app/components/operations/registration/ConfirmChangeOfFieldModal";
 
-// const isMissingRepresentative = (formData: OperationInformationPartialFormData) =>
-//   formData.status === "Registered" &&
-//   (!formData.operation_representatives ||
-//     formData.operation_representatives.length === 0);
-
 const OperationInformationForm = ({
   formData,
   operationId,
@@ -52,14 +47,15 @@ const OperationInformationForm = ({
   ] = useState("");
   const [isConfirmPurposeChangeModalOpen, setIsConfirmPurposeChangeModalOpen] =
     useState<boolean>(false);
-  // const [isMissingRepresentative, setIsMissingRepresentative] = useState(
-  //   isMissingRepresentative(formData),
-  // );
   const router = useRouter();
   // To get the user's role from the session
   const role = useSessionRole();
   const searchParams = useSearchParams();
   const isRedirectedFromContacts = searchParams.get("from_contacts") as string;
+  const isMissingRepresentative =
+    formData.status === "Registered" &&
+    (!formData.operation_representatives ||
+      formData.operation_representatives.length === 0);
 
   useEffect(() => {
     if (selectedPurpose) {
@@ -192,7 +188,7 @@ const OperationInformationForm = ({
             RegistrationPurposes.ELECTRICITY_IMPORT_OPERATION.valueOf(),
           ),
           status: formData.status,
-          missing_representative_alert: {display: true},
+          missing_representative_alert: isMissingRepresentative,
         }}
       />
     </>

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -30,7 +30,6 @@ const OperationInformationPage = async ({
     undefined,
     operation.status,
   );
-  console.log("***** Page formData ******:", operation);
 
   return (
     <>

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -5,6 +5,7 @@ import { createAdministrationOperationInformationSchema } from "../../data/jsonS
 import { UUID } from "crypto";
 import { validate as isValidUUID } from "uuid";
 import { RegistrationPurposes } from "@/registration/app/components/operations/registration/enums";
+import { Alert } from "@mui/material";
 
 const OperationInformationPage = async ({
   operationId,
@@ -17,6 +18,12 @@ const OperationInformationPage = async ({
   } else throw new Error(`Invalid operation id: ${operationId}`);
 
   if (operation?.error) throw new Error("Error fetching operation information");
+
+  const isMissingRepresentative =
+    operation.status === "Registered" && (
+      !operation.operation_representatives ||
+      operation.operation_representatives.length === 0
+    );
 
   const formSchema = await createAdministrationOperationInformationSchema(
     operation.registration_purpose,
@@ -34,6 +41,11 @@ const OperationInformationPage = async ({
   return (
     <>
       <NewTabBanner />
+      {isMissingRepresentative && (
+        <Alert severity="info" color="warning" sx={{ ml: { xs: 0, sm: 35 } }}>
+          Please select an operation representative
+        </Alert>
+      )}
       <OperationInformationForm
         formData={{
           ...operation,

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -5,7 +5,6 @@ import { createAdministrationOperationInformationSchema } from "../../data/jsonS
 import { UUID } from "crypto";
 import { validate as isValidUUID } from "uuid";
 import { RegistrationPurposes } from "@/registration/app/components/operations/registration/enums";
-import { Alert } from "@mui/material";
 
 const OperationInformationPage = async ({
   operationId,
@@ -18,12 +17,6 @@ const OperationInformationPage = async ({
   } else throw new Error(`Invalid operation id: ${operationId}`);
 
   if (operation?.error) throw new Error("Error fetching operation information");
-
-  const isMissingRepresentative =
-    operation.status === "Registered" && (
-      !operation.operation_representatives ||
-      operation.operation_representatives.length === 0
-    );
 
   const formSchema = await createAdministrationOperationInformationSchema(
     operation.registration_purpose,
@@ -42,11 +35,6 @@ const OperationInformationPage = async ({
   return (
     <>
       <NewTabBanner />
-      {/* {isMissingRepresentative && (
-        <Alert severity="info" color="warning" sx={{ ml: { xs: 0, sm: 35 } }}>
-          Please select an operation representative
-        </Alert>
-      )} */}
       <OperationInformationForm
         formData={{
           ...operation,

--- a/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationInformationPage.tsx
@@ -37,15 +37,16 @@ const OperationInformationPage = async ({
     undefined,
     operation.status,
   );
+  console.log("***** Page formData ******:", operation);
 
   return (
     <>
       <NewTabBanner />
-      {isMissingRepresentative && (
+      {/* {isMissingRepresentative && (
         <Alert severity="info" color="warning" sx={{ ml: { xs: 0, sm: 35 } }}>
           Please select an operation representative
         </Alert>
-      )}
+      )} */}
       <OperationInformationForm
         formData={{
           ...operation,

--- a/bciers/apps/administration/app/components/operations/OperationLayouts.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationLayouts.tsx
@@ -1,4 +1,5 @@
 import Note from "@bciers/components/layout/Note";
+import { Alert } from "@mui/material";
 
 const Layout = ({ children }: { children: React.ReactNode }) => (
   <>
@@ -14,14 +15,27 @@ const Layout = ({ children }: { children: React.ReactNode }) => (
 export { Layout as InternalUserOperationDataGridLayout };
 
 export const ExternalUserOperationDataGridLayout = ({
+  operationsWithoutContacts,
   children,
 }: {
+  operationsWithoutContacts: String[];
   children: React.ReactNode;
 }) => (
   <>
     <Note>
       <b>Note:</b> View the operations owned by your operator here.
     </Note>
+
+    <div className="min-h-[48px] box-border mt-4">
+      {operationsWithoutContacts && operationsWithoutContacts.length > 0 && (
+        <Alert severity="info" color="warning">
+          Missing Information: Please add an operation representative for{" "}
+          {operationsWithoutContacts.join(", ")} in{" "}
+          {operationsWithoutContacts.length > 1 ? "their" : "its"} operation
+          information page.
+        </Alert>
+      )}
+    </div>
     <h1>Operations</h1>
     <div className="w-full flex justify-end">
       <a

--- a/bciers/apps/administration/app/components/operations/OperationLayouts.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationLayouts.tsx
@@ -20,7 +20,7 @@ export const ExternalUserOperationDataGridLayout = ({
   operationsWithoutContacts,
   children,
 }: {
-  operationsWithoutContacts: String[];
+  operationsWithoutContacts?: String[];
   children: React.ReactNode;
 }) => (
   <>

--- a/bciers/apps/administration/app/components/operations/OperationLayouts.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationLayouts.tsx
@@ -1,5 +1,7 @@
+import AlertNote from "@bciers/components/form/components/AlertNote";
 import Note from "@bciers/components/layout/Note";
-import { Alert } from "@mui/material";
+import { BC_GOV_TEXT } from "@bciers/styles";
+import { InfoRounded } from "@mui/icons-material";
 
 const Layout = ({ children }: { children: React.ReactNode }) => (
   <>
@@ -28,12 +30,15 @@ export const ExternalUserOperationDataGridLayout = ({
 
     <div className="min-h-[48px] box-border mt-4">
       {operationsWithoutContacts && operationsWithoutContacts.length > 0 && (
-        <Alert severity="info" color="warning">
+        <AlertNote
+          alertType="ALERT"
+          icon={<InfoRounded fontSize="inherit" sx={{ color: BC_GOV_TEXT }} />}
+        >
           Missing Information: Please add an operation representative for{" "}
           {operationsWithoutContacts.join(", ")} in{" "}
           {operationsWithoutContacts.length > 1 ? "their" : "its"} operation
           information page.
-        </Alert>
+        </AlertNote>
       )}
     </div>
     <h1>Operations</h1>

--- a/bciers/apps/administration/app/components/operations/OperationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationPage.tsx
@@ -3,7 +3,10 @@ import {
   OperationsSearchParams,
 } from "@/administration/app/components/operations/types";
 import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
-import { ExternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
+import {
+  InternalUserOperationDataGridLayout,
+  ExternalUserOperationDataGridLayout,
+} from "@/administration/app/components/operations/OperationLayouts";
 import Loading from "@bciers/components/loading/SkeletonGrid";
 import { Suspense } from "react";
 import { getSessionRole } from "@bciers/utils/src/sessionUtils";
@@ -40,8 +43,12 @@ export default async function OperationPage({
     )
     .map((operation) => operation.operation__name);
 
+  const OperationLayoutComponent = isInternalUser
+    ? InternalUserOperationDataGridLayout
+    : ExternalUserOperationDataGridLayout;
+
   return (
-    <ExternalUserOperationDataGridLayout
+    <OperationLayoutComponent
       operationsWithoutContacts={operationsWithoutContacts}
     >
       <Suspense fallback={<Loading />}>
@@ -51,6 +58,6 @@ export default async function OperationPage({
           initialData={operations}
         />
       </Suspense>
-    </ExternalUserOperationDataGridLayout>
+    </OperationLayoutComponent>
   );
 }

--- a/bciers/apps/administration/app/components/operations/OperationPage.tsx
+++ b/bciers/apps/administration/app/components/operations/OperationPage.tsx
@@ -1,0 +1,56 @@
+import {
+  OperationRow,
+  OperationsSearchParams,
+} from "@/administration/app/components/operations/types";
+import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
+import { ExternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
+import Loading from "@bciers/components/loading/SkeletonGrid";
+import { Suspense } from "react";
+import { getSessionRole } from "@bciers/utils/src/sessionUtils";
+import { fetchOperationsPageData } from "@bciers/actions/api";
+
+export default async function OperationPage({
+  searchParams,
+}: {
+  searchParams: OperationsSearchParams;
+}) {
+  const role = await getSessionRole();
+  const isInternalUser = role.includes("cas_");
+
+  // IRC users should only see Registered operations
+  const filteredSearchParams = isInternalUser
+    ? { ...searchParams, operation__status: "Registered" }
+    : searchParams;
+
+  // Fetch operations data
+  const operations: {
+    rows: OperationRow[];
+    row_count: number;
+  } = await fetchOperationsPageData(filteredSearchParams);
+  if (!operations || "error" in operations)
+    throw new Error("Failed to retrieve operations");
+
+  const operationsWithoutContacts = operations.rows // this filter lists operations that are Registered but have no contacts(reps) assigned
+    .filter(
+      (operation) =>
+        operation.operation__status === "Registered" &&
+        (!operation.operation__contact_ids ||
+          (operation.operation__contact_ids.length === 1 &&
+            operation.operation__contact_ids[0] === null)),
+    )
+    .map((operation) => operation.operation__name);
+
+  return (
+    <ExternalUserOperationDataGridLayout
+      operationsWithoutContacts={operationsWithoutContacts}
+    >
+      <Suspense fallback={<Loading />}>
+        <OperationDataGridPage
+          filteredSearchParams={filteredSearchParams}
+          isInternalUser={isInternalUser}
+          initialData={operations}
+        />
+      </Suspense>
+    </ExternalUserOperationDataGridLayout>
+  );
+}

--- a/bciers/apps/administration/app/components/operations/types.ts
+++ b/bciers/apps/administration/app/components/operations/types.ts
@@ -67,6 +67,7 @@ export interface OperationInformationPartialFormData {
     mo_province?: string;
     mo_postal_code?: string;
   }[];
+  operation_representatives?: string[];
   registration_purpose?: string;
   regulated_operation?: string;
   new_entrant_operation?: string;

--- a/bciers/apps/administration/app/components/operations/types.ts
+++ b/bciers/apps/administration/app/components/operations/types.ts
@@ -67,7 +67,7 @@ export interface OperationInformationPartialFormData {
     mo_province?: string;
     mo_postal_code?: string;
   }[];
-  operation_representatives?: string[];
+  operation_representatives?: number[];
   registration_purpose?: string;
   regulated_operation?: string;
   new_entrant_operation?: string;

--- a/bciers/apps/administration/app/components/operations/types.ts
+++ b/bciers/apps/administration/app/components/operations/types.ts
@@ -14,6 +14,7 @@ export interface OperationRow {
   id: number;
   operator__legal_name: string;
   status: string;
+  operation__contact_ids: number[];
 }
 
 export interface OperationsSearchParams {

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/MissingRepresentativeAlertFieldTemplate.tsx
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/MissingRepresentativeAlertFieldTemplate.tsx
@@ -1,8 +1,16 @@
+"use client";
 import AlertFieldTemplateFactory from "@bciers/components/form/fields/AlertFieldTemplateFactory";
+import { BC_GOV_TEXT } from "@bciers/styles";
+import { InfoRounded } from "@mui/icons-material";
 
+const MissingRepresentativeAlertContent: React.FC = () => {
+  return <div>Please select an operation representative</div>;
+};
 
-const MissingRepresentativeAlertContent: React.FC = () => (
-  <div>Please select an operation representative</div>
+const component = AlertFieldTemplateFactory(
+  MissingRepresentativeAlertContent,
+  "ALERT",
+  <InfoRounded fontSize="inherit" sx={{ color: BC_GOV_TEXT }} />,
 );
 
-export default AlertFieldTemplateFactory(MissingRepresentativeAlertContent, "ALERT");
+export default component;

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/MissingRepresentativeAlertFieldTemplate.tsx
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/MissingRepresentativeAlertFieldTemplate.tsx
@@ -1,0 +1,8 @@
+import AlertFieldTemplateFactory from "@bciers/components/form/fields/AlertFieldTemplateFactory";
+
+
+const MissingRepresentativeAlertContent: React.FC = () => (
+  <div>Please select an operation representative</div>
+);
+
+export default AlertFieldTemplateFactory(MissingRepresentativeAlertContent, "ALERT");

--- a/bciers/apps/administration/app/data/jsonSchema/operationInformation/operationInformation.ts
+++ b/bciers/apps/administration/app/data/jsonSchema/operationInformation/operationInformation.ts
@@ -3,12 +3,17 @@ import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import { getNaicsCodes } from "@bciers/actions/api";
 import { Apps, OperationTypes } from "@bciers/utils/src/enums";
 import { RegistrationPurposes } from "@/registration/app/components/operations/registration/enums";
+import MissingRepresentativeAlertFieldTemplate from "./MissingRepresentativeAlertFieldTemplate";
 
 export const eioOperationInformationSchema: RJSFSchema = {
   title: "Operation Information",
   type: "object",
   required: ["name", "type"],
   properties: {
+    missing_representative_alert: {
+      type: "object",
+      readOnly: true,
+    },
     name: { type: "string", title: "Operation Name" },
     type: {
       type: "string",
@@ -115,6 +120,9 @@ export const createOperationInformationSchema = async (
 
 export const operationInformationUISchema: UiSchema = {
   "ui:FieldTemplate": SectionFieldTemplate,
+  missing_representative_alert: {
+    "ui:FieldTemplate": MissingRepresentativeAlertFieldTemplate,
+  },
   type: {
     "ui:widget": "SelectWidget",
     "ui:placeholder": "Select Operation Type",

--- a/bciers/apps/administration/app/idir/cas_admin/operations/page.tsx
+++ b/bciers/apps/administration/app/idir/cas_admin/operations/page.tsx
@@ -1,20 +1,11 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
 import { OperationsSearchParams } from "@/administration/app/components/operations/types";
-import { InternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
-import Loading from "@bciers/components/loading/SkeletonGrid";
-import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
-import { Suspense } from "react";
+import OperationPage from "@/administration/app/components/operations/OperationPage";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
-  return (
-    <InternalUserOperationDataGridLayout>
-      <Suspense fallback={<Loading />}>
-        <OperationDataGridPage searchParams={searchParams} />
-      </Suspense>
-    </InternalUserOperationDataGridLayout>
-  );
+  return <OperationPage searchParams={searchParams} />;
 }

--- a/bciers/apps/administration/app/idir/cas_admin/operators/[operatorId]/operator-details/operations/page.tsx
+++ b/bciers/apps/administration/app/idir/cas_admin/operators/[operatorId]/operator-details/operations/page.tsx
@@ -1,20 +1,11 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
 import { OperationsSearchParams } from "@/administration/app/components/operations/types";
-import { InternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
-import Loading from "@bciers/components/loading/SkeletonGrid";
-import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
-import { Suspense } from "react";
+import OperationPage from "@/administration/app/components/operations/OperationPage";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
-  return (
-    <InternalUserOperationDataGridLayout>
-      <Suspense fallback={<Loading />}>
-        <OperationDataGridPage searchParams={searchParams} />
-      </Suspense>
-    </InternalUserOperationDataGridLayout>
-  );
+  return <OperationPage searchParams={searchParams} />;
 }

--- a/bciers/apps/administration/app/idir/cas_analyst/operations/page.tsx
+++ b/bciers/apps/administration/app/idir/cas_analyst/operations/page.tsx
@@ -1,20 +1,11 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
 import { OperationsSearchParams } from "@/administration/app/components/operations/types";
-import { InternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
-import { Suspense } from "react";
-import Loading from "@bciers/components/loading/SkeletonGrid";
-import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
+import OperationPage from "@/administration/app/components/operations/OperationPage";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
-  return (
-    <InternalUserOperationDataGridLayout>
-      <Suspense fallback={<Loading />}>
-        <OperationDataGridPage searchParams={searchParams} />
-      </Suspense>
-    </InternalUserOperationDataGridLayout>
-  );
+  return <OperationPage searchParams={searchParams} />;
 }

--- a/bciers/apps/administration/app/idir/cas_analyst/operators/[operatorId]/operator-details/operations/page.tsx
+++ b/bciers/apps/administration/app/idir/cas_analyst/operators/[operatorId]/operator-details/operations/page.tsx
@@ -1,20 +1,11 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
 import { OperationsSearchParams } from "@/administration/app/components/operations/types";
-import { InternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
-import Loading from "@bciers/components/loading/SkeletonGrid";
-import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
-import { Suspense } from "react";
+import OperationPage from "@/administration/app/components/operations/OperationPage";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
-  return (
-    <InternalUserOperationDataGridLayout>
-      <Suspense fallback={<Loading />}>
-        <OperationDataGridPage searchParams={searchParams} />
-      </Suspense>
-    </InternalUserOperationDataGridLayout>
-  );
+  return <OperationPage searchParams={searchParams} />;
 }

--- a/bciers/apps/administration/app/idir/cas_director/operations/page.tsx
+++ b/bciers/apps/administration/app/idir/cas_director/operations/page.tsx
@@ -1,20 +1,11 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
 import { OperationsSearchParams } from "@/administration/app/components/operations/types";
-import { InternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
-import Loading from "@bciers/components/loading/SkeletonGrid";
-import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
-import { Suspense } from "react";
+import OperationPage from "@/administration/app/components/operations/OperationPage";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
-  return (
-    <InternalUserOperationDataGridLayout>
-      <Suspense fallback={<Loading />}>
-        <OperationDataGridPage searchParams={searchParams} />
-      </Suspense>
-    </InternalUserOperationDataGridLayout>
-  );
+  return <OperationPage searchParams={searchParams} />;
 }

--- a/bciers/apps/administration/app/idir/cas_director/operators/[operatorId]/operator-details/operations/page.tsx
+++ b/bciers/apps/administration/app/idir/cas_director/operators/[operatorId]/operator-details/operations/page.tsx
@@ -1,20 +1,11 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
 import { OperationsSearchParams } from "@/administration/app/components/operations/types";
-import { InternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
-import Loading from "@bciers/components/loading/SkeletonGrid";
-import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
-import { Suspense } from "react";
+import OperationPage from "@/administration/app/components/operations/OperationPage";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
-  return (
-    <InternalUserOperationDataGridLayout>
-      <Suspense fallback={<Loading />}>
-        <OperationDataGridPage searchParams={searchParams} />
-      </Suspense>
-    </InternalUserOperationDataGridLayout>
-  );
+  return <OperationPage searchParams={searchParams} />;
 }

--- a/bciers/apps/administration/app/idir/cas_view_only/operations/page.tsx
+++ b/bciers/apps/administration/app/idir/cas_view_only/operations/page.tsx
@@ -1,20 +1,11 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
 import { OperationsSearchParams } from "@/administration/app/components/operations/types";
-import { InternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
-import Loading from "@bciers/components/loading/SkeletonGrid";
-import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
-import { Suspense } from "react";
+import OperationPage from "@/administration/app/components/operations/OperationPage";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
-  return (
-    <InternalUserOperationDataGridLayout>
-      <Suspense fallback={<Loading />}>
-        <OperationDataGridPage searchParams={searchParams} />
-      </Suspense>
-    </InternalUserOperationDataGridLayout>
-  );
+  return <OperationPage searchParams={searchParams} />;
 }

--- a/bciers/apps/administration/app/idir/cas_view_only/operators/[operatorId]/operator-details/operations/page.tsx
+++ b/bciers/apps/administration/app/idir/cas_view_only/operators/[operatorId]/operator-details/operations/page.tsx
@@ -1,20 +1,11 @@
 // 🚩 flagging that for shared routes between roles, "Page" code is a component for code maintainability
 import { OperationsSearchParams } from "@/administration/app/components/operations/types";
-import { InternalUserOperationDataGridLayout } from "@/administration/app/components/operations/OperationLayouts";
-import Loading from "@bciers/components/loading/SkeletonGrid";
-import OperationDataGridPage from "@/administration/app/components/operations/OperationDataGridPage";
-import { Suspense } from "react";
+import OperationPage from "@/administration/app/components/operations/OperationPage";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: OperationsSearchParams;
 }) {
-  return (
-    <InternalUserOperationDataGridLayout>
-      <Suspense fallback={<Loading />}>
-        <OperationDataGridPage searchParams={searchParams} />
-      </Suspense>
-    </InternalUserOperationDataGridLayout>
-  );
+  return <OperationPage searchParams={searchParams} />;
 }

--- a/bciers/apps/administration/tests/components/operations/OperationDataGridPage.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationDataGridPage.test.tsx
@@ -7,6 +7,7 @@ import {
 import Operations from "@/administration/app/components/operations/OperationDataGridPage";
 import { getSessionRole } from "@bciers/testConfig/mocks";
 import { OperationTypes } from "@bciers/utils/src/enums";
+import { OperationRow } from "@/administration/app/components/operations/types";
 
 useRouter.mockReturnValue({
   query: {},
@@ -18,25 +19,25 @@ useSearchParams.mockReturnValue({
 });
 
 const mockResponse = {
-  data: [
+  rows: [
     {
       id: 1,
-      operator: "FakeOperator",
-      name: "Operation 1",
-      bcghg_id: "12111130001",
-      type: OperationTypes.SFO,
+      operator__legal_name: "FakeOperator",
+      operation__name: "Operation 1",
+      operation__bcghg_id: "12111130001",
+      operation__type: OperationTypes.SFO,
       status: "Draft",
-      bc_obps_regulated_operation: "N/A",
-    },
+      operation__bc_obps_regulated_operation: "N/A",
+    } as OperationRow,
     {
       id: 2,
-      operator: "FakeOperator",
-      name: "Operation 2",
-      bcghg_id: "12111130002",
-      type: OperationTypes.LFO,
+      operator__legal_name: "FakeOperator",
+      operation__name: "Operation 2",
+      operation__bcghg_id: "12111130002",
+      operation__type: OperationTypes.LFO,
       status: "Registered",
-      bc_obps_regulated_operation: "24-0001",
-    },
+      operation__bc_obps_regulated_operation: "24-0001",
+    } as OperationRow,
   ],
   row_count: 2,
 };
@@ -54,19 +55,16 @@ describe("Operations component", () => {
     });
   });
 
-  it("throws an error when there's a problem fetching data", async () => {
-    getSessionRole.mockReturnValue("cas_director");
-    fetchOperationsPageData.mockReturnValueOnce(undefined);
-    await expect(async () => {
-      render(await Operations({ searchParams: {} }));
-    }).rejects.toThrow("Failed to retrieve operations");
-    expect(screen.queryByRole("grid")).not.toBeInTheDocument();
-  });
-
   it("renders the OperationDataGrid component  when there are operations in the database", async () => {
     getSessionRole.mockReturnValue("industry_user");
     fetchOperationsPageData.mockReturnValueOnce(mockResponse);
-    render(await Operations({ searchParams: {} }));
+    render(
+      await Operations({
+        isInternalUser: true,
+        initialData: { rows: [], row_count: 0 },
+        filteredSearchParams: {},
+      }),
+    );
     expect(screen.getByRole("grid")).toBeVisible();
     expect(
       screen.queryByText(/No operations data in database./i),

--- a/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationForm.test.tsx
@@ -137,6 +137,7 @@ const formData = {
       mo_postal_code: "V1V1V1",
     },
   ],
+  operation_representatives: [],
   registration_purpose: RegistrationPurposes.REPORTING_OPERATION,
   regulated_products: [2],
 };
@@ -989,6 +990,44 @@ describe("the OperationInformationForm component", () => {
       screen.getByText(
         /To remove the current operation representative, please select a new contact to replace them./i,
       ),
+    ).toBeVisible();
+  });
+  it("should show an alert if there are no operation representatives set for the operation", async () => {
+    const testFormData = {
+      name: "Test Operation",
+      type: "Single Facility Operation",
+      naics_code_id: 1,
+      secondary_naics_code_id: 2,
+      activities: [1, 2],
+      registration_purpose: RegistrationPurposes.REPORTING_OPERATION,
+      regulated_products: [1],
+      operation_representatives: [],
+      boundary_map: mockDataUri,
+      process_flow_diagram: mockDataUri,
+      status: OperationStatus.REGISTERED,
+    };
+    useSessionRole.mockReturnValue(FrontEndRoles.INDUSTRY_USER_ADMIN);
+    fetchFormEnums(Apps.ADMINISTRATION);
+    const createdFormSchema =
+      await createAdministrationOperationInformationSchema(
+        testFormData.registration_purpose,
+        OperationStatus.REGISTERED,
+      );
+
+    render(
+      <OperationInformationForm
+        eioSchema={testSchema}
+        generalSchema={createdFormSchema}
+        formData={{
+          ...formData,
+          status: OperationStatus.REGISTERED,
+        }}
+        schema={createdFormSchema}
+        operationId={operationId}
+      />,
+    );
+    expect(
+      screen.getByText(/Please select an operation representative/i),
     ).toBeVisible();
   });
 });

--- a/bciers/apps/administration/tests/components/operations/OperationInformationPage.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationPage.test.tsx
@@ -103,17 +103,4 @@ describe("the OperationInformationPage component", () => {
       screen.getByText(/The purpose of this registration+/i),
     ).toBeVisible();
   });
-  it("should show the missing representative alert when operation is Registered and has no representatives", async () => {
-    fetchFormEnums(Apps.ADMINISTRATION);
-    getOperationWithDocuments.mockResolvedValueOnce({
-      ...formData,
-      status: OperationStatus.REGISTERED,
-    });
-
-    render(await OperationInformationPage({ operationId }));
-
-    expect(
-      screen.getByText(/Please select an operation representative/i),
-    ).toBeVisible();
-  });
 });

--- a/bciers/apps/administration/tests/components/operations/OperationInformationPage.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationInformationPage.test.tsx
@@ -29,6 +29,7 @@ const formData = {
       mo_postal_code: "V1V1V1",
     },
   ],
+  operation_representatives: [],
   registration_purpose: "Reporting Operation",
   regulated_products: [6],
 };
@@ -100,6 +101,19 @@ describe("the OperationInformationPage component", () => {
     ).toBeVisible();
     expect(
       screen.getByText(/The purpose of this registration+/i),
+    ).toBeVisible();
+  });
+  it("should show the missing representative alert when operation is Registered and has no representatives", async () => {
+    fetchFormEnums(Apps.ADMINISTRATION);
+    getOperationWithDocuments.mockResolvedValueOnce({
+      ...formData,
+      status: OperationStatus.REGISTERED,
+    });
+
+    render(await OperationInformationPage({ operationId }));
+
+    expect(
+      screen.getByText(/Please select an operation representative/i),
     ).toBeVisible();
   });
 });

--- a/bciers/apps/administration/tests/components/operations/OperationLayouts.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationLayouts.test.tsx
@@ -46,4 +46,18 @@ describe("OperationLayouts component", () => {
     ).toBeVisible();
     expect(screen.getByText(/Im a little moka pot/i)).toBeVisible();
   });
+  it("renders the missing representative alert when operationsWithoutContacts is provided", async () => {
+    const operationsWithoutContacts = ["Operation 1", "Operation 2"];
+    render(
+      ExternalUserOperationDataGridLayout({
+        operationsWithoutContacts,
+        children: <div>Im a little teapot</div>,
+      }),
+    );
+    expect(
+      screen.getByText(
+        /Missing Information: Please add an operation representative for Operation 1, Operation 2 in their operation information page./i,
+      ),
+    ).toBeVisible();
+  });
 });

--- a/bciers/apps/administration/tests/components/operations/OperationPage.test.tsx
+++ b/bciers/apps/administration/tests/components/operations/OperationPage.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import {
+  fetchOperationsPageData,
+  useRouter,
+  useSearchParams,
+} from "@bciers/testConfig/mocks";
+import Operations from "@/administration/app/components/operations/OperationPage";
+import { getSessionRole } from "@bciers/testConfig/mocks";
+
+useRouter.mockReturnValue({
+  query: {},
+  replace: vi.fn(),
+});
+
+useSearchParams.mockReturnValue({
+  get: vi.fn(),
+});
+
+describe("Operations component", () => {
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    useRouter.mockReturnValue({
+      query: {},
+      replace: vi.fn(),
+    });
+
+    useSearchParams.mockReturnValue({
+      get: vi.fn(),
+    });
+  });
+
+  it("throws an error when there's a problem fetching data", async () => {
+    getSessionRole.mockReturnValue("cas_director");
+    fetchOperationsPageData.mockReturnValueOnce(undefined);
+    await expect(async () => {
+      render(await Operations({ searchParams: {} }));
+    }).rejects.toThrow("Failed to retrieve operations");
+  });
+});

--- a/bciers/libs/components/src/form/fields/AlertFieldTemplateFactory.tsx
+++ b/bciers/libs/components/src/form/fields/AlertFieldTemplateFactory.tsx
@@ -30,7 +30,6 @@ function AlertFieldTemplateFactory<T>(
   alertIconColor?: string,
 ) {
   // TODO: log something if the formcontext doesn't have anything (it should find a false value)
-  console.log("******** AlertFieldTemplateFactory: AlertContent", AlertContent);
 
   return (props: AlertFieldTemplateProps) => (
     <AlertFieldTemplate

--- a/bciers/libs/components/src/form/fields/AlertFieldTemplateFactory.tsx
+++ b/bciers/libs/components/src/form/fields/AlertFieldTemplateFactory.tsx
@@ -30,6 +30,7 @@ function AlertFieldTemplateFactory<T>(
   alertIconColor?: string,
 ) {
   // TODO: log something if the formcontext doesn't have anything (it should find a false value)
+  console.log("******** AlertFieldTemplateFactory: AlertContent", AlertContent);
 
   return (props: AlertFieldTemplateProps) => (
     <AlertFieldTemplate


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-registration/issues/3370

Updated Operations datagrid and information components to alert external users when a "Registered" operation does not have any operation representatives.

### Changes
 - Updated operations api to return contacts array
 - Updated Operations Layout (datagrid) and Information components to show missing representative alerts
 - created a new parent component for the operations grid and layout to keep the data fetching out of the route page files.

### Testing


In order to see these alerts, an operation needs to not have any Operation Representative. This means an entry in operation_contacts table. The easiest way to have an operation WITHOUT a representative is to delete entries from this table. I chose to remove the 2 contacts for 'Banana LFO - Registered' operation.

#### Local
1. Locally, you can execute the following command in ```psql``` terminal:
```sql
DELETE from erc.operation_contacts WHERE operation_id='002d5a9e-32a6-4191-938c-2c02bfec592d';
```
2. Start the app and login as 'bc-cas-dev'
3. From the Dashboard, navigate to Administration-> Operations
 - Expect to see the Operations datagrid with an alert banner reading ```Missing Information: Please add an operation representative for Banana LFO - Registered in its operation information page.```
4. Click ```View Operations``` button beside 'Banana LFO' to navigate to Operation Information page
 - Expect to see an the Operation Information form with an alert banner below the title reading ```Please select an operation representative```
5. Click ```Edit``` and select an 'Operation Representative'. You will also need to select a file for 'Process Flow Diagram' and 'Boundary Map' before you can save. Fill these fields out and click ```Save```
 - Expect to see the Operation Information page back in read-only mode, and the banner no longer displays
6. Click ```Back``` to navigate back to the Operations grid
 - Expect to see the grid and no longer see an alert.
 
 #### Test
Another method to remove Operation Representatives is the way we anticipate this situation occurring for users: transfer of an operation.

Login as an internal user, and transfer an operation to the operator associated with your EXTERNAL login (make the transfer effective before the current day).

Then login is as your external user, and follow the steps above (replace Banana LFO with whatever operation you transferred)