### PR TITLE
refactor: implement compliance test helper in 5 files within api, models and service/bccr + add report_operation to the compliance test helper

### DIFF
--- a/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/test_operation.py
+++ b/bc_obps/compliance/tests/api/_compliance_report_versions/_compliance_report_version_id/test_operation.py
@@ -21,12 +21,8 @@ class TestReportOperationByComplianceReportVersionEndpoint(CommonTestSetup):
         approved_user_operator = make_recipe(
             'registration.tests.utils.approved_user_operator', operator=test_data.operation.operator
         )
-        # create the report_operation linked to the report_version
-        make_recipe(
-            'reporting.tests.utils.report_operation',
-            report_version=test_data.report_version,
-            operation_name='reporting name',
-        )
+        test_data.report_operation.operation_name = 'reporting name'
+        test_data.report_operation.save()
 
         # Act
         # Mock the authorization and perform the request

--- a/bc_obps/compliance/tests/api/test_compliance_report_versions.py
+++ b/bc_obps/compliance/tests/api/test_compliance_report_versions.py
@@ -1,6 +1,4 @@
-from decimal import Decimal
 from model_bakery.baker import make_recipe
-from registration.models.operation import Operation
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
 from registration.utils import custom_reverse_lazy
 from unittest.mock import patch
@@ -8,6 +6,7 @@ from urllib.parse import urlencode
 from compliance.models import ComplianceReportVersion
 from bc_obps.settings import NINJA_PAGINATION_PER_PAGE
 from reporting.models.reporting_year import ReportingYear
+from compliance.tests.utils.compliance_test_helper import ComplianceTestHelper
 
 
 class TestComplianceReportVersionsEndpoint(CommonTestSetup):
@@ -26,36 +25,21 @@ class TestComplianceReportVersionsEndpoint(CommonTestSetup):
     def test_crv_endpoint_industry_user(self, mock_get_versions):
 
         operator = make_recipe('registration.tests.utils.operator')
-        operation1 = make_recipe(
-            'registration.tests.utils.operation', operator=operator, status=Operation.Statuses.REGISTERED
-        )
-        operation2 = make_recipe(
-            'registration.tests.utils.operation', operator=operator, status=Operation.Statuses.REGISTERED
-        )
-        report1 = make_recipe('compliance.tests.utils.report', operator=operator, operation=operation1)
-        report2 = make_recipe('compliance.tests.utils.report', operator=operator, operation=operation2)
-        # Arrange
-
-        version1 = make_recipe(
-            'compliance.tests.utils.compliance_report_version',
-            compliance_report__report=report1,
-            report_compliance_summary__report_version__report_operation__operation_name='whee',
-            report_compliance_summary__report_version__report_operation__operator_legal_name='whee',
-        )
-        version1.report_compliance_summary.excess_emissions = Decimal("50.0000")
-        version1.report_compliance_summary.save()
-
-        version2 = make_recipe(
-            'compliance.tests.utils.compliance_report_version',
-            compliance_report__report=report2,
-            report_compliance_summary__report_version__report_operation__operation_name='whee',
-            report_compliance_summary__report_version__report_operation__operator_legal_name='whee',
-        )
-        version2.report_compliance_summary.excess_emissions = Decimal("75.0000")
-        version2.report_compliance_summary.save()
+        test_data1 = ComplianceTestHelper.build_test_data()
+        test_data2 = ComplianceTestHelper.build_test_data()
+        test_data1.operation.operator = operator
+        test_data1.report.operator = operator
+        test_data1.operation.save()
+        test_data1.report.save()
+        test_data2.operation.operator = operator
+        test_data2.report.operator = operator
+        test_data2.operation.save()
+        test_data2.report.save()
 
         # Return a queryset, not a list
-        mock_get_versions.return_value = ComplianceReportVersion.objects.filter(pk__in=[version1.pk, version2.pk])
+        mock_get_versions.return_value = ComplianceReportVersion.objects.filter(
+            pk__in=[test_data1.compliance_report_version.pk, test_data2.compliance_report_version.pk]
+        )
 
         TestUtils.authorize_current_user_as_operator_user(self, operator=operator)
         resp = TestUtils.mock_get_with_auth_role(self, "industry_user", self._url(paginate_result=False))

--- a/bc_obps/compliance/tests/models/test_compliance_obligation.py
+++ b/bc_obps/compliance/tests/models/test_compliance_obligation.py
@@ -1,9 +1,11 @@
 from decimal import Decimal
 from rls.tests.helpers import assert_policies_for_cas_roles, assert_policies_for_industry_user
+from compliance.models.compliance_report_version import ComplianceReportVersion
 from compliance.models.compliance_obligation import ComplianceObligation
 from common.tests.utils.helpers import BaseTestCase
 from registration.tests.constants import TIMESTAMP_COMMON_FIELDS
 from model_bakery.baker import make_recipe
+from compliance.tests.utils.compliance_test_helper import ComplianceTestHelper
 
 
 class ComplianceObligationTest(BaseTestCase):
@@ -31,72 +33,48 @@ class TestComplianceObligationRls(BaseTestCase):
         new_user_operator = make_recipe('registration.tests.utils.approved_user_operator')
         old_user_operator = make_recipe('registration.tests.utils.approved_user_operator')
 
-        # operation
-        operation = make_recipe(
-            'registration.tests.utils.operation', operator=new_user_operator.operator, status="Registered"
+        # create the test data
+        old_test_data = ComplianceTestHelper.build_test_data(
+            crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET
         )
+        new_test_data = ComplianceTestHelper.build_test_data(
+            crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET
+        )
+        new_test_data.report.operator = new_user_operator.operator
+        new_test_data.operation.operator = new_user_operator.operator
+        new_test_data.report.save()
+        old_test_data.report.operator = old_user_operator.operator
+        old_test_data.operation.operator = old_user_operator.operator
+        old_test_data.report.save()
         # timeline of current and historical ownership
         make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
-            operation=operation,
+            operation=old_test_data.operation,
             operator=old_user_operator.operator,
         )
         make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
-            operation=operation,
+            operation=new_test_data.operation,
             operator=new_user_operator.operator,
         )
