### PR TITLE
chore: trigger github issue creation/update if nightly fails

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -225,7 +225,21 @@ jobs:
           echo "Reported status for ${{ github.run_id }} to Airflow $dag_run_id with status ${{env.status}}"
       - name: Create failed build issue
         uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b # v1.2.0
-        if: failure()
+        if: |-
+          ${{
+          needs.test-code.result == 'failure'
+          || needs.test-backend.result == 'failure'
+          || needs.test-administration-e2e.result == 'failure'
+          || needs.test-registration-e2e.result == 'failure'
+          || needs.test-dashboard-e2e.result == 'failure'
+          || needs.test-compliance-e2e.result == 'failure'
+          || needs.build-compliance-e2e.result == 'failure'
+          || needs.build-dashboard.result == 'failure'
+          || needs.zap-owasp.result == 'failure'
+          || needs.schemaspy.result == 'failure'
+          || needs.trivy.result == 'failure'
+          || needs.codeql.result == 'failure'
+          }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           label-name: "nightly failed"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -244,3 +244,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           label-name: "nightly failed"
           title-template: "Failed nightly build and test: {{workflow}}"
+          body-template: |
+            GitHub Actions workflow [{{workflow}} #{{runNumber}}](https://github.com/{{repo.owner}}/{{repo.repo}}/actions/runs/{{runId}}) failed.
+
+            Alerting @bcgov/cas-developers
+
+            Event: {{eventName}}
+            Branch: [{{refname}}](https://github.com/{{repo.owner}}/{{repo.repo}}/tree/{{refname}})
+            Commit: [{{sha}}](https://github.com/{{repo.owner}}/{{repo.repo}}/commit/{{sha}})
+
+            <sup><i>Created by [jayqi/failed-build-issue-action](https://github.com/jayqi/failed-build-issue-action)</i></sup>


### PR DESCRIPTION
Fixes to the action trigger that creates an issue when there are nightly build/test failures. Adds a GitHub `@mention` to the issue/comment created as well.

## Changes 🚧

- Fix trigger to use `needs.xyz.result` rather than `failure()` (which only tracks the _current_ job not entire workflow).
- Add mention for cas-developers
