### PR TITLE
chore: fixed activity selection

### DIFF
--- a/bc_obps/service/report_service.py
+++ b/bc_obps/service/report_service.py
@@ -110,8 +110,13 @@ class ReportService:
                 report_version__id=report_version_id
             )
             for f in facility_reports:
-                # Activities are not removed from the facility report for LFOs, this is done on the facility
-                FacilityReportService.add_activities_to_facility_report(facility_report=f, activities=data.activities)
+                # For LFOs, only set activities if the facility doesn't have any yet (initial setup)
+                # This prevents overwriting user-selected activities at the facility level
+                if not f.activities.exists():
+                    FacilityReportService.add_activities_to_facility_report(
+                        facility_report=f, activities=data.activities
+                    )
+                # Always update regulated products
                 FacilityReportService.prune_report_product_data_for_facility_report(
                     facility_report=f, regulated_products=data.regulated_products
                 )


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/863
**Changes** 
1. **service/report_service.py**
       - Added conditional check if not f.activities.exists() before setting activities on LFO facilities
       - Regulated products continue to be updated on all saves (as intended)
2. **service/tests/test_report_service.py**
       - Renamed and updated test_lfo_does_not_update_facility_activities_if_facility_already_has_activities to verify that existing facility activities are NOT overwritten
      - Added new test test_lfo_sets_initial_activities_for_facility_without_activities to verify that initial activities ARE set for facilities without activities
      
      
      
**To Test**
**Test Case 1:** Initial Setup (Should set activities)
1. Create a new report for an LFO
2. On Review Operation Information page, select activity (e.g., "GSC excluding line tracing")
3. Click "Save & Continue"
4. Navigate to Review Facilities
5. Select a facility and click "Continue"
6. Expected: The facility should have the operation-level activity pre-selected

**Test Case 2:** Facility Customization Preserved (Bug Fix)
1. On the Review Facility Information page, deselect the default activity
2. Select a different activity (e.g., "Aluminum or alumina production")
3. Click "Save"
4. Navigate back to Review Operation Information page
5. Click "Save & Continue"
6. Navigate back to the facility
7. Expected: Only "Aluminum or alumina production" should be selected (NOT both activities)
8. Before Fix: Both "GSC excluding line tracing" and "Aluminum or alumina production" would be selected

**Test Case 3:** SFO Behavior Unchanged
1. Create/open a report for an SFO
2. On Review Operation Information page, change activities
3. Click "Save & Continue"
4. Expected: SFO facility activities should always sync with operation activities (existing behavior)

**Test Case 4:** Multiple Facilities
1. For an LFO with multiple facilities
2. Customize activities differently on each facility
3. Go back to operation page and save
4. Expected: Each facility should retain its custom activities