### PR TITLE
Chore/584 review facility activities matches operation

### DIFF
--- a/bc_obps/common/tests/endpoints/auth/constants.py
+++ b/bc_obps/common/tests/endpoints/auth/constants.py
@@ -528,6 +528,11 @@ ENDPOINTS = {
             "endpoint_name": "get_report_operation_by_version_id",
             "kwargs": {"version_id": MOCK_INT},
         },
+        {
+            "method": "get",
+            "endpoint_name": "get_report_operation_activities_by_version_id",
+            "kwargs": {"version_id": MOCK_INT},
+        },
         {"method": "get", "endpoint_name": "build_form_schema"},
         {"method": "get", "endpoint_name": "get_dashboard_operations_list"},
         {"method": "get", "endpoint_name": "get_dashboard_reports_list"},

--- a/bc_obps/reporting/api/report_operation.py
+++ b/bc_obps/reporting/api/report_operation.py
@@ -13,6 +13,7 @@ from reporting.api.permissions import (
     approved_authorized_roles_report_version_composite_auth,
 )
 from ..schema.report_operation import (
+    ActivitySchema,
     ReportOperationDataSchema,
     ReportOperationIn,
     ReportOperationOut,
@@ -46,6 +47,17 @@ def get_report_operation_data(request: HttpRequest, version_id: int) -> dict:
 )
 def get_report_operation_by_version_id(request: HttpRequest, version_id: int) -> dict:
     return ReportOperationService.get_report_operation_by_version_id(version_id)
