### PR TITLE
fix: dependabot alert 203

### DIFF
--- a/bciers/package.json
+++ b/bciers/package.json
@@ -151,6 +151,6 @@
   "packageManager": "yarn@4.2.0",
   "resolutions": {
     "qs": "^6.14.1",
-    "tar": "^7.5.7"
+    "tar": "^7.5.8"
   }
 }

--- a/bciers/yarn.lock
+++ b/bciers/yarn.lock
@@ -17288,16 +17288,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.7":
-  version: 7.5.7
-  resolution: "tar@npm:7.5.7"
+"tar@npm:^7.5.8":
+  version: 7.5.9
+  resolution: "tar@npm:7.5.9"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/51f261afc437e1112c3e7919478d6176ea83f7f7727864d8c2cce10f0b03a631d1911644a567348c3063c45abdae39718ba97abb073d22aa3538b9a53ae1e31c
+  checksum: 10c0/e870beb1b2477135ca2abe86b2d18f7b35d0a4e3a37bbc523d3b8f7adca268dfab543f26528a431d569897f8c53a7cac745cdfbc4411c2f89aeeacc652b81b0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/bcgov/cas-registration/security/dependabot/203. Pins a higher version of the Tar package