### PR TITLE
fix: ensure tags already released to main are only immutable

### DIFF
--- a/.bin/check-immutable-migration-files.sh
+++ b/.bin/check-immutable-migration-files.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 # Get the latest release tag from the main branch, as we consider migrations immutable from that point
 git fetch --tags origin main
 latest_main_tag=$(git tag --merged origin/main | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
-
-latest_tag=$(git describe --tags --abbrev=0)
 files_diff=$(git diff --name-only origin/main -- bc_obps/**/migrations)
 
 poetry --directory ./bc_obps run python manage.py check_immutable_migration_files --tag "$latest_main_tag" --diff "$files_diff"


### PR DESCRIPTION
Addresses #3590. Updates the immutable migration check to run against `main` branch, as we consider any migrations that have made it that far immutable. This should correct the false-failure in ShipIt when doing a release. 

## Changes 🚧

- Check migrations against `main` branch's latest tag rather than current branch's latest tag.
