### PR TITLE
chore: reduce size of gh_pages branch

### DIFF
--- a/.github/workflows/schemaspy.yaml
+++ b/.github/workflows/schemaspy.yaml
@@ -80,3 +80,4 @@ jobs:
         with:
           folder: output
           target-folder: schemaspy
+          single-commit: true


### PR DESCRIPTION
use the single-commit flag when deploying to the gh_pages branch as per the github action [documentation](https://github.com/JamesIves/github-pages-deploy-action) to only keep the latest commit & remove the existing history