### PR TITLE
chore: update vite to 6.4.1

### DIFF
--- a/bciers/package.json
+++ b/bciers/package.json
@@ -97,7 +97,7 @@
     "tslib": "^2.3.0",
     "typescript": "5.7.3",
     "uuid": "^9.0.1",
-    "vite": "6.3.6",
+    "vite": "6.4.1",
     "vite-require": "^0.2.3",
     "vitest": "^3.0.5"
   },

--- a/bciers/yarn.lock
+++ b/bciers/yarn.lock
@@ -1760,7 +1760,7 @@ __metadata:
     tslib: "npm:^2.3.0"
     typescript: "npm:5.7.3"
     uuid: "npm:^9.0.1"
-    vite: "npm:6.3.6"
+    vite: "npm:6.4.1"
     vite-require: "npm:^0.2.3"
     vite-tsconfig-paths: "npm:^5.1.4"
     vitest: "npm:^3.0.5"
@@ -18559,7 +18559,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:6.3.6, vite@npm:^5.0.0 || ^6.0.0":
+"vite@npm:6.4.1":
+  version: 6.4.1
+  resolution: "vite@npm:6.4.1"
+  dependencies:
+    esbuild: "npm:^0.25.0"
+    fdir: "npm:^6.4.4"
+    fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.2"
+    postcss: "npm:^8.5.3"
+    rollup: "npm:^4.34.9"
+    tinyglobby: "npm:^0.2.13"
+  peerDependencies:
+    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    jiti: ">=1.21.0"
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/77bb4c5b10f2a185e7859cc9a81c789021bc18009b02900347d1583b453b58e4b19ff07a5e5a5b522b68fc88728460bb45a63b104d969e8c6a6152aea3b849f7
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0 || ^6.0.0":
   version: 6.3.6
   resolution: "vite@npm:6.3.6"
   dependencies:


### PR DESCRIPTION
no card, addressing: https://github.com/advisories/GHSA-93m4-6634-74q7