### PR TITLE
4261 make error message noticeable

### DIFF
--- a/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
+++ b/bciers/apps/administration/tests/components/contacts/ContactForm.test.tsx
@@ -108,6 +108,48 @@ export const fillContactForm = async () => {
   await userEvent.type(screen.getByLabelText(/Postal Code/i), "A1B 2C3");
 };
 
+const getEditableInputByLabel = (label: RegExp) => {
+  const editableInput = screen
+    .getAllByLabelText(label)
+    .find(
+      (element) =>
+        !element.hasAttribute("readonly") && !element.hasAttribute("disabled"),
+    );
+
+  expect(editableInput).toBeDefined();
+  return editableInput as HTMLInputElement;
+};
+
+const createContactRequestBody = {
+  first_name: "John",
+  last_name: "Doe",
+  position_title: "Senior Officer",
+  email: "john.doe@example.com",
+  phone_number: "+1 604 401 1234",
+  street_address: "123 Main St",
+  municipality: "Cityville",
+  province: "AB",
+  postal_code: "A1B2C3",
+};
+
+const editNameFields = ({
+  firstName,
+  lastName,
+}: {
+  firstName: string;
+  lastName: string;
+}) => {
+  const firstNameField = getEditableInputByLabel(/First Name/i);
+  const lastNameField = getEditableInputByLabel(/Last Name/i);
+
+  return (async () => {
+    await userEvent.clear(firstNameField);
+    await userEvent.type(firstNameField, firstName);
+    await userEvent.clear(lastNameField);
+    await userEvent.type(lastNameField, lastName);
+  })();
+};
+
 const checkInlineMessage = (shouldExist = true) => {
   const message = screen.queryByText(
     /you can assign this representative to an operation directly in the operation information form\. to do so, go to the , select an operation, and go to the operation information form\./i,
@@ -261,6 +303,7 @@ describe("ContactForm component", () => {
           schema={createContactSchema(contactsSchema, true)}
           formData={{}}
           isCreating
+          allowEdit
         />,
       );
 
@@ -283,17 +326,7 @@ describe("ContactForm component", () => {
           "POST",
           "/contacts",
           {
-            body: JSON.stringify({
-              first_name: "John",
-              last_name: "Doe",
-              position_title: "Senior Officer",
-              email: "john.doe@example.com",
-              phone_number: "+1 604 401 1234",
-              street_address: "123 Main St",
-              municipality: "Cityville",
-              province: "AB",
-              postal_code: "A1B2C3",
-            }),
+            body: JSON.stringify(createContactRequestBody),
           },
         );
         expect(mockReplace).toHaveBeenCalledWith(
@@ -314,7 +347,7 @@ describe("ContactForm component", () => {
       timeout: 10000,
     },
     async () => {
-      render(
+      const { unmount } = render(
         <ContactForm
           schema={createContactSchema(contactsSchema, true)}
           formData={{}}
@@ -330,70 +363,52 @@ describe("ContactForm component", () => {
       };
       actionHandler.mockReturnValueOnce(response);
 
-      // Personal Information
-      await userEvent.type(screen.getByLabelText(/First Name/i), "John");
-      await userEvent.type(screen.getByLabelText(/Last Name/i), "Doe");
-      // Work Information
-      await userEvent.type(
-        screen.getByLabelText(/Job Title \/ Position/i),
-        "Senior Officer",
-      );
-      // Contact Information
-      await userEvent.type(
-        screen.getByLabelText(/Business Email Address/i),
-        "john.doe@example.com",
-      );
-      await userEvent.type(
-        screen.getByLabelText(/Business Telephone Number/i),
-        "+16044011234",
-      );
-
-      await userEvent.type(
-        screen.getByLabelText(/Business Mailing Address+/i),
-        "123 Street",
-      );
-      await userEvent.type(screen.getByLabelText(/Municipality+/i), "Toronto");
-
-      const provinceDropdown = screen.getByLabelText(/Province+/i);
-      await userEvent.click(provinceDropdown);
-      await userEvent.click(screen.getByText(/ontario/i));
-
-      await userEvent.type(screen.getByLabelText(/Postal Code+/i), "H0H 0H0");
+      await fillContactForm();
 
       // Submit
       await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
       // assert first invocation: POST
-      expect(actionHandler).toHaveBeenNthCalledWith(
-        1,
-        "registration/contacts",
-        "POST",
-        "/contacts",
-        {
-          body: JSON.stringify({
+      await waitFor(() => {
+        expect(actionHandler).toHaveBeenNthCalledWith(
+          1,
+          "registration/contacts",
+          "POST",
+          "/contacts",
+          {
+            body: JSON.stringify(createContactRequestBody),
+          },
+        );
+      });
+
+      // Mimic app behavior after create/redirect by remounting in existing-contact mode.
+      unmount();
+      const readOnlyContactSchema = createContactSchema(contactsSchema, false);
+      render(
+        <ContactForm
+          schema={readOnlyContactSchema}
+          formData={{
+            id: 123,
             first_name: "John",
             last_name: "Doe",
             position_title: "Senior Officer",
             email: "john.doe@example.com",
             phone_number: "+1 604 401 1234",
-            street_address: "123 Street",
-            municipality: "Toronto",
-            province: "ON",
-            postal_code: "H0H0H0",
-          }),
-        },
+            street_address: "123 Main St",
+            municipality: "Cityville",
+            province: "AB",
+            postal_code: "A1B2C3",
+            places_assigned: [],
+          }}
+          allowEdit
+        />,
       );
 
-      // switch to edit mode
       await userEvent.click(screen.getByRole("button", { name: /edit/i }));
-
-      // update Personal Information
-      const firstNameField = screen.getByLabelText(/First Name/i);
-      await userEvent.clear(firstNameField);
-      await userEvent.type(firstNameField, "John updated");
-      const lastNameField = screen.getByLabelText(/Last Name/i);
-      await userEvent.clear(lastNameField);
-      await userEvent.type(lastNameField, "Doe updated");
+      await editNameFields({
+        firstName: "John updated",
+        lastName: "Doe updated",
+      });
 
       response = {
         id: 123,
@@ -407,25 +422,28 @@ describe("ContactForm component", () => {
       await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
       // assert second invocation: PUT
-      expect(actionHandler).toHaveBeenNthCalledWith(
-        2,
-        "registration/contacts/123",
-        "PUT",
-        "/contacts/123",
-        {
-          body: JSON.stringify({
-            first_name: "John updated",
-            last_name: "Doe updated",
-            position_title: "Senior Officer",
-            email: "john.doe@example.com",
-            phone_number: "+1 604 401 1234",
-            street_address: "123 Street",
-            municipality: "Toronto",
-            province: "ON",
-            postal_code: "H0H0H0",
-          }),
-        },
-      );
+      await waitFor(() => {
+        expect(actionHandler).toHaveBeenNthCalledWith(
+          2,
+          "registration/contacts/123",
+          "PUT",
+          "/contacts/123",
+          {
+            body: JSON.stringify({
+              first_name: "John updated",
+              last_name: "Doe updated",
+              places_assigned: [],
+              position_title: "Senior Officer",
+              email: "john.doe@example.com",
+              phone_number: "+1 604 401 1234",
+              street_address: "123 Main St",
+              municipality: "Cityville",
+              province: "AB",
+              postal_code: "A1B2C3",
+            }),
+          },
+        );
+      });
     },
   );
   it("updates existing contact form data and hits the correct endpoint", async () => {
@@ -441,12 +459,10 @@ describe("ContactForm component", () => {
     await userEvent.click(screen.getByRole("button", { name: /edit/i }));
 
     // update Personal Information
-    const firstNameField = screen.getByLabelText(/First Name/i);
-    await userEvent.clear(firstNameField);
-    await userEvent.type(firstNameField, "John updated");
-    const lastNameField = screen.getByLabelText(/Last Name/i);
-    await userEvent.clear(lastNameField);
-    await userEvent.type(lastNameField, "Doe updated");
+    await editNameFields({
+      firstName: "John updated",
+      lastName: "Doe updated",
+    });
 
     const response = {
       id: 123,

--- a/bciers/apps/administration/tests/components/facilities/FacilityPage.test.tsx
+++ b/bciers/apps/administration/tests/components/facilities/FacilityPage.test.tsx
@@ -33,7 +33,7 @@ describe("Facilities component", () => {
     });
 
     await expect(async () => {
-      await render(
+      render(
         await FacilityPage({
           operationId: "025328a0-f9e8-4e1a-888d-aa192cb053db",
           facilityId: "garbage-bugs-dump-truck-fire",
@@ -113,6 +113,11 @@ describe("Facilities component", () => {
       }),
     );
     expect(screen.getByText(/Test Facility Name/i)).toBeVisible();
-    expect(screen.queryByText(/well/i)).toBeVisible();
+    expect(screen.getByText(/large facility/i)).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: /edit/i,
+      }),
+    ).toBeVisible();
   });
 });

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/apply-compliance-units/ApplyComplianceUnitsComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/apply-compliance-units/ApplyComplianceUnitsComponent.tsx
@@ -169,7 +169,7 @@ export default function ApplyComplianceUnitsComponent({
     );
     if (!response || response.error) {
       setStatus("idle");
-      setErrors([response?.error || "Failed to get compliance units data"]);
+      setErrors([response?.error || "Failed to get compliance units data."]);
     } else {
       // Set the remaining cap from the response (what’s left to apply)
       setRemainingCap(Number(response.compliance_unit_cap_remaining));
@@ -210,7 +210,7 @@ export default function ApplyComplianceUnitsComponent({
     );
     if (!response || response.error) {
       setStatus("submitted");
-      setErrors([response.error || "Failed to apply compliance units"]);
+      setErrors([response.error || "Failed to apply compliance units."]);
     } else {
       setStatus("applied");
       setErrors(undefined);

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/automatic-overdue-penalty/review-penalty-summary/PenaltySummaryReviewComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/automatic-overdue-penalty/review-penalty-summary/PenaltySummaryReviewComponent.tsx
@@ -69,6 +69,7 @@ const PenaltySummaryReviewComponent = ({
         formData={formData}
         className="w-full"
       >
+        <FormAlerts key="alerts" errors={errors} />
         <ComplianceStepButtons
           backUrl={backUrl}
           continueUrl={saveAndContinueUrl}
@@ -81,8 +82,6 @@ const PenaltySummaryReviewComponent = ({
           onMiddleButtonClick={handleGeneratePenaltyInvoice}
           className="mt-44"
         />
-        {/* Render any errors */}
-        <FormAlerts key="alerts" errors={errors} />
       </FormBase>
     </>
   );

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/download-payment-instructions/PaymentInstructionsDownloadComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/download-payment-instructions/PaymentInstructionsDownloadComponent.tsx
@@ -124,6 +124,7 @@ export default function PaymentInstructionsDownloadComponent({
         ].includes(invoiceType as ComplianceInvoiceTypes),
       }}
     >
+      <FormAlerts key="alerts" errors={errors} />
       <ComplianceStepButtons
         key="form-buttons"
         backUrl={backUrl}
@@ -134,7 +135,6 @@ export default function PaymentInstructionsDownloadComponent({
         middleButtonText={"Download Payment Instructions"}
         onMiddleButtonClick={handleDownloadInstructions}
       />
-      <FormAlerts key="alerts" errors={errors} />
     </FormBase>
   );
 }

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/ggeapar-interest/review-interest-summary/InterestSummaryReviewComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/ggeapar-interest/review-interest-summary/InterestSummaryReviewComponent.tsx
@@ -57,6 +57,7 @@ const InterestSummaryReviewComponent = ({
       formData={formData}
       className="w-full"
     >
+      <FormAlerts key="alerts" errors={errors} />
       <ComplianceStepButtons
         backUrl={backUrl}
         continueUrl={continueUrl}
@@ -69,8 +70,6 @@ const InterestSummaryReviewComponent = ({
         onMiddleButtonClick={handleGenerateInterestInvoice}
         className="mt-44"
       />
-      {/* Render any errors */}
-      <FormAlerts key="alerts" errors={errors} />
     </FormBase>
   );
 };

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/review-compliance-summary/ComplianceSummaryReviewComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/review-compliance-summary/ComplianceSummaryReviewComponent.tsx
@@ -63,6 +63,7 @@ export function ComplianceSummaryReviewComponent({
         maxCreditUsagePercentage: data.max_credit_usage_percentage,
       }}
     >
+      <FormAlerts key="alerts" errors={errors} />
       <ComplianceStepButtons
         backUrl={backUrl}
         continueUrl={saveAndContinueUrl}
@@ -74,9 +75,6 @@ export function ComplianceSummaryReviewComponent({
         }
         onMiddleButtonClick={handleGenerateInvoice}
       />
-
-      {/* Render any errors */}
-      <FormAlerts key="alerts" errors={errors} />
     </FormBase>
   );
 }

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manual-handling/internal/InternalManualHandlingComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manual-handling/internal/InternalManualHandlingComponent.tsx
@@ -72,7 +72,7 @@ const InternalManualHandlingComponent = ({
     });
 
     if (response?.error) {
-      setErrors([response.error || "Failed to submit request"]);
+      setErrors([response.error || "Failed to submit request."]);
     } else {
       setErrors(undefined);
 

--- a/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/internal/review-by-director/InternalReviewByDirectorComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/internal/review-by-director/InternalReviewByDirectorComponent.tsx
@@ -63,7 +63,7 @@ const InternalReviewByDirectorComponent = ({
 
   const handleSubmit = async (decision: "Approved" | "Declined") => {
     if (!isCasDirector) {
-      setErrors(["You are not authorized to submit this request"]);
+      setErrors(["You are not authorized to submit this request."]);
       return;
     }
     if (isSubmitting) {
@@ -83,7 +83,7 @@ const InternalReviewByDirectorComponent = ({
     if (response && !response.error) {
       router.push(continueUrl);
     } else {
-      setErrors([response.error || "Failed to submit request"]);
+      setErrors([response.error || "Failed to submit request."]);
       setIsSubmitting(false);
     }
   };

--- a/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/internal/review-credits-issuance-request/InternalReviewCreditsIssuanceRequestComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/internal/review-credits-issuance-request/InternalReviewCreditsIssuanceRequestComponent.tsx
@@ -77,7 +77,7 @@ const InternalReviewCreditsIssuanceRequestComponent = ({
     if (response && !response.error) {
       router.push(continueUrl);
     } else {
-      setErrors([response.error || "Failed to submit request"]);
+      setErrors([response.error || "Failed to submit request."]);
       setIsSubmitting(false);
     }
   };

--- a/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
+++ b/bciers/apps/registration/tests/components/operations/registration/OperationInformationForm.test.tsx
@@ -598,7 +598,7 @@ describe("the OperationInformationForm component", () => {
     await userEvent.click(
       screen.getByRole("button", { name: /save and continue/i }),
     );
-    expect(screen.getAllByRole("alert")).toHaveLength(9);
+    expect(screen.getAllByRole("alert")).toHaveLength(10);
     expect(
       screen.getByText(
         /Select an operation or add a new operation in the form below/i,

--- a/bciers/apps/registration/tests/components/transfers/TransferForm.test.tsx
+++ b/bciers/apps/registration/tests/components/transfers/TransferForm.test.tsx
@@ -205,24 +205,28 @@ describe("The TransferForm component", () => {
     await selectEntityAndAssertFields("Facility");
   });
 
-  it("fetches facilities when operation changes", async () => {
-    renderTransferForm();
-    selectOperator(/current operator\*/i, "Operator 1");
-    selectOperator(/select the new operator\*/i, "Operator 2");
-    await selectEntityAndAssertFields("Facility");
-    await selectOperation(
-      /select the operation that the facility\(s\) currently belongs to\*/i,
-      "Operation 1",
-    );
-    expect(fetchFacilitiesPageData).toHaveBeenCalledWith(
-      "8be4c7aa-6ab3-4aad-9206-0ef914fea065",
-      {
-        paginate_results: false,
-        end_date: true,
-        status: "Active",
-      },
-    );
-  });
+  it(
+    "fetches facilities when operation changes",
+    { timeout: 10000 },
+    async () => {
+      renderTransferForm();
+      selectOperator(/current operator\*/i, "Operator 1");
+      selectOperator(/select the new operator\*/i, "Operator 2");
+      await selectEntityAndAssertFields("Facility");
+      await selectOperation(
+        /select the operation that the facility\(s\) currently belongs to\*/i,
+        "Operation 1",
+      );
+      expect(fetchFacilitiesPageData).toHaveBeenCalledWith(
+        "8be4c7aa-6ab3-4aad-9206-0ef914fea065",
+        {
+          paginate_results: false,
+          end_date: true,
+          status: "Active",
+        },
+      );
+    },
+  );
 
   it("submits the form and shows success screen", async () => {
     actionHandler.mockResolvedValueOnce({});

--- a/bciers/apps/reporting/src/app/components/attachments/AttachmentsForm.tsx
+++ b/bciers/apps/reporting/src/app/components/attachments/AttachmentsForm.tsx
@@ -64,6 +64,7 @@ const AttachmentsForm: React.FC<Props> = ({
   const [isRedirecting, setIsRedirecting] = useState<boolean>(false);
 
   const [errors, setErrors] = useState<string[]>();
+  const [hasValidationError, setHasValidationError] = useState(false);
   const [validationErrors, setValidationErrors] = useState<{
     [fileType: string]: string;
   }>({});
@@ -92,9 +93,11 @@ const AttachmentsForm: React.FC<Props> = ({
       setValidationErrors({
         verification_statement: "Verification statement is required",
       });
+      setHasValidationError(true);
       return false;
     } else {
       setValidationErrors({});
+      setHasValidationError(false);
       return true;
     }
   };
@@ -177,123 +180,122 @@ const AttachmentsForm: React.FC<Props> = ({
   );
 
   return (
-    <>
-      <MultiStepWrapperWithTaskList
-        steps={navigationInformation.headerSteps}
-        initialStep={navigationInformation.headerStepIndex}
-        taskListElements={navigationInformation.taskList}
-        onSubmit={() => handleSubmit(true)}
-        cancelUrl="#"
-        backUrl={navigationInformation.backUrl}
-        continueUrl={navigationInformation.continueUrl}
-        errors={errors}
-        isSaving={isSaving}
-        isRedirecting={isRedirecting}
-        noFormSave={() => handleSubmit(false)}
-        submitButtonDisabled={submitDisabled}
-      >
-        <div className="w-full form-group field field-object form-heading-label">
-          <div className="form-heading">Attachments</div>
-        </div>
-        {isSupplementaryReport && (
-          <Alert severity="warning" icon={<AlertIcon fill="#635231" />}>
-            Review your attachments and replace any that are no longer
-            applicable to this report.
-          </Alert>
-        )}
-        <p>
-          Please upload any of the documents below that is applicable to your
-          report:
-        </p>
-        {buildAttachmentElement(
-          "Verification Statement",
-          "verification_statement",
-          {
-            required: isVerificationStatementMandatory,
-            error: validationErrors.verification_statement,
-          },
-        )}
-        {buildAttachmentElement("WCI.352 and WCI.362", "wci_352_362")}
-        {buildAttachmentElement(
-          "Additional reportable information",
-          "additional_reportable_information",
-        )}
-        {buildAttachmentElement(
-          "Confidentiality request, if you are requesting confidentiality of this report under the B.C. Reg. 249/2015 Reporting Regulation",
-          "confidentiality_request",
-        )}
-        <p>
-          <b>Note:</b>
-        </p>
-        <ul>
-          <li>
-            An operator may claim that disclosure of the information referred to
-            in Section 44(2)(a) to (d) be prohibited under Section 21 of the
-            Freedom of Information and Protection of Privacy Act (FOIPPA) and
-            request that the information be kept confidential
-          </li>
-          <li>
-            A claim must be done in accordance with Section 44(5) of the
-            Regulation
-          </li>
-          <li>
-            The Director under GGIRCA will be in contact with you regarding your
-            request
-          </li>
-        </ul>{" "}
-        {isSupplementaryReport && (
-          <div className="mt-4 border-t pt-4">
-            <p>
-              Before clicking &apos;Save & Continue&apos;, please confirm that
-              you understand and agree with the following statements:
-            </p>
-            <div className="flex items-start mt-3">
-              <Checkbox
-                id="confirm-relevant-attachment-check"
-                checked={confirmExistingAttachmentsRelevant}
-                onChange={(e) =>
-                  setConfirmExistingAttachmentsRelevant(e.target.checked)
-                }
-                inputProps={{
-                  "aria-labelledby":
-                    "confirm-existing-attachments-relevant-label",
-                }}
-              />
-              <label
-                id="confirm-existing-attachments-relevant-label"
-                className="ml-2"
-                htmlFor="confirm-relevant-attachment-check"
-              >
-                I confirm that I have uploaded any attachments that are required
-                to be updated for the new submission of this report.
-              </label>
-            </div>
-            <div className="flex items-start mt-3">
-              <Checkbox
-                id="confirm-required-attachment-check"
-                checked={confirmRequiredAttachmentsUploaded}
-                onChange={(e) =>
-                  setConfirmRequiredAttachmentsUploaded(e.target.checked)
-                }
-                inputProps={{
-                  "aria-labelledby":
-                    "confirm-required-attachments-uploaded-label",
-                }}
-              />
-              <label
-                id="confirm-required-attachments-uploaded-label"
-                className="ml-2"
-                htmlFor="confirm-required-attachment-check"
-              >
-                I confirm that any previously uploaded attachments that have not
-                been updated are still relevant to the new submission of this
-                report.
-              </label>
-            </div>
+    <MultiStepWrapperWithTaskList
+      steps={navigationInformation.headerSteps}
+      initialStep={navigationInformation.headerStepIndex}
+      taskListElements={navigationInformation.taskList}
+      onSubmit={() => handleSubmit(true)}
+      cancelUrl="#"
+      backUrl={navigationInformation.backUrl}
+      continueUrl={navigationInformation.continueUrl}
+      errors={errors}
+      validationError={hasValidationError}
+      isSaving={isSaving}
+      isRedirecting={isRedirecting}
+      noFormSave={() => handleSubmit(false)}
+      submitButtonDisabled={submitDisabled}
+    >
+      <div className="w-full form-group field field-object form-heading-label">
+        <div className="form-heading">Attachments</div>
+      </div>
+      {isSupplementaryReport && (
+        <Alert severity="warning" icon={<AlertIcon fill="#635231" />}>
+          Review your attachments and replace any that are no longer applicable
+          to this report.
+        </Alert>
+      )}
+      <p>
+        Please upload any of the documents below that is applicable to your
+        report:
+      </p>
+      {buildAttachmentElement(
+        "Verification Statement",
+        "verification_statement",
+        {
+          required: isVerificationStatementMandatory,
+          error: validationErrors.verification_statement,
+        },
+      )}
+      {buildAttachmentElement("WCI.352 and WCI.362", "wci_352_362")}
+      {buildAttachmentElement(
+        "Additional reportable information",
+        "additional_reportable_information",
+      )}
+      {buildAttachmentElement(
+        "Confidentiality request, if you are requesting confidentiality of this report under the B.C. Reg. 249/2015 Reporting Regulation",
+        "confidentiality_request",
+      )}
+      <p>
+        <b>Note:</b>
+      </p>
+      <ul>
+        <li>
+          An operator may claim that disclosure of the information referred to
+          in Section 44(2)(a) to (d) be prohibited under Section 21 of the
+          Freedom of Information and Protection of Privacy Act (FOIPPA) and
+          request that the information be kept confidential
+        </li>
+        <li>
+          A claim must be done in accordance with Section 44(5) of the
+          Regulation
+        </li>
+        <li>
+          The Director under GGIRCA will be in contact with you regarding your
+          request
+        </li>
+      </ul>{" "}
+      {isSupplementaryReport && (
+        <div className="mt-4 border-t pt-4">
+          <p>
+            Before clicking &apos;Save & Continue&apos;, please confirm that you
+            understand and agree with the following statements:
+          </p>
+          <div className="flex items-start mt-3">
+            <Checkbox
+              id="confirm-relevant-attachment-check"
+              checked={confirmExistingAttachmentsRelevant}
+              onChange={(e) =>
+                setConfirmExistingAttachmentsRelevant(e.target.checked)
+              }
+              inputProps={{
+                "aria-labelledby":
+                  "confirm-existing-attachments-relevant-label",
+              }}
+            />
+            <label
+              id="confirm-existing-attachments-relevant-label"
+              className="ml-2"
+              htmlFor="confirm-relevant-attachment-check"
+            >
+              I confirm that I have uploaded any attachments that are required
+              to be updated for the new submission of this report.
+            </label>
           </div>
-        )}
-      </MultiStepWrapperWithTaskList>
-    </>
+          <div className="flex items-start mt-3">
+            <Checkbox
+              id="confirm-required-attachment-check"
+              checked={confirmRequiredAttachmentsUploaded}
+              onChange={(e) =>
+                setConfirmRequiredAttachmentsUploaded(e.target.checked)
+              }
+              inputProps={{
+                "aria-labelledby":
+                  "confirm-required-attachments-uploaded-label",
+              }}
+            />
+            <label
+              id="confirm-required-attachments-uploaded-label"
+              className="ml-2"
+              htmlFor="confirm-required-attachment-check"
+            >
+              I confirm that any previously uploaded attachments that have not
+              been updated are still relevant to the new submission of this
+              report.
+            </label>
+          </div>
+        </div>
+      )}
+    </MultiStepWrapperWithTaskList>
   );
 };
 

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
@@ -50,7 +50,7 @@ export const FacilityReview: React.FC<Props> = ({
     const endpoint = `reporting/report-version/${version_id}/facility-report/${facility_id}`;
     const pathToRevalidate = `reporting/reports/${version_id}/facilities/${facility_id}/review-facility-information`;
     if (formData.activities.length === 0) {
-      setErrors(["You must select at least one activity"]);
+      setErrors(["You must select at least one activity."]);
       return false;
     }
 
@@ -88,7 +88,7 @@ export const FacilityReview: React.FC<Props> = ({
     );
 
     if (getUpdatedFacilityData.error) {
-      setErrors(["Unable to sync data"]);
+      setErrors(["Unable to sync data."]);
       return;
     }
 

--- a/bciers/apps/reporting/src/app/components/operations/OperationReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReviewForm.tsx
@@ -105,7 +105,7 @@ export default function OperationReviewForm({
   const handleSync = async () => {
     const newData = await getUpdatedReportOperationDetails(version_id);
     if (newData.error) {
-      setErrors(["Unable to sync data"]);
+      setErrors(["Unable to sync data."]);
       return;
     }
     setPageSchema(

--- a/bciers/apps/reporting/src/app/components/operations/reviewFacilities/ReviewFacilitiesForm.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/reviewFacilities/ReviewFacilitiesForm.tsx
@@ -132,7 +132,7 @@ export default function LFOFacilitiesForm({
     setFormData({ ...e.formData });
     const anyFacilitySelected = isAnyFacilitySelected(e.formData);
     if (!anyFacilitySelected) {
-      setErrors(["No facilities selected"]);
+      setErrors(["No facilities selected."]);
       setSubmittingDisabled(true);
     } else {
       setErrors(undefined);

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -77,7 +77,7 @@ const ProductionDataForm: React.FC<Props> = ({
       !["Small Aggregate", "Medium Facility"].includes(facilityType) &&
       formData.product_selection.length < 1
     ) {
-      setErrors(["A product must be selected"]);
+      setErrors(["A product must be selected."]);
       return false;
     }
     const response = await postProductionData(

--- a/bciers/apps/reporting/src/tests/components/facility/FacilityReviewForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/facility/FacilityReviewForm.test.tsx
@@ -156,7 +156,7 @@ describe("The FacilityReview component", () => {
     expect(mockActionHandler).toHaveBeenCalled();
 
     await waitFor(() => {
-      expect(getByText("Some error occurred")).toBeInTheDocument();
+      expect(getByText("Some error occurred")).toBeVisible();
     });
   });
 
@@ -167,9 +167,7 @@ describe("The FacilityReview component", () => {
     await act(() => calledProps.onSubmit());
 
     await waitFor(() => {
-      expect(
-        getByText("You must select at least one activity"),
-      ).toBeInTheDocument();
+      expect(getByText("You must select at least one activity.")).toBeVisible();
     });
     expect(mockActionHandler).not.toHaveBeenCalled();
   });

--- a/bciers/apps/reporting/src/tests/components/operations/reviewFacilities/ReviewFacilities.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/operations/reviewFacilities/ReviewFacilities.test.tsx
@@ -89,25 +89,25 @@ describe("LFOFacilitiesForm", () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getByText("Review Facilities")).toBeInTheDocument();
+      expect(screen.getByText("Review Facilities")).toBeVisible();
     });
 
     expect(
       screen.getByText(
         "List of facilities currently assigned to this operation",
       ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Facility 1")).toBeInTheDocument();
-    expect(screen.getByText("Facility 2")).toBeInTheDocument();
+    ).toBeVisible();
+    expect(screen.getByText("Facility 1")).toBeVisible();
+    expect(screen.getByText("Facility 2")).toBeVisible();
     expect(
       screen.getByText("Past facilities that belonged to this operation"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Facility 3")).toBeInTheDocument();
-    expect(screen.getByText("Facility 4")).toBeInTheDocument();
+    ).toBeVisible();
+    expect(screen.getByText("Facility 3")).toBeVisible();
+    expect(screen.getByText("Facility 4")).toBeVisible();
 
     expect(
       screen.getByText("Sync latest data from Administration"),
-    ).toBeInTheDocument();
+    ).toBeVisible();
 
     expectButton(config.buttons.back, true);
     expectButton(config.buttons.saveAndContinue, true);
@@ -134,7 +134,7 @@ describe("LFOFacilitiesForm", () => {
     fireEvent.click(checkbox1);
     fireEvent.click(checkbox3);
 
-    expect(screen.getByText("No facilities selected")).toBeInTheDocument();
+    expect(screen.getByText("No facilities selected.")).toBeVisible();
     expectButton(config.buttons.continue, false);
     expectButton(config.buttons.save, false);
   });
@@ -166,11 +166,11 @@ describe("LFOFacilitiesForm", () => {
       fireEvent.click(saveButton);
       // Assert that the confirmation modal is displayed
       await waitFor(() => {
-        expect(screen.getByText("Confirmation")).toBeInTheDocument();
+        expect(screen.getByText("Confirmation")).toBeVisible();
       });
       expect(
         screen.getByText("You have deselected the following facilities:"),
-      ).toBeInTheDocument();
+      ).toBeVisible();
       // Assert that the deselected facility is displayed
       expect(screen.getAllByText("Facility 1")).toHaveLength(2);
       // Assert that the unselected facility (was not and still is not selected) is not displayed
@@ -190,7 +190,7 @@ describe("LFOFacilitiesForm", () => {
       });
       fireEvent.click(saveAndContinueButton);
       await waitFor(() => {
-        expect(screen.getByText("Confirmation")).toBeInTheDocument();
+        expect(screen.getByText("Confirmation")).toBeVisible();
       });
       const continueButton = screen.getByRole("button", {
         name: config.buttons.continue,
@@ -244,7 +244,7 @@ describe("LFOFacilitiesForm", () => {
     });
     fireEvent.click(saveAndContinueButton);
     await waitFor(() => {
-      expect(screen.getByText("Confirmation")).toBeInTheDocument();
+      expect(screen.getByText("Confirmation")).toBeVisible();
     });
 
     const cancelButton = screen.getByRole("button", {
@@ -283,8 +283,8 @@ describe("LFOFacilitiesForm", () => {
     });
 
     // Ensure that current facilities are still rendered
-    expect(screen.getByText("Facility 1")).toBeInTheDocument();
-    expect(screen.getByText("Facility 2")).toBeInTheDocument();
+    expect(screen.getByText("Facility 1")).toBeVisible();
+    expect(screen.getByText("Facility 2")).toBeVisible();
   });
 
   it("should hide sync button when is_sync_allowed is false", async () => {
@@ -303,7 +303,7 @@ describe("LFOFacilitiesForm", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Review Facilities")).toBeInTheDocument();
+      expect(screen.getByText("Review Facilities")).toBeVisible();
     });
 
     // Sync button should not be present

--- a/bciers/libs/components/src/form/FormAlerts.test.tsx
+++ b/bciers/libs/components/src/form/FormAlerts.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import FormAlerts from "./FormAlerts";
 
+vi.mock("@bciers/components/icons/AlertIcon", () => ({
+  default: () => <svg data-testid="alert-icon" />,
+}));
+
 describe("FormAlerts", () => {
   test("does not render when errors is undefined", () => {
     render(<FormAlerts errors={undefined} />);
@@ -18,8 +22,13 @@ describe("FormAlerts", () => {
 
     const alerts = screen.getAllByRole("alert");
     expect(alerts).toHaveLength(2);
-    expect(screen.getByText("First error")).toBeInTheDocument();
-    expect(screen.getByText("Second error")).toBeInTheDocument();
+    expect(screen.getByText("First error")).toBeVisible();
+    expect(screen.getByText("Second error")).toBeVisible();
+  });
+
+  test("renders the AlertIcon inside each alert", () => {
+    render(<FormAlerts errors={["An error"]} />);
+    expect(screen.getByTestId("alert-icon")).toBeVisible();
   });
 
   test("renders React nodes inside alerts", () => {
@@ -33,7 +42,7 @@ describe("FormAlerts", () => {
     render(<FormAlerts errors={errors} />);
 
     expect(screen.getAllByRole("alert")).toHaveLength(2);
-    expect(screen.getByText("Simple error")).toBeInTheDocument();
-    expect(screen.getByText("bold")).toBeInTheDocument();
+    expect(screen.getByText("Simple error")).toBeVisible();
+    expect(screen.getByText("bold")).toBeVisible();
   });
 });

--- a/bciers/libs/components/src/form/FormAlerts.tsx
+++ b/bciers/libs/components/src/form/FormAlerts.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Alert } from "@mui/material";
+import AlertIcon from "@bciers/components/icons/AlertIcon";
 
 interface FormAlertsProps {
   errors: (string | React.ReactNode)[] | undefined;
@@ -19,7 +20,12 @@ const FormAlerts: React.FC<FormAlertsProps> = ({ errors }) => {
   return (
     <div className="min-h-[48px] box-border mt-4">
       {errors.map((error, index) => (
-        <Alert key={index} severity="error">
+        <Alert
+          key={index}
+          severity="error"
+          className="my-2 items-center"
+          icon={<AlertIcon />}
+        >
           {error}
         </Alert>
       ))}

--- a/bciers/libs/components/src/form/FormBase.test.tsx
+++ b/bciers/libs/components/src/form/FormBase.test.tsx
@@ -105,4 +105,70 @@ describe("The FormBase component", () => {
     fireEvent.click(submitButton);
     expect(screen.queryByText(/^.* is required/i)).not.toBeInTheDocument();
   });
+
+  it("shows validation error alert when form is submitted with errors", () => {
+    const props = {
+      schema: testSchema,
+    } as any;
+    render(
+      <FormBase {...props}>
+        <button type="submit">Submit</button>
+      </FormBase>,
+    );
+    const submitButton = screen.getByRole("button", { name: /Submit/i });
+    fireEvent.click(submitButton);
+    expect(
+      screen.getByText(
+        /This form can't be saved yet. Please fix the errors above./i,
+      ),
+    ).toBeVisible();
+  });
+
+  it("shows a custom validation error message when validationErrorMessage prop is provided", () => {
+    const props = {
+      schema: testSchema,
+      validationErrorMessage: "Custom error message for this form.",
+    } as any;
+    render(
+      <FormBase {...props}>
+        <button type="submit">Submit</button>
+      </FormBase>,
+    );
+    const submitButton = screen.getByRole("button", { name: /Submit/i });
+    fireEvent.click(submitButton);
+    expect(
+      screen.getByText(/Custom error message for this form./i),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(
+        /This form can't be saved yet. Please fix the errors above./i,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides validation error alert after form is successfully submitted", () => {
+    const props = {
+      schema: testSchema,
+    } as any;
+    render(
+      <FormBase {...props}>
+        <button type="submit">Submit</button>
+      </FormBase>,
+    );
+    const submitButton = screen.getByRole("button", { name: /Submit/i });
+    const input = screen.getByRole("textbox", { name: "field*" });
+    fireEvent.click(submitButton);
+    expect(
+      screen.getByText(
+        /This form can't be saved yet. Please fix the errors above./i,
+      ),
+    ).toBeVisible();
+    fireEvent.change(input, { target: { value: "anything" } });
+    fireEvent.click(submitButton);
+    expect(
+      screen.getByText(
+        /This form can't be saved yet. Please fix the errors above./i,
+      ),
+    ).not.toBeVisible();
+  });
 });

--- a/bciers/libs/components/src/form/FormBase.tsx
+++ b/bciers/libs/components/src/form/FormBase.tsx
@@ -47,7 +47,7 @@ export interface FormPropsWithTheme<T> extends Omit<FormProps<T>, "validator"> {
   validator?: any;
   formRef?: any;
   setErrorReset?: (error: undefined) => void;
-  validationErrorMessage?: string;
+  validationErrorMessage?: string; // overrides the default message in FormValidationError
 }
 
 // For efficiency, we pre-compute the themed form components
@@ -68,7 +68,7 @@ const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
     readonly,
     setErrorReset,
     theme,
-    validationErrorMessage = "This form can't be saved yet. Please fix the errors above.",
+    validationErrorMessage,
   } = props;
   if (theme && theme !== defaultTheme && theme !== readOnlyTheme) {
     throw new Error("Unsupported form theme");

--- a/bciers/libs/components/src/form/FormBase.tsx
+++ b/bciers/libs/components/src/form/FormBase.tsx
@@ -1,10 +1,11 @@
 import defaultTheme from "./theme/defaultTheme";
 import readOnlyTheme from "./theme/readOnlyTheme";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { customizeValidator } from "@rjsf/validator-ajv8";
 import { FormProps, IChangeEvent, withTheme, ThemeProps } from "@rjsf/core";
 import customTransformErrors from "@bciers/utils/src/customTransformErrors";
 import { RJSFValidationError } from "@rjsf/utils";
+import FormValidationError from "./components/FormValidationError";
 
 // Best I can do for manual text validation for the DateWidget
 const currentYear = new Date().getFullYear();
@@ -46,6 +47,7 @@ export interface FormPropsWithTheme<T> extends Omit<FormProps<T>, "validator"> {
   validator?: any;
   formRef?: any;
   setErrorReset?: (error: undefined) => void;
+  validationErrorMessage?: string;
 }
 
 // For efficiency, we pre-compute the themed form components
@@ -56,6 +58,7 @@ const ReadOnlyForm = withTheme(readOnlyTheme);
 // formbase with forwardRef
 const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
   const {
+    children,
     disabled,
     formData,
     omitExtraData,
@@ -65,6 +68,7 @@ const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
     readonly,
     setErrorReset,
     theme,
+    validationErrorMessage = "This form can't be saved yet. Please fix the errors above.",
   } = props;
   if (theme && theme !== defaultTheme && theme !== readOnlyTheme) {
     throw new Error("Unsupported form theme");
@@ -75,14 +79,23 @@ const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
       : DefaultForm;
   const [formState, setFormState] = useState(formData ?? {});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const validationErrorRef = useRef<HTMLDivElement>(null);
 
   // Handling form state externally as RJSF was resetting the form data on submission and
   // creating buggy behaviour if there was an API error and the user attempted to resubmit
   const handleSubmit = (e: IChangeEvent) => {
+    if (validationErrorRef.current) validationErrorRef.current.hidden = true;
     setIsSubmitting(true);
     setFormState(e.formData);
     if (setErrorReset) setErrorReset(undefined); // Reset error state on form submission
     if (onSubmit) onSubmit(e, formState);
+  };
+
+  // Use imperative DOM update instead of state to avoid triggering a React re-render.
+  // A re-render would pass changed children to RJSF, causing it to re-derive form state
+  // and reset conditional fields (e.g. toggled sections driven by dependencies).
+  const handleError = () => {
+    if (validationErrorRef.current) validationErrorRef.current.hidden = false;
   };
 
   const handleChange = (e: IChangeEvent) => {
@@ -103,6 +116,7 @@ const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
       onChange={handleChange}
       noHtml5Validate
       omitExtraData={omitExtraData ?? true}
+      onError={handleError}
       onSubmit={handleSubmit}
       showErrorList={false}
       transformErrors={transformErrors}
@@ -113,7 +127,16 @@ const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
           constAsDefaults: "never",
         } as any
       }
-    />
+    >
+      {children ? (
+        <>
+          <div ref={validationErrorRef} hidden>
+            <FormValidationError message={validationErrorMessage} />
+          </div>
+          {children}
+        </>
+      ) : null}
+    </Form>
   );
 };
 

--- a/bciers/libs/components/src/form/MultiStepBase.test.tsx
+++ b/bciers/libs/components/src/form/MultiStepBase.test.tsx
@@ -274,7 +274,7 @@ describe("The MultiStepBase component", () => {
       name: /Save and Continue/i,
     });
     fireEvent.click(saveAndContinueButton);
-    expect(screen.getByRole("alert")).toBeVisible();
+    expect(screen.getAllByRole("alert")).toHaveLength(2); // 1 extra for FormValidationError
     expect(mockOnSubmit).not.toHaveBeenCalled(); // submit function is not called because we hit validation errors first
   });
 

--- a/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.test.tsx
+++ b/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.test.tsx
@@ -123,6 +123,65 @@ describe("MultiStepFormWithTaskList", () => {
     expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
   });
 
+  it("does not render validation error when validationError is false", () => {
+    render(
+      <MultiStepWrapperWithTaskList
+        initialStep={0}
+        steps={["Step 1"]}
+        taskListElements={taskListElements}
+        onSubmit={mockOnSubmit}
+        continueUrl={""}
+        validationError={false}
+      />,
+    );
+
+    expect(
+      screen.queryByText(
+        /This form can't be saved yet. Please fix the errors above./i,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders default validation error message when validationError is true", () => {
+    render(
+      <MultiStepWrapperWithTaskList
+        initialStep={0}
+        steps={["Step 1"]}
+        taskListElements={taskListElements}
+        onSubmit={mockOnSubmit}
+        continueUrl={""}
+        validationError={true}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        /This form can't be saved yet. Please fix the errors above./i,
+      ),
+    ).toBeVisible();
+  });
+
+  it("renders custom validation error message when validationErrorMessage is provided", () => {
+    render(
+      <MultiStepWrapperWithTaskList
+        initialStep={0}
+        steps={["Step 1"]}
+        taskListElements={taskListElements}
+        onSubmit={mockOnSubmit}
+        continueUrl={""}
+        validationError={true}
+        validationErrorMessage="Custom validation message."
+      />,
+    );
+
+    expect(screen.getByText("Custom validation message.")).toBeVisible();
+    expect(
+      screen.queryByText(
+        /This form can't be saved yet. Please fix the errors above./i,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders an alternave text for the save button if provided", () => {
     render(
       <MultiStepWrapperWithTaskList

--- a/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
+++ b/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
@@ -50,7 +50,7 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
   noSaveButton,
   submitButtonDisabled,
   validationError,
-  validationErrorMessage = "This form can't be saved yet. Please fix the errors above.",
+  validationErrorMessage,
 }) => {
   return (
     <Box sx={{ p: 3 }}>

--- a/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
+++ b/bciers/libs/components/src/form/MultiStepWrapperWithTaskList.tsx
@@ -7,6 +7,7 @@ import { Box } from "@mui/material";
 import MultiStepHeader from "@bciers/components/form/components/MultiStepHeader";
 import ReportingStepButtons from "@bciers/components/form/components/ReportingStepButtons";
 import FormAlerts from "@bciers/components/form/FormAlerts";
+import FormValidationError from "@bciers/components/form/components/FormValidationError";
 /**
  * Similar to the MultiStepFormWithTaskList,
  * except doesn't display a form, but can be used as a wrapper for any other page for a consistent look.
@@ -29,6 +30,8 @@ interface Props {
   noFormSave?: () => void;
   noSaveButton?: boolean;
   submitButtonDisabled?: boolean;
+  validationError?: boolean;
+  validationErrorMessage?: string;
 }
 
 const MultiStepWrapperWithTaskList: React.FC<Props> = ({
@@ -46,6 +49,8 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
   noFormSave,
   noSaveButton,
   submitButtonDisabled,
+  validationError,
+  validationErrorMessage = "This form can't be saved yet. Please fix the errors above.",
 }) => {
   return (
     <Box sx={{ p: 3 }}>
@@ -59,6 +64,10 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
         </div>
         <div className="w-full">
           {children}
+          {validationError && (
+            <FormValidationError message={validationErrorMessage} />
+          )}
+          <FormAlerts errors={errors} />
           <ReportingStepButtons
             backUrl={backUrl}
             continueUrl={continueUrl}
@@ -70,9 +79,6 @@ const MultiStepWrapperWithTaskList: React.FC<Props> = ({
             noSaveButton={noSaveButton}
             submitButtonDisabled={submitButtonDisabled}
           />
-
-          {/* Render form alerts */}
-          <FormAlerts errors={errors} />
         </div>
       </div>
     </Box>

--- a/bciers/libs/components/src/form/NavigationForm.tsx
+++ b/bciers/libs/components/src/form/NavigationForm.tsx
@@ -106,7 +106,6 @@ const NavigationForm: React.FC<NavigationFormProps> = (props) => {
       }
     }
   };
-
   return (
     <FormBase
       {...props}
@@ -117,6 +116,7 @@ const NavigationForm: React.FC<NavigationFormProps> = (props) => {
         shouldNavigateRef.current = false; // Reset after submission
       }}
     >
+      <FormAlerts key="alerts" errors={errors} />
       <ReportingStepButtons
         key="form-buttons"
         backUrl={backUrl}
@@ -131,8 +131,6 @@ const NavigationForm: React.FC<NavigationFormProps> = (props) => {
         noSaveButton={noSaveButton}
         backButtonText={backButtonText}
       />
-      {/* Render form alerts */}
-      <FormAlerts key="alerts" errors={errors} />
     </FormBase>
   );
 };

--- a/bciers/libs/components/src/form/components/FormValidationError.test.tsx
+++ b/bciers/libs/components/src/form/components/FormValidationError.test.tsx
@@ -1,17 +1,23 @@
 import { render, screen } from "@testing-library/react";
 import FormValidationError from "./FormValidationError";
 
-vi.mock("@bciers/components/icons/AlertIcon", () => ({
-  default: () => <svg data-testid="alert-icon" />,
-}));
-
 describe("FormValidationError", () => {
-  it("renders the alert with error styling, icon, and provided message", () => {
-    render(<FormValidationError message="Something went wrong." />);
+  it("renders the alert with the default message", () => {
+    render(<FormValidationError />);
+    expect(
+      screen.getByText(
+        /This form can't be saved yet. Please fix the errors above./i,
+      ),
+    ).toBeVisible();
+  });
 
-    const alert = screen.getByRole("alert");
-    expect(alert).toBeVisible();
-    expect(screen.getByText("Something went wrong.")).toBeVisible();
-    expect(screen.getByTestId("alert-icon")).toBeVisible();
+  it("renders the alert with a custom message when provided", () => {
+    render(<FormValidationError message="Custom error." />);
+    expect(screen.getByText("Custom error.")).toBeVisible();
+    expect(
+      screen.queryByText(
+        /This form can't be saved yet. Please fix the errors above./i,
+      ),
+    ).not.toBeInTheDocument();
   });
 });

--- a/bciers/libs/components/src/form/components/FormValidationError.test.tsx
+++ b/bciers/libs/components/src/form/components/FormValidationError.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import FormValidationError from "./FormValidationError";
+
+vi.mock("@bciers/components/icons/AlertIcon", () => ({
+  default: () => <svg data-testid="alert-icon" />,
+}));
+
+describe("FormValidationError", () => {
+  it("renders the alert with error styling, icon, and provided message", () => {
+    render(<FormValidationError message="Something went wrong." />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeVisible();
+    expect(screen.getByText("Something went wrong.")).toBeVisible();
+    expect(screen.getByTestId("alert-icon")).toBeVisible();
+  });
+});

--- a/bciers/libs/components/src/form/components/FormValidationError.tsx
+++ b/bciers/libs/components/src/form/components/FormValidationError.tsx
@@ -1,0 +1,14 @@
+import { Alert } from "@mui/material";
+import AlertIcon from "@bciers/components/icons/AlertIcon";
+
+interface FormValidationErrorProps {
+  message: string;
+}
+
+const FormValidationError = ({ message }: FormValidationErrorProps) => (
+  <Alert severity="error" className="my-2 items-center" icon={<AlertIcon />}>
+    {message}
+  </Alert>
+);
+
+export default FormValidationError;

--- a/bciers/libs/components/src/form/components/FormValidationError.tsx
+++ b/bciers/libs/components/src/form/components/FormValidationError.tsx
@@ -1,14 +1,11 @@
-import { Alert } from "@mui/material";
-import AlertIcon from "@bciers/components/icons/AlertIcon";
+import FormAlerts from "@bciers/components/form/FormAlerts";
 
 interface FormValidationErrorProps {
-  message: string;
+  message?: string;
 }
 
-const FormValidationError = ({ message }: FormValidationErrorProps) => (
-  <Alert severity="error" className="my-2 items-center" icon={<AlertIcon />}>
-    {message}
-  </Alert>
-);
+const FormValidationError = ({
+  message = "This form can't be saved yet. Please fix the errors above.",
+}: FormValidationErrorProps) => <FormAlerts errors={[message]} />;
 
 export default FormValidationError;

--- a/bciers/libs/components/src/form/formDataUtils.ts
+++ b/bciers/libs/components/src/form/formDataUtils.ts
@@ -4,27 +4,9 @@ import { Dict } from "@bciers/types/dictionary";
 export const createNestedFormData = (formData: Dict, schema: Dict) => {
   const nestedSchema: Dict = {};
   Object.keys(schema.properties).forEach((section) => {
-    const sectionProperties = Object.keys(
-      schema.properties[section].properties || {},
-    );
-    // Only copy properties that belong to this section (based on the schema).
-    // Spreading ALL flat data into every section causes problems with RJSF's omitExtraData:
-    // a section with extra (non-schema) properties is not considered "empty", so it is
-    // excluded from the validated data entirely, producing a top-level section-required
-    // error that SectionFieldTemplate cannot display. Keeping only relevant properties
-    // ensures an empty section stays {}, which RJSF does include, allowing field-level
-    // required errors to appear next to each individual field.
-    //
-    // Null values are also excluded: null from the API means "not provided" and should
-    // be treated as absent so that required-field validation fires correctly (AJV's
-    // `required` check passes when a key exists even if its value is null).
-    nestedSchema[section] = sectionProperties.reduce((acc: Dict, prop) => {
-      const value = formData[prop];
-      if (value !== null && value !== undefined) {
-        acc[prop] = value;
-      }
-      return acc;
-    }, {});
+    // Create a new object for each section instead of assigning the same reference
+    // This prevents all sections from sharing the same object and getting polluted with each other's data
+    nestedSchema[section] = { ...formData };
   });
   return nestedSchema;
 };

--- a/bciers/libs/components/src/form/formDataUtils.ts
+++ b/bciers/libs/components/src/form/formDataUtils.ts
@@ -4,9 +4,27 @@ import { Dict } from "@bciers/types/dictionary";
 export const createNestedFormData = (formData: Dict, schema: Dict) => {
   const nestedSchema: Dict = {};
   Object.keys(schema.properties).forEach((section) => {
-    // Create a new object for each section instead of assigning the same reference
-    // This prevents all sections from sharing the same object and getting polluted with each other's data
-    nestedSchema[section] = { ...formData };
+    const sectionProperties = Object.keys(
+      schema.properties[section].properties || {},
+    );
+    // Only copy properties that belong to this section (based on the schema).
+    // Spreading ALL flat data into every section causes problems with RJSF's omitExtraData:
+    // a section with extra (non-schema) properties is not considered "empty", so it is
+    // excluded from the validated data entirely, producing a top-level section-required
+    // error that SectionFieldTemplate cannot display. Keeping only relevant properties
+    // ensures an empty section stays {}, which RJSF does include, allowing field-level
+    // required errors to appear next to each individual field.
+    //
+    // Null values are also excluded: null from the API means "not provided" and should
+    // be treated as absent so that required-field validation fires correctly (AJV's
+    // `required` check passes when a key exists even if its value is null).
+    nestedSchema[section] = sectionProperties.reduce((acc: Dict, prop) => {
+      const value = formData[prop];
+      if (value !== null && value !== undefined) {
+        acc[prop] = value;
+      }
+      return acc;
+    }, {});
   });
   return nestedSchema;
 };


### PR DESCRIPTION
[ISSUE 4261](https://github.com/bcgov/cas-registration/issues/4261)

### What changed

- Added a reusable validation error component:
  - `libs/components/src/form/components/FormValidationError.tsx`
- Updated `FormBase` to render an inline validation alert when submit fails validation:
  - Added `validationErrorMessage` prop with a default message:
    - `"This form can't be saved yet. Please fix the errors above."`
  - Hooked into RJSF `onError` to show the alert.
  - Hides the alert on successful submit attempt.
  - Implemented this without triggering extra React re-renders that could reset conditional fields.
- Added coverage for the new behavior:
  - `FormValidationError.test.tsx` (new)
  - `FormBase.test.tsx` updates for:
    - default validation message
    - custom `validationErrorMessage`
    - hide-on-successful-submit behavior
- Updated tests impacted by the additional alert and recent form behavior:
  - `MultiStepBase.test.tsx`: alert count expectations updated.
  - `OperationInformationForm.test.tsx`: alert count updated (`9 -> 10`).
  - `TransferForm.test.tsx`: stabilized by adding timeout wrapper.
  - `FacilityPage.test.tsx`: stabilized assertions and updated visible-content checks.
  - `ContactForm.test.tsx`:
    - stabilized create/edit flow by mirroring app behavior after create (remount as existing record before edit),
    - removed brittle selectors and duplicated form payload setup,
