### PR TITLE
316 - remove data_is_fresh from endpoints that don't need it

### DIFF
--- a/bc_obps/compliance/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/compliance_units.py
+++ b/bc_obps/compliance/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/compliance_units.py
@@ -9,7 +9,6 @@ from compliance.service.bc_carbon_registry.schema import FifteenDigitString
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from registration.schema.generic import Message
 from compliance.constants import COMPLIANCE
-from compliance.service.elicensing.elicensing_data_refresh_service import ElicensingDataRefreshService
 from compliance.api.permissions import approved_industry_user_compliance_report_version_composite_auth
 
 
@@ -60,14 +59,8 @@ def apply_compliance_units(
     # Determine if the user can still apply more units
     can_apply_compliance_units = ApplyComplianceUnitsService.can_apply_compliance_units(compliance_report_version_id)
 
-    # Get the data_is_fresh flag
-    refresh_result = ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id(
-        compliance_report_version_id=compliance_report_version_id
-    )
-
     # Return flags in response
     return 200, {
         "success": True,
         "can_apply_compliance_units": can_apply_compliance_units,
-        "data_is_fresh": refresh_result.data_is_fresh,
     }

--- a/bc_obps/compliance/api/_bccr/_compliance_report_versions/_compliance_report_version_id/applied_compliance_units.py
+++ b/bc_obps/compliance/api/_bccr/_compliance_report_versions/_compliance_report_version_id/applied_compliance_units.py
@@ -8,7 +8,6 @@ from compliance.service.bc_carbon_registry.apply_compliance_units_service import
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from registration.schema.generic import Message
 from compliance.constants import COMPLIANCE
-from compliance.service.elicensing.elicensing_data_refresh_service import ElicensingDataRefreshService
 from compliance.api.permissions import approved_industry_user_compliance_report_version_composite_auth
 
 
@@ -32,13 +31,7 @@ def get_applied_compliance_units(
     # Determine if the user can still apply more units
     can_apply_compliance_units = ApplyComplianceUnitsService.can_apply_compliance_units(compliance_report_version_id)
 
-    # Get the data_is_fresh flag
-    refresh_result = ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id(
-        compliance_report_version_id=compliance_report_version_id
-    )
-
     return 200, {
         "applied_compliance_units": [asdict(unit) for unit in applied_compliance_units_data],
         "can_apply_compliance_units": can_apply_compliance_units,
-        "data_is_fresh": refresh_result.data_is_fresh,
     }

--- a/bc_obps/compliance/api/_compliance_report_versions/_compliance_report_version_id/_obligation/payments.py
+++ b/bc_obps/compliance/api/_compliance_report_versions/_compliance_report_version_id/_obligation/payments.py
@@ -23,6 +23,6 @@ def get_compliance_obligation_payments_by_compliance_report_version_id(
         compliance_report_version_id=compliance_report_version_id
     )
     response = ElicensingPaymentListOut(
-        data_is_fresh=payment_data.data_is_fresh, rows=list(payment_data.data), row_count=len(payment_data.data)  # type: ignore [arg-type] # Mypy does not recognize queryset as iterable. Function is working as expected
+        rows=list(payment_data), row_count=len(payment_data)  # type: ignore [arg-type] # Mypy does not recognize queryset as iterable. Function is working as expected
     )
     return 200, response

--- a/bc_obps/compliance/api/_compliance_report_versions/_compliance_report_version_id/obligation.py
+++ b/bc_obps/compliance/api/_compliance_report_versions/_compliance_report_version_id/obligation.py
@@ -32,9 +32,8 @@ def get_obligation_by_compliance_report_version_id(
     obligation_data = ComplianceObligationService.get_obligation_data_by_report_version(compliance_report_version_id)
 
     payment_data = ElicensingPaymentListOut(
-        data_is_fresh=payments.data_is_fresh,
-        rows=list(payments.data),  # type: ignore [arg-type] # Mypy does not recognize queryset as iterable. Function is working as expected
-        row_count=len(payments.data),
+        rows=list(payments),  # type: ignore [arg-type] # Mypy does not recognize queryset as iterable. Function is working as expected
+        row_count=len(payments),
     )
 
     response = ObligationWithPaymentsOut(

--- a/bc_obps/compliance/api/_compliance_report_versions/_compliance_report_version_id/penalty.py
+++ b/bc_obps/compliance/api/_compliance_report_versions/_compliance_report_version_id/penalty.py
@@ -30,7 +30,6 @@ def get_penalty_by_compliance_report_version_id(
     )
 
     payment_data = ElicensingPaymentListOut(
-        data_is_fresh=penalty_with_payments_data["payments_is_fresh"],
         rows=list(penalty_with_payments_data["payments"]),
         row_count=len(penalty_with_payments_data["payments"]),
     )
@@ -38,7 +37,6 @@ def get_penalty_by_compliance_report_version_id(
     penalty_with_payments = PenaltyWithPaymentsOut(
         outstanding_amount=penalty_with_payments_data["outstanding_amount"],
         penalty_status=penalty_with_payments_data["penalty_status"],
-        data_is_fresh=penalty_with_payments_data["data_is_fresh"],
         payment_data=payment_data,
     )
 

--- a/bc_obps/compliance/dataclass.py
+++ b/bc_obps/compliance/dataclass.py
@@ -1,8 +1,7 @@
 from decimal import Decimal
 from dataclasses import dataclass, field
 from typing import Literal, Optional, List, TypedDict
-from django.db.models import QuerySet
-from compliance.models import ElicensingPayment, ElicensingInvoice
+from compliance.models import ElicensingInvoice
 
 
 @dataclass
@@ -69,10 +68,6 @@ class BCCRComplianceAccountResponseDetails:
 
 
 ## Elicensing Dataclasses
-@dataclass
-class PaymentDataWithFreshnessFlag:
-    data_is_fresh: bool
-    data: QuerySet[ElicensingPayment]
 
 
 @dataclass
@@ -114,7 +109,6 @@ class ObligationData:
     obligation_id: str
     penalty_status: str
     fee_amount_dollars: Optional[Decimal]
-    data_is_fresh: bool
 
 
 @dataclass

--- a/bc_obps/compliance/schema/apply_compliance_units.py
+++ b/bc_obps/compliance/schema/apply_compliance_units.py
@@ -31,7 +31,6 @@ class AppliedComplianceUnitsOut(Schema):
 
     applied_compliance_units: List[AppliedComplianceUnit]
     can_apply_compliance_units: bool
-    data_is_fresh: bool
 
 
 class ApplyComplianceUnitsOut(Schema):

--- a/bc_obps/compliance/schema/automatic_overdue_penalty.py
+++ b/bc_obps/compliance/schema/automatic_overdue_penalty.py
@@ -6,7 +6,6 @@ from typing import Any
 
 class _PenaltyStatusBase(Schema):
     penalty_status: str
-    data_is_fresh: bool
 
     @staticmethod
     def resolve_penalty_status(obj: Any) -> str:

--- a/bc_obps/compliance/schema/compliance_obligation.py
+++ b/bc_obps/compliance/schema/compliance_obligation.py
@@ -22,5 +22,4 @@ class ObligationWithPaymentsOut(Schema):
     equivalent_value: Decimal
     obligation_id: str
     penalty_status: str
-    data_is_fresh: bool
     payment_data: ElicensingPaymentListOut

--- a/bc_obps/compliance/schema/elicensing_payments.py
+++ b/bc_obps/compliance/schema/elicensing_payments.py
@@ -20,6 +20,5 @@ class ElicensingPaymentOut(ModelSchema):
 
 
 class ElicensingPaymentListOut(Schema):
-    data_is_fresh: bool
     rows: List[ElicensingPaymentOut]
     row_count: int

--- a/bc_obps/compliance/schema/late_submission_penalty.py
+++ b/bc_obps/compliance/schema/late_submission_penalty.py
@@ -14,7 +14,6 @@ class LateSubmissionPenaltyOut(Schema):
     penalty_amount: Decimal
     faa_interest: Decimal
     total_amount: Decimal
-    data_is_fresh: bool
 
     @staticmethod
     def resolve_penalty_status(obj: Any) -> str:

--- a/bc_obps/compliance/service/compliance_obligation_service.py
+++ b/bc_obps/compliance/service/compliance_obligation_service.py
@@ -195,7 +195,7 @@ class ComplianceObligationService:
             ComplianceObligation.DoesNotExist: If no obligation exists for the compliance report version
         """
         # Refresh elicensing data before accessing it
-        refreshed_data = ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id(
+        ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id(
             compliance_report_version_id=compliance_report_version_id
         )
 
@@ -222,5 +222,4 @@ class ComplianceObligationService:
             obligation_id=obligation.obligation_id,
             penalty_status=obligation.penalty_status,
             fee_amount_dollars=obligation.fee_amount_dollars,
-            data_is_fresh=refreshed_data.data_is_fresh,
         )

--- a/bc_obps/compliance/service/penalty_calculation_service.py
+++ b/bc_obps/compliance/service/penalty_calculation_service.py
@@ -73,7 +73,6 @@ class PenaltyCalculationService:
             "total_penalty": penalty.penalty_amount,
             "faa_interest": faa_interest,
             "total_amount": total_amount,
-            "data_is_fresh": refresh_result.data_is_fresh,
         }
 
     @classmethod
@@ -94,7 +93,6 @@ class PenaltyCalculationService:
                 - penalty_amount: Total penalty amount
                 - faa_interest: FAA interest amount (currently 0.00)
                 - total_amount: Total amount including FAA interest
-                - data_is_fresh: Flag indicating if data is fresh from eLicensing API
         """
         refresh_result = ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id(
             compliance_report_version_id=compliance_report_version_id
@@ -114,7 +112,6 @@ class PenaltyCalculationService:
                 "penalty_amount": Decimal('0.00'),
                 "faa_interest": Decimal('0.00'),
                 "total_amount": Decimal('0.00'),
-                "data_is_fresh": refresh_result.data_is_fresh,
             }
 
         penalty_amount = late_submission_penalty.penalty_amount
@@ -128,7 +125,6 @@ class PenaltyCalculationService:
             "penalty_amount": penalty_amount,
             "faa_interest": faa_interest,
             "total_amount": total_amount,
-            "data_is_fresh": refresh_result.data_is_fresh,
         }
 
     @classmethod
@@ -258,7 +254,6 @@ class PenaltyCalculationService:
                 - total_penalty: Total penalty from eLicensing
                 - faa_interest: FAA interest from eLicensing
                 - total_amount: Total penalty including FAA interest
-                - data_is_fresh: Flag indicating if the data is fresh from the eLicensing API
         """
         refresh_result = ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id(
             compliance_report_version_id=obligation.compliance_report_version_id
@@ -335,7 +330,6 @@ class PenaltyCalculationService:
             "total_penalty": total_penalty,
             "faa_interest": faa_interest,
             "total_amount": total_amount,
-            "data_is_fresh": refresh_result.data_is_fresh,
         }
 
         # Format all Decimal values to 2 decimal places

--- a/bc_obps/compliance/service/penalty_summary_service.py
+++ b/bc_obps/compliance/service/penalty_summary_service.py
@@ -23,17 +23,14 @@ class PenaltySummaryService:
             Dict with the following keys:
             - outstanding_amount (Decimal): Remaining penalty after applying all penalty payments.
             - penalty_status (str): Current penalty status from penalty calculation data.
-            - data_is_fresh (bool): Whether the penalty calculation data is up to date.
-            - payments_is_fresh (bool): Whether the payment data is up to date.
             - payments (QuerySet[ElicensingPayment]): Payments associated with the penalty invoice.
         """
         penalty_data = PenaltyCalculationService.get_automatic_overdue_penalty_data(compliance_report_version_id)
 
-        payments_wrapper = ComplianceDashboardService.get_penalty_payments_by_compliance_report_version_id(
+        payments = ComplianceDashboardService.get_penalty_payments_by_compliance_report_version_id(
             compliance_report_version_id=compliance_report_version_id
         )
 
-        payments = payments_wrapper.data
         payments_sum: Decimal = payments.aggregate(total=Sum("amount"))["total"] or Decimal("0.00")
 
         outstanding_amount: Decimal = penalty_data["total_amount"] - payments_sum
@@ -41,7 +38,5 @@ class PenaltySummaryService:
         return {
             "outstanding_amount": outstanding_amount,
             "penalty_status": penalty_data["penalty_status"],
-            "data_is_fresh": penalty_data["data_is_fresh"],
-            "payments_is_fresh": payments_wrapper.data_is_fresh,
             "payments": payments,
         }

--- a/bc_obps/compliance/tests/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/test_compliance_units.py
+++ b/bc_obps/compliance/tests/api/_bccr/_accounts/_account_id/_compliance_report_versions/_compliance_report_version_id/test_compliance_units.py
@@ -198,7 +198,6 @@ class TestComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoi
         response_data = response.json()
         assert response_data["success"] is True
         assert response_data["can_apply_compliance_units"] is True
-        assert response_data["data_is_fresh"] is True
 
         # Verify service calls
         mock_apply_compliance_units.assert_called_once_with(
@@ -274,7 +273,6 @@ class TestComplianceUnitsEndpoint(SimpleTestCase):  # Use SimpleTestCase to avoi
         response_data = response.json()
         assert response_data["success"] is True
         assert response_data["can_apply_compliance_units"] is True
-        assert response_data["data_is_fresh"] is True
 
         # Verify service call
         mock_apply_compliance_units.assert_called_once_with(

--- a/bc_obps/compliance/tests/api/_bccr/_compliance_report_versions/_compliance_report_version_id/test_applied_compliance_units.py
+++ b/bc_obps/compliance/tests/api/_bccr/_compliance_report_versions/_compliance_report_version_id/test_applied_compliance_units.py
@@ -60,7 +60,6 @@ class TestAppliedComplianceUnitsEndpoint(SimpleTestCase):
                 }
             ],
             "can_apply_compliance_units": True,
-            "data_is_fresh": True,
         }
 
     @patch(ELICENSING_DATA_REFRESH_WRAPPER_PATH)
@@ -79,7 +78,6 @@ class TestAppliedComplianceUnitsEndpoint(SimpleTestCase):
         assert response.json() == {
             "applied_compliance_units": [],
             "can_apply_compliance_units": False,
-            "data_is_fresh": True,
         }
 
     @patch(SERVICE_PATH)

--- a/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/_obligation/test_payments.py
+++ b/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/_obligation/test_payments.py
@@ -12,7 +12,7 @@ class TestComplianceObligationPaymentsEndpoint(CommonTestSetup):
         # Arrange: Create a mock payment record
         payment = make_recipe('compliance.tests.utils.elicensing_payment', amount=200, received_date="2024-05-01")
 
-        mock_get_payments.return_value = type("MockResponse", (), {"data": [payment], "data_is_fresh": True})
+        mock_get_payments.return_value = [payment]
 
         # Mock authorization
         operator = make_recipe('registration.tests.utils.operator')
@@ -37,7 +37,6 @@ class TestComplianceObligationPaymentsEndpoint(CommonTestSetup):
         assert response.status_code == 200
         response_data = response.json()
 
-        assert response_data["data_is_fresh"] is True
         assert response_data["row_count"] == 1
         assert isinstance(response_data["rows"], list)
         assert response_data["rows"][0]["amount"] == "200"  # Decimal gets serialized as string

--- a/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/test_automatic_overdue_penalty.py
+++ b/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/test_automatic_overdue_penalty.py
@@ -29,7 +29,6 @@ class TestAutomaticOverduePenaltyEndpoint(CommonTestSetup):
             "total_penalty": Decimal("38656.43"),
             "faa_interest": Decimal("0.00"),
             "total_amount": Decimal("38656.43"),
-            "data_is_fresh": True,
         }
         mock_get_automatic_overdue_penalty_data.return_value = penalty_data
 
@@ -64,4 +63,3 @@ class TestAutomaticOverduePenaltyEndpoint(CommonTestSetup):
         assert response_data["total_penalty"] == "38656.43"
         assert response_data["faa_interest"] == "0.00"
         assert response_data["total_amount"] == "38656.43"
-        assert response_data["data_is_fresh"]

--- a/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/test_late_submission_penalty.py
+++ b/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/test_late_submission_penalty.py
@@ -24,7 +24,6 @@ class TestLateSubmissionPenaltyEndpoint(CommonTestSetup):
             "penalty_amount": Decimal("15000.00"),
             "faa_interest": Decimal("0.00"),
             "total_amount": Decimal("15000.00"),
-            "data_is_fresh": True,
         }
         mock_get_late_submission_penalty_data.return_value = penalty_data
 
@@ -56,4 +55,3 @@ class TestLateSubmissionPenaltyEndpoint(CommonTestSetup):
         assert response_data["penalty_amount"] == "15000.00"
         assert response_data["faa_interest"] == "0.00"
         assert response_data["total_amount"] == "15000.00"
-        assert response_data["data_is_fresh"]

--- a/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/test_obligation.py
+++ b/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/test_obligation.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from model_bakery.baker import make_recipe
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.utils import custom_reverse_lazy
-from compliance.dataclass import ObligationData, PaymentDataWithFreshnessFlag
+from compliance.dataclass import ObligationData
 from compliance.models import ElicensingPayment
 
 VALIDATE_VERSION_OWNERSHIP_PATH = "compliance.api.permissions._validate_version_ownership_in_url"
@@ -39,14 +39,10 @@ class TestObligationByComplianceReportVersionEndpoint(CommonTestSetup):
             fee_amount_dollars=Decimal("40000.00"),
             obligation_id="23-0001-1-1",
             penalty_status="NONE",
-            data_is_fresh=True,
         )
         mock_get_obligation_data.return_value = mock_obligation_data
 
-        mock_payment_data = PaymentDataWithFreshnessFlag(
-            data_is_fresh=True,
-            data=ElicensingPayment.objects.none(),
-        )
+        mock_payment_data = ElicensingPayment.objects.none()
         mock_get_payment_data.return_value = mock_payment_data
 
         # Act
@@ -64,8 +60,6 @@ class TestObligationByComplianceReportVersionEndpoint(CommonTestSetup):
         assert response_data["outstanding_balance"] == "1000.00"
         assert response_data["equivalent_value"] == "40000.00"
         assert response_data["obligation_id"] == "23-0001-1-1"
-        assert response_data["data_is_fresh"] is True
-        assert response_data["payment_data"]["data_is_fresh"] is True
         assert response_data["payment_data"]["rows"] == []
         assert response_data["payment_data"]["row_count"] == 0
 
@@ -95,14 +89,10 @@ class TestObligationByComplianceReportVersionEndpoint(CommonTestSetup):
             fee_amount_dollars=Decimal("0.00"),
             obligation_id="23-0001-1-1",
             penalty_status="NONE",
-            data_is_fresh=True,
         )
         mock_get_obligation_data.return_value = mock_obligation_data
 