+
+
+@router.get(
+    "/report-version/{version_id}/report-operation-activities",
+    response={200: list[ActivitySchema], custom_codes_4xx: Message},
+    tags=EMISSIONS_REPORT_TAGS,
+    description="""Takes report_version_id  and returns a list of activities associated with the report operation.""",
+    auth=approved_authorized_roles_report_version_composite_auth,
+)
+def get_report_operation_activities_by_version_id(request: HttpRequest, version_id: int) -> list:
+    return ReportOperationService.get_report_operation_activities_by_version_id(version_id)
 
 
 """

--- a/bc_obps/reporting/schema/activity.py
+++ b/bc_obps/reporting/schema/activity.py
@@ -10,4 +10,4 @@ class FacilityReportActivityDataOut(ModelSchema):
 
     class Meta:
         model = Activity
-        fields = ['id', 'name', 'slug']
+        fields = ['id', 'name', 'slug', 'applicable_to']

--- a/bc_obps/reporting/service/report_operation_service.py
+++ b/bc_obps/reporting/service/report_operation_service.py
@@ -106,3 +106,11 @@ class ReportOperationService:
             "operation_report_status": report_version.status,
             "operation_id": report_operation.report_version.report.operation.id,
         }
+
+    @classmethod
+    def get_report_operation_activities_by_version_id(cls, report_version_id: int) -> list:
+        report_operation = ReportOperation.objects.get(report_version__id=report_version_id)
+        report_operation_activities = report_operation.activities.order_by('weight', 'name').values(
+            "id", "name", "applicable_to"
+        )
+        return [dict(activity) for activity in report_operation_activities]

--- a/bc_obps/reporting/tests/api/test_report_operation_api.py
+++ b/bc_obps/reporting/tests/api/test_report_operation_api.py
@@ -106,6 +106,26 @@ class TestReportOperationDataApi(CommonTestSetup):
 
         assert response_json["all_representatives"] == self.report_operation["report_operation_representatives"]
 
+    @patch(
+        "reporting.service.report_operation_service.ReportOperationService.get_report_operation_activities_by_version_id"
+    )
+    def test_returns_report_operation_activity_data(self, mock_get_activities):
+        """Test GET /report-version/{version_id}/report-operation-activities returns activities list"""
+        expected_activities = [
+            {"id": 1, "name": "Activity 1", "applicable_to": "TypeA"},
+            {"id": 2, "name": "Activity 2", "applicable_to": "TypeB"},
+        ]
+
+        # Patch the service method to return our expected activities
+        mock_get_activities.return_value = expected_activities
+        endpoint = custom_reverse_lazy(
+            "get_report_operation_activities_by_version_id",
+            kwargs={"version_id": self.report_version.id},
+        )
+        response = TestUtils.mock_get_with_auth_role(self, "industry_user", endpoint)
+        assert response.status_code == 200
+        assert response.json() == expected_activities
+
     @patch("reporting.service.report_facilities_service.ReportFacilitiesService.get_all_facilities_for_review")
     @patch("reporting.service.sync_validation_service.SyncValidationService.is_sync_allowed")
     @patch("reporting.service.report_operation_service.ReportOperationService.update_report_operation")

--- a/bc_obps/reporting/tests/service/test_report_emission_allocation_service.py
+++ b/bc_obps/reporting/tests/service/test_report_emission_allocation_service.py
@@ -261,7 +261,8 @@ class TestReportEmissionAllocationService(TestCase):
 
         # Iterate through allocations and expected data for field-wise validation
         for allocation, expected in zip(
-            report_product_emission_allocations.order_by('report_product__product_id'), expected_data
+            report_product_emission_allocations.order_by('report_product__product_id', 'emission_category_id'),
+            expected_data,
         ):
             self.assertEqual(
                 allocation.report_version_id, expected["report_version_id"], "Mismatched report version ID"

--- a/bc_obps/reporting/tests/service/test_report_operation_service.py
+++ b/bc_obps/reporting/tests/service/test_report_operation_service.py
@@ -98,3 +98,12 @@ class TestReportOperationService:
         assert result["operation_report_status"] == self.report_version.status
         assert self.representative in result["report_operation_representatives"]
         assert self.representative.id in result["operation_representative_name"]
+
+    def test_get_report_operation_activities_by_version_id(self):
+        self.report_operation.activities.add(self.activity)
+        result = ReportOperationService.get_report_operation_activities_by_version_id(self.report_version.id)
+
+        assert len(result) == 1
+        assert result[0]["id"] == self.activity.id
+        assert result[0]["name"] == self.activity.name
+        assert result[0]["applicable_to"] == self.activity.applicable_to

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewPage.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewPage.tsx
@@ -2,10 +2,10 @@ import FacilityReviewForm from "./FacilityReviewForm";
 import { HasFacilityId } from "@reporting/src/app/utils/defaultPageFactoryTypes";
 import { getOrderedActivities } from "@reporting/src/app/utils/getOrderedActivities";
 import { getFacilityReportDetails } from "@reporting/src/app/utils/getFacilityReportDetails";
-import { getAllActivities } from "@reporting/src/app/utils/getAllActivities";
 import { buildFacilitySchema } from "@reporting/src/data/jsonSchema/facilities";
 import { getNavigationInformation } from "../taskList/navigationInformation";
 import { HeaderStep, ReportingPage } from "../taskList/types";
+import { getReportOperationActivities } from "../../utils/getReportOperationActivities";
 
 export default async function FacilityReviewPage({
   version_id,
@@ -14,8 +14,8 @@ export default async function FacilityReviewPage({
   const orderedActivities = await getOrderedActivities(version_id, facility_id);
 
   const facilityData = await getFacilityReportDetails(version_id, facility_id);
-  const activitiesData = await getAllActivities();
-  const selectedActivities = activitiesData.filter((item: { id: any }) =>
+  const activitiesData = await getReportOperationActivities(version_id);
+  const selectedActivities = activitiesData.filter((item: { id: number }) =>
     facilityData.activities.includes(item.id),
   );
 
@@ -33,7 +33,7 @@ export default async function FacilityReviewPage({
   const formData = {
     ...facilityData,
     activities: selectedActivities.map(
-      (activity: { name: any }) => activity.name,
+      (activity: { name: string }) => activity.name,
     ),
   };
   const isSyncAllowed = facilityData.is_sync_allowed ?? true;

--- a/bciers/apps/reporting/src/app/utils/getReportOperationActivities.ts
+++ b/bciers/apps/reporting/src/app/utils/getReportOperationActivities.ts
@@ -1,0 +1,12 @@
+import { actionHandler } from "@bciers/actions";
+
+export async function getReportOperationActivities(reportVersionId: number) {
+  const endpoint = `reporting/report-version/${reportVersionId}/report-operation-activities`;
+  const response = await actionHandler(endpoint, "GET");
+  if (response.error) {
+    throw new Error(
+      `Failed to fetch the report operation activities for report version ${reportVersionId}.`,
+    );
+  }
+  return response;
+}


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-reporting/issues/584

### Changes
 - Created a new endpoint to return report_operation_activities
 - Replaced ALL Activities with report_operation_activities on FacilityReviewPage

#### Changes Unrelated to Card
 - Fixed a flaky test in test_report_emission_allocation_service.py

### Testing
**Expected behaviour:**
The activity list on the Facility Review page will match those selected on the Review Operation Information page. 

No other changes regarding selected/deselected or preserving or deleting activity data was included in this PR.