### PR TITLE
3990 improved access to reporting grid

### DIFF
--- a/bc_obps/registration/api/_user_operators/_current/has_registered_operation.py
+++ b/bc_obps/registration/api/_user_operators/_current/has_registered_operation.py
@@ -32,6 +32,13 @@ def get_current_user_operator_has_registered_operation(request: HttpRequest) -> 
             return 200, {"has_registered_operation": False}
         # Use the service to check if the operator has a registered operation
         has_registered_operation = OperationDataAccessService.check_current_users_registered_operation(operator.id)
+        if not has_registered_operation:
+            has_any_current_operation = OperationDataAccessService.check_current_users_any_current_operation(
+                operator.id
+            )
+            had_operation = OperationDataAccessService.check_current_users_past_operations(operator.id)
+            # If the user has no current associated operation but DID previously have an operation, they are considered registered
+            return 200, {"has_registered_operation": had_operation and not has_any_current_operation}
         return 200, {"has_registered_operation": has_registered_operation}
     except ObjectDoesNotExist:
         # Handle the case where no user_operator is found for the user

--- a/bc_obps/reporting/api/validate_user_reporting_access.py
+++ b/bc_obps/reporting/api/validate_user_reporting_access.py
@@ -45,6 +45,12 @@ def validate_user_reporting_access(request: HttpRequest, report_version_id: Opti
     )
 
     if not has_reporting_registered_operation:
+        has_any_current_operation = OperationDataAccessService.check_current_users_any_current_operation(operator.id)
+        had_past_operation = OperationDataAccessService.check_current_users_past_operations(operator.id)
+        # If the user has no current associated operation but DID used to have an operation, they are considered registered
+        if not has_any_current_operation and had_past_operation:
+            return {"status": UserStatusEnum.REGISTERED.value}
+
         return {"status": UserStatusEnum.NOT_REGISTERED.value}
 
     # If no report_version_id provided, return just the registration status

--- a/bc_obps/service/data_access_service/operation_service.py
+++ b/bc_obps/service/data_access_service/operation_service.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from registration.models import Operation, User, RegulatedProduct, Activity
 from ninja.types import DictStrAny
 from django.db.models import QuerySet
+from registration.models.operation_designated_operator_timeline import OperationDesignatedOperatorTimeline
 from service.user_operator_service import UserOperatorService
 
 
@@ -59,6 +60,20 @@ class OperationDataAccessService:
             .exclude(registration_purpose=Operation.Purposes.POTENTIAL_REPORTING_OPERATION)
             .exists()
         )
