### PR TITLE
fix: use base image matching pgo

### DIFF
--- a/helm/migration-test/cas-obps-postgres-migration-test/templates/cronJobs/test-pgbackup-age.yaml
+++ b/helm/migration-test/cas-obps-postgres-migration-test/templates/cronJobs/test-pgbackup-age.yaml
@@ -21,7 +21,7 @@ spec:
           serviceAccountName: airflow-deployer
           containers:
             - name: postgres-age-check
-              image: postgres:16
+              image: {{ .Values.pgImage }}
               resources:
                 requests:
                   cpu: 50m

--- a/helm/migration-test/cas-obps-postgres-migration-test/templates/cronJobs/test-postgres-migrations.yaml
+++ b/helm/migration-test/cas-obps-postgres-migration-test/templates/cronJobs/test-postgres-migrations.yaml
@@ -21,7 +21,7 @@ spec:
           serviceAccountName: airflow-deployer
           containers:
           - name: postgres-migration-test
-            image: postgres:16
+            image: {{ .Values.pgImage }}
             resources:
               requests:
                 cpu: 50m

--- a/helm/migration-test/cas-obps-postgres-migration-test/values.yaml
+++ b/helm/migration-test/cas-obps-postgres-migration-test/values.yaml
@@ -3,3 +3,5 @@
 fullnameOverride: pg-migration-test
 
 sourceNamespace: ~
+
+pgImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres:ubi8-16.11-2547


### PR DESCRIPTION
Fix for failing `check-backup-age` task in Airflow. Replaces the generic Postgres image with one that matches our Postgres Operator. 