### PR TITLE
feat: automated task to generate invoices on a specific-date

### DIFF
--- a/bc_obps/compliance/service/elicensing/elicensing_obligation_service.py
+++ b/bc_obps/compliance/service/elicensing/elicensing_obligation_service.py
@@ -188,7 +188,6 @@ class ElicensingObligationService:
             logger.warning(f"No compliance period found for reporting year {current_reporting_year.reporting_year}")
             return
 
-        # Check if today is the invoice generation date
         if not cls._is_invoice_generation_date_today(compliance_period):
             return
 
@@ -199,12 +198,7 @@ class ElicensingObligationService:
             return
 
         for obligation in obligations:
-            try:
-                cls.handle_obligation_integration(obligation.id, compliance_period)
-            except Exception as e:
-                logger.error(f"Failed to process obligation {obligation.obligation_id}: {e}")
-                # Continue processing other obligations even if one fails
-                continue
+            cls.handle_obligation_integration(obligation.id, compliance_period)
 
     @classmethod
     def _get_obligations_for_invoice_generation(

--- a/bc_obps/compliance/tasks.py
+++ b/bc_obps/compliance/tasks.py
@@ -74,4 +74,11 @@ SCHEDULED_TASKS = [
         schedule_minute=0,
         tag="elicensing",
     ),
+    ScheduledTaskConfig(
+        func=ElicensingObligationService.generate_invoices_for_current_period,
+        schedule_type="daily",
+        schedule_hour=3,
+        schedule_minute=0,
+        tag="invoice_generation",
+    ),
 ]

--- a/bc_obps/compliance/tests/service/elicensing/test_elicensing_obligation_service.py
+++ b/bc_obps/compliance/tests/service/elicensing/test_elicensing_obligation_service.py
@@ -16,6 +16,114 @@ from dataclasses import dataclass
 
 pytestmark = pytest.mark.django_db
 
