### PR TITLE
chore: fix zero comparison for earned_credits to avoid records where amount is zero

### DIFF
--- a/bc_obps/compliance/service/compliance_report_version_service.py
+++ b/bc_obps/compliance/service/compliance_report_version_service.py
@@ -137,7 +137,7 @@ class ComplianceReportVersionService:
         """
         if excess_emissions > ZERO_DECIMAL:
             return ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET
-        elif credited_emissions > ZERO_DECIMAL:
+        elif int(credited_emissions) > ZERO_DECIMAL:
             return ComplianceReportVersion.ComplianceStatus.EARNED_CREDITS
         else:
             return ComplianceReportVersion.ComplianceStatus.NO_OBLIGATION_OR_EARNED_CREDITS


### PR DESCRIPTION
One line fix: Cast the decmial credited_emissions to integer before comparing with zero