### PR TITLE
chore: fix error with timeline fixtures in test environment

### DIFF
--- a/bc_obps/registration/fixtures/test/operation_designated_operator_timeline.json
+++ b/bc_obps/registration/fixtures/test/operation_designated_operator_timeline.json
@@ -6,7 +6,7 @@
       "created_at": "2024-06-05T23:20:41.567Z",
       "operation": "ebc45617-ae4c-4c76-ab36-5a59c3aef407",
       "operator": "3068caa0-25cd-4e48-aa4d-167acf1ecd3f",
-      "start_date": "2024-06-05T23:20:40Z"
+      "start_date": "2021-06-05T23:20:40Z"
     }
   },
   {
@@ -86,7 +86,7 @@
       "created_at": "2024-06-05T23:20:41.567Z",
       "operation": "1f045617-ae4c-4c76-ab36-5a59c3aef407",
       "operator": "3068caa0-25cd-4e48-aa4d-167acf1ecd3f",
-      "start_date": "2024-06-05T23:20:40Z"
+      "start_date": "2021-06-05T23:20:40Z"
     }
   },
   {


### PR DESCRIPTION
There are reports with reporting year < 2024 in the test fixtures...not sure why. But when a recent change added a check on the ownership via the timeline, our fixtures showed ownership started at 2024. Updating a couple of the timeline fixtures to start in 2021 fixes the issue.