### PR TITLE
fix: add newRecord field to sub-account creation payload

### DIFF
--- a/bc_obps/compliance/service/bc_carbon_registry/schema.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/schema.py
@@ -278,3 +278,4 @@ class SubAccountPayload(BaseModel):
     transfer_approval_required: Optional[bool] = True
     disable_outgoing_transfer: Optional[bool] = False
     terms_conditions: Optional[bool] = True
+    newRecord: Optional[bool] = True


### PR DESCRIPTION
Added a new field to the payload used for creating sub-accounts in BCCR.