### PR TITLE
350: IncreasedCreditHandler works when credits have already been approved/declined/requested

### DIFF
--- a/bc_obps/compliance/service/supplementary_version_service.py
+++ b/bc_obps/compliance/service/supplementary_version_service.py
@@ -424,12 +424,8 @@ class IncreasedCreditHandler:
         ).first()
         if not original_earned_credit_record:
             return False
-
         # Return True if excess emissions increased from previous version
-        return (
-            new_summary.excess_emissions > ZERO_DECIMAL
-            and previous_summary.excess_emissions < new_summary.excess_emissions
-        )
+        return ZERO_DECIMAL < previous_summary.credited_emissions < new_summary.credited_emissions
 
     @staticmethod
     @transaction.atomic()
@@ -461,7 +457,6 @@ class IncreasedCreditHandler:
         previous_earned_credit = ComplianceEarnedCredit.objects.get(
             compliance_report_version=previous_compliance_version
         )
-
         if previous_earned_credit.issuance_status == ComplianceEarnedCredit.IssuanceStatus.APPROVED:
             ComplianceEarnedCreditsService.create_earned_credits_record(
                 compliance_report_version, credited_emission_delta

--- a/bc_obps/compliance/service/supplementary_version_service.py
+++ b/bc_obps/compliance/service/supplementary_version_service.py
@@ -424,11 +424,10 @@ class IncreasedCreditHandler:
         ).first()
         if not original_earned_credit_record:
             return False
-
         if (
             ZERO_DECIMAL < previous_summary.credited_emissions < new_summary.credited_emissions
-            and original_earned_credit_record.issuance_status
-            == ComplianceEarnedCredit.IssuanceStatus.CREDITS_NOT_ISSUED
+            and original_earned_credit_record.issuance_status == ComplianceEarnedCredit.IssuanceStatus.APPROVED
+            or original_earned_credit_record.issuance_status == ComplianceEarnedCredit.IssuanceStatus.DECLINED
         ):
             return True
         return False
@@ -441,31 +440,37 @@ class IncreasedCreditHandler:
         previous_summary: ReportComplianceSummary,
         version_count: int,
     ) -> Optional[ComplianceReportVersion]:
-        # Increase the credits in the original earned_credit record by the appropriate amount
-        earned_credit = ComplianceEarnedCredit.objects.get(
-            compliance_report_version__compliance_report=compliance_report
-        )
-
-        credited_emission_delta = int(new_summary.credited_emissions - previous_summary.credited_emissions)
-        earned_credit.earned_credits_amount = earned_credit.earned_credits_amount + credited_emission_delta
-        earned_credit.save()
-
         # Get the previous compliance report version
         previous_compliance_version = (
             SupplementaryVersionService._get_previous_compliance_version_by_report_and_summary(
                 compliance_report, previous_summary
             )
         )
+        credited_emission_delta = int(new_summary.credited_emissions - previous_summary.credited_emissions)
 
-        # Create a compliance_report_version record with the 'no obligation or earned credits' status
+        # Create a compliance_report_version record with the 'earned credits' status
         compliance_report_version = ComplianceReportVersion.objects.create(
             compliance_report=compliance_report,
             report_compliance_summary=new_summary,
-            status=ComplianceReportVersion.ComplianceStatus.NO_OBLIGATION_OR_EARNED_CREDITS,
+            status=ComplianceReportVersion.ComplianceStatus.EARNED_CREDITS,
             credited_emissions_delta_from_previous=credited_emission_delta,
             is_supplementary=True,
             previous_version=previous_compliance_version,
         )
+
+        # Get the previous earned_credit record
+        previous_earned_credit = ComplianceEarnedCredit.objects.get(
+            compliance_report_version=previous_compliance_version
+        )
+
+        if previous_earned_credit.issuance_status == ComplianceEarnedCredit.IssuanceStatus.APPROVED:
+            ComplianceEarnedCreditsService.create_earned_credits_record(
+                compliance_report_version, credited_emission_delta
+            )
+        if previous_earned_credit.issuance_status == ComplianceEarnedCredit.IssuanceStatus.DECLINED:
+            # since no amount arg is provided, it will be taken from the report version's credited emissions
+            ComplianceEarnedCreditsService.create_earned_credits_record(compliance_report_version)
+
         return compliance_report_version
 
 


### PR DESCRIPTION
card: https://github.com/bcgov/cas-compliance/issues/350

This PR:
- changes the IncreasedCreditHandler so it now handles cases when there is already an earned credits record that has been approved or declined NEW! or have been requested (status is either issuance requrested or changes required) (https://github.com/bcgov/cas-compliance/issues/343 handles if credits were never requested)
- pytests the approved and declined cases
- pytests that the correct handler is used