-        # old operator's data
-        old_operator_report = make_recipe(
-            'reporting.tests.utils.report', operation=operation, operator=old_user_operator.operator
-        )
-        old_operator_compliance_report = make_recipe(
-            'compliance.tests.utils.compliance_report', report=old_operator_report
-        )
-
-        old_operator_compliance_report_version = make_recipe(
-            'compliance.tests.utils.compliance_report_version', compliance_report=old_operator_compliance_report
-        )
-
-        old_operator_compliance_obligation = make_recipe(
-            'compliance.tests.utils.compliance_obligation',
-            compliance_report_version=old_operator_compliance_report_version,
-        )
-        # new operator's data
-        new_operator_report = make_recipe(
-            'reporting.tests.utils.report', operation=operation, operator=new_user_operator.operator
-        )
-        new_operator_compliance_report = make_recipe(
-            'compliance.tests.utils.compliance_report', report=new_operator_report
-        )
-
-        new_operator_compliance_report_version = make_recipe(
-            'compliance.tests.utils.compliance_report_version', compliance_report=new_operator_compliance_report
-        )
-
-        new_operator_compliance_obligation = make_recipe(
-            'compliance.tests.utils.compliance_obligation',
-            compliance_report_version=new_operator_compliance_report_version,
-        )
-
         # extra object for insert
         new_operator_compliance_report_version_for_insert = make_recipe(
             'compliance.tests.utils.compliance_report_version',
-            compliance_report=new_operator_compliance_report,
+            compliance_report=new_test_data.compliance_report,
             is_supplementary=False,
         )
         old_operator_compliance_report_version_for_insert = make_recipe(
             'compliance.tests.utils.compliance_report_version',
-            compliance_report=old_operator_compliance_report,
+            compliance_report=old_test_data.compliance_report,
             is_supplementary=False,
         )
 
         # current
         def select_function(cursor):
-            ComplianceObligation.objects.get(id=new_operator_compliance_obligation.id)
+            ComplianceObligation.objects.get(id=new_test_data.compliance_obligation.id)
 
         def forbidden_select_function(cursor):
-            ComplianceObligation.objects.get(id=old_operator_compliance_obligation.id)
+            ComplianceObligation.objects.get(id=old_test_data.compliance_obligation.id)
 
         def insert_function(cursor):
             ComplianceObligation.objects.create(
@@ -114,7 +92,7 @@ class TestComplianceObligationRls(BaseTestCase):
                         %s
                     )
                 """,
-                (old_operator_compliance_report_version.id,),
+                (old_test_data.compliance_report_version.id,),
             )
 
         def update_function(cursor):
@@ -124,7 +102,7 @@ class TestComplianceObligationRls(BaseTestCase):
                     SET fee_amount_dollars = %s
                     WHERE id = %s
                 """,
-                (Decimal('8888'), new_operator_compliance_obligation.id),
+                (Decimal('8888'), new_test_data.compliance_obligation.id),
             )
             return cursor.rowcount
 
@@ -135,7 +113,7 @@ class TestComplianceObligationRls(BaseTestCase):
                     SET fee_amount_dollars = %s
                     WHERE id = %s
                 """,
-                (Decimal('8888'), old_operator_compliance_obligation.id),
+                (Decimal('8888'), old_test_data.compliance_obligation.id),
             )
             return cursor.rowcount
 
@@ -145,7 +123,7 @@ class TestComplianceObligationRls(BaseTestCase):
                    DELETE FROM "erc"."compliance_obligation"
                    WHERE id = %s
                 """,
-                (new_operator_compliance_obligation.id,),
+                (new_test_data.compliance_obligation.id,),
             )
             return cursor.rowcount
 
@@ -155,7 +133,7 @@ class TestComplianceObligationRls(BaseTestCase):
                    DELETE FROM "erc"."compliance_obligation"
                    WHERE id = %s
                 """,
-                (old_operator_compliance_obligation.id,),
+                (old_test_data.compliance_obligation.id,),
             )
             return cursor.rowcount
 
@@ -174,10 +152,10 @@ class TestComplianceObligationRls(BaseTestCase):
 
         # previous
         def select_function(cursor):
-            ComplianceObligation.objects.get(id=old_operator_compliance_obligation.id)
+            ComplianceObligation.objects.get(id=old_test_data.compliance_obligation.id)
 
         def forbidden_select_function(cursor):
-            ComplianceObligation.objects.get(id=new_operator_compliance_obligation.id)
+            ComplianceObligation.objects.get(id=new_test_data.compliance_obligation.id)
 
         def insert_function(cursor):
             ComplianceObligation.objects.create(
@@ -195,7 +173,7 @@ class TestComplianceObligationRls(BaseTestCase):
                         %s
                     )
                 """,
-                (new_operator_compliance_report_version.id,),
+                (new_test_data.compliance_report_version.id,),
             )
 
         def update_function(cursor):
@@ -205,7 +183,7 @@ class TestComplianceObligationRls(BaseTestCase):
                     SET fee_amount_dollars = %s
                     WHERE id = %s
                 """,
-                (Decimal('8888'), old_operator_compliance_obligation.id),
+                (Decimal('8888'), old_test_data.compliance_obligation.id),
             )
             return cursor.rowcount
 
@@ -216,7 +194,7 @@ class TestComplianceObligationRls(BaseTestCase):
                     SET fee_amount_dollars = %s
                     WHERE id = %s
                 """,
-                (Decimal('8888'), new_operator_compliance_obligation.id),
+                (Decimal('8888'), new_test_data.compliance_obligation.id),
             )
             return cursor.rowcount
 
@@ -226,7 +204,7 @@ class TestComplianceObligationRls(BaseTestCase):
                    DELETE FROM "erc"."compliance_obligation"
                    WHERE id = %s
                 """,
-                (old_operator_compliance_obligation.id,),
+                (old_test_data.compliance_obligation.id,),
             )
             return cursor.rowcount
 
@@ -236,7 +214,7 @@ class TestComplianceObligationRls(BaseTestCase):
                    DELETE FROM "erc"."compliance_obligation"
                    WHERE id = %s
                 """,
-                (old_operator_compliance_obligation.id,),
+                (old_test_data.compliance_obligation.id,),
             )
             return cursor.rowcount
 
@@ -254,16 +232,7 @@ class TestComplianceObligationRls(BaseTestCase):
         )
 
     def test_compliance_obligation_rls_cas_users(self):
-        operator = make_recipe('registration.tests.utils.operator')
-        operation = make_recipe('registration.tests.utils.operation', operator=operator)
-        report = make_recipe('reporting.tests.utils.report', operation=operation)
-        compliance_report = make_recipe('compliance.tests.utils.compliance_report', report=report)
-        compliance_report_version = make_recipe(
-            'compliance.tests.utils.compliance_report_version', compliance_report=compliance_report
-        )
-        make_recipe(
-            'compliance.tests.utils.compliance_obligation', id=888, compliance_report_version=compliance_report_version
-        )
+        ComplianceTestHelper.build_test_data(crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET)
 
         def select_function(cursor):
             assert ComplianceObligation.objects.count() == 1

