### PR TITLE
chore: only release migration-test charts

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -24,6 +24,6 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:
-          charts_dir: helm
+          charts_dir: helm/migration-test
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Small change to set the Chart Release action to only run for the `migration-test` charts and _not_ the core `cas-bciers` chart.

💊 Side effects may include the chart releaser actually working.