+
+    @classmethod
+    def check_current_users_any_current_operation(cls, operator_id: UUID) -> bool:
+        """
+        Returns True if the userOperator's operator has at least one operation in any status.
+        """
+        return Operation.objects.filter(operator_id=operator_id).exists()
+
+    @classmethod
+    def check_current_users_past_operations(cls, operator_id: UUID) -> bool:
+        """
+        Returns True if the userOperator's operator has had at least one operation in their timeline.
+        """
+        return OperationDesignatedOperatorTimeline.objects.filter(operator_id=operator_id).exists()
 
     @classmethod
     def create_operation(


### PR DESCRIPTION
Card: #3990 

This PR addresses the specific issue of an operator who has transferred their only operation away, and is now unable to access the report grid to see or continue their report.

### Changes
Middleware that gates access to the reporting grid checks to make sure the operator has at least one Registered Operation. Edge case handling has been added where, if 0 operations are associated with an operator BUT the operator did have an operation in their timeline, then return as if it has a Registered Operation. This preserves the function of the middleware outside of this edge case.

#### Alternative handling
A discussion among the Owl Team led us to the conclusion that the best strategy might be to just remove the check for a Registered Operation altogether, so that any user can access the reporting grid, even if it is empty. Implementing this would be very straightforward:
 - remove the ```conditions``` for the Reporting dashboard links from the dashboard fixtures external.json
 - remove withRuleHasRegisteredOperation from the reporting middleware stack
 I decided to preserve the current design which points users towards Registration before Reporting, but as the alternative implementation is so simple, we could make that choice at any time.

### Testing

Testing requires a user that is an approved user_operator for an operator that:
 - has very few (preferably one) operations. We want a small number of operations because we will need to transfer all operations away from the operator.
 - has started or can start a 2024 report.

#### Local testing
1. Login to the app with your IDIR, complete your profile, and hit 'Submit'
2. Log out of your IDIR account.
3. In a local terminal, run ```psql registration```
4. Run the following SQL commands. Make sure to replace {**your_name**} with your first name in the first line.
```sql
-- update your internal user to cas_analyst so you can perform transfers
UPDATE erc.user SET app_role_id='cas_analyst' WHERE first_name='**your_name**';

-- update bc-cas-dev-secondary to be associated with Charlie Operator
UPDATE erc."user"
SET business_guid='438eff6c-d2e7-40ab-8220-29d3a86ef314'::uuid, bceid_business_name='Charlie Solutions - name from admin'
WHERE user_guid='279c80cf-5781-4c28-8727-40a133d17c0d'::uuid;

-- make bc-cas-dev-secondary an approved user_operator for Charlie
INSERT INTO erc.user_operator
(created_at, updated_at, archived_at, id, "role", status, verified_at, archived_by_id, created_by_id, operator_id, updated_by_id, user_id, verified_by_id, user_friendly_id)
VALUES('2025-11-20 14:49:22.865', NULL, NULL, 'da7d182b-2ca6-4703-b1ec-aa4bd9b5e6b7'::uuid, 'admin', 'Approved', '2024-02-26 06:24:57.293', NULL, NULL, '438eff6c-d2e7-40ab-8220-29d3a86ef314'::uuid, NULL, '279c80cf-5781-4c28-8727-40a133d17c0d'::uuid, 'ba2ba62a-1218-42e0-942a-ab9e92ce8822'::uuid, 5);

-- create a new BORO ID 
INSERT INTO erc.bc_obps_regulated_operation
(id, issued_at, "comments", status, issued_by_id)
VALUES('24-0042', '2024-10-13 08:27:00.000', 'Test comment', 'Active', NULL);

-- Update the Cat LFO Operation with the new BORO ID
UPDATE erc.operation
SET bc_obps_regulated_operation_id='24-0042'
WHERE id='b35a2095-80e6-4b75-990e-ccf19a57edfa'::uuid;
```
These statements:
a) give your IDIR the cas_analyst role so it can perform transfers
b) update the BCEID bc-cas-dev-secondary to be an approved user_operator for Charlie Solutions, an operator with just one operation
c) create and assign a BORO ID to Cat LFO, because it is needed to submit a report
5. Log in to the app as bc-cas-dev-secondary (the password can be found in 1Password)
6. Click on 'View Annual Reports' to access the reporting grid
7. Next to 'Cat LFO', click ```Start``` to create a report
8. Proceed through the report, filling in fields required to progress.
**Note: when you get to the 'Review Facilities' page, you will need to follow the ```Add it here``` link to Administration to add a facility. For ease, below are some valid coordinates for your new facility.
Valid latitude = 51
Valid longitude = -128
9. On the 'Report Information' page, you can mark your new facility as 'Completed' and hit 'Save and Continue'
10. Complete all verification, uploads, and document scans needed to complete submission validation.
11. You can Submit the report at this point. Or you can submit it after the transfer.
12. Log out as bc-cas-dev-secondary
13. Log in using your IDIR
14. Click 'Transfer an operation or facility'
15. For ```Current Operator```, select 'Charlie Solutions'. For ```Select the new operator```, pick 'Bravo Enterprises'.
16. Select the 'operation' radio button and 'Cat LFO' for the operation. Make the effective date yesterday.
17. Click 'Transfer Entity'
18. Log out as your internal user.
19. Log back in as bc-cas-dev-secondary
 -- Expect to see the Dashboard with links to the reporting grids
20. Click on 'View Annual Reports'
 -- Expect to see the reporting grid for the current year
21. You can test all the actions now like creating, submitting, or deleting a supplemental report
NOTE: If you did not finish submitting the report, and you DELETE the draft, you will not be able to start a new report