### PR TITLE
chore: Improve CI by not fetching the whole git history

### DIFF
--- a/.github/workflows/build-administration.yaml
+++ b/.github/workflows/build-administration.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Build administration container
         uses: ./.github/actions/nx-app-build
         with:

--- a/.github/workflows/build-compliance-e2e.yaml
+++ b/.github/workflows/build-compliance-e2e.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Build compliance container
         uses: ./.github/actions/nx-app-build
         with:

--- a/.github/workflows/build-compliance.yaml
+++ b/.github/workflows/build-compliance.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Build compliance container
         uses: ./.github/actions/nx-app-build
         with:

--- a/.github/workflows/build-dashboard-e2e.yaml
+++ b/.github/workflows/build-dashboard-e2e.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Build dashboard container
         uses: ./.github/actions/nx-app-build
         with:

--- a/.github/workflows/build-dashboard.yaml
+++ b/.github/workflows/build-dashboard.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Build dashboard container
         uses: ./.github/actions/nx-app-build
         with:

--- a/.github/workflows/build-registration.yaml
+++ b/.github/workflows/build-registration.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Build registration container
         uses: ./.github/actions/nx-app-build
         with:

--- a/.github/workflows/build-reporting.yaml
+++ b/.github/workflows/build-reporting.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Build reporting container
         uses: ./.github/actions/nx-app-build
         with:


### PR DESCRIPTION
- Saving 2 minutes by not fetching the entire Git history when building the apps