### PR TITLE
Chore/fix filter on fee parsing logic

### DIFF
--- a/bc_obps/compliance/service/elicensing/elicensing_data_refresh_service.py
+++ b/bc_obps/compliance/service/elicensing/elicensing_data_refresh_service.py
@@ -1,6 +1,4 @@
 from compliance.enums import ComplianceInvoiceTypes
-from compliance.models.compliance_penalty import CompliancePenalty
-
 from compliance.service.elicensing.elicensing_api_client import ELicensingAPIClient
 from django.db import transaction
 from compliance.models import (
@@ -10,6 +8,7 @@ from compliance.models import (
     ElicensingPayment,
     ElicensingAdjustment,
     ComplianceObligation,
+    CompliancePenalty,
 )
 from datetime import date, timedelta
 from decimal import Decimal
@@ -135,8 +134,8 @@ class ElicensingDataRefreshService:
             )
             for fee in invoice_response.fees:
                 if 'GGIRCA Compliance Obligation' in fee.description or fee.description in [
-                    'Late Submission',
-                    'Automatic Overdue',
+                    CompliancePenalty.PenaltyType.LATE_SUBMISSION,
+                    CompliancePenalty.PenaltyType.AUTOMATIC_OVERDUE,
                 ]:
                     fee_record, _ = ElicensingLineItem.objects.update_or_create(
                         elicensing_invoice=invoice_record,

--- a/bc_obps/compliance/tests/service/elicensing/test_elicensing_data_refresh_service.py
+++ b/bc_obps/compliance/tests/service/elicensing/test_elicensing_data_refresh_service.py
@@ -53,7 +53,7 @@ class TestElicensingOperatorService:
 
     @patch(RLS_BYPASS_RLS_PATH)
     def test_refreshes_data_from_elicensing(self, mock_bypass_rls, mock_query_invoice):
-        """Test sync_client_with_elicensing successfully creates a new client"""
+        """Test refresh success"""
         # Setup mocks
         client_operator = make_recipe('compliance.tests.utils.elicensing_client_operator')
 
@@ -147,7 +147,7 @@ class TestElicensingOperatorService:
 
     @patch(RLS_BYPASS_RLS_PATH)
     def test_parses_penalty_fees_from_elicensing(self, mock_bypass_rls, mock_query_invoice):
-        """Test sync_client_with_elicensing successfully creates a new client"""
+        """Test fee filter parses penalty fees"""
         # Setup mocks
         client_operator = make_recipe('compliance.tests.utils.elicensing_client_operator')
 


### PR DESCRIPTION
Previous fix #4302 excluded penalty fees when filtering which fees to parse from elicensing. This fixes the fix! (and adds a test)