### PR TITLE
fix: add schedule_month to scheduled task sync

### DIFF
--- a/bc_obps/task_scheduler/service/scheduled_task/sync.py
+++ b/bc_obps/task_scheduler/service/scheduled_task/sync.py
@@ -50,6 +50,7 @@ class ScheduledTaskSynchronizer:
             'schedule_minute',
             'schedule_day_of_week',
             'schedule_day_of_month',
+            'schedule_month',
             'tag',
         ]
 
@@ -93,6 +94,7 @@ class ScheduledTaskSynchronizer:
                 schedule_minute=task_config.get('schedule_minute'),
                 schedule_day_of_week=task_config.get('schedule_day_of_week'),
                 schedule_day_of_month=task_config.get('schedule_day_of_month'),
+                schedule_month=task_config.get('schedule_month'),
                 status=ScheduledTask.Status.PENDING,
             )
 


### PR DESCRIPTION
came up in https://github.com/bcgov/cas-compliance/issues/369

The scheduled task service functions were missing the `schedule_month`, which means that even though we set the month in `tasks.py`, it wasn't being saved to the db.