### PR TITLE
chore: fixed report start error

### DIFF
--- a/bciers/apps/reporting/src/app/components/changeReview/templates/ReasonForChange.tsx
+++ b/bciers/apps/reporting/src/app/components/changeReview/templates/ReasonForChange.tsx
@@ -12,14 +12,13 @@ const ReasonForChangeForm: React.FC<ReasonForChangeProps> = ({
   reasonForChange,
   onReasonChange,
 }) => {
-  const borderColor = DARK_GREY_BG_COLOR;
   const styles: React.CSSProperties = {
     width: "100%",
     padding: "8px",
     fontSize: "16px",
     fontFamily: "BCSans, sans-serif",
     borderRadius: "4px",
-    border: `1px solid ${borderColor}`,
+    border: `1px solid ${DARK_GREY_BG_COLOR}`,
     backgroundColor: "white",
     resize: "vertical",
   };

--- a/bciers/apps/reporting/src/app/components/operations/cells/ActionCell.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/cells/ActionCell.tsx
@@ -52,20 +52,22 @@ const ActionCell: React.FC<ActionCellProps> = ({ row, isReportingOpen }) => {
   };
 
   const handleStartClick = async () => {
+    setHasClicked(true); // Disable button immediately to prevent duplicate clicks
+    let newReportVersionId: string | number | null;
     if (reportId) {
       // create a new report version
-      const newReportVersionId = await handleNewDraftVersion();
+      newReportVersionId = await handleNewDraftVersion();
       setReportVersionId(newReportVersionId);
     } else {
       // create a new report
       const reportingYearObj = await getReportingYear();
-      const newReportVersionId = await handleStartReport(
+      newReportVersionId = await handleStartReport(
         reportingYearObj.reporting_year,
       );
       setReportVersionId(newReportVersionId);
     }
-    if (typeof reportVersionId === "number")
-      router.push(`${reportVersionId}/review-operation-information`);
+    if (newReportVersionId)
+      router.push(`${newReportVersionId}/review-operation-information`);
   };
 
   // Show "Available Soon" for all actions if reporting is not open
@@ -118,7 +120,9 @@ const ActionCell: React.FC<ActionCellProps> = ({ row, isReportingOpen }) => {
       onClick={async () => {
         setHasClicked(true);
         await buttonAction();
-        setHasClicked(false);
+        if (buttonText !== "Start") {
+          setHasClicked(false);
+        }
       }}
     >
       {buttonText}


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/956

When a user clicked the "Start" button in the ActionCell component, it would send a request to create a new report. However, if the user clicked the button multiple times before the navigation completed, it would send duplicate requests to create reports for the same operation and reporting year. This caused an error:
`We couldn't create a report for operation ID 'ef9044dd-2a27-4d26-86fe-02e51e0755f7' and reporting year '2025': A report already exists for this operation and year, unable to create a new one.`

**Root Cause:**
The button's onClick handler was setting hasClicked to true to disable the button, but then resetting it back to false after the button action completed. This meant that during the async operation (creating the report and navigating), if a user clicked the button again quickly, it could trigger duplicate report creation requests.

**Solution:**
- Added setHasClicked(true) at the beginning of handleStartClick to immediately disable the button when the Start action is triggered
- Modified the button's onClick handler to only reset hasClicked to false for "Continue" and "View Details" actions, but keep it true for the "Start" action
- This ensures the "Start" button remains disabled after the first click, preventing duplicate report creation requests