-        mock_payment_data = PaymentDataWithFreshnessFlag(
-            data_is_fresh=True,
-            data=ElicensingPayment.objects.none(),
-        )
+        mock_payment_data = ElicensingPayment.objects.none()
         mock_get_payment_data.return_value = mock_payment_data
 
         # Act
@@ -143,14 +133,10 @@ class TestObligationByComplianceReportVersionEndpoint(CommonTestSetup):
             fee_amount_dollars=Decimal("39999999.60"),
             obligation_id="24-0999-999-999",
             penalty_status="NONE",
-            data_is_fresh=True,
         )
         mock_get_obligation_data.return_value = mock_obligation_data
 
-        mock_payment_data = PaymentDataWithFreshnessFlag(
-            data_is_fresh=True,
-            data=ElicensingPayment.objects.none(),
-        )
+        mock_payment_data = ElicensingPayment.objects.none()
         mock_get_payment_data.return_value = mock_payment_data
 
         # Act

--- a/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/test_penalty.py
+++ b/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/test_penalty.py
@@ -24,8 +24,6 @@ class TestPenaltyByComplianceReportVersionEndpoint(CommonTestSetup):
         mock_get_summary.return_value = {
             "outstanding_amount": Decimal("38656.43"),
             "penalty_status": "Accruing",
-            "data_is_fresh": True,
-            "payments_is_fresh": True,
             "payments": ElicensingPayment.objects.none(),
         }
 
