### PR TITLE
chore: resolve vulnerability CVE-2025-15284

### DIFF
--- a/bciers/package.json
+++ b/bciers/package.json
@@ -148,5 +148,8 @@
     "vitest": "^4.0.16",
     "vitest-fetch-mock": "^0.4.5"
   },
-  "packageManager": "yarn@4.2.0"
+  "packageManager": "yarn@4.2.0",
+  "resolutions": {
+    "qs": "^6.14.1"
+  }
 }

--- a/bciers/yarn.lock
+++ b/bciers/yarn.lock
@@ -15426,12 +15426,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.13.0, qs@npm:^6.4.0":
-  version: 6.13.0
-  resolution: "qs@npm:6.13.0"
+"qs@npm:^6.14.1":
+  version: 6.14.1
+  resolution: "qs@npm:6.14.1"
   dependencies:
-    side-channel: "npm:^1.0.6"
-  checksum: 10c0/62372cdeec24dc83a9fb240b7533c0fdcf0c5f7e0b83343edd7310f0ab4c8205a5e7c56406531f2e47e1b4878a3821d652be4192c841de5b032ca83619d8f860
+    side-channel: "npm:^1.1.0"
+  checksum: 10c0/0e3b22dc451f48ce5940cbbc7c7d9068d895074f8c969c0801ac15c1313d1859c4d738e46dc4da2f498f41a9ffd8c201bd9fb12df67799b827db94cc373d2613
   languageName: node
   linkType: hard
 
@@ -16791,7 +16791,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.6, side-channel@npm:^1.1.0":
+"side-channel@npm:^1.1.0":
   version: 1.1.0
   resolution: "side-channel@npm:1.1.0"
   dependencies:


### PR DESCRIPTION
Vulnerability: CVE-2025-15284 - High severity DoS vulnerability in qs package (arrayLimit bypass)                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                          
Root cause: `qs@6.13.0` was a transitive dependency pulled in by `body-parser`, `express`, and `union`. Dependabot couldn't fix it automatically because these packages hadn't updated their qs dependency yet.                                                                                                                 
                                                                                                                                                                                                                                                                                                                          
Solution: Added a Yarn resolution in package.json to force all instances of qs to use the patched version `6.14.1`