### PR TITLE
chore: add category to Trivy SARIF uploads

### DIFF
--- a/.github/workflows/trivy-container.yaml
+++ b/.github/workflows/trivy-container.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-container-results.sarif
+          category: trivy-container-scan
       - name: Generate unique artifact name
         id: artifact-name
         run: |

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
+          category: trivy-code-scan
       - name: Upload Trivy scan results as artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This should resolve the issue of overwriting Trivy scan results.