--- a/bc_obps/compliance/tests/models/test_compliance_report_version.py
+++ b/bc_obps/compliance/tests/models/test_compliance_report_version.py
@@ -3,6 +3,7 @@ from compliance.models.compliance_report_version import ComplianceReportVersion
 from rls.tests.helpers import assert_policies_for_cas_roles, assert_policies_for_industry_user
 from common.tests.utils.helpers import BaseTestCase
 from registration.tests.constants import TIMESTAMP_COMMON_FIELDS
+from compliance.tests.utils.compliance_test_helper import ComplianceTestHelper
 
 
 class ComplianceReportVersionTest(BaseTestCase):
@@ -34,76 +35,49 @@ class TestComplianceReportVersionRls(BaseTestCase):
         new_user_operator = make_recipe('registration.tests.utils.approved_user_operator')
         old_user_operator = make_recipe('registration.tests.utils.approved_user_operator')
 
-        # operation
-        operation = make_recipe(
-            'registration.tests.utils.operation', operator=new_user_operator.operator, status="Registered"
-        )
+        new_test_data = ComplianceTestHelper.build_test_data()
+        old_test_data = ComplianceTestHelper.build_test_data()
+
+        new_test_data.report.operator = new_user_operator.operator
+        new_test_data.operation.operator = new_user_operator.operator
+        new_test_data.report.save()
+        old_test_data.report.operator = old_user_operator.operator
+        old_test_data.operation.operator = old_user_operator.operator
+        old_test_data.report.save()
+
         # timeline of current and historical ownership
         make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
-            operation=operation,
+            operation=new_test_data.operation,
             operator=old_user_operator.operator,
         )
         make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
-            operation=operation,
+            operation=new_test_data.operation,
             operator=new_user_operator.operator,
-        )
-        # old operator's data
-        old_operator_report = make_recipe(
-            'reporting.tests.utils.report', operation=operation, operator=old_user_operator.operator
-        )
-        old_operator_compliance_report = make_recipe(
-            'compliance.tests.utils.compliance_report', report=old_operator_report
-        )
-
-        old_operator_compliance_report_version = make_recipe(
-            'compliance.tests.utils.compliance_report_version', compliance_report=old_operator_compliance_report
-        )
-
-        # new operator's data
-        new_operator_report = make_recipe(
-            'reporting.tests.utils.report', operation=operation, operator=new_user_operator.operator
-        )
-        new_operator_compliance_report = make_recipe(
-            'compliance.tests.utils.compliance_report', report=new_operator_report
-        )
-
-        new_operator_compliance_report_version = make_recipe(
-            'compliance.tests.utils.compliance_report_version', compliance_report=new_operator_compliance_report
         )
 
         # extra objects for insert function
-        new_operator_report_version = make_recipe(
-            'reporting.tests.utils.report_version',
-            report=new_operator_report,
-        )
-
         new_operator_report_compliance_summary = make_recipe(
-            'reporting.tests.utils.report_compliance_summary', report_version=new_operator_report_version
-        )
-
-        old_operator_report_version = make_recipe(
-            'reporting.tests.utils.report_version',
-            report=old_operator_report,
+            'reporting.tests.utils.report_compliance_summary', report_version=new_test_data.report_version
         )
 
         old_operator_report_compliance_summary = make_recipe(
-            'reporting.tests.utils.report_compliance_summary', report_version=old_operator_report_version
+            'reporting.tests.utils.report_compliance_summary', report_version=new_test_data.report_version
         )
 
         assert ComplianceReportVersion.objects.count() == 2
 
         # test to access currently owned operation data
         def select_function(cursor):
-            ComplianceReportVersion.objects.get(id=new_operator_compliance_report_version.id)
+            ComplianceReportVersion.objects.get(id=new_test_data.compliance_report_version.id)
 
         def forbidden_select_function(cursor):
-            ComplianceReportVersion.objects.get(id=old_operator_compliance_report_version.id)
+            ComplianceReportVersion.objects.get(id=old_test_data.compliance_report_version.id)
 
         def insert_function(cursor):
             ComplianceReportVersion.objects.create(
-                compliance_report=new_operator_compliance_report,
+                compliance_report=new_test_data.compliance_report,
                 report_compliance_summary=new_operator_report_compliance_summary,
                 status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_FULLY_MET,
                 excess_emissions_delta_from_previous=10,
@@ -131,7 +105,7 @@ class TestComplianceReportVersionRls(BaseTestCase):
                     )
                 """,
                 (
-                    old_operator_compliance_report.id,
+                    old_test_data.compliance_report.id,
                     old_operator_report_compliance_summary.id,
                     "Obligation fully met",
                     10,
@@ -149,7 +123,7 @@ class TestComplianceReportVersionRls(BaseTestCase):
                 """,
                 (
                     ComplianceReportVersion.ComplianceStatus.NO_OBLIGATION_OR_EARNED_CREDITS,
-                    new_operator_compliance_report_version.id,
+                    new_test_data.compliance_report_version.id,
                 ),
             )
             return cursor.rowcount
@@ -163,7 +137,7 @@ class TestComplianceReportVersionRls(BaseTestCase):
                 """,
                 (
                     ComplianceReportVersion.ComplianceStatus.NO_OBLIGATION_OR_EARNED_CREDITS,
-                    old_operator_compliance_report_version.id,
+                    old_test_data.compliance_report_version.id,
                 ),
             )
             return cursor.rowcount
@@ -174,7 +148,7 @@ class TestComplianceReportVersionRls(BaseTestCase):
                    DELETE FROM "erc"."compliance_report_version"
                    WHERE id = %s
                 """,
-                (new_operator_compliance_report_version.id,),
+                (new_test_data.compliance_report_version.id,),
             )
             return cursor.rowcount
 
