### PR TITLE
fix: add merge_group sha to happo skip

### DIFF
--- a/.github/workflows/test-nx-project-e2e.yaml
+++ b/.github/workflows/test-nx-project-e2e.yaml
@@ -171,7 +171,7 @@ jobs:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
           HAPPO_PROJECT: cas-${{ inputs.nx_project }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: |
           cd bciers
           node libs/e2e/src/utils/happo-skip.js


### PR DESCRIPTION
Should fix merge queue failures due to happo.