### PR TITLE
fix: fix compliance summaries grid pagination

### DIFF
--- a/bc_obps/compliance/api/compliance_report_versions.py
+++ b/bc_obps/compliance/api/compliance_report_versions.py
@@ -6,11 +6,12 @@ from common.api.utils import get_current_user_guid
 from compliance.models import ComplianceReportVersion
 from compliance.schema.compliance_report_version import ComplianceReportVersionListOut
 from service.error_service.custom_codes_4xx import custom_codes_4xx
-from ninja.pagination import paginate, PageNumberPagination
+from ninja.pagination import paginate
 from compliance.service.compliance_dashboard_service import ComplianceDashboardService
 from registration.schema.generic import Message
 from .router import router
 from compliance.constants import COMPLIANCE
+from registration.utils import CustomPagination
 
 
 @router.get(
@@ -20,7 +21,7 @@ from compliance.constants import COMPLIANCE
     description="Get all compliance report versions for the current user's operations",
     auth=authorize("approved_authorized_roles"),
 )
-@paginate(PageNumberPagination)
+@paginate(CustomPagination)
 def get_compliance_report_versions_list(request: HttpRequest) -> QuerySet[ComplianceReportVersion]:
     user_guid = get_current_user_guid(request)
     return ComplianceDashboardService.get_compliance_report_versions_for_dashboard(user_guid)

--- a/bc_obps/compliance/api/compliance_report_versions.py
+++ b/bc_obps/compliance/api/compliance_report_versions.py
@@ -12,6 +12,7 @@ from registration.schema.generic import Message
 from .router import router
 from compliance.constants import COMPLIANCE
 from registration.utils import CustomPagination
+from ninja import Query
 
 
 @router.get(
@@ -22,6 +23,10 @@ from registration.utils import CustomPagination
     auth=authorize("approved_authorized_roles"),
 )
 @paginate(CustomPagination)
-def get_compliance_report_versions_list(request: HttpRequest) -> QuerySet[ComplianceReportVersion]:
+def get_compliance_report_versions_list(
+    request: HttpRequest,
+    paginate_result: bool = Query(True, description="Whether to paginate the results"),
+) -> QuerySet[ComplianceReportVersion]:
     user_guid = get_current_user_guid(request)
+    # NOTE: PageNumberPagination raises an error if we pass the response as a tuple (like 200, ...)
     return ComplianceDashboardService.get_compliance_report_versions_for_dashboard(user_guid)

--- a/bc_obps/compliance/api/compliance_report_versions.py
+++ b/bc_obps/compliance/api/compliance_report_versions.py
@@ -25,7 +25,7 @@ from ninja import Query
 @paginate(CustomPagination)
 def get_compliance_report_versions_list(
     request: HttpRequest,
-    paginate_result: bool = Query(True, description="Whether to paginate the results"),
+    paginate_result: bool = Query(False, description="Whether to paginate the results"),
 ) -> QuerySet[ComplianceReportVersion]:
     user_guid = get_current_user_guid(request)
     # NOTE: PageNumberPagination raises an error if we pass the response as a tuple (like 200, ...)

--- a/bciers/apps/compliance/src/app/components/compliance-summaries/ComplianceSummariesDataGrid.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summaries/ComplianceSummariesDataGrid.tsx
@@ -3,7 +3,6 @@
 import DataGrid from "@bciers/components/datagrid/DataGrid";
 import { ComplianceSummary } from "@/compliance/src/app/types";
 import complianceSummaryColumns from "../datagrid/models/compliance-summaries/complianceSummaryColumns";
-import { fetchComplianceSummariesPageData } from "@/compliance/src/app/utils/fetchComplianceSummariesPageData";
 
 const ComplianceSummariesDataGrid = ({
   initialData,
@@ -20,8 +19,8 @@ const ComplianceSummariesDataGrid = ({
   return (
     <DataGrid
       columns={columns}
-      fetchPageData={fetchComplianceSummariesPageData}
       initialData={initialData}
+      paginationMode="client"
     />
   );
 };


### PR DESCRIPTION
Paginated screenshots, navigating with the arrows at the bottom of the grid:
<img width="1358" height="1129" alt="image" src="https://github.com/user-attachments/assets/bc90cb56-b291-45e9-9033-3593b02696fb" />
<img width="1358" height="1129" alt="image" src="https://github.com/user-attachments/assets/2d208fc9-6c75-459e-9e55-4a9d994b30d1" />
<img width="1358" height="1129" alt="image" src="https://github.com/user-attachments/assets/4b2f2c9f-403e-4fd3-94b9-2a38640ca596" />
However, because this is a quick fix (full fix in 260), if users navigate via the URL to pages 1+, they won't see records: 
<img width="1345" height="955" alt="image" src="https://github.com/user-attachments/assets/b8675383-5bee-4b74-bb8e-0895a5ee3ced" />


Local testing instructions:
- make shell
- run
```
 from registration.models import Operation
from reporting.models import ReportingYear
from model_bakery import baker
```
- run the following to create a compliance version. Run it as many times as you want to create as many records as you want:
```
reporting_year_2024 = ReportingYear.objects.get(reporting_year='2024')

operation = baker.make_recipe(
        "registration.tests.utils.operation",
        bc_obps_regulated_operation=baker.make_recipe("registration.tests.utils.boro_id"),
        status=Operation.Statuses.REGISTERED,
        name='whatever'
    )
report = baker.make_recipe("reporting.tests.utils.report", reporting_year=reporting_year_2024, operation=operation)
compliance_report_instance = baker.make_recipe("compliance.tests.utils.compliance_report", report=report)
report_version = baker.make_recipe(
    "reporting.tests.utils.report_version", report=report
)
baker.make_recipe(
    "reporting.tests.utils.report_operation",
    report_version=report_version,
    operation_name="Test Operation Name",
)

# Create a report compliance summary
report_compliance_summary = baker.make_recipe(
    "reporting.tests.utils.report_compliance_summary", report_version=report_version
)

# Create a compliance report version
compliance_report_version = baker.make_recipe(
    "compliance.tests.utils.compliance_report_version",
    compliance_report=compliance_report_instance,
    report_compliance_summary=report_compliance_summary,
)
```
