### PR TITLE
chore: updated facility report save

### DIFF
--- a/bc_obps/service/report_service.py
+++ b/bc_obps/service/report_service.py
@@ -122,12 +122,7 @@ class ReportService:
                 report_version__id=report_version_id
             )
             for f in facility_reports:
-                # For LFOs, only set activities if the facility doesn't have any yet (initial setup)
-                # This prevents overwriting user-selected activities at the facility level
-                if not f.activities.exists():
-                    FacilityReportService.add_activities_to_facility_report(
-                        facility_report=f, activities=data.activities
-                    )
+                FacilityReportService.set_activities_for_facility_report(facility_report=f, activities=data.activities)
                 # Always update regulated products
                 FacilityReportService.prune_report_product_data_for_facility_report(
                     facility_report=f, regulated_products=data.regulated_products


### PR DESCRIPTION
**Card:** https://github.com/bcgov/cas-reporting/issues/950

**Changes**
1. Updated save report service
    - Removed logic that prevented saving activities once they already existed.
    - Used setActivities so that when an LFO report is saved with activity changes, the facility report activities are correctly updated (add/remove).
2. Updated tests

**To test**
1. Go to http://localhost:3000/reporting/reports/current-reports
2. Start an LFO report (e.g., Banana LFO).
3. Navigate to the Review Operation Information page: http://localhost:3000/reporting/reports/19/review-operation-information
4. Update reporting activities (select 5–6) and save.
5.Navigate to the Report Information page: http://localhost:3000/reporting/reports/19/facilities/report-information
6. Open Review Facility Information for a few facilities and verify that the same activities selected on the Review Operation Information page are checked.
7. Update activities on the Review Operation Information page (add/remove) and confirm the changes are reflected on the Review Facility Information page.