@@ -184,7 +158,7 @@ class TestComplianceReportVersionRls(BaseTestCase):
                    DELETE FROM "erc"."compliance_report_version"
                    WHERE id = %s
                 """,
-                (old_operator_compliance_report_version.id,),
+                (old_test_data.compliance_report_version.id,),
             )
             return cursor.rowcount
 
@@ -203,15 +177,15 @@ class TestComplianceReportVersionRls(BaseTestCase):
 
         # test to access previously owned operation data
         def select_function(cursor):
-            ComplianceReportVersion.objects.get(id=old_operator_compliance_report_version.id)
+            ComplianceReportVersion.objects.get(id=old_test_data.compliance_report_version.id)
 
         def forbidden_select_function(cursor):
-            ComplianceReportVersion.objects.get(id=new_operator_compliance_report_version.id)
+            ComplianceReportVersion.objects.get(id=new_test_data.compliance_report_version.id)
 
         def insert_function(cursor):
 
             ComplianceReportVersion.objects.create(
-                compliance_report=old_operator_compliance_report,
+                compliance_report=old_test_data.compliance_report,
                 report_compliance_summary=old_operator_report_compliance_summary,
                 status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_FULLY_MET,
                 excess_emissions_delta_from_previous=10,
@@ -239,7 +213,7 @@ class TestComplianceReportVersionRls(BaseTestCase):
                     )
                 """,
                 (
-                    new_operator_compliance_report.id,
+                    new_test_data.compliance_report.id,
                     new_operator_report_compliance_summary.id,
                     "Obligation fully met",
                     10,
@@ -257,7 +231,7 @@ class TestComplianceReportVersionRls(BaseTestCase):
                 """,
                 (
                     ComplianceReportVersion.ComplianceStatus.NO_OBLIGATION_OR_EARNED_CREDITS,
-                    old_operator_compliance_report_version.id,
+                    old_test_data.compliance_report_version.id,
                 ),
             )
             return cursor.rowcount
@@ -271,7 +245,7 @@ class TestComplianceReportVersionRls(BaseTestCase):
                 """,
                 (
                     ComplianceReportVersion.ComplianceStatus.NO_OBLIGATION_OR_EARNED_CREDITS,
-                    new_operator_compliance_report_version.id,
+                    new_test_data.compliance_report_version.id,
                 ),
             )
             return cursor.rowcount
@@ -282,7 +256,7 @@ class TestComplianceReportVersionRls(BaseTestCase):
                    DELETE FROM "erc"."compliance_report_version"
                    WHERE id = %s
                 """,
-                (old_operator_compliance_report_version.id,),
+                (old_test_data.compliance_report_version.id,),
             )
             return cursor.rowcount
 
@@ -292,7 +266,7 @@ class TestComplianceReportVersionRls(BaseTestCase):
                    DELETE FROM "erc"."compliance_report_version"
                    WHERE id = %s
                 """,
-                (new_operator_compliance_report_version.id,),
+                (new_test_data.compliance_report_version.id,),
             )
             return cursor.rowcount
 
@@ -310,11 +284,7 @@ class TestComplianceReportVersionRls(BaseTestCase):
         )
 
     def test_compliance_report_version_rls_cas_users(self):
-        operator = make_recipe('registration.tests.utils.operator')
-        operation = make_recipe('registration.tests.utils.operation', operator=operator)
-        report = make_recipe('reporting.tests.utils.report', operation=operation)
-        compliance_report = make_recipe('compliance.tests.utils.compliance_report', report=report)
-        make_recipe('compliance.tests.utils.compliance_report_version', id=88, compliance_report=compliance_report)
+        ComplianceTestHelper.build_test_data()
 
         def select_function(cursor):
             assert ComplianceReportVersion.objects.count() == 1

--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_apply_compliance_units_service.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_apply_compliance_units_service.py
@@ -1,13 +1,14 @@
+from compliance.models.compliance_report_version import ComplianceReportVersion
 from compliance.models.elicensing_adjustment import ElicensingAdjustment
 import pytest
 from unittest.mock import patch, Mock
 from model_bakery import baker
 from common.exceptions import UserError
 from compliance.service.bc_carbon_registry.apply_compliance_units_service import ApplyComplianceUnitsService
-from compliance.dataclass import BCCRUnit, ComplianceUnitsPageData, ObligationData
-from registration.models.operation import Operation
+from compliance.dataclass import BCCRUnit, ComplianceUnitsPageData
 from decimal import Decimal
 from compliance.dataclass import RefreshWrapperReturn
+from compliance.tests.utils.compliance_test_helper import ComplianceTestHelper
 
 pytestmark = pytest.mark.django_db
 
@@ -183,25 +184,22 @@ class TestApplyComplianceUnitsService:
             ]
         }
 
