### PR TITLE
hotfix: schema guards prior to elicensing release to prod

### DIFF
--- a/bc_obps/compliance/service/elicensing/schema.py
+++ b/bc_obps/compliance/service/elicensing/schema.py
@@ -138,6 +138,8 @@ class PaymentDistribution:
     reason: str
     amount: Decimal
     taxAmount: Decimal
+    invoiceNumber: Optional[str] = None
+    reversedAmount: Optional[Decimal] = None
 
 
 @dataclass
@@ -154,6 +156,7 @@ class Payment:
     onlineTransactionId: Optional[str] = None
     onlineApprovalCode: Optional[str] = None
     distributions: List[PaymentDistribution] = field(default_factory=list)
+    adjustmentAmount: Optional[Decimal] = None
 
 
 @dataclass


### PR DESCRIPTION
The elicensing API test environment includes 3 new fields. I'm not 100% certain that these changes will make it to prod, but temporarily adding the fields as optional to our schema will guard against failure if they do. 