### PR TITLE
fix for track status of issuance link

### DIFF
--- a/bciers/apps/compliance/src/middlewares/withRuleHasComplianceRouteAccessBCeID.test.ts
+++ b/bciers/apps/compliance/src/middlewares/withRuleHasComplianceRouteAccessBCeID.test.ts
@@ -51,7 +51,6 @@ vi.mock("@/compliance/src/app/utils/getComplianceSummary", () => ({
 // Helpers & Setup
 // --------------------
 const DOMAIN = "https://localhost:3000";
-const BASE = `/${constants.COMPLIANCE_BASE}`;
 const defaultCrvId = 123;
 
 function makeReq(path: string): NextRequest {
@@ -75,9 +74,9 @@ const getPathname = (res?: NextResponse | null) => {
   return loc ? new URL(loc).pathname : undefined;
 };
 
-const reviewSummariesPath = `${BASE}/${constants.AppRoutes.REVIEW_COMPLIANCE_SUMMARIES}`;
+const reviewSummariesPath = "compliance/compliance-administration";
 const crvBase = `${reviewSummariesPath}/${defaultCrvId}`;
-const summariesIdBase = `${BASE}/${constants.AppRoutes.REVIEW_COMPLIANCE_SUMMARIES}/${defaultCrvId}`;
+const summariesIdBase = `${reviewSummariesPath}/${defaultCrvId}`;
 
 const pathForSeg = (seg: string) => `${crvBase}/${seg}`;
 const pathUnderSummaries = (seg: string) => `${summariesIdBase}/${seg}`;

--- a/bciers/next.config.base.js
+++ b/bciers/next.config.base.js
@@ -30,7 +30,6 @@ const baseConfig = {
         destination: "/",
         permanent: true,
       },
-      // brianna?
       {
         source: "/compliance-administration",
         destination: "/compliance-administration/compliance-summaries",


### PR DESCRIPTION
Action cell link is fine. I think the problem is in the middleware. The earned credits redirect looks like this:
```
redirect: makeRuleRedirect<RuleContext>(HUB_SUMMARIES_PATH, (id, ctx) => {
      if (ctx.redirectToTrackStatusById[id]) {
        return AppRoutes.RI_TRACK_STATUS;
      }
      if (ctx.redirectToRequestIssuanceCreditsById[id]) {
        return AppRoutes.RI_EARNED_CREDITS;
      }
      return undefined; // → fall back to hub
    }),
``` 
vs `redirect: makeRuleRedirect(HUB_SUMMARIES_PATH),` elsewhere

I got the broken page to load with the changes in this PR, but I haven't done any testing yet to see if I broke any of the other pages. ~maybe the redirect in the next config was working for the other places but not track status because of the resolver?