@@ -52,8 +50,6 @@ class TestPenaltyByComplianceReportVersionEndpoint(CommonTestSetup):
         data = response.json()
         assert data["outstanding_amount"] == "38656.43"
         assert data["penalty_status"] == "Accruing"
-        assert data["data_is_fresh"]
-        assert data["payment_data"]["data_is_fresh"]
         assert data["payment_data"]["row_count"] == 0
         assert data["payment_data"]["rows"] == []
 

--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_apply_compliance_units_service.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_apply_compliance_units_service.py
@@ -200,7 +200,6 @@ class TestApplyComplianceUnitsService:
             fee_amount_dollars=Decimal("3000.00"),
             obligation_id="23-0001-1-1",
             penalty_status="NONE",
-            data_is_fresh=True,
         )
         mock_get_obligation_data.return_value = mock_obligation_data
 

--- a/bc_obps/compliance/tests/service/test_compliance_dashboard_service.py
+++ b/bc_obps/compliance/tests/service/test_compliance_dashboard_service.py
@@ -83,9 +83,8 @@ class TestComplianceDashboardService:
         returned_data = ComplianceDashboardService.get_compliance_obligation_payments_by_compliance_report_version_id(
             compliance_report_version_id=obligation.compliance_report_version_id
         )
-        assert returned_data.data_is_fresh == True  # noqa: E712
-        assert returned_data.data.first() == payment_1
-        assert returned_data.data.last() == payment_2
+        assert returned_data.first() == payment_1
+        assert returned_data.last() == payment_2
 
     def test_get_penalty_payments_by_compliance_report_version_id(self, mock_refresh):
         """Test retrieval of penalty payments linked to a compliance report version"""
