### PR TITLE
379 add e2e for compliance earned credits

### DIFF
--- a/bciers/.gitignore
+++ b/bciers/.gitignore
@@ -37,6 +37,7 @@ testem.log
 # e2e
 playwright-report
 test-results
+blob-report
 
 # System Files
 .DS_Store

--- a/bciers/apps/compliance-e2e/poms/compliance-summaries.ts
+++ b/bciers/apps/compliance-e2e/poms/compliance-summaries.ts
@@ -69,29 +69,34 @@ export class ComplianceSummariesPOM {
 
   /**
    * Click an action link in the compliance summaries grid for a given operation
-   * and optionally assert the resulting URL and a UI element on the target page.
+   * and optionally assert the resulting URL.
    */
   async openActionForOperation(options: {
     operationName: string;
     linkName: string | RegExp;
     urlPattern?: string | RegExp;
   }) {
-    const { operationName, linkName } = options;
+    const { operationName, linkName, urlPattern } = options;
 
+    // Find the row for this operation
     const row = await this.getRowByOperationName(operationName);
 
+    // Find the action link within that row
     const actionLink = row.getByRole("link", { name: linkName });
     await expect(actionLink).toBeVisible();
 
+    // Get the href from the link
     const href = await actionLink.getAttribute("href");
 
-    if (!href) {
-      throw new Error("Manage Obligation action link has no href");
-    }
+    // Build absolute URL
+    const targetUrl = new URL(href, this.url).toString();
 
-    const targetUrl =
-      (process.env.E2E_BASEURL ?? "http://localhost:3000") + href;
-
+    // Navigate explicitly instead of relying on client-side routing
     await this.page.goto(targetUrl, { waitUntil: "load" });
+
+    // Optionally assert URL
+    if (urlPattern) {
+      await expect(this.page).toHaveURL(urlPattern);
+    }
   }
 }

--- a/bciers/apps/compliance-e2e/poms/manage-obligation/tasklist.ts
+++ b/bciers/apps/compliance-e2e/poms/manage-obligation/tasklist.ts
@@ -19,7 +19,6 @@ export class ManageObligationTaskListPOM {
       "i",
     );
 
-    // Task list items are MUI ListItemButton → role="button"
     const button = this.page.getByRole("button", { name: labelRegex });
 
     await expect(button).toBeVisible();

--- a/bciers/apps/compliance-e2e/poms/request-issuance/review-compliance-earned-credits.ts
+++ b/bciers/apps/compliance-e2e/poms/request-issuance/review-compliance-earned-credits.ts
@@ -1,0 +1,26 @@
+import { Locator, Page, expect } from "@playwright/test";
+import { ISSUANCE_STATUS_FIELD } from "@/compliance-e2e/utils/constants";
+
+export class ReviewComplianceEarnedCreditsPOM {
+  constructor(private readonly page: Page) {}
+
+  /**
+   * Assert that the issuance_status field has value.
+   */
+
+  get issuanceStatusField(): Locator {
+    return this.page.locator(ISSUANCE_STATUS_FIELD);
+  }
+
+  async getIssuanceStatusText(): Promise<string> {
+    await this.issuanceStatusField.waitFor();
+    const text = (await this.issuanceStatusField.textContent()) ?? "";
+    return text.trim();
+  }
+
+  async assertIssuanceStatusValue(expected: string) {
+    await expect(this.issuanceStatusField).toBeVisible();
+    const text = await this.getIssuanceStatusText();
+    await expect(text).toBe(expected);
+  }
+}

--- a/bciers/apps/compliance-e2e/poms/request-issuance/tasklist.ts
+++ b/bciers/apps/compliance-e2e/poms/request-issuance/tasklist.ts
@@ -1,0 +1,28 @@
+import { Page, expect } from "@playwright/test";
+import { ComplianceTaskTitles } from "@/compliance-e2e/utils/enums";
+import { REQUEST_ISSUANCE_CREDITS_URL_PATTERN } from "@/compliance-e2e/utils/constants";
+
+export class RequestIssuanceTaskListPOM {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /**
+   * Clicks the "Request Issuance of Earned Credits" task list item
+   * and waits for the URL to reach the route.
+   */
+  async clickRequestIssuance() {
+    const labelRegex = new RegExp(ComplianceTaskTitles.REQUEST_ISSUANCE, "i");
+
+    const button = this.page.getByRole("button", { name: labelRegex });
+
+    await expect(button).toBeVisible();
+
+    await Promise.all([
+      this.page.waitForURL(REQUEST_ISSUANCE_CREDITS_URL_PATTERN),
+      button.click(),
+    ]);
+  }
+}

