### PR TITLE
chore: release v0.2.2 of PG migration test chart

### DIFF
--- a/helm/migration-test/cas-obps-postgres-migration-test/Chart.yaml
+++ b/helm/migration-test/cas-obps-postgres-migration-test/Chart.yaml
@@ -4,6 +4,6 @@ description: A chart for testing the backups of the CAS BCIERS Postgres cluster.
 
 type: application
 
-version: 0.2.1
+version: 0.2.2
 
 appVersion: "0.1.0"


### PR DESCRIPTION
Releases the latest version of the chart, which includes the fix to the `check-backup-age` cronjob