### PR TITLE
chore: manually updated filelock version to 3.20.1

### DIFF
--- a/bc_obps/.tool-versions
+++ b/bc_obps/.tool-versions
@@ -1,3 +1,3 @@
-python 3.14.2
+python 3.12.11
 poetry 2.1.1
 postgres 16.2


### PR DESCRIPTION
- manual update of `filelock` because dependabot had issues