### PR TITLE
535 Update report-compliance fixtures

### DIFF
--- a/bc_obps/reporting/fixtures/mock/report.json
+++ b/bc_obps/reporting/fixtures/mock/report.json
@@ -25,8 +25,8 @@
       "id": 3,
       "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488f",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
-      "created_at": "2025-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2024
+      "created_at": "2026-05-28 20:09:05.41476+00",
+      "reporting_year_id": 2025
     }
   },
   {
@@ -35,8 +35,8 @@
       "id": 4,
       "operation_id": "84ea41f0-4039-44d8-9f91-0e1d5fd47930",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
-      "created_at": "2025-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2024
+      "created_at": "2026-05-28 20:09:05.41476+00",
+      "reporting_year_id": 2025
     }
   },
   {
@@ -45,8 +45,8 @@
       "id": 5,
       "operation_id": "3f47b2e1-9a4c-4d3f-8b21-7e9a0c5d2f6b",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
-      "created_at": "2025-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2024
+      "created_at": "2026-05-28 20:09:05.41476+00",
+      "reporting_year_id": 2025
     }
   },
   {


### PR DESCRIPTION
Resolves https://github.com/bcgov/cas-compliance/issues/353

### 🚀 Impact:
- Updates compliance type report versions to 2025 reporting year for compliance period 2025:
    - Compliance SFO – Obligation not met – name from admin
    - Compliance SFO – Earned credits – name from admin
    - Compliance SFO – No obligation or earned credits – name from admin


###  📝 Note:

Currently, in develop branch, submitting report `Compliance SFO - Obligation not met`,  creates a compliance report version for compliance period **2024**.
<img width="1695" height="771" alt="image" src="https://github.com/user-attachments/assets/6f2092aa-73fa-4dca-bb4a-032acc7da21d" />


---

## 🔬 Local Testing:  

#### Start Test Environment
1. Start the API server:  
   ```sh
   cd bc_obps
   make prepare_backend
   ```  
2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

---


####  Submit an obligation report
1. Log in using `bc-cas-dev`
2. For report `Compliance SFO - Obligation not met`, navigate to http://localhost:3000/reporting/reports/3/sign-off
3. Complete the form
4. Click Submit
**Expected results:**  
- Form submits
5. Navigate to compliance http://localhost:3000/compliance/compliance-administration/compliance-summaries
**Expected results:**  
- One record for `Compliance SFO - Obligation not met`
- Compliance period =**2025**
<img width="1695" height="771" alt="image" src="https://github.com/user-attachments/assets/50ccc47e-9673-4f72-8f86-def0e0ba90aa" />



---