@@ -116,9 +115,8 @@ class TestComplianceDashboardService:
             compliance_report_version_id=penalty.compliance_obligation.compliance_report_version_id
         )
 
-        assert returned_data.data_is_fresh == True  # noqa: E712
-        assert returned_data.data.first() == payment_1
-        assert returned_data.data.last() == payment_2
+        assert returned_data.first() == payment_1
+        assert returned_data.last() == payment_2
 
     def test_get_compliance_report_versions_for_dashboard_excludes_versions_correctly(
         self,

--- a/bc_obps/compliance/tests/service/test_compliance_obligation_service.py
+++ b/bc_obps/compliance/tests/service/test_compliance_obligation_service.py
@@ -254,7 +254,6 @@ class TestComplianceObligationService:
         )
         assert result.equivalent_value == Decimal('2000.00')  # This is the outstanding balance in dollars
         assert result.obligation_id == "23-0001-1-1"
-        assert result.data_is_fresh
 
         # Verify refresh was called
         mock_refresh_data.assert_called_once_with(compliance_report_version_id=compliance_report_version.id)

--- a/bc_obps/compliance/tests/service/test_penalty_calculation_service.py
+++ b/bc_obps/compliance/tests/service/test_penalty_calculation_service.py
@@ -307,7 +307,6 @@ class TestPenaltyCalculationService:
             "total_penalty": Decimal("1000000.00"),
             "faa_interest": Decimal("0"),
             "total_amount": Decimal("1000000.00"),
