### PR TITLE
chore: make schemaspy action callable from other actions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,6 +1,5 @@
-# This workflow builds and tests nightly on the `develop` branch. Scheduled jobs always run on the default branch, which is `develop` in our case.
-
 name: nightly
+# This workflow builds and tests nightly on the `develop` branch. Scheduled jobs always run on the default branch, which is `develop` in our case.
 
 on:
   schedule:

--- a/.github/workflows/schemaspy.yaml
+++ b/.github/workflows/schemaspy.yaml
@@ -1,6 +1,7 @@
 name: SchemaSpy
 on:
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR is a fix to let the Schemaspy workflow be callable from the Nightly build workflow. 