### PR TITLE
update dashboard e2e

### DIFF
--- a/bciers/apps/dashboard-e2e/tests/external/dashboard.spec.ts
+++ b/bciers/apps/dashboard-e2e/tests/external/dashboard.spec.ts
@@ -92,7 +92,7 @@ userRoles.forEach((role) => {
               break;
             case DashboardTiles.COMPLIANCE:
               tileTexts = Object.values(ComplianceTileText);
-              skipUrlCheck = true;
+              skipUrlCheck = true; //Does not have a sub-dashboard
               break;
             case DashboardTiles.REPORT_A_PROBLEM:
               // Report a Problem is a link to an email address, check visibility and href but do not click
@@ -102,11 +102,12 @@ userRoles.forEach((role) => {
               );
               skipUrlCheck = true;
               break;
-            case DashboardTiles.ACCESS_REQUEST:
+            case DashboardTiles.INTERNAL_USER_ACCESS_REQUEST:
               // This is for internal user
-              tileTexts = Object.values(AccessRequestText);
               await expect(
-                page.getByText(tileTexts[0], { exact: true }),
+                page.getByText(Object.values(AccessRequestText)[0], {
+                  exact: true,
+                }),
               ).toBeHidden();
               skipUrlCheck = true;
               break;
@@ -116,23 +117,9 @@ userRoles.forEach((role) => {
         }
 
         if (!skipUrlCheck) {
-          // Go to dashboard page of each route
+          // Verify that sub-dashboard exists
           await page.getByRole("link", { name: tile }).first().click();
           await dashboardPage.urlIsCorrect(tile.toLocaleLowerCase(), true);
-
-          // Assert visibility of each tile text on the dashboard page
-          for (const text of tileTexts) {
-            // Special case for select operator (only visible for pending)
-            if (text === AdministrationTileText.SELECT_OPERATOR) {
-              dashboardPage.assertSelectOperatorIsVisible(text, pendingUser);
-            } else {
-              if (reporter && text === AdministrationTileText.ACCESS_REQUEST) {
-                await dashboardPage.linkIsVisible(text, false);
-              } else {
-                await dashboardPage.linkIsVisible(text, true);
-              }
-            }
-          }
 
           // Say cheese!
           component = `External user ${tile} Dashboard for role: ${role}`;
@@ -142,6 +129,21 @@ userRoles.forEach((role) => {
           });
           // Go back to dashboard
           await dashboardPage.route();
+        }
+
+        // Assert visibility of each tile text on the dashboard page
+        for (const text of tileTexts) {
+          // Special case for select operator (only visible for pending)
+          if (text === AdministrationTileText.SELECT_OPERATOR) {
+            dashboardPage.assertSelectOperatorIsVisible(text, pendingUser);
+          } else {
+            console.log("text", text);
+            if (reporter && text === AdministrationTileText.ACCESS_REQUEST) {
+              await dashboardPage.linkIsVisible(text, false);
+            } else {
+              await dashboardPage.linkIsVisible(text, true);
+            }
+          }
         }
       }
     });

--- a/bciers/apps/dashboard-e2e/tests/internal/dashboard.spec.ts
+++ b/bciers/apps/dashboard-e2e/tests/internal/dashboard.spec.ts
@@ -52,22 +52,21 @@ userRoles.forEach((role) => {
             break;
           case DashboardTiles.TRANSFERS:
             tileTexts = Object.values(InternalTransfersTileText);
-            skipUrlCheck = true;
+            skipUrlCheck = true; //Does not have a sub-dashboard
             break;
           case DashboardTiles.REPORTING:
             tileTexts = Object.values(InternalReportingTileText);
-            skipUrlCheck = true;
             break;
           case DashboardTiles.COMPLIANCE:
             tileTexts = Object.values(InternalComplianceTileText);
             skipUrlCheck = true;
             break;
-          case DashboardTiles.ACCESS_REQUEST:
+          case DashboardTiles.INTERNAL_USER_ACCESS_REQUEST:
             tileTexts = Object.values(AccessRequestText);
             await expect(
               page.getByRole("link", { name: tileTexts[0], exact: true }),
             ).toBeVisible();
-            skipUrlCheck = true;
+            skipUrlCheck = true; //Does not have a sub-dashboard
             break;
           case DashboardTiles.REPORT_A_PROBLEM:
             await dashboardPage.assertMailToLinkIsVisible(
@@ -81,11 +80,19 @@ userRoles.forEach((role) => {
             break;
         }
 
+        // Verify that sub-dashboard exists
         if (!skipUrlCheck) {
           await page.getByRole("link", { name: tile }).first().click();
           await dashboardPage.urlIsCorrect(tile.toLocaleLowerCase(), true);
+          component = `Internal user ${tile} Dashboard for role: ${role}`;
+          await takeStabilizedScreenshot(happoPlaywright, page, {
+            component: component,
+            variant: "default",
+          });
+          await dashboardPage.route();
         }
 
+        // Assert visibility of each tile text on the dashboard page
         for (const text of tileTexts) {
           if (
             role !== UserRole.CAS_ANALYST &&
@@ -95,15 +102,6 @@ userRoles.forEach((role) => {
           } else {
             await dashboardPage.linkIsVisible(text, true);
           }
-        }
-
-        if (!skipUrlCheck) {
-          component = `Internal user ${tile} Dashboard for role: ${role}`;
-          await takeStabilizedScreenshot(happoPlaywright, page, {
-            component: component,
-            variant: "default",
-          });
-          await dashboardPage.route();
         }
       }
     });

--- a/bciers/apps/dashboard-e2e/utils/enums.ts
+++ b/bciers/apps/dashboard-e2e/utils/enums.ts
@@ -4,7 +4,7 @@ export enum DashboardTiles {
   REPORTING = "Reporting",
   COMPLIANCE = "Compliance",
   REPORT_A_PROBLEM = "Report a Problem",
-  ACCESS_REQUEST = "Clean Growth User Access Management",
+  INTERNAL_USER_ACCESS_REQUEST = "Clean Growth User Access Management",
   TRANSFERS = "Transfers",
 }
 

--- a/bciers/apps/dashboard-e2e/utils/enums.ts
+++ b/bciers/apps/dashboard-e2e/utils/enums.ts
@@ -23,6 +23,7 @@ export enum RegistrationTileText {
 
 export enum ReportingTileText {
   SUBMIT_REPORT = "View Annual Reports",
+  PAST_REPORTS = "View Past Reports",
 }
 
 export enum ComplianceTileText {


### PR DESCRIPTION
Card: #3868 

Updates the internal and external dashboard E2E files to cover the recent changes made:
- External: Add `View Past Reports` link, updating the compliance tile was covered under 3859.
- Internal: Updating the compliance tile was covered under #3859. Refactored the file instead so that others with !skipUrlCheck can have the links checked as well.
