### PR TITLE
chore/817 adding alert note for missing product on emissions allocation page

### DIFF
--- a/bc_obps/reporting/api/production_data.py
+++ b/bc_obps/reporting/api/production_data.py
@@ -53,8 +53,6 @@ def load_production_data(request: HttpRequest, version_id: int, facility_id: UUI
         .order_by("product_id")
         .all()
     )
-    allowed_products = ReportOperation.objects.get(report_version_id=version_id).regulated_products.exclude(
-        is_regulated=False
-    )
+    allowed_products = ReportProductService.get_allowed_products(version_id)
 
     return 200, {"report_products": report_products, "allowed_products": allowed_products}

--- a/bc_obps/reporting/api/production_data.py
+++ b/bc_obps/reporting/api/production_data.py
@@ -3,7 +3,6 @@ from uuid import UUID
 from django.http import HttpRequest
 from common.api.utils import get_current_user_guid
 from reporting.constants import EMISSIONS_REPORT_TAGS
-from reporting.models.report_operation import ReportOperation
 from reporting.models.report_product import ReportProduct
 from reporting.schema.report_product import ProductionDataOut, ReportProductSchemaIn
 from reporting.service.report_product_service import ReportProductService

--- a/bc_obps/reporting/schema/report_emission_allocation.py
+++ b/bc_obps/reporting/schema/report_emission_allocation.py
@@ -46,3 +46,4 @@ class ReportEmissionAllocationSchemaOut(Schema):
     report_product_emission_allocation_totals: List[ReportProductEmissionAllocationSchemaOut]
     allocation_methodology: str
     allocation_other_methodology_description: str
+    has_missing_products: bool

--- a/bc_obps/reporting/service/report_product_service.py
+++ b/bc_obps/reporting/service/report_product_service.py
@@ -85,3 +85,9 @@ class ReportProductService:
             .order_by("product__id")
             .filter(report_version_id=report_version_id, facility_report__facility_id=facility_id)
         )
+
+    @classmethod
+    def get_allowed_products(cls, report_version_id: int) -> QuerySet[RegulatedProduct]:
+        return ReportOperation.objects.get(report_version_id=report_version_id).regulated_products.exclude(
+            is_regulated=False
+        )

--- a/bc_obps/reporting/tests/api/test_report_emission_allocation_api.py
+++ b/bc_obps/reporting/tests/api/test_report_emission_allocation_api.py
@@ -334,6 +334,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                 ],
                 'allocation_methodology': 'Calculator',
                 'allocation_other_methodology_description': '',
+                'has_missing_products': True,
             }
         )
         self.mock_post_payload = {

--- a/bc_obps/reporting/tests/service/test_report_emission_allocation_service.py
+++ b/bc_obps/reporting/tests/service/test_report_emission_allocation_service.py
@@ -1,9 +1,6 @@
 import dataclasses
 from decimal import Decimal
-from unittest.mock import patch, MagicMock
-from django.db.models import QuerySet
 from django.test import TestCase
-from registration.models import regulated_product
 from reporting.schema.report_emission_allocation import ReportEmissionAllocationsSchemaIn
 from reporting.models.emission_category import EmissionCategory
 from reporting.tests.service.test_report_activity_save_service.infrastructure import TestInfrastructure
@@ -145,7 +142,7 @@ class TestReportEmissionAllocationService(TestCase):
             product_id=29,  # "Sugar: solid"
         )
 
