### PR TITLE
chore: add missing formatting 'f'

### DIFF
--- a/bc_obps/compliance/service/elicensing_invoice_service.py
+++ b/bc_obps/compliance/service/elicensing_invoice_service.py
@@ -93,7 +93,7 @@ class ElicensingInvoiceService:
                 {
                     'date': f'{DATE_TODAY}',
                     'description': 'FAA Interest',
-                    'amount': '${invoice.invoice_interest_balance:,.2f}',
+                    'amount': f'${invoice.invoice_interest_balance:,.2f}',
                 }
             )
             amount_due += invoice.invoice_interest_balance


### PR DESCRIPTION
Missed an 'f' when formatting an interpolated python string.

Was:
<img width="953" height="148" alt="image" src="https://github.com/user-attachments/assets/81ac0719-e9ad-40ad-98bf-b611e84a8dce" />

Fixed:
<img width="1061" height="617" alt="Screenshot from 2025-11-25 13-51-15" src="https://github.com/user-attachments/assets/7d4162f9-7900-4c7a-8b3e-8a038d9901ad" />