-            "data_is_fresh": True,
         }
 
     @patch(
@@ -356,7 +355,6 @@ class TestPenaltyCalculationService:
         assert result["penalty_amount"] == Decimal("15000.00")
         assert result["faa_interest"] == Decimal("0.00")
         assert result["total_amount"] == Decimal("15000.00")
-        assert result["data_is_fresh"] is True
 
     @patch(
         'compliance.service.elicensing.elicensing_data_refresh_service.ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id'
@@ -379,7 +377,6 @@ class TestPenaltyCalculationService:
         assert result["penalty_amount"] == Decimal("0.00")
         assert result["faa_interest"] == Decimal("0.00")
         assert result["total_amount"] == Decimal("0.00")
-        assert result["data_is_fresh"] is True
 
     @patch(
         'compliance.service.elicensing.elicensing_data_refresh_service.ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id'

--- a/bciers/apps/compliance/src/app/types.ts
+++ b/bciers/apps/compliance/src/app/types.ts
@@ -125,7 +125,6 @@ export interface Payment {
 }
 
 export interface PaymentData {
-  data_is_fresh?: boolean;
   rows: Payment[];
   row_count: number;
 }
@@ -137,7 +136,6 @@ export interface ObligationData {
   obligation_id: string;
   payment_data: PaymentData;
   penalty_status?: string;
-  data_is_fresh?: string;
 }
 
 export interface PayObligationTrackPaymentsFormData extends ObligationData {
@@ -197,7 +195,6 @@ export interface AutomaticOverduePenalty {
   total_penalty: string;
   faa_interest: string;
   total_amount: string;
-  data_is_fresh: boolean;
 }
 
 export interface LateSubmissionPenalty {
@@ -207,13 +204,11 @@ export interface LateSubmissionPenalty {
   penalty_amount: string;
   faa_interest: string;
   total_amount: string;
-  data_is_fresh: boolean;
 }
 
 export interface PenaltyData {
   outstanding_amount: string;
   penalty_status: string;
-  data_is_fresh: boolean;
   payment_data: PaymentData;
 }
 

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/automatic-overdue-penalty/pay-penalty-track-payments/PenaltyPaymentStatusNote.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/automatic-overdue-penalty/pay-penalty-track-payments/PenaltyPaymentStatusNote.test.tsx
@@ -35,8 +35,7 @@ describe("PenaltyPaymentStatusNote", () => {
   ) => ({
     outstanding_amount,
     penalty_status,
-    data_is_fresh: true,
-    payment_data: { data_is_fresh: true, rows: [], row_count: 0 },
+    payment_data: { rows: [], row_count: 0 },
     payments: [],
   });
 

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/automatic-overdue-penalty/pay-penalty-track-payments/PenaltyTrackPaymentsComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/automatic-overdue-penalty/pay-penalty-track-payments/PenaltyTrackPaymentsComponent.test.tsx
@@ -30,9 +30,7 @@ const baseData = {
   reporting_year: 2024,
   outstanding_amount: "2500.0",
   penalty_status: PenaltyStatus.ACCRUING,
-  data_is_fresh: true,
   payment_data: {
-    data_is_fresh: true,
     rows: [
       {
         id: 1,

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/automatic-overdue-penalty/pay-penalty-track-payments/PenaltyTrackPaymentsPayPage.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/automatic-overdue-penalty/pay-penalty-track-payments/PenaltyTrackPaymentsPayPage.test.tsx
@@ -63,7 +63,6 @@ describe("PenaltyTrackPaymentsPayPage", () => {
     equivalent_value: 500.0,
     penalty_id: "test-penalty-id",
     payment_data: {
-      data_is_fresh: true,
       rows: [
         {
           id: 1,
@@ -136,7 +135,6 @@ describe("PenaltyTrackPaymentsPayPage", () => {
       equivalent_value: 500.0,
       penalty_id: "test-penalty-id",
       payment_data: {
-        data_is_fresh: true,
         rows: [
           {
             id: 1,

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/automatic-overdue-penalty/review-penalty-summary/PenaltySummaryReviewComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/automatic-overdue-penalty/review-penalty-summary/PenaltySummaryReviewComponent.test.tsx
@@ -68,7 +68,6 @@ const mockData = {
   total_penalty: "1100.00",
   faa_interest: "50.00",
   total_amount: "1000.00",
-  data_is_fresh: true,
 };
 
 // Mocks

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/ggeapar-interest/review-interest-summary/InterestSummaryReviewComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/ggeapar-interest/review-interest-summary/InterestSummaryReviewComponent.test.tsx
@@ -14,7 +14,6 @@ const mockData = {
   penalty_amount: "100.00",
   faa_interest: "10.00",
   total_amount: "110.00",
-  data_is_fresh: true,
 };
 
 describe("InterestSummaryReviewComponent", () => {

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsPayPage.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsPayPage.test.tsx
@@ -63,7 +63,6 @@ describe("ObligationTrackPaymentsPayPage", () => {
     obligation_id: "test-obligation-id",
     penalty_status: "NONE",
     payment_data: {
-      data_is_fresh: true,
       rows: [
         {
           id: 1,
@@ -130,7 +129,6 @@ describe("ObligationTrackPaymentsPayPage", () => {
       obligation_id: "test-obligation-id",
       penalty_status: "NONE",
       payment_data: {
-        data_is_fresh: true,
         rows: [
           {
             id: 1,

--- a/docs/compliance/refresh_elicensing_data.md
+++ b/docs/compliance/refresh_elicensing_data.md
@@ -18,19 +18,19 @@ The e-licensing refresh service (bc_obps/compliance/service/elicensing/elicensin
 
 ## Example Usage
 
-If a service requires e-licensing data, it should first call the wrapper & save the boolean return value to a variable. The service should then fetch the required data from the BCIERS models & return the data along with the boolean flag to the API. The flag can in turn be passed to the frontend where a message can be displayed if the communication with e-licensing was not successful.
+If a service requires e-licensing data, it should call the wrapper to refresh the data in order to get the most recent invoice. The service should then fetch the required data from the BCIERS models & return the data to the API. A flag is returned indicating if the update is unsuccessful, but it should not be passed to the frontend for a message to be displayed per endpoint, this is done with shared layout ElicensingStaleDataAlert.
 
 Example (get payments for an obligation)
 
 ```python
 def get_compliance_obligation_payments_by_compliance_report_version_id(
         cls, compliance_report_version_id: int
-    ) -> PaymentDataWithFreshnessFlag:
+    ) -> QuerySet[ElicensingPayment]:
 
         refreshed_data = ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id(
             compliance_report_version_id=compliance_report_version_id
         )
-        payments = ElicensingPayment.objects.filter(elicensing_line_item__elicensing_invoice=refreshed_data.invoice)
-
-        return PaymentDataWithFreshnessFlag(data_is_fresh=refreshed_data.data_is_fresh, data=payments)
+        return ElicensingPayment.objects.select_related('elicensing_line_item').filter(
+            elicensing_line_item__elicensing_invoice=refreshed_data.invoice
+        )
 ```


### PR DESCRIPTION
removed data_is_fresh (and payments_is_fresh) from:
- Payments endpoint etc...
- Obligations endpoint etc...
- Apply Compliance Units endpoint etc...

left it in anything related to the refresh wrapper since it still needs it