-        operation = baker.make_recipe(
-            "registration.tests.utils.operation",
-            bc_obps_regulated_operation=baker.make_recipe("registration.tests.utils.boro_id"),
-            status=Operation.Statuses.REGISTERED,
+        test_data = ComplianceTestHelper.build_test_data(
+            crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET
         )
-        mock_compliance_report_version_service.get_compliance_report_version.return_value = baker.make_recipe(
-            "compliance.tests.utils.compliance_report_version", compliance_report__report__operation=operation
+        mock_compliance_report_version_service.get_compliance_report_version.return_value = (
+            test_data.compliance_report_version
         )
         mock_compliance_charge_rate_service.get_rate_for_year.return_value = Decimal("75.00")
+        test_data.compliance_obligation.reporting_year = 2023
+        test_data.compliance_obligation.outstanding_balance = Decimal("400.00")
+        test_data.compliance_obligation.equivalent_value = Decimal("30000.00")
+        test_data.compliance_obligation.fee_amount_dollars = Decimal("3000.00")
+        test_data.compliance_obligation.obligation_id = "23-0001-1-1"
+        test_data.compliance_obligation.penalty_status = "NONE"
+        test_data.compliance_obligation.save()
 
-        mock_obligation_data = ObligationData(
-            reporting_year=2023,
-            outstanding_balance=Decimal("400.00"),
-            equivalent_value=Decimal("30000.00"),
-            fee_amount_dollars=Decimal("3000.00"),
-            obligation_id="23-0001-1-1",
-            penalty_status="NONE",
-        )
-        mock_get_obligation_data.return_value = mock_obligation_data
+        mock_get_obligation_data.return_value = test_data.compliance_obligation
 
         # Stub compute caps: limit 500, remaining 400
         mock_compute_compliance_unit_caps.return_value = (Decimal("500.00"), Decimal("400.00"))
@@ -256,17 +254,16 @@ class TestApplyComplianceUnitsService:
         "compliance.service.elicensing.elicensing_data_refresh_service.ElicensingDataRefreshService.refresh_data_wrapper_by_compliance_report_version_id"
     )
     def test_calculate_apply_units_cap_success(self, mock_refresh):
-        invoice = baker.make_recipe("compliance.tests.utils.elicensing_invoice")
-        obligation = baker.make_recipe(
-            "compliance.tests.utils.compliance_obligation",
-            fee_amount_dollars=Decimal("1000"),
-            elicensing_invoice_id=invoice.id,
+        test_data = ComplianceTestHelper.build_test_data(
+            crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET, create_invoice_data=True
         )
+        test_data.compliance_obligation.fee_amount_dollars = Decimal("1000.00")
+        test_data.compliance_obligation.save()
 
-        mock_refresh.return_value = RefreshWrapperReturn(data_is_fresh=True, invoice=invoice)
+        mock_refresh.return_value = RefreshWrapperReturn(data_is_fresh=True, invoice=test_data.invoice)
 
         result = ApplyComplianceUnitsService._calculate_apply_units_cap(
-            compliance_report_version_id=obligation.compliance_report_version_id
+            compliance_report_version_id=test_data.compliance_report_version.id
         )
         assert result == Decimal("500.00")
 
@@ -464,20 +461,22 @@ class TestApplyComplianceUnitsService:
         mock_refresh_data,
     ):
         # Arrange
-        mock_obligation = Mock(
-            fee_amount_dollars=Decimal("1000.00"),
-            equivalent_value=Decimal("100.00"),
+        test_data = ComplianceTestHelper.build_test_data(
+            crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET, create_invoice_data=True
         )
-        mock_get_obligation_data.return_value = mock_obligation
+        test_data.compliance_obligation.fee_amount_dollars = Decimal("1000.00")
+        test_data.compliance_obligation.equivalent_value = Decimal("100.00")
+        test_data.compliance_obligation.save()
 
-        mock_invoice = Mock()
-        mock_invoice.outstanding_balance = Decimal("500.00")
-        mock_invoice.elicensing_line_items.all.return_value = []
-        mock_refresh_data.return_value.invoice = mock_invoice
+        mock_get_obligation_data.return_value = test_data.compliance_obligation
+
+        test_data.invoice.outstanding_balance = Decimal("500.00")
+        test_data.invoice.elicensing_line_items.set([])
+        test_data.invoice.save()
+        mock_refresh_data.return_value.invoice = test_data.invoice
 
         mock_bccr_service.validate_holding_account_ownership.return_value = True
 
-        compliance_report_version = baker.make_recipe("compliance.tests.utils.compliance_report_version")
         account_id = "123"
         payload = {
             "bccr_compliance_account_id": "456",
@@ -499,7 +498,7 @@ class TestApplyComplianceUnitsService:
         }
 
         # Act
-        ApplyComplianceUnitsService.apply_compliance_units(account_id, compliance_report_version.id, payload)
+        ApplyComplianceUnitsService.apply_compliance_units(account_id, test_data.compliance_report_version.id, payload)
 
         # Assert
         mock_bccr_service.client.transfer_compliance_units.assert_called_once()
@@ -520,12 +519,12 @@ class TestApplyComplianceUnitsService:
             "id": "unit-2",
         } in transfer_payload["mixedUnitList"]
 
-        mock_can_apply_units.assert_called_once_with(compliance_report_version.id)
+        mock_can_apply_units.assert_called_once_with(test_data.compliance_report_version.id)
         mock_create_adjustment.assert_called_once()
         assert mock_create_adjustment.call_args.kwargs["adjustment_total"] == -Decimal("80.00")
         mock_bccr_service.validate_holding_account_ownership.assert_called_once_with(
             holding_account_id=account_id,
-            compliance_report_version_id=compliance_report_version.id,
+            compliance_report_version_id=test_data.compliance_report_version.id,
         )
 
     def test_apply_compliance_units_filters_zero_quantities(
@@ -538,18 +537,23 @@ class TestApplyComplianceUnitsService:
         mock_refresh_data,
     ):
         # Arrange
-        mock_obligation = Mock(fee_amount_dollars=Decimal("1000.00"), equivalent_value=Decimal("100.00"))
-        mock_get_obligation_data.return_value = mock_obligation
+        test_data = ComplianceTestHelper.build_test_data(
+            crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET, create_invoice_data=True
+        )
+        test_data.compliance_obligation.fee_amount_dollars = Decimal("1000.00")
+        test_data.compliance_obligation.equivalent_value = Decimal("100.00")
+        test_data.compliance_obligation.save()
+        mock_get_obligation_data.return_value = test_data.compliance_obligation
 
-        mock_invoice = Mock(outstanding_balance=Decimal("500.00"))
-        mock_invoice.elicensing_line_items.all.return_value = []
-        mock_refresh_data.return_value.invoice = mock_invoice
+        test_data.invoice.outstanding_balance = Decimal("500.00")
+        test_data.invoice.elicensing_line_items.set([])
+        test_data.invoice.save()
+        mock_refresh_data.return_value.invoice = test_data.invoice
 
         mock_bccr_service.client.transfer_compliance_units.return_value = {"success": True}
 
         mock_bccr_service.validate_holding_account_ownership.return_value = True
 
-        compliance_report_version = baker.make_recipe("compliance.tests.utils.compliance_report_version")
         account_id = "123"
         payload = {
             "bccr_compliance_account_id": "456",
@@ -583,7 +587,7 @@ class TestApplyComplianceUnitsService:
         }
 
         # Act
-        ApplyComplianceUnitsService.apply_compliance_units(account_id, compliance_report_version.id, payload)
+        ApplyComplianceUnitsService.apply_compliance_units(account_id, test_data.compliance_report_version.id, payload)
 
         # Assert
         transfer_payload = mock_bccr_service.client.transfer_compliance_units.call_args[0][0]
@@ -595,7 +599,7 @@ class TestApplyComplianceUnitsService:
         assert mock_create_adjustment.call_args.kwargs["adjustment_total"] == -Decimal("80.00")
         mock_bccr_service.validate_holding_account_ownership.assert_called_once_with(
             holding_account_id=account_id,
-            compliance_report_version_id=compliance_report_version.id,
+            compliance_report_version_id=test_data.compliance_report_version.id,
         )
 
     def test_apply_compliance_units_all_zero_quantities(
@@ -608,18 +612,19 @@ class TestApplyComplianceUnitsService:
         mock_refresh_data,
     ):
         # Arrange
-        mock_obligation = Mock(fee_amount_dollars=Decimal("1000.00"), equivalent_value=Decimal("100.00"))
-        mock_get_obligation_data.return_value = mock_obligation
+        test_data = ComplianceTestHelper.build_test_data(
+            crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET, create_invoice_data=True
+        )
 
-        mock_invoice = Mock(outstanding_balance=Decimal("500.00"))
-        mock_invoice.elicensing_line_items.all.return_value = []
-        mock_refresh_data.return_value.invoice = mock_invoice
+        mock_get_obligation_data.return_value = test_data.compliance_obligation
+
+        test_data.invoice.elicensing_line_items.set([])
+        mock_refresh_data.return_value.invoice = test_data.invoice
 
         mock_bccr_service.client.transfer_compliance_units.return_value = {"success": True}
 
         mock_bccr_service.validate_holding_account_ownership.return_value = True
 
-        compliance_report_version = baker.make_recipe("compliance.tests.utils.compliance_report_version")
         account_id = "123"
         payload = {
             "bccr_compliance_account_id": "456",
@@ -641,7 +646,7 @@ class TestApplyComplianceUnitsService:
         }
 
         # Act
-        ApplyComplianceUnitsService.apply_compliance_units(account_id, compliance_report_version.id, payload)
+        ApplyComplianceUnitsService.apply_compliance_units(account_id, test_data.compliance_report_version.id, payload)
 
         # Assert
         call_args = mock_bccr_service.client.transfer_compliance_units.call_args[0][0]
@@ -649,7 +654,7 @@ class TestApplyComplianceUnitsService:
         assert mock_create_adjustment.call_args.kwargs["adjustment_total"] == -Decimal("0.00")
         mock_bccr_service.validate_holding_account_ownership.assert_called_once_with(
             holding_account_id=account_id,
-            compliance_report_version_id=compliance_report_version.id,
+            compliance_report_version_id=test_data.compliance_report_version.id,
         )
 
     @patch(
@@ -658,32 +663,39 @@ class TestApplyComplianceUnitsService:
     @patch('compliance.service.compliance_charge_rate_service.ComplianceChargeRateService.get_rate_for_year')
     def test_compute_units_cap_with_supplementary_and_unit_adjustments(self, mock_get_charge_rate, mock_refresh):
         mock_get_charge_rate.return_value = Decimal('80.00')
-        invoice = baker.make_recipe("compliance.tests.utils.elicensing_invoice")
-        obligation = baker.make_recipe(
-            "compliance.tests.utils.compliance_obligation",
-            fee_amount_dollars=Decimal('1000'),
-            elicensing_invoice_id=invoice.id,
+        test_data = ComplianceTestHelper.build_test_data(
+            crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET, create_invoice_data=True
         )
-        line_item = baker.make_recipe("compliance.tests.utils.elicensing_line_item", elicensing_invoice=invoice)
-        supplementary_version = baker.make_recipe("compliance.tests.utils.compliance_report_version")
+        test_data.invoice.outstanding_balance = Decimal('100.01')
+        test_data.invoice.fee_balance = Decimal('100.01')
+        test_data.invoice.interest_balance = Decimal('0.00')
+        test_data.invoice.save()
+        test_data.compliance_obligation.fee_amount_dollars = Decimal("1000")
+        test_data.compliance_obligation.save()
+
+        test_supplementary_data = ComplianceTestHelper.build_test_data(
+            crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET,
+            create_invoice_data=True,
+            previous_data=test_data,
+        )
         baker.make_recipe(
             "compliance.tests.utils.elicensing_adjustment",
             reason=ElicensingAdjustment.Reason.SUPPLEMENTARY_REPORT_ADJUSTMENT,
-            supplementary_compliance_report_version=supplementary_version,
-            elicensing_line_item=line_item,
+            supplementary_compliance_report_version=test_supplementary_data.compliance_report_version,
+            elicensing_line_item=test_data.invoice.elicensing_line_items.first(),
             amount=Decimal('-500'),
         )
         baker.make_recipe(
             "compliance.tests.utils.elicensing_adjustment",
             reason='Compliance Units Applied',
-            elicensing_line_item=line_item,
+            elicensing_line_item=test_data.invoice.elicensing_line_items.first(),
             amount=Decimal('-100'),
         )
 
-        mock_refresh.return_value = RefreshWrapperReturn(data_is_fresh=True, invoice=invoice)
+        mock_refresh.return_value = RefreshWrapperReturn(data_is_fresh=True, invoice=test_data.invoice)
 
         result = ApplyComplianceUnitsService._compute_compliance_unit_caps(
-            compliance_report_version_id=obligation.compliance_report_version_id
+            compliance_report_version_id=test_data.compliance_report_version.id
         )
         print(result)
         assert result == (Decimal("250.00"), Decimal("150"))
@@ -710,13 +722,12 @@ class TestApplyComplianceUnitsService:
             "The sub-account does not belong to the holding account."
         )
 
-        operation = baker.make_recipe(
-            "registration.tests.utils.operation",
-            bc_obps_regulated_operation=baker.make_recipe("registration.tests.utils.boro_id"),
-            status=Operation.Statuses.REGISTERED,
+        # Test data
+        test_data = ComplianceTestHelper.build_test_data(
+            crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET, create_invoice_data=True
         )
-        mock_compliance_report_version_service.get_compliance_report_version.return_value = baker.make_recipe(
-            "compliance.tests.utils.compliance_report_version", compliance_report__report__operation=operation
+        mock_compliance_report_version_service.get_compliance_report_version.return_value = (
+            test_data.compliance_report_version
         )
 
         # Act & Assert
@@ -742,16 +753,13 @@ class TestApplyComplianceUnitsService:
     ):
         """Test that applying units with invalid ownership raises an error."""
         # Arrange
-        operation = baker.make_recipe(
-            "registration.tests.utils.operation",
-            bc_obps_regulated_operation=baker.make_recipe("registration.tests.utils.boro_id"),
-            status=Operation.Statuses.REGISTERED,
-        )
-        compliance_report_version = baker.make_recipe(
-            "compliance.tests.utils.compliance_report_version", compliance_report__report__operation=operation
+        test_data = ComplianceTestHelper.build_test_data(
+            crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET, create_invoice_data=True
         )
 
-        mock_compliance_report_version_service.get_compliance_report_version.return_value = compliance_report_version
+        mock_compliance_report_version_service.get_compliance_report_version.return_value = (
+            test_data.compliance_report_version
+        )
 
         # Mock ownership validation to return False (invalid ownership)
         mock_bccr_service.validate_holding_account_ownership.return_value = False
@@ -767,12 +775,14 @@ class TestApplyComplianceUnitsService:
         with pytest.raises(
             UserError, match="The holding account does not own the compliance sub-account for this operation."
         ):
-            ApplyComplianceUnitsService.apply_compliance_units(account_id, compliance_report_version.id, payload)
+            ApplyComplianceUnitsService.apply_compliance_units(
+                account_id, test_data.compliance_report_version.id, payload
+            )
 
         # Verify that ownership validation was called
         mock_bccr_service.validate_holding_account_ownership.assert_called_once_with(
             holding_account_id=account_id,
-            compliance_report_version_id=compliance_report_version.id,
+            compliance_report_version_id=test_data.compliance_report_version.id,
         )
 
         # Verify that no further processing occurred

--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_service.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_service.py
@@ -5,6 +5,7 @@ from common.exceptions import UserError
 from compliance.service.bc_carbon_registry.account_service import BCCarbonRegistryAccountService
 from compliance.dataclass import BCCRAccountResponseDetails, BCCRComplianceAccountResponseDetails
 from registration.models.operation import Operation
+from compliance.tests.utils.compliance_test_helper import ComplianceTestHelper
 
 pytestmark = pytest.mark.django_db
 
@@ -168,27 +169,7 @@ class TestBCCarbonRegistryAccountService:
     def test_create_compliance_account(self, service, mock_api_client, compliance_report_instance):
         # Arrange
         service.client = mock_api_client
-        # Create a report version with report operation
-        report_version = baker.make_recipe(
-            "reporting.tests.utils.report_version", report=compliance_report_instance.report
-        )
-        baker.make_recipe(
-            "reporting.tests.utils.report_operation",
-            report_version=report_version,
-            operation_name="Test Operation Name",
-        )
-
-        # Create a report compliance summary
-        report_compliance_summary = baker.make_recipe(
-            "reporting.tests.utils.report_compliance_summary", report_version=report_version
-        )
-
-        # Create a compliance report version
-        compliance_report_version = baker.make_recipe(
-            "compliance.tests.utils.compliance_report_version",
-            compliance_report=compliance_report_instance,
-            report_compliance_summary=report_compliance_summary,
-        )
+        test_data = ComplianceTestHelper.build_test_data()
 
         mock_api_client.create_sub_account.return_value = {"entity": {"id": "789", "parent_name": "Parent Corp"}}
 
@@ -199,7 +180,7 @@ class TestBCCarbonRegistryAccountService:
             type_of_account_holder="Corporation",
             compliance_year=2024,
             boro_id="BORO123",
-            compliance_report_version=compliance_report_version,
+            compliance_report_version=test_data.compliance_report_version,
         )
 
         # Assert
@@ -219,21 +200,21 @@ class TestBCCarbonRegistryAccountService:
     def test_get_or_create_compliance_account_existing(self, service, mock_api_client):
         # Arrange
         service.client = mock_api_client
-        compliance_report = baker.make_recipe(
-            "compliance.tests.utils.compliance_report", bccr_subaccount_id="123456789012345"
-        )
+        test_data = ComplianceTestHelper.build_test_data()
+        test_data.compliance_report.bccr_subaccount_id = "123456789012345"
+        test_data.compliance_report.save()
         holding_account = BCCRAccountResponseDetails(
             entity_id="123",
             organization_classification_id="456",
             type_of_account_holder="Corporation",
             trading_name="Test Corp",
         )
-        compliance_report_version = baker.make_recipe("compliance.tests.utils.compliance_report_version")
+
         # Act
         result = service.get_or_create_compliance_account(
             holding_account_details=holding_account,
-            compliance_report=compliance_report,
-            compliance_report_version=compliance_report_version,
+            compliance_report=test_data.compliance_report,
+            compliance_report_version=test_data.compliance_report_version,
         )
         # Assert
         assert isinstance(result, BCCRComplianceAccountResponseDetails)
@@ -244,20 +225,9 @@ class TestBCCarbonRegistryAccountService:
     def test_validate_holding_account_ownership_with_existing_subaccount_valid(self, service, mock_api_client):
         # Arrange
         service.client = mock_api_client
-        operation = baker.make_recipe(
-            "registration.tests.utils.operation",
-            bc_obps_regulated_operation=baker.make_recipe("registration.tests.utils.boro_id", id="24-0019"),
-            status=Operation.Statuses.REGISTERED,
-        )
-        compliance_report = baker.make_recipe(
-            "compliance.tests.utils.compliance_report",
-            bccr_subaccount_id="987654321012345",
-            report__operation=operation,
-        )
-        compliance_report_version = baker.make_recipe(
-            "compliance.tests.utils.compliance_report_version",
-            compliance_report=compliance_report,
-        )
+        test_data = ComplianceTestHelper.build_test_data()
+        test_data.compliance_report.bccr_subaccount_id = "987654321012345"
+        test_data.compliance_report.save()
 
         # Mock sub-account details with matching master account
         mock_api_client.get_account_details.return_value = {
@@ -272,7 +242,7 @@ class TestBCCarbonRegistryAccountService:
         # Act
         result = service.validate_holding_account_ownership(
             holding_account_id="123456789012345",
-            compliance_report_version_id=compliance_report_version.id,
+            compliance_report_version_id=test_data.compliance_report_version.id,
         )
 
         # Assert
@@ -284,20 +254,9 @@ class TestBCCarbonRegistryAccountService:
     def test_validate_holding_account_ownership_with_existing_subaccount_invalid(self, service, mock_api_client):
         # Arrange
         service.client = mock_api_client
-        operation = baker.make_recipe(
-            "registration.tests.utils.operation",
-            bc_obps_regulated_operation=baker.make_recipe("registration.tests.utils.boro_id", id="24-0019"),
-            status=Operation.Statuses.REGISTERED,
-        )
-        compliance_report = baker.make_recipe(
-            "compliance.tests.utils.compliance_report",
-            bccr_subaccount_id="987654321012345",
-            report__operation=operation,
-        )
-        compliance_report_version = baker.make_recipe(
-            "compliance.tests.utils.compliance_report_version",
-            compliance_report=compliance_report,
-        )
+        test_data = ComplianceTestHelper.build_test_data()
+        test_data.compliance_report.bccr_subaccount_id = "987654321012345"
+        test_data.compliance_report.save()
 
         # Mock sub-account details with different master account
         mock_api_client.get_account_details.return_value = {
@@ -313,7 +272,7 @@ class TestBCCarbonRegistryAccountService:
         with pytest.raises(UserError, match="The sub-account does not belong to the holding account."):
             service.validate_holding_account_ownership(
                 holding_account_id="123456789012345",
-                compliance_report_version_id=compliance_report_version.id,
+                compliance_report_version_id=test_data.compliance_report_version.id,
             )
 
         mock_api_client.get_account_details.assert_called_once_with(
@@ -323,18 +282,9 @@ class TestBCCarbonRegistryAccountService:
     def test_validate_holding_account_ownership_no_existing_subaccount_valid(self, service, mock_api_client):
         # Arrange
         service.client = mock_api_client
-        operation = baker.make_recipe(
-            "registration.tests.utils.operation",
-            bc_obps_regulated_operation=baker.make_recipe("registration.tests.utils.boro_id", id="24-0019"),
-            status=Operation.Statuses.REGISTERED,
-        )
-        compliance_report = baker.make_recipe(
-            "compliance.tests.utils.compliance_report", bccr_subaccount_id=None, report__operation=operation
-        )
-        compliance_report_version = baker.make_recipe(
-            "compliance.tests.utils.compliance_report_version",
-            compliance_report=compliance_report,
-        )
+        test_data = ComplianceTestHelper.build_test_data()
+        test_data.compliance_report.bccr_subaccount_id = None
+        test_data.compliance_report.save()
 
         # Mock holding account details
         mock_api_client.get_account_details.return_value = {
@@ -361,7 +311,7 @@ class TestBCCarbonRegistryAccountService:
         # Act
         result = service.validate_holding_account_ownership(
             holding_account_id="123456789012345",
-            compliance_report_version_id=compliance_report_version.id,
+            compliance_report_version_id=test_data.compliance_report_version.id,
         )
 
         # Assert
@@ -371,18 +321,9 @@ class TestBCCarbonRegistryAccountService:
     def test_validate_holding_account_ownership_no_existing_subaccount_invalid(self, service, mock_api_client):
         # Arrange
         service.client = mock_api_client
-        operation = baker.make_recipe(
-            "registration.tests.utils.operation",
-            bc_obps_regulated_operation=baker.make_recipe("registration.tests.utils.boro_id", id="24-0019"),
-            status=Operation.Statuses.REGISTERED,
-        )
-        compliance_report = baker.make_recipe(
-            "compliance.tests.utils.compliance_report", bccr_subaccount_id=None, report__operation=operation
-        )
-        compliance_report_version = baker.make_recipe(
-            "compliance.tests.utils.compliance_report_version",
-            compliance_report=compliance_report,
-        )
+        test_data = ComplianceTestHelper.build_test_data()
+        test_data.compliance_report.bccr_subaccount_id = None
+        test_data.compliance_report.save()
 
         # Mock holding account details
         mock_api_client.get_account_details.return_value = {
@@ -402,7 +343,7 @@ class TestBCCarbonRegistryAccountService:
         # Act
         result = service.validate_holding_account_ownership(
             holding_account_id="123456789012345",
-            compliance_report_version_id=compliance_report_version.id,
+            compliance_report_version_id=test_data.compliance_report_version.id,
         )
 
         # Assert
@@ -412,18 +353,9 @@ class TestBCCarbonRegistryAccountService:
     def test_validate_holding_account_ownership_holding_account_not_found(self, service, mock_api_client):
         # Arrange
         service.client = mock_api_client
-        operation = baker.make_recipe(
-            "registration.tests.utils.operation",
-            bc_obps_regulated_operation=baker.make_recipe("registration.tests.utils.boro_id", id="24-0019"),
-            status=Operation.Statuses.REGISTERED,
-        )
-        compliance_report = baker.make_recipe(
-            "compliance.tests.utils.compliance_report", bccr_subaccount_id=None, report__operation=operation
-        )
-        compliance_report_version = baker.make_recipe(
-            "compliance.tests.utils.compliance_report_version",
-            compliance_report=compliance_report,
-        )
+        test_data = ComplianceTestHelper.build_test_data()
+        test_data.compliance_report.bccr_subaccount_id = None
+        test_data.compliance_report.save()
 
         # Mock holding account not found
         mock_api_client.get_account_details.return_value = {"entities": []}
@@ -431,7 +363,7 @@ class TestBCCarbonRegistryAccountService:
         # Act
         result = service.validate_holding_account_ownership(
             holding_account_id="123456789012345",
-            compliance_report_version_id=compliance_report_version.id,
+            compliance_report_version_id=test_data.compliance_report_version.id,
         )
 
         # Assert
@@ -440,31 +372,10 @@ class TestBCCarbonRegistryAccountService:
     def test_get_or_create_compliance_account_new(self, service, mock_api_client):
         # Arrange
         service.client = mock_api_client
-        operation = baker.make_recipe(
-            "registration.tests.utils.operation",
-            bc_obps_regulated_operation=baker.make_recipe("registration.tests.utils.boro_id"),
-            status=Operation.Statuses.REGISTERED,
-        )
-        report = baker.make_recipe("reporting.tests.utils.report", operation=operation)
-        compliance_report = baker.make_recipe(
-            "compliance.tests.utils.compliance_report", report=report, bccr_subaccount_id=None
-        )
 
-        # Create the required relationships for compliance_report_version
-        report_version = baker.make_recipe("reporting.tests.utils.report_version", report=report)
-        baker.make_recipe(
-            "reporting.tests.utils.report_operation",
-            report_version=report_version,
-            operation_name="Test Operation Name",
-        )
-        report_compliance_summary = baker.make_recipe(
-            "reporting.tests.utils.report_compliance_summary", report_version=report_version
-        )
-        compliance_report_version = baker.make_recipe(
-            "compliance.tests.utils.compliance_report_version",
-            compliance_report=compliance_report,
-            report_compliance_summary=report_compliance_summary,
-        )
+        test_data = ComplianceTestHelper.build_test_data()
+        test_data.compliance_report.bccr_subaccount_id = None
+        test_data.compliance_report.save()
 
         holding_account = BCCRAccountResponseDetails(
             entity_id="123",
@@ -477,8 +388,8 @@ class TestBCCarbonRegistryAccountService:
         # Act
         result = service.get_or_create_compliance_account(
             holding_account_details=holding_account,
-            compliance_report=compliance_report,
-            compliance_report_version=compliance_report_version,
+            compliance_report=test_data.compliance_report,
+            compliance_report_version=test_data.compliance_report_version,
         )
         # Assert
         assert isinstance(result, BCCRComplianceAccountResponseDetails)

--- a/bc_obps/compliance/tests/utils/compliance_test_helper.py
+++ b/bc_obps/compliance/tests/utils/compliance_test_helper.py
@@ -40,6 +40,12 @@ class BaseComplianceTestInfrastructure:
         )
         ## INITIAL EMISSION REPORT VERSION
         self.report_version = make_recipe('reporting.tests.utils.report_version', report=self.report)
+        ## INITIAL REPORT OPERATION
+        self.report_operation = make_recipe(
+            "reporting.tests.utils.report_operation",
+            report_version=self.report_version,
+            operation_name="Test Operation Name",
+        )
         ## INITIAL REPORT COMPLIANCE SUMMARY
         self.report_compliance_summary = make_recipe(
             'reporting.tests.utils.report_compliance_summary',


### PR DESCRIPTION
resolves https://github.com/bcgov/cas-compliance/issues/519
resolves https://github.com/bcgov/cas-compliance/issues/520
resolves https://github.com/bcgov/cas-compliance/issues/521
resolves https://github.com/bcgov/cas-compliance/issues/525
resolves https://github.com/bcgov/cas-compliance/issues/527


Changes Made
- Added report_operation to the build_test_data BaseComplianceTestInfrastructure
- refactored 5 test files
	- api/test_compliance_report_versions
	- models/test_compliance_obligation
	- models/test_compliance_report_version
	- service/bccr/test_bccr_service
	- service/bccr/test_apply_compliance_units_service
