### PR TITLE
chore: trigger main github workflow for merge queue

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches: [develop, main]
   workflow_dispatch:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Addresses #4193.
Adds an action trigger to the Main workflow that runs when a PR is added to the merge queue.