-        report_operation = make_recipe(
+        make_recipe(
             "reporting.tests.utils.report_operation",
             report_version=self.test_infrastructure.report_version,
             regulated_products=[report_product_1.product, report_product_2.product],
@@ -404,7 +401,7 @@ class TestReportEmissionAllocationService(TestCase):
             allocation2.allocated_quantity, self.ALLOCATING_AMOUNT_3, "Expected this allocation to be updated"
         )
 
-    def test_has_missing_products(self):
+    def test_has_missing_products_no_missing_products(self):
 
         retrieved_emission_allocations_data = ReportEmissionAllocationService.get_emission_allocation_data(
             self.test_infrastructure.report_version, self.test_infrastructure.facility_report.facility_id
@@ -413,15 +410,25 @@ class TestReportEmissionAllocationService(TestCase):
         # No missing products in our setup
         assert not retrieved_emission_allocations_data.has_missing_products
 
-        report_product_3 = make_recipe(
-            "reporting.tests.utils.report_product",
-            report_version=self.test_infrastructure.report_version,
-            facility_report=self.test_infrastructure.facility_report,
-            product=make_recipe("registration.tests.utils.regulated_"),
+    # Only regulated products are checked for missing products
+    def test_has_missing_products_missing_regulated_products(self):
+
+        product = make_recipe("registration.tests.utils.regulated_product", is_regulated=True)
+        self.test_infrastructure.report_version.report_operation.regulated_products.add(product)
+
+        retrieved_emission_allocations_data = ReportEmissionAllocationService.get_emission_allocation_data(
+            self.test_infrastructure.report_version, self.test_infrastructure.facility_report.facility_id
         )
 
-        report_operation = make_recipe(
-            "reporting.tests.utils.report_operation",
-            report_version=self.test_infrastructure.report_version,
-            regulated_products=[report_product_1.product, report_product_2.product],
+        assert retrieved_emission_allocations_data.has_missing_products
+
+    def test_has_missing_products_missing_non_regulated_products(self):
+
+        product = make_recipe("registration.tests.utils.regulated_product", is_regulated=False)
+        self.test_infrastructure.report_version.report_operation.regulated_products.add(product)
+
+        retrieved_emission_allocations_data = ReportEmissionAllocationService.get_emission_allocation_data(
+            self.test_infrastructure.report_version, self.test_infrastructure.facility_report.facility_id
         )
+
+        assert not retrieved_emission_allocations_data.has_missing_products

--- a/bc_obps/reporting/tests/service/test_report_product_service.py
+++ b/bc_obps/reporting/tests/service/test_report_product_service.py
@@ -218,3 +218,13 @@ class TestReportProductService:
         assert ReportProduct.objects.filter(facility_report=self.facility_report).count() == 3
 
         assert ReportProduct.objects.filter(facility_report=self.facility_report, product_id=fog_product_id).exists()
+
+    def test_get_allowed_products_returns_all_listed_regulated_products(self):
+        regulated_products = make_recipe("registration.tests.utils.regulated_product", is_regulated=True, _quantity=2)
+        unregulated_products = make_recipe(
+            "registration.tests.utils.regulated_product", is_regulated=False, _quantity=2
+        )
+
+        self.report_operation.regulated_products.set([*regulated_products, *unregulated_products])
+
+        assert ReportProductService.get_allowed_products(self.report_version_id) == regulated_products

--- a/bc_obps/reporting/tests/service/test_report_product_service.py
+++ b/bc_obps/reporting/tests/service/test_report_product_service.py
@@ -1,14 +1,13 @@
+from django.test import TestCase
 import pytest
 from registration.models.regulated_product import RegulatedProduct
 from reporting.models.report_product import ReportProduct
 from reporting.service.report_product_service import ReportProductService
 from model_bakery.baker import make_recipe
 
-pytestmark = pytest.mark.django_db
 
-
-class TestReportProductService:
-    def setup_method(self):
+class TestReportProductService(TestCase):
+    def setUp(self):
         self.test_user_guid = make_recipe('registration.tests.utils.industry_operator_user').user_guid
 
         report_version = make_recipe("reporting.tests.utils.report_version")
@@ -227,4 +226,8 @@ class TestReportProductService:
 
         self.report_operation.regulated_products.set([*regulated_products, *unregulated_products])
 
-        assert ReportProductService.get_allowed_products(self.report_version_id) == regulated_products
+        self.assertQuerySetEqual(
+            ReportProductService.get_allowed_products(self.report_version_id),
+            regulated_products,
+            ordered=False,
+        )

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -13,13 +13,14 @@ import { EmissionAllocationData, Product } from "./types";
 import { calculateEmissionData } from "./calculateEmissionsData";
 import { NavigationInformation } from "../taskList/types";
 import transformToNumberOrUndefined from "@bciers/utils/src/transformToNumberOrUndefined";
+import { EmissionAllocationResponse } from "@reporting/src/app/utils/getEmissionAllocations";
 
 // 📊 Interface for props passed to the component
 interface Props {
   version_id: number;
   facility_id: string;
   orderedActivities: any;
-  initialData: any;
+  initialData: EmissionAllocationResponse;
   navigationInformation: NavigationInformation;
   isPulpAndPaper: boolean;
   overlappingIndustrialProcessEmissions: number;
@@ -366,7 +367,7 @@ export default function FacilityEmissionAllocationForm({
           formData.fuel_excluded_emission_allocation_data,
         ),
         total_emission_allocations: formData.total_emission_allocations,
-        missing_product_alert: {
+        missing_product_alert: initialData.has_missing_products && {
           version_id,
           facility_id,
         },

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationForm.tsx
@@ -366,6 +366,10 @@ export default function FacilityEmissionAllocationForm({
           formData.fuel_excluded_emission_allocation_data,
         ),
         total_emission_allocations: formData.total_emission_allocations,
+        missing_product_alert: {
+          version_id,
+          facility_id,
+        },
       }}
     />
   );

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationPage.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationPage.tsx
@@ -18,11 +18,9 @@ export default async function FacilityEmissionAllocationPage({
   );
   const orderedActivities = await getOrderedActivities(version_id, facility_id);
   const initialData = await getEmissionAllocations(version_id, facility_id);
-
-  const facData = await getFacilityReportDetails(version_id, facility_id);
-
   // Get facility type for not applicable methodology in LFO small and medium facilities
-  const facilityType = facData.facility_type;
+  const facilityType = (await getFacilityReportDetails(version_id, facility_id))
+    .facility_type;
 
   // These values are used when reporting the pulp & paper activity
   let isPulpAndPaper = false;

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationPage.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationPage.tsx
@@ -19,15 +19,10 @@ export default async function FacilityEmissionAllocationPage({
   const orderedActivities = await getOrderedActivities(version_id, facility_id);
   const initialData = await getEmissionAllocations(version_id, facility_id);
 
-  const facData = await getFacilityReportDetails(version_id, facility_id)
+  const facData = await getFacilityReportDetails(version_id, facility_id);
 
-
-  console.log(orderedActivities)
-  console.log(initialData)
-  console.log(facData)
   // Get facility type for not applicable methodology in LFO small and medium facilities
-  const facilityType = (facData)
-    .facility_type;
+  const facilityType = facData.facility_type;
 
   // These values are used when reporting the pulp & paper activity
   let isPulpAndPaper = false;

--- a/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationPage.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityEmissionAllocationPage.tsx
@@ -18,8 +18,15 @@ export default async function FacilityEmissionAllocationPage({
   );
   const orderedActivities = await getOrderedActivities(version_id, facility_id);
   const initialData = await getEmissionAllocations(version_id, facility_id);
+
+  const facData = await getFacilityReportDetails(version_id, facility_id)
+
+
+  console.log(orderedActivities)
+  console.log(initialData)
+  console.log(facData)
   // Get facility type for not applicable methodology in LFO small and medium facilities
-  const facilityType = (await getFacilityReportDetails(version_id, facility_id))
+  const facilityType = (facData)
     .facility_type;
 
   // These values are used when reporting the pulp & paper activity

--- a/bciers/apps/reporting/src/app/utils/getEmissionAllocations.ts
+++ b/bciers/apps/reporting/src/app/utils/getEmissionAllocations.ts
@@ -1,5 +1,14 @@
 import { actionHandler } from "@bciers/actions";
 
+export type EmissionAllocationResponse = {
+  report_product_emission_allocations: any[];
+  facility_total_emissions: number;
+  report_product_emission_allocation_totals: any[];
+  allocation_methodology: string;
+  allocation_other_methodology_description: string;
+  has_missing_products: boolean;
+};
+
 export async function getEmissionAllocations(
   reportVersionId: number,
   facilityId: string,
@@ -11,5 +20,5 @@ export async function getEmissionAllocations(
       `Failed to fetch the emission allocations for report version ${reportVersionId}, facility ${facilityId}.`,
     );
   }
-  return response;
+  return response as EmissionAllocationResponse;
 }

--- a/bciers/apps/reporting/src/data/jsonSchema/facility/MissingProductAlertFieldTemplate.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/facility/MissingProductAlertFieldTemplate.tsx
@@ -1,0 +1,29 @@
+import AlertFieldTemplateFactory from "@bciers/components/form/fields/AlertFieldTemplateFactory";
+import Link from "next/link";
+
+interface Props {
+  version_id: number;
+  facility_id: string;
+}
+
+const MissingProductAlertContent: React.FC<Props> = ({
+  version_id,
+  facility_id,
+}) => {
+  const LinkToProductionPage = () => (
+    <Link
+      href={`/reports/${version_id}/facilities/${facility_id}/production-data`}
+    >
+      production data page
+    </Link>
+  );
+  return (
+    <div>
+      Only products selected on the <LinkToProductionPage /> appear here. To
+      allocate emissions to a product that isn&apos;t shown below, return to the{" "}
+      <LinkToProductionPage /> and select it first.
+    </div>
+  );
+};
+
+export default AlertFieldTemplateFactory(MissingProductAlertContent, "ALERT");

--- a/bciers/apps/reporting/src/data/jsonSchema/facility/facilityEmissionAllocation.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/facility/facilityEmissionAllocation.tsx
@@ -11,6 +11,7 @@ import {
   WidgetProps,
   FieldTemplateProps,
 } from "@rjsf/utils";
+import MissingProductAlertFieldTemplate from "./MissingProductAlertFieldTemplate";
 
 /**
  * Widget to display the title of an emission allocation category
@@ -171,6 +172,10 @@ export const emissionAllocationSchema: RJSFSchema = {
   title: "Allocation of Emissions",
   required: ["allocation_methodology"],
   properties: {
+    missing_product_alert: {
+      type: "object",
+      readOnly: true,
+    },
     allocation_methodology: {
       type: "string",
       title: "Methodology",
@@ -301,6 +306,7 @@ export const emissionAllocationUiSchema: UiSchema = {
   "ui:FieldTemplate": FieldTemplate,
   "ui:classNames": "form-heading-label",
   "ui:order": [
+    "missing_product_alert",
     "allocation_methodology",
     "allocation_other_methodology_description",
     "basic_emission_allocation_data_title",
@@ -309,6 +315,9 @@ export const emissionAllocationUiSchema: UiSchema = {
     "fuel_excluded_emission_allocation_data",
     "total_emission_allocations",
   ],
+  missing_product_alert: {
+    "ui:FieldTemplate": MissingProductAlertFieldTemplate,
+  },
   allocation_methodology: {
     "ui:widget": "SelectWidget",
     "ui:placeholder": "Select the allocation methodology",

--- a/bciers/apps/reporting/src/data/jsonSchema/productionData.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/productionData.tsx
@@ -24,7 +24,7 @@ export const buildProductionDataSchema = (
     title: "Production Data",
     properties: {
       product_selection_title: {
-        title: "Products that apply to this facility",
+        title: "Select the products that apply to this facility:",
         type: "string",
       },
       product_selection: {

--- a/bciers/apps/reporting/src/tests/components/facility/FacilityEmissionAllocationForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/facility/FacilityEmissionAllocationForm.test.tsx
@@ -4,6 +4,7 @@ import FacilityEmissionAllocationForm from "@reporting/src/app/components/facili
 import { actionHandler, useRouter } from "@bciers/testConfig/mocks";
 import { dummyNavigationInformation } from "../taskList/utils";
 import userEvent from "@testing-library/user-event";
+import { EmissionAllocationResponse } from "@reporting/src/app/utils/getEmissionAllocations";
 
 // ✨ Mocks
 const mockRouterPush = vi.fn();
@@ -24,7 +25,7 @@ const config = {
   mockFacilityId: "abc",
   mockRouteSubmit: `additional-reporting-data`,
 };
-const mockInitialData = {
+const mockInitialData: EmissionAllocationResponse = {
   allocation_methodology: "Other",
   allocation_other_methodology_description: "description",
   report_product_emission_allocations: [
@@ -61,7 +62,7 @@ const mockInitialData = {
       ],
     },
   ],
-  facility_total_emissions: "150.0000",
+  facility_total_emissions: 150.0,
   report_product_emission_allocation_totals: [
     {
       report_product_id: 1,
@@ -74,6 +75,7 @@ const mockInitialData = {
       allocated_quantity: "85.0000",
     },
   ],
+  has_missing_products: false,
 };
 
 // ⛏️ Helper function to simulate form POST submission and assert the result
@@ -283,5 +285,36 @@ describe("FacilityEmissionAllocationForm component", () => {
     );
     const methodology = screen.queryAllByText(/Not Applicable/i)[0];
     expect(methodology).toBeUndefined();
+  });
+
+  it("renders a warning if there are missing products", async () => {
+    const initialData = {
+      ...mockInitialData,
+      has_missing_products: true,
+    };
+
+    render(
+      <FacilityEmissionAllocationForm
+        version_id={config.mockVersionId}
+        facility_id={config.mockFacilityId}
+        orderedActivities={[]}
+        initialData={initialData}
+        facilityType=""
+        navigationInformation={{
+          taskList: [],
+          continueUrl: "",
+          backUrl: "",
+          headerSteps: [],
+          headerStepIndex: 0,
+        }}
+        isPulpAndPaper={false}
+        overlappingIndustrialProcessEmissions={0}
+        operationType="Single Facility Operation"
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Only products selected on the production data page appear here. To allocate emissions to a product that isn't shown below, return to the production data page and select it first./i,
+    );
   });
 });

--- a/bciers/apps/reporting/src/tests/components/products/ProductionDataPage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/products/ProductionDataPage.test.tsx
@@ -71,7 +71,7 @@ describe("The Production Data component", () => {
 
     expect(screen.getAllByText(/production data/i)).toHaveLength(1);
     expect(
-      screen.getByText("Products that apply to this facility"),
+      screen.getByText("Select the products that apply to this facility:"),
     ).toBeInTheDocument();
     expect(screen.getAllByRole("checkbox")).toHaveLength(2);
     expect(screen.getByText(/testProduct/)).toBeInTheDocument();

--- a/bciers/apps/reporting/src/tests/data/jsonSchema/facility/MissingProductAlertFieldTemplate.test.tsx
+++ b/bciers/apps/reporting/src/tests/data/jsonSchema/facility/MissingProductAlertFieldTemplate.test.tsx
@@ -1,0 +1,45 @@
+import MissingProductAlertFieldTemplate from "@reporting/src/data/jsonSchema/facility/MissingProductAlertFieldTemplate";
+import Form from "@rjsf/core";
+import { RJSFSchema, UiSchema } from "@rjsf/utils";
+import { render, screen } from "@testing-library/react";
+
+const schema: RJSFSchema = {
+  type: "object",
+  properties: {
+    missing_product_alert: {
+      type: "object",
+      readOnly: true,
+    },
+  },
+};
+
+const uiSchema: UiSchema = {
+  missing_product_alert: {
+    "ui:FieldTemplate": MissingProductAlertFieldTemplate,
+  },
+};
+
+describe("The Missing Product Alert", () => {
+  it("renders links to the production data page", () => {
+    render(
+      <Form
+        schema={schema}
+        uiSchema={uiSchema}
+        validator={{} as any}
+        formData={{}}
+        formContext={{
+          missing_product_alert: {
+            version_id: 123,
+            facility_id: "abcd",
+          },
+        }}
+      />,
+    );
+
+    const links = screen.getAllByRole("link", { name: "production data page" });
+
+    for (const link of links) {
+      expect(link.href).toMatch("/reports/123/facilities/abcd/production-data");
+    }
+  });
+});


### PR DESCRIPTION
PR that does a couple of things:

- adds a `has_missing_products` flag to the facility emissions allocation API response
- uses this flag to display an alert
