### PR TITLE
chore: remove schemaspy action from nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -127,9 +127,6 @@ jobs:
     with:
       zap_fail_on_risk_level: 3
     secrets: inherit
-  schemaspy:
-    uses: ./.github/workflows/schemaspy.yaml
-    secrets: inherit
   trivy:
     uses: ./.github/workflows/trivy.yaml
   codeql:


### PR DESCRIPTION
Removes schemaspy from the `nightly` workflow. After discussion in teams, it would be better to run it at a different cadence (probably weekly).