### PR TITLE
Bug: Outstanding balance is incorrect when previous CRV requires manual handling #418

### DIFF
--- a/bc_obps/compliance/service/supplementary_version_service.py
+++ b/bc_obps/compliance/service/supplementary_version_service.py
@@ -45,7 +45,7 @@ class SupplementaryScenarioHandler(Protocol):
         ...
 
 
-# Concrete strategy for flagging compliance report versions as requiring manual handling when the previous version also required manual handling. (There are too many variables in how a version can be manually handled in ways that the app is not aware of, so we can't really safely and accurately predict how to handle any subsequent child versions once a version has been closed via actions outside of the app.)
+# Concrete strategy for flagging compliance report versions as requiring manual handling and having 0 excess anad credited emissions when the previous version also required manual handling. (There are too many variables in how a version can be manually handled in ways that the app is not aware of, so we can't really safely and accurately predict how to handle any subsequent child versions once a version has been closed via actions outside of the app.)
 class ManualHandler:
     @staticmethod
     def can_handle(new_summary: ReportComplianceSummary, previous_summary: ReportComplianceSummary) -> bool:

--- a/bc_obps/compliance/tests/service/test_supplementary_version_service.py
+++ b/bc_obps/compliance/tests/service/test_supplementary_version_service.py
@@ -667,7 +667,6 @@ class TestManualHandler(BaseSupplementaryVersionServiceTest):
         assert result.compliance_report == self.compliance_report
         assert result.report_compliance_summary == self.new_summary
         assert result.status == ComplianceReportVersion.ComplianceStatus.NO_OBLIGATION_OR_EARNED_CREDITS
-        # brianna?
         assert result.excess_emissions_delta_from_previous == Decimal('0')
         assert result.credited_emissions_delta_from_previous == Decimal('0')
         assert result.is_supplementary is True


### PR DESCRIPTION
card: https://github.com/bcgov/cas-compliance/issues/418

This PR:
- creates a new manual handling handler that checks if the previous version was handled manually. If so, all subsequent versions are flagged for manual handling too
- pytest for the new handler