### PR TITLE
chore: added reporting year on dashboard

### DIFF
--- a/bciers/apps/dashboard/app/dashboard/page.tsx
+++ b/bciers/apps/dashboard/app/dashboard/page.tsx
@@ -1,59 +1,76 @@
 import Tiles from "@bciers/components/navigation/Tiles";
-import Note from "@bciers/components/layout/Note";
+import ReportingYearHeader from "@bciers/components/reporting/ReportingYearHeader";
 import { fetchDashboardData } from "@bciers/actions";
 import { ContentItem } from "@bciers/types/tiles";
 import { FrontEndRoles } from "@bciers/utils/src/enums";
 import evalDashboardRules from "@bciers/utils/src/evalDashboardRules";
 import { getSessionRole } from "@bciers/utils/src/sessionUtils";
 import AccessTimeFilledIcon from "@mui/icons-material/AccessTimeFilled";
+import { getReportingYear } from "@reporting/src/app/utils/getReportingYear";
+
+// Component for the pending access message
+function PendingAccessMessage() {
+  return (
+    <section
+      className="text-center my-20 text-2xl flex flex-col gap-3"
+      data-testid="dashboard-pending-message"
+    >
+      <span>
+        <AccessTimeFilledIcon sx={{ color: "#FFCC00", fontSize: 50 }} />
+      </span>
+      <div style={{ fontSize: "16px" }}>
+        <p>By logging in, you have automatically requested access.</p>
+        <p>
+          Once approved, you will receive a confirmation email. You can then log
+          back in using your IDIR.
+        </p>
+      </div>
+    </section>
+  );
+}
 
 export default async function Page() {
   const role = await getSessionRole();
-  const isIndustryUser = role.includes("industry");
+  const isPendingUser = role === FrontEndRoles.CAS_PENDING;
+  const isIndustryUser = role.includes("industry_");
 
-  let data: ContentItem[] = [];
+  // Early return for pending users
+  if (isPendingUser) {
+    return (
+      <div>
+        <PendingAccessMessage />
+      </div>
+    );
+  }
 
-  // Check role before fetching data
-  if (role && role !== FrontEndRoles.CAS_PENDING) {
-    // 🚀 API fetch dashboard tiles
-    // 🚩 Source: bc_obps/common/fixtures/dashboard/bciers/[IdProviderType]
-    data = (await fetchDashboardData(
-      "common/dashboard-data?dashboard=bciers",
-    )) as ContentItem[];
-    // Evaluate display rules in the dashboard data
-    data = await evalDashboardRules(data);
+  // Fetch dashboard data for authenticated users
+  // 🚀 API fetch dashboard tiles
+  // 🚩 Source: bc_obps/common/fixtures/dashboard/bciers/[IdProviderType]
+  let data = (await fetchDashboardData(
+    "common/dashboard-data?dashboard=bciers",
+  )) as ContentItem[];
+  // Evaluate display rules in the dashboard data
+  data = await evalDashboardRules(data);
+
+  // Get reporting year information only for industry users
+  let reportingYearData;
+
+  if (isIndustryUser) {
+    reportingYearData = await getReportingYear();
   }
 
   return (
     <div>
-      {role === FrontEndRoles.CAS_PENDING ? (
-        <section
-          className="text-center my-20 text-2xl flex flex-col gap-3"
-          data-testid="dashboard-pending-message"
-        >
-          <span>
-            <AccessTimeFilledIcon sx={{ color: "#FFCC00", fontSize: 50 }} />
-          </span>
-          <div style={{ fontSize: "16px" }}>
-            <p>By logging in, you have automatically requested access.</p>
-            <p>
-              Once approved, you will receive a confirmation email. You can then
-              log back in using your IDIR.
-            </p>
-          </div>
-        </section>
-      ) : (
-        <>
-          {isIndustryUser && (
-            <Note variant="important">
-              <b>Important:</b> Please always ensure that the information in{" "}
-              <b>Registration</b> is complete and accurate before submitting or
-              amending reports in <b>Reporting.</b>
-            </Note>
-          )}
-          <Tiles tiles={data} />
-        </>
+      {isIndustryUser && reportingYearData && (
+        <ReportingYearHeader
+          reportingYear={reportingYearData.reporting_year}
+          reportDueYear={reportingYearData.report_due_year}
+          variant="dashboard"
+          showInfoBox={true}
+        />
       )}
+
+      <Tiles tiles={data} />
     </div>
   );
 }

--- a/bciers/apps/dashboard/tests/routes/dashboard/page.test.tsx
+++ b/bciers/apps/dashboard/tests/routes/dashboard/page.test.tsx
@@ -7,6 +7,17 @@ vi.mock("@bciers/utils/src/sessionUtils", () => ({
   getSessionRole: vi.fn(),
 }));
 
+vi.mock("@reporting/src/app/utils/getReportingYear", () => ({
+  getReportingYear: vi.fn(() =>
+    Promise.resolve({
+      reporting_year: 2024,
+      report_due_date: "2025-05-31",
+      reporting_window_end: "2025-03-31",
+      report_due_year: 2025,
+    }),
+  ),
+}));
+
 const roles = [
   "cas_admin",
   "cas_analyst",
@@ -98,9 +109,6 @@ const tiles = [
     ],
   },
 ];
-
-const noteContent =
-  "Important: Please always ensure that the information in Registration is complete and accurate before submitting or amending reports in Reporting.";
 
 const msgContent =
   "By logging in, you have automatically requested access.Once approved, you will receive a confirmation email. You can then log back in using your IDIR.";
@@ -203,48 +211,6 @@ describe("Registration dashboard page", () => {
     expect(
       screen.getByRole("link", { name: /report problems to/i }),
     ).toBeVisible();
-  });
-
-  it("renders the Note component for industry_admin role", async () => {
-    (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
-      "industry_admin",
-    );
-
-    render(await DashboardPage());
-
-    const note = screen.getByTestId("note");
-    expect(note).toBeVisible();
-    expect(note).toHaveTextContent(noteContent);
-  });
-
-  it("renders the Note component for industry_user role", async () => {
-    (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
-      "industry_user",
-    );
-
-    render(await DashboardPage());
-
-    const note = screen.getByTestId("note");
-    expect(note).toBeVisible();
-    expect(note).toHaveTextContent(noteContent);
-  });
-
-  it("does not render the Note component for cas_admin", async () => {
-    (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue("cas_admin");
-
-    render(await DashboardPage());
-
-    expect(screen.queryByTestId("note")).not.toBeInTheDocument();
-  });
-
-  it("does not render the Note component for cas_analyst", async () => {
-    (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
-      "cas_analyst",
-    );
-
-    render(await DashboardPage());
-
-    expect(screen.queryByTestId("note")).not.toBeInTheDocument();
   });
 
   it("renders the dashboard-pending-message card for cas_pending role", async () => {

--- a/bciers/apps/reporting/src/app/components/operations/ReportsBasePage.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/ReportsBasePage.tsx
@@ -1,8 +1,8 @@
 import { Tabs } from "@bciers/components/tabs/Tabs";
+import ReportingYearHeader from "@bciers/components/reporting/ReportingYearHeader";
 import { getSessionRole } from "@bciers/utils/src/sessionUtils";
 import { ReactNode } from "react";
 import { getReportingYear } from "../../utils/getReportingYear";
-import dayjs from "dayjs";
 
 interface ReportsBasePageProps {
   activeTab: number;
@@ -14,12 +14,11 @@ export default async function ReportsBasePage({
   children,
 }: Readonly<ReportsBasePageProps>) {
   const userRole = await getSessionRole();
+  const isIndustryUser = userRole.includes("industry_");
 
-  const reportingYearObj = await getReportingYear();
-  const reportDueDate = reportingYearObj.report_due_date;
-  const reportDueYearOnly = dayjs(reportDueDate).year();
+  const reportingYearData = await getReportingYear();
 
-  const tabs = userRole.includes("industry_")
+  const tabs = isIndustryUser
     ? [
         //tabs for external users
         { label: "View annual report(s)", href: "/reports/current-reports" },
@@ -31,41 +30,41 @@ export default async function ReportsBasePage({
         { label: "View past reports", href: "/reports/previous-years" },
         { label: "Download report attachments", href: "/reports/attachments" },
       ];
+
   const CURRENT_REPORTS_TAB_INDEX = 0;
   const PAST_REPORTS_TAB_INDEX = 1;
   const ATTACHMENTS_TAB_INDEX = 2;
 
-  let pageTitle = "";
-  switch (activeTab) {
-    case CURRENT_REPORTS_TAB_INDEX:
-      pageTitle = `Reporting year ${reportingYearObj.reporting_year}`;
-      break;
-    case PAST_REPORTS_TAB_INDEX:
-      pageTitle = "Past Reports";
-      break;
-    case ATTACHMENTS_TAB_INDEX:
-      pageTitle = "Download Report Attachments";
-      break;
-    default:
-      pageTitle = "Reports";
-  }
+  const isCurrentReportsTab = activeTab === CURRENT_REPORTS_TAB_INDEX;
+
+  const getPageTitle = () => {
+    switch (activeTab) {
+      case CURRENT_REPORTS_TAB_INDEX:
+        return `Reporting year ${reportingYearData.reporting_year}`;
+      case PAST_REPORTS_TAB_INDEX:
+        return "Past Reports";
+      case ATTACHMENTS_TAB_INDEX:
+        return "Download Report Attachments";
+      default:
+        return "Reports";
+    }
+  };
+
+  const pageTitle = getPageTitle();
 
   return (
     <div className="py-4">
       <div className="flex flex-col">
-        {activeTab === CURRENT_REPORTS_TAB_INDEX && (
-          <div className="flex justify-between items-center">
-            <h2 className="text-2xl font-bold">{pageTitle}</h2>
-            {userRole.includes("industry_") && (
-              <h3 className="text-bc-text text-right">
-                Reports due May 31, {reportDueYearOnly}
-              </h3>
-            )}
-          </div>
-        )}
-        {activeTab !== CURRENT_REPORTS_TAB_INDEX && (
+        {isCurrentReportsTab && isIndustryUser ? (
+          <ReportingYearHeader
+            reportingYear={reportingYearData.reporting_year}
+            reportDueYear={reportingYearData.report_due_year}
+            variant="inline"
+          />
+        ) : (
           <h2 className="text-2xl font-bold">{pageTitle}</h2>
         )}
+
         <Tabs
           tabs={tabs}
           activeTab={activeTab}

--- a/bciers/apps/reporting/src/app/utils/getReportingYear.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportingYear.ts
@@ -1,14 +1,20 @@
 import { actionHandler } from "@bciers/actions";
+import dayjs from "dayjs";
 
 export const getReportingYear = async (): Promise<{
   reporting_year: number;
   report_due_date: string;
   reporting_window_end: string;
+  report_due_year: number;
 }> => {
   const endpoint = "reporting/reporting-year";
   const response = await actionHandler(endpoint, "GET");
   if (response.error) {
     throw new Error(`Failed to fetch the reporting for report year.`);
   }
-  return response;
+
+  return {
+    ...response,
+    report_due_year: dayjs(response.report_due_date).year(),
+  };
 };

--- a/bciers/apps/reporting/src/tests/components/operations/ReportsBasePage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/operations/ReportsBasePage.test.tsx
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { getSessionRole } from "@bciers/utils/src/sessionUtils";
+import ReportsBasePage from "@reporting/src/app/components/operations/ReportsBasePage";
+
+vi.mock("@bciers/utils/src/sessionUtils", () => ({
+  getSessionRole: vi.fn(),
+}));
+
+vi.mock("@bciers/actions", () => ({
+  actionHandler: vi.fn(() =>
+    Promise.resolve({
+      reporting_year: 2024,
+      report_due_date: "2025-05-31",
+      reporting_window_end: "2025-03-31",
+      report_due_year: 2025,
+    }),
+  ),
+}));
+
+describe("ReportsBasePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("For industry users", () => {
+    it("renders inline reporting year header for industry_user on current reports tab", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "industry_user",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 0,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      // Check for both h2 (reporting year) and h3 (due date) in inline variant
+      expect(
+        screen.getByRole("heading", { level: 2, name: /reporting year 2024/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", {
+          level: 3,
+          name: /reports due may 31, 2025/i,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders inline reporting year header for industry_user_admin on current reports tab", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "industry_user_admin",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 0,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      expect(
+        screen.getByRole("heading", { level: 2, name: /reporting year 2024/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", {
+          level: 3,
+          name: /reports due may 31, 2025/i,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders Past Reports title on past reports tab for industry users", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "industry_user",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 1,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      expect(
+        screen.getByRole("heading", { name: /past reports/i }),
+      ).toBeInTheDocument();
+      // Should not show the due date when not on current reports tab
+      expect(
+        screen.queryByText(/reports due may 31, 2025/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders correct tabs for industry users", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "industry_user",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 0,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      expect(
+        screen.getByRole("tab", { name: /view annual report\(s\)/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: /view past reports/i }),
+      ).toBeInTheDocument();
+      // Industry users should not see attachments tab
+      expect(
+        screen.queryByRole("tab", { name: /download report attachments/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("For internal users", () => {
+    it("renders regular page title for cas_admin on current reports tab", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "cas_admin",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 0,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      expect(
+        screen.getByRole("heading", { name: /reporting year 2024/i }),
+      ).toBeInTheDocument();
+      // Should not show the inline due date for internal users
+      expect(
+        screen.queryByRole("heading", { level: 3, name: /reports due/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders regular page title for cas_analyst on current reports tab", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "cas_analyst",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 0,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      expect(
+        screen.getByRole("heading", { name: /reporting year 2024/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders correct tabs for internal users including attachments", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "cas_admin",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 0,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      expect(
+        screen.getByRole("tab", { name: /view annual reports/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: /view past reports/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: /download report attachments/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders Download Report Attachments title for attachments tab", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "cas_admin",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 2,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      expect(
+        screen.getByRole("heading", {
+          name: /download report attachments/i,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders Past Reports title on past reports tab for internal users", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "cas_analyst",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 1,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      expect(
+        screen.getByRole("heading", { name: /past reports/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Children rendering", () => {
+    it("renders children content", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "cas_admin",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 0,
+          children: <div data-testid="child-content">Test Content</div>,
+        }),
+      );
+
+      expect(screen.getByTestId("child-content")).toBeInTheDocument();
+      expect(screen.getByText("Test Content")).toBeInTheDocument();
+    });
+  });
+
+  describe("Tab navigation", () => {
+    it("has correct href for current reports tab", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "industry_user",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 0,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      const tab = screen.getByRole("tab", {
+        name: /view annual report\(s\)/i,
+      });
+      expect(tab).toHaveAttribute("href", "/reports/current-reports");
+    });
+
+    it("has correct href for past reports tab", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "industry_user",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 0,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      const tab = screen.getByRole("tab", { name: /view past reports/i });
+      expect(tab).toHaveAttribute("href", "/reports/previous-years");
+    });
+
+    it("has correct href for attachments tab for internal users", async () => {
+      (getSessionRole as ReturnType<typeof vi.fn>).mockResolvedValue(
+        "cas_admin",
+      );
+
+      render(
+        await ReportsBasePage({
+          activeTab: 0,
+          children: <div>Test Children</div>,
+        }),
+      );
+
+      const tab = screen.getByRole("tab", {
+        name: /download report attachments/i,
+      });
+      expect(tab).toHaveAttribute("href", "/reports/attachments");
+    });
+  });
+});

--- a/bciers/libs/components/src/reporting/ReportingYearHeader.test.tsx
+++ b/bciers/libs/components/src/reporting/ReportingYearHeader.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ReportingYearHeader from "./ReportingYearHeader";
+
+describe("ReportingYearHeader", () => {
+  describe("Dashboard variant", () => {
+    it("renders the reporting year and due date in stacked layout", () => {
+      render(
+        <ReportingYearHeader
+          reportingYear={2024}
+          reportDueYear={2025}
+          variant="dashboard"
+        />,
+      );
+
+      expect(
+        screen.getByRole("heading", { name: /reporting year 2024/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/reports due/i)).toBeInTheDocument();
+      expect(screen.getByText(/may 31, 2025/i)).toBeInTheDocument();
+    });
+
+    it("renders without info box by default", () => {
+      render(
+        <ReportingYearHeader
+          reportingYear={2024}
+          reportDueYear={2025}
+          variant="dashboard"
+        />,
+      );
+
+      expect(
+        screen.queryByText(/ensure operation information is up to date/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders with info box when showInfoBox is true", () => {
+      render(
+        <ReportingYearHeader
+          reportingYear={2024}
+          reportDueYear={2025}
+          variant="dashboard"
+          showInfoBox={true}
+        />,
+      );
+
+      expect(
+        screen.getByText(/ensure operation information is up to date/i),
+      ).toBeInTheDocument();
+    });
+
+    it("renders info box with proper styling when enabled", () => {
+      const { container } = render(
+        <ReportingYearHeader
+          reportingYear={2024}
+          reportDueYear={2025}
+          variant="dashboard"
+          showInfoBox={true}
+        />,
+      );
+
+      const paper = container.querySelector(".MuiPaper-root");
+      expect(paper).toBeInTheDocument();
+
+      // Check for InfoIcon
+      const icon = container.querySelector('svg[data-testid="InfoIcon"]');
+      expect(icon).toBeInTheDocument();
+    });
+  });
+
+  describe("Inline variant", () => {
+    it("renders the reporting year and due date side by side", () => {
+      render(
+        <ReportingYearHeader
+          reportingYear={2024}
+          reportDueYear={2025}
+          variant="inline"
+        />,
+      );
+
+      const h2 = screen.getByRole("heading", {
+        level: 2,
+        name: /reporting year 2024/i,
+      });
+      const h3 = screen.getByRole("heading", {
+        level: 3,
+        name: /reports due may 31, 2025/i,
+      });
+
+      expect(h2).toBeInTheDocument();
+      expect(h3).toBeInTheDocument();
+    });
+
+    it("does not render info box in inline variant even if showInfoBox is true", () => {
+      render(
+        <ReportingYearHeader
+          reportingYear={2024}
+          reportDueYear={2025}
+          variant="inline"
+          showInfoBox={true}
+        />,
+      );
+
+      expect(
+        screen.queryByText(/ensure operation information is up to date/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("uses flex layout for inline variant", () => {
+      const { container } = render(
+        <ReportingYearHeader
+          reportingYear={2024}
+          reportDueYear={2025}
+          variant="inline"
+        />,
+      );
+
+      const wrapper = container.querySelector(".flex.justify-between");
+      expect(wrapper).toBeInTheDocument();
+    });
+  });
+
+  describe("Default behavior", () => {
+    it("uses dashboard variant by default", () => {
+      render(<ReportingYearHeader reportingYear={2024} reportDueYear={2025} />);
+
+      // Dashboard variant has a paragraph for due date
+      expect(screen.getByText(/reports due/i).tagName).toBe("P");
+    });
+
+    it("handles different year values correctly", () => {
+      render(
+        <ReportingYearHeader
+          reportingYear={2023}
+          reportDueYear={2024}
+          variant="dashboard"
+        />,
+      );
+
+      expect(
+        screen.getByRole("heading", { name: /reporting year 2023/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/may 31, 2024/i)).toBeInTheDocument();
+    });
+
+    it("handles future years correctly", () => {
+      render(
+        <ReportingYearHeader
+          reportingYear={2030}
+          reportDueYear={2031}
+          variant="inline"
+        />,
+      );
+
+      expect(
+        screen.getByRole("heading", { name: /reporting year 2030/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/may 31, 2031/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/bciers/libs/components/src/reporting/ReportingYearHeader.tsx
+++ b/bciers/libs/components/src/reporting/ReportingYearHeader.tsx
@@ -1,0 +1,62 @@
+import { Paper, Typography, Box } from "@mui/material";
+import InfoIcon from "@mui/icons-material/Info";
+import { BC_GOV_TEXT, LIGHT_BLUE_BG_COLOR } from "@bciers/styles";
+
+interface ReportingYearHeaderProps {
+  reportingYear: number;
+  reportDueYear: number;
+  /**
+   * Layout variant:
+   * - "dashboard": Title and due date stacked, with info box below
+   * - "inline": Title and due date side-by-side (for reports page)
+   */
+  variant?: "dashboard" | "inline";
+  /**
+   * Show the info box about keeping operation information up to date
+   */
+  showInfoBox?: boolean;
+}
+
+export default function ReportingYearHeader({
+  reportingYear,
+  reportDueYear,
+  variant = "dashboard",
+  showInfoBox = false,
+}: ReportingYearHeaderProps) {
+  if (variant === "inline") {
+    return (
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">Reporting year {reportingYear}</h2>
+        <h3 className="text-bc-text text-right">
+          Reports due May 31, {reportDueYear}
+        </h3>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <h2 className="text-2xl font-bold">Reporting year {reportingYear}</h2>
+      <p className="text-bc-text text-left">
+        Reports due <b>May 31, {reportDueYear}</b>
+      </p>
+      {showInfoBox && (
+        <Paper
+          sx={{
+            p: 2,
+            mb: 3,
+            bgcolor: LIGHT_BLUE_BG_COLOR,
+            color: BC_GOV_TEXT,
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center" }}>
+            <InfoIcon sx={{ mr: 1 }} />
+            <Typography variant="body2">
+              Ensure operation information is up to date before reporting.
+            </Typography>
+          </Box>
+        </Paper>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-registration/issues/3756

**Changes:-** 
1. Created a reusable ReportingYearHeader component.
2. Integrated the component into the BCIERS Dashboard and Reporting Dashboard (ReportsBasePage).
3. Updated the getReportingYear functionality.
4. Added unit tests for ReportingYearHeader and ReportsBasePage.
5. Updated existing Dashboard tests.

**How to test:**
1. Navigate to: http://localhost:3000/dashboard
2. You should see:
     - Reporting Year
     - Reports Due Date
     - reminder to ensure operation info is updated before reporting