### PR TITLE
chore: added print instructions

### DIFF
--- a/bciers/libs/components/src/downloadPDFButton/DownloadPdfButton.test.tsx
+++ b/bciers/libs/components/src/downloadPDFButton/DownloadPdfButton.test.tsx
@@ -14,7 +14,7 @@ describe("DownloadPdfButton", () => {
     expect(button).toBeVisible();
     expect(button).toHaveTextContent("Save as PDF");
 
-    // description contains the browser print hint
+    // description contains the browser print/savePDF hint
     expect(screen.getByText(/Or use your browser/i)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
**Card:** https://github.com/bcgov/cas-reporting/issues/772

**Changes:**
- Created a reusable PDF-print button component:libs/components/src/savePDFButton/DownloadPdfButton.tsx
- Added the button to reporting pages:
   - apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx — added savePdfButton
   - apps/reporting/src/app/components/submitted/ReportForm.tsx — added DownloadPdfButton
- added tests

**To test:-**
1. Submitted Page 
    - Open: http://localhost:5000/reporting/reports/6/submitted
    - Confirm a "Save as PDF" / "Print" button appears near the top of the report and clicking it opens the browser print dialog.

2. Final Review Page
    - Open: http://localhost:5000/reporting/reports/9/final-review
    - Confirm the button appears and clicking it opens the print dialog.