### PR TITLE
chore: remove compliance example e2e test

### DIFF
--- a/bciers/apps/compliance-e2e/tests/example.spec.ts
+++ b/bciers/apps/compliance-e2e/tests/example.spec.ts
@@ -1,6 +1,0 @@
-// import testNxProjectUrl from "@bciers/e2e/utils/test-nx-app-url";
-
-// testNxProjectUrl(["compliance"]);
-import testNxProjectLandingPage from "@bciers/e2e/utils/test-nx-app-landing-page";
-
-testNxProjectLandingPage(["compliance"]);


### PR DESCRIPTION
Additional work for #3900 to remove the `example.spec.ts` to prevent CI from failing, and happo from taking screenshots.