+ELICENSING_OBLIGATION_SERVICE_PATH = "compliance.service.elicensing.elicensing_obligation_service"
+TIMEZONE_PATH = f"{ELICENSING_OBLIGATION_SERVICE_PATH}.timezone"
+TRANSACTION_PATH = f"{ELICENSING_OBLIGATION_SERVICE_PATH}.transaction"
+ELICENSING_OBLIGATION_SERVICE = (
+    "compliance.service.elicensing.elicensing_obligation_service.ElicensingObligationService"
+)
+IS_TODAY_PATH = f"{ELICENSING_OBLIGATION_SERVICE}._is_invoice_generation_date_today"
+GET_OBLIGATIONS_PATH = f"{ELICENSING_OBLIGATION_SERVICE}._get_obligations_for_invoice_generation"
+HANDLE_INTEGRATION_PATH = f"{ELICENSING_OBLIGATION_SERVICE}.handle_obligation_integration"
+
+ELICENSING_API_SERVICE = "compliance.service.elicensing.elicensing_api_client.ELicensingAPIClient"
+ELICENSING_CREATE_FEES_PATH = f"{ELICENSING_API_SERVICE}.create_fees"
+ELICENSING_CREATE_INVOICE_PATH = f"{ELICENSING_API_SERVICE}.create_invoice"
+
+GET_CURRENT_YEAR_PATH = "service.reporting_year_service.ReportingYearService.get_current_reporting_year"
+
+REFRESH_DATA_SERVICE = f"{ELICENSING_OBLIGATION_SERVICE_PATH}.ElicensingDataRefreshService"
+REFRESH_DATA_PATH = f"{REFRESH_DATA_SERVICE}.refresh_data_wrapper_by_compliance_report_version_id"
+REFRESH_DATA_BY_INVOICE_PATH = f"{REFRESH_DATA_SERVICE}.refresh_data_by_invoice"
+
+RETRYABLE_OBLIGATION_INTEGRATION_PATH = "compliance.tasks.retryable_process_obligation_integration"
+
+SYNC_WITH_ELICENSING_PATH = (
+    f"{ELICENSING_OBLIGATION_SERVICE_PATH}.ElicensingOperatorService.sync_client_with_elicensing"
+)
+
+UPDATE_COMPLIANCE_STATUS_PATH = (
+    "compliance.service.compliance_report_version_service.ComplianceReportVersionService.update_compliance_status"
+)
+
+
+@pytest.fixture
+def mock_timezone():
+    with patch(TIMEZONE_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_transaction():
+    with patch(TRANSACTION_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_is_today():
+    with patch(IS_TODAY_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_get_obligations():
+    with patch(GET_OBLIGATIONS_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_handle_integration():
+    with patch(HANDLE_INTEGRATION_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_create_fees():
+    with patch(ELICENSING_CREATE_FEES_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_create_invoice():
+    with patch(ELICENSING_CREATE_INVOICE_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_get_year():
+    with patch(GET_CURRENT_YEAR_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_refresh():
+    with patch(REFRESH_DATA_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_refresh_by_invoice():
+    with patch(REFRESH_DATA_BY_INVOICE_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_retryable_integration():
+    with patch(RETRYABLE_OBLIGATION_INTEGRATION_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_update_status():
+    with patch(UPDATE_COMPLIANCE_STATUS_PATH) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_sync_client():
+    with patch(SYNC_WITH_ELICENSING_PATH) as mock:
+        yield mock
+
 
 @dataclass
 class TestInvoiceResponse:
@@ -50,7 +158,18 @@ def mock_obligation() -> MagicMock:
     return obligation
 
 
+class _FauxQueryset(list):
+    def exists(self):
+        return bool(self)
+
+
 class TestElicensingObligationService:
+    def _set_vancouver_today(self, mock_timezone, d: date) -> None:
+        """Helper to mock Vancouver timezone's 'today' date."""
+        mock_dt = MagicMock()
+        mock_dt.astimezone.return_value.date.return_value = d
+        mock_timezone.now.return_value = mock_dt
+
     def test_map_obligation_to_fee_data(self, mock_obligation: MagicMock) -> None:
         """Test mapping obligation data to fee data"""
         result = ElicensingObligationService._map_obligation_to_fee_data(mock_obligation)
@@ -72,17 +191,8 @@ class TestElicensingObligationService:
         assert result["businessAreaCode"] == "OBPS"
         assert result["fees"] == [fee_id]
 
-    @pytest.mark.django_db
-    @patch('compliance.service.elicensing.elicensing_api_client.ELicensingAPIClient.create_fees')
-    @patch('compliance.service.elicensing.elicensing_api_client.ELicensingAPIClient.create_invoice')
-    @patch(
-        'compliance.service.elicensing.elicensing_data_refresh_service.ElicensingDataRefreshService.refresh_data_by_invoice'
-    )
-    @patch(
-        'compliance.service.compliance_report_version_service.ComplianceReportVersionService.update_compliance_status'
-    )
     def test_process_obligation_integration_success(
-        self, mock_update_status, mock_refresh, mock_create_invoice, mock_create_fees
+        self, mock_update_status, mock_refresh_by_invoice, mock_create_invoice, mock_create_fees
     ) -> None:
         """Test successful full obligation integration process"""
         # Setup mocks
@@ -105,7 +215,7 @@ class TestElicensingObligationService:
         mock_invoice_response = TestInvoiceResponse(invoiceNumber='inv-001')
         mock_create_invoice.return_value = mock_invoice_response
 
-        mock_refresh.return_value = None
+        mock_refresh_by_invoice.return_value = None
         mock_update_status.return_value = None
 
         invoice = make_recipe('compliance.tests.utils.elicensing_invoice', invoice_number='inv-001')
@@ -120,10 +230,6 @@ class TestElicensingObligationService:
 
         mock_update_status.assert_called_once_with(obligation.compliance_report_version)
 
-    @patch('compliance.service.elicensing.elicensing_api_client.ELicensingAPIClient.create_fees')
-    @patch(
-        'compliance.service.elicensing.elicensing_operator_service.ElicensingOperatorService.sync_client_with_elicensing'
-    )
     def test_process_obligation_integration_failure_sets_pending_status(
         self, mock_sync_client, mock_create_fees
     ) -> None:
@@ -148,9 +254,6 @@ class TestElicensingObligationService:
             == ComplianceReportVersion.ComplianceStatus.OBLIGATION_PENDING_INVOICE_CREATION
         )
 
-    @patch('compliance.tasks.retryable_process_obligation_integration')
-    @patch('compliance.service.elicensing.elicensing_obligation_service.transaction')
-    @patch('compliance.service.elicensing.elicensing_obligation_service.timezone')
     def test_handle_obligation_integration_runs_when_invoice_generation_date_passed(
         self, mock_timezone, mock_transaction, mock_retryable_integration
     ):
@@ -177,7 +280,6 @@ class TestElicensingObligationService:
         mock_transaction.on_commit.assert_called_once()
         mock_retryable_integration.execute.assert_called_once_with(obligation.id)
 
-    @patch('compliance.service.elicensing.elicensing_obligation_service.timezone')
     def test_handle_obligation_integration_sets_pending_status_when_invoice_generation_date_not_passed(
         self, mock_timezone
     ):
@@ -204,3 +306,252 @@ class TestElicensingObligationService:
             obligation.compliance_report_version.status
             == ComplianceReportVersion.ComplianceStatus.OBLIGATION_PENDING_INVOICE_CREATION
         )
+
+    def test_is_invoice_generation_date_reached(self, mock_timezone):
+        gen_date = date(2025, 11, 1)
+
+        # Before (False)
+        self._set_vancouver_today(mock_timezone, date(2025, 10, 31))
+        cp = make_recipe("compliance.tests.utils.compliance_period", invoice_generation_date=gen_date)
+        assert ElicensingObligationService._is_invoice_generation_date_reached(cp) is False
+
+        # On the date (True)
+        self._set_vancouver_today(mock_timezone, date(2025, 11, 1))
+        cp = make_recipe("compliance.tests.utils.compliance_period", invoice_generation_date=gen_date)
+        assert ElicensingObligationService._is_invoice_generation_date_reached(cp) is True
+
+        # After (True)
+        self._set_vancouver_today(mock_timezone, date(2025, 11, 2))
+        cp = make_recipe("compliance.tests.utils.compliance_period", invoice_generation_date=gen_date)
+        assert ElicensingObligationService._is_invoice_generation_date_reached(cp) is True
+
+    def test_is_invoice_generation_date_today(self, mock_timezone):
+        gen_date = date(2025, 11, 1)
+
+        cases = [
+            (date(2025, 10, 31), False),  # before
+            (date(2025, 11, 1), True),  # exact
+            (date(2025, 11, 2), False),  # after
+        ]
+
+        for today, expected in cases:
+            self._set_vancouver_today(mock_timezone, today)
+            cp = make_recipe(
+                "compliance.tests.utils.compliance_period",
+                invoice_generation_date=gen_date,
+            )
+            result = ElicensingObligationService._is_invoice_generation_date_today(cp)
+            assert result is expected
+
+    def test_get_obligations_for_invoice_generation(self):
+        cp_target = make_recipe("compliance.tests.utils.compliance_period")
+        cp_other = make_recipe("compliance.tests.utils.compliance_period")
+
+        # Obligation in target period, no invoice, not superseded -> should be included
+        obligation_ok = make_recipe(
+            "compliance.tests.utils.compliance_obligation",
+            compliance_report_version__compliance_report__compliance_period=cp_target,
+            elicensing_invoice=None,
+            compliance_report_version__status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET,
+        )
+
+        # Obligation in target period, but already has an invoice -> should be excluded
+        make_recipe(
+            "compliance.tests.utils.compliance_obligation",
+            compliance_report_version__compliance_report__compliance_period=cp_target,
+            elicensing_invoice=make_recipe("compliance.tests.utils.elicensing_invoice"),
+        )
+
+        # Obligation in target period, no invoice, but superseded -> should be excluded
+        make_recipe(
+            "compliance.tests.utils.compliance_obligation",
+            compliance_report_version__compliance_report__compliance_period=cp_target,
+            elicensing_invoice=None,
+            compliance_report_version__status=ComplianceReportVersion.ComplianceStatus.SUPERCEDED,
+        )
+
+        # Obligation in a different compliance period -> should be excluded
+        make_recipe(
+            "compliance.tests.utils.compliance_obligation",
+            compliance_report_version__compliance_report__compliance_period=cp_other,
+            elicensing_invoice=None,
+            compliance_report_version__status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET,
+        )
+
+        # Act
+        qs = ElicensingObligationService._get_obligations_for_invoice_generation(cp_target)
+
+        # Assert
+        assert set(qs) == {obligation_ok}
+
+    def test_generate_invoices_for_current_period__happy_path(
+        self,
+        mock_get_year,
+        mock_is_today,
+        mock_get_obligations,
+        mock_handle_integration,
+    ):
+        """
+        Happy path test:
+        - Compliance period exists
+        - Today is invoice generation date
+        - Obligations exist that need invoice generation
+        - handle_obligation_integration called for each obligation
+        """
+        # Arrange
+        ry = ReportingYear.objects.get(reporting_year=2024)
+
+        cp, created = CompliancePeriod.objects.get_or_create(
+            reporting_year=ry,
+            defaults={"invoice_generation_date": date(2024, 11, 1)},
+        )
+        if not created and cp.invoice_generation_date != date(2024, 11, 1):
+            cp.invoice_generation_date = date(2024, 11, 1)
+            cp.save(update_fields=["invoice_generation_date"])
+
+        obligations = _FauxQueryset([MagicMock(id=101), MagicMock(id=202)])
+
+        mock_get_year.return_value = ry
+        mock_is_today.return_value = True
+        mock_get_obligations.return_value = obligations
+
+        # Act
+        ElicensingObligationService.generate_invoices_for_current_period()
+
+        # Assert
+        mock_get_year.assert_called_once()
+        mock_is_today.assert_called_once_with(cp)
+        mock_get_obligations.assert_called_once_with(cp)
+
+        assert mock_handle_integration.call_count == 2
+        mock_handle_integration.assert_any_call(101, cp)
+        mock_handle_integration.assert_any_call(202, cp)
+
+    def test_generate_invoices_for_current_period__no_compliance_period_found(
+        self,
+        mock_get_year,
+        mock_is_today,
+        mock_get_obligations,
+        mock_handle_integration,
+    ):
+        """
+        Test case: No compliance period exists for the current reporting year
+        - Should return early
+        - Should not call subsequent methods
+        """
+        # Arrange
+        ry = ReportingYear.objects.get(reporting_year=2024)
+        mock_get_year.return_value = ry
+
+        # Ensure no compliance period exists for this reporting year
+        CompliancePeriod.objects.filter(reporting_year=ry).delete()
+
+        # Act
+        ElicensingObligationService.generate_invoices_for_current_period()
+
+        # Assert
+        mock_get_year.assert_called_once()
+        mock_is_today.assert_not_called()
+        mock_get_obligations.assert_not_called()
+        mock_handle_integration.assert_not_called()
+
+    def test_generate_invoices_for_current_period__not_invoice_generation_date(
+        self,
+        mock_get_year,
+        mock_is_today,
+        mock_get_obligations,
+        mock_handle_integration,
+    ):
+        """
+        Test case: Today is not the invoice generation date
+        - Should return early without processing obligations
+        - Should not call handle_obligation_integration
+        """
+        # Arrange
+        ry = ReportingYear.objects.get(reporting_year=2024)
+        cp, created = CompliancePeriod.objects.get_or_create(
+            reporting_year=ry,
+            defaults={"invoice_generation_date": date(2024, 11, 1)},
+        )
+
+        mock_get_year.return_value = ry
+        mock_is_today.return_value = False  # Not invoice generation date
+
+        # Act
+        ElicensingObligationService.generate_invoices_for_current_period()
+
+        # Assert
+        mock_get_year.assert_called_once()
+        mock_is_today.assert_called_once_with(cp)
+        mock_get_obligations.assert_not_called()
+        mock_handle_integration.assert_not_called()
+
+    def test_generate_invoices_for_current_period__no_obligations_found(
+        self,
+        mock_get_year,
+        mock_is_today,
+        mock_get_obligations,
+        mock_handle_integration,
+    ):
+        """
+        Test case: No obligations found that need invoice generation
+        - Should log info message and return early
+        - Should not call handle_obligation_integration
+        """
+        # Arrange
+        ry = ReportingYear.objects.get(reporting_year=2024)
+        cp, created = CompliancePeriod.objects.get_or_create(
+            reporting_year=ry,
+            defaults={"invoice_generation_date": date(2024, 11, 1)},
+        )
+
+        empty_obligations = _FauxQueryset([])  # Empty queryset
+
+        mock_get_year.return_value = ry
+        mock_is_today.return_value = True
+        mock_get_obligations.return_value = empty_obligations
+
+        # Act
+        ElicensingObligationService.generate_invoices_for_current_period()
+
+        # Assert
+        mock_get_year.assert_called_once()
+        mock_is_today.assert_called_once_with(cp)
+        mock_get_obligations.assert_called_once_with(cp)
+        mock_handle_integration.assert_not_called()
+
+    def test_generate_invoices_for_current_period__single_obligation(
+        self,
+        mock_get_year,
+        mock_is_today,
+        mock_get_obligations,
+        mock_handle_integration,
+    ):
+        """
+        Test case: Single obligation needs invoice generation
+        - Should process exactly one obligation
+        - Should call handle_obligation_integration once
+        """
+        # Arrange
+        ry = ReportingYear.objects.get(reporting_year=2024)
+        cp, created = CompliancePeriod.objects.get_or_create(
+            reporting_year=ry,
+            defaults={"invoice_generation_date": date(2024, 11, 1)},
+        )
+
+        single_obligation = _FauxQueryset([MagicMock(id=999)])  # Single obligation
+
+        mock_get_year.return_value = ry
+        mock_is_today.return_value = True
+        mock_get_obligations.return_value = single_obligation
+
+        # Act
+        ElicensingObligationService.generate_invoices_for_current_period()
+
+        # Assert
+        mock_get_year.assert_called_once()
+        mock_is_today.assert_called_once_with(cp)
+        mock_get_obligations.assert_called_once_with(cp)
+
+        assert mock_handle_integration.call_count == 1
+        mock_handle_integration.assert_called_once_with(999, cp)


### PR DESCRIPTION
[ISSUE 307](https://github.com/bcgov/cas-compliance/issues/307)

## Changes Made

### 1. Enhanced ElicensingObligationService

**New Methods Added:**
- `_is_invoice_generation_date_reached()` - Checks if the current date has reached or passed the invoice generation date
- `_is_invoice_generation_date_today()` - Checks if the current date exactly matches the invoice generation date
- `generate_invoices_for_current_period()` - Main method that orchestrates invoice generation for the current period
- `_get_obligations_for_invoice_generation()` - Retrieves obligations eligible for invoice generation

**Refactored Methods:**
- `handle_obligation_integration()` - Extracted date checking logic into separate helper methods for better maintainability

### 2. Scheduled Task Configuration

**New Scheduled Task:**
- Added `ElicensingObligationService.generate_invoices_for_current_period` to the scheduled tasks
- Configured to run daily at 3:00 AM

