### PR TITLE
fix: 453 add min width to invoice column to fix the dancing issue

### DIFF
--- a/bciers/apps/compliance/src/app/components/datagrid/models/elicensingInvoices/elicensingInvoiceColumns.tsx
+++ b/bciers/apps/compliance/src/app/components/datagrid/models/elicensingInvoices/elicensingInvoiceColumns.tsx
@@ -21,6 +21,7 @@ const elicensingInvoiceColumns = (isInternalUser: boolean): GridColDef[] => {
     {
       field: "operation_name",
       headerName: "Operation Name",
+      minWidth: 160,
       flex: 1,
     },
     {


### PR DESCRIPTION
[ISSUE 453](https://github.com/bcgov/cas-compliance/issues/453)

Having `flex: 1` on all columns makes the table unstable, because it tries to adjust the columns responsively, and this can cause a loop where two columns compete for width. Adding a `minWidth` to one of the columns makes the table more stable by ensuring at least one column cannot shrink below a specified width.