--- a/bciers/apps/compliance-e2e/tests/workflows/manage-obligation/report-compliance-obligation.spec.ts
+++ b/bciers/apps/compliance-e2e/tests/workflows/manage-obligation/report-compliance-obligation.spec.ts
@@ -28,12 +28,7 @@ test.describe("Test compliance report version manage obligation flow", () => {
     const gridComplianceSummaries = new ComplianceSummariesPOM(page);
     await gridComplianceSummaries.route();
 
-    // Assert the compliance report version record exists with the expected Operation Name
-    await gridComplianceSummaries.getRowByOperationName(
-      ComplianceOperations.OBLIGATION_NOT_MET,
-    );
-
-    // Assert the record has expected status
+    // Assert the compliance report version record exists and has expected status
     await gridComplianceSummaries.assertStatusForOperation(
       ComplianceOperations.OBLIGATION_NOT_MET,
       ComplianceDisplayStatus.OBLIGATION_NOT_MET,

--- a/bciers/apps/compliance-e2e/tests/workflows/request-issuance/report-compliance-earned-credits.spec.ts
+++ b/bciers/apps/compliance-e2e/tests/workflows/request-issuance/report-compliance-earned-credits.spec.ts
@@ -1,0 +1,50 @@
+import { setupBeforeAllTest } from "@bciers/e2e/setupBeforeAll";
+import { UserRole } from "@bciers/e2e/utils/enums";
+import {
+  ComplianceOperations,
+  ComplianceDisplayStatus,
+  GridActionText,
+} from "@/compliance-e2e/utils/enums";
+import { CurrentReportsPOM } from "@/reporting-e2e/poms/current-reports";
+import { ComplianceSummariesPOM } from "@/compliance-e2e/poms/compliance-summaries";
+import { ReviewComplianceEarnedCreditsPOM } from "@/compliance-e2e/poms/request-issuance/review-compliance-earned-credits";
+import { RequestIssuanceTaskListPOM } from "@/compliance-e2e/poms/request-issuance/tasklist";
+
+// 👤 run test using the storageState for role UserRole.INDUSTRY_USER_ADMIN
+const test = setupBeforeAllTest(UserRole.INDUSTRY_USER_ADMIN);
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Test compliance report version request issuance of earned credits flow", () => {
+  test("creates a compliance report version for an earned-credits report", async ({
+    page,
+  }) => {
+    // Submit the report for "Earned credits"
+    const gridReportingReports = new CurrentReportsPOM(page);
+    await gridReportingReports.submitReportEarnedCredits();
+
+    // Navigate to the compliance summaries grid
+    const gridComplianceSummaries = new ComplianceSummariesPOM(page);
+    await gridComplianceSummaries.route();
+
+    // Assert the compliance report version record exists and has expected status
+    await gridComplianceSummaries.assertStatusForOperation(
+      ComplianceOperations.EARNED_CREDITS,
+      ComplianceDisplayStatus.EARNED_CREDITS,
+    );
+
+    // Open the "Request Issuance" action for that operation
+    await gridComplianceSummaries.openActionForOperation({
+      operationName: ComplianceOperations.EARNED_CREDITS,
+      linkName: GridActionText.REQUEST_ISSUANCE_CREDITS,
+    });
+
+    // Assert the record has an issuance status
+    const reviewCompliance = new ReviewComplianceEarnedCreditsPOM(page);
+    await reviewCompliance.assertIssuanceStatusValue("Issuance not requested");
+
+    // From the Request Issuance task list, click "Request Issuance of Earned Credits"
+    const taskListManageObligation = new RequestIssuanceTaskListPOM(page);
+    await taskListManageObligation.clickRequestIssuance();
+  });
+});

--- a/bciers/apps/compliance-e2e/utils/constants.ts
+++ b/bciers/apps/compliance-e2e/utils/constants.ts
@@ -8,12 +8,19 @@ export const TEST_SIGNATURE_NAME = "Test Signer";
 export const SUBMISSION_SUCCESS_TEXT = "Successful Submission";
 
 export const INVOICE_NUMBER_FIELD = "#root_invoice_number";
+export const ISSUANCE_STATUS_FIELD =
+  'xpath=//label[@for="root_issuance_status"]/../following-sibling::div//span';
 
 export const COMPLIANCE_SUMMARIES_BASE_PATH =
   "/compliance/compliance-administration/compliance-summaries";
 
-export const REVIEW_OBLIGATION_URL_PATTERN = `${COMPLIANCE_SUMMARIES_BASE_PATH}/\\d+/review-compliance-obligation-report$`;
-
+export const REVIEW_OBLIGATION_URL_PATTERN = new RegExp(
+  `${COMPLIANCE_SUMMARIES_BASE_PATH}/\\d+/review-compliance-obligation-report$`,
+);
 export const DOWNLOAD_PAYMENT_INSTRUCTIONS_URL_PATTERN = new RegExp(
   `${COMPLIANCE_SUMMARIES_BASE_PATH}/\\d+/download-payment-instructions$`,
+);
+
+export const REQUEST_ISSUANCE_CREDITS_URL_PATTERN = new RegExp(
+  `${COMPLIANCE_SUMMARIES_BASE_PATH}/\\d+/request-issuance-of-earned-credits$`,
 );

--- a/bciers/apps/compliance-e2e/utils/enums.ts
+++ b/bciers/apps/compliance-e2e/utils/enums.ts
@@ -18,6 +18,7 @@ export enum ComplianceDisplayStatus {
 
 export enum ComplianceTaskTitles {
   DOWNLOAD_PAYMENT_INSTRUCTIONS = "Download Payment Instructions",
+  REQUEST_ISSUANCE = "Request Issuance of Earned Credits",
 }
 
 // Grid Columns
@@ -27,6 +28,7 @@ export enum ComplianceSummariesGridHeaders {
 
 // Grid Action Text
 export enum GridActionText {
+  REQUEST_ISSUANCE_CREDITS = "Request Issuance of Credits",
   MANAGE_OBLIGATION = "Manage Obligation",
   VIEW_DETAILS = "View Details",
   CONTACT_US = "Contact Us",


### PR DESCRIPTION
Addresses: 
[379](https://github.com/bcgov/cas-compliance/issues/379)

### 🚀 Impact:

- Adds happy path for non-supplementary report generates earned credits compliance report

**Note:** 

CI possibly failing with similar report submit bug [4057](https://github.com/bcgov/cas-reporting/issues/939):

<img width="1053" height="691" alt="image" src="https://github.com/user-attachments/assets/6f5c5b8f-00c6-40bd-b095-d7c4a39a3b73" />
