### PR TITLE
Chore/batch 3 sonarqube high maintainability fixes

### DIFF
--- a/bc_obps/registration/tests/endpoints/user/test_user_app_role.py
+++ b/bc_obps/registration/tests/endpoints/user/test_user_app_role.py
@@ -3,4 +3,4 @@ from registration.tests.utils.helpers import CommonTestSetup
 
 class TestUserAppRoleEndpoint(CommonTestSetup):
     def test_get_app_role(self):
-        pass
+        pass  # This test is set to be implemented with https://github.com/bcgov/cas-registration/issues/2547

--- a/bc_obps/registration/tests/utils/helpers.py
+++ b/bc_obps/registration/tests/utils/helpers.py
@@ -134,6 +134,7 @@ class TestUtils:
 
         return operator, owning_operation, facility
 
+    @staticmethod
     def assert_facility_db_state(facility, expect_address=None, expect_well_authorization_numbers=None):
         """
         Asserts the state of a Facility object and related models.

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -42,14 +42,16 @@ def update_model_instance(
     Returns:
         instance (models.Model): The updated instance.
     """
+    # Normalize input to dict
     if isinstance(fields_to_update, dict):
-        for data_key, instance_key in fields_to_update.items():
-            if data_key in data_dict and hasattr(instance, instance_key):
-                setattr(instance, instance_key, data_dict[data_key])
+        normalized_fields_to_update = fields_to_update
     else:
-        for field in fields_to_update:
-            if field in data_dict and hasattr(instance, field):
-                setattr(instance, field, data_dict[field])
+        normalized_fields_to_update = {field: field for field in fields_to_update}
+
+    for data_key, instance_key in normalized_fields_to_update.items():
+        if data_key in data_dict and hasattr(instance, instance_key):
+            setattr(instance, instance_key, data_dict[data_key])
+
     try:
         # Perform full validation of the instance based on the model's field constraints.
         instance.full_clean()

--- a/bc_obps/reporting/service/report_review_changes_service.py
+++ b/bc_obps/reporting/service/report_review_changes_service.py
@@ -349,43 +349,11 @@ class ReportReviewChangesService:
         # Detect renames first (mutates prev_facilities so we don't later mark as added/removed)
         changes.extend(cls._detect_renames(prev_facilities, curr_facilities))
 
-        # Detect removed facilities
-        for fac_name, prev_fac in list(prev_facilities.items()):
-            if fac_name not in curr_facilities:
-                changes.append(
-                    {
-                        "field": f"root['facility_reports']['{fac_name}']",
-                        "old_value": prev_fac,
-                        "new_value": None,
-                        "change_type": "removed",
-                    }
-                )
-
-        # Detect added facilities
-        for fac_name, curr_fac in curr_facilities.items():
-            if fac_name not in prev_facilities:
-                changes.append(
-                    {
-                        "field": f"root['facility_reports']['{fac_name}']",
-                        "old_value": None,
-                        "new_value": curr_fac,
-                        "change_type": "added",
-                    }
-                )
+        # Detect removed and added facilities
+        changes.extend(cls._detect_removed_and_added_facilities(prev_facilities, curr_facilities))
 
         # Detect modified facilities
-        for fac_name, curr_fac in curr_facilities.items():
-            if fac_name in prev_facilities:
-                prev_fac = prev_facilities[fac_name]
-                diff = DeepDiff(prev_fac, curr_fac, ignore_order=True, exclude_regex_paths=[r".*?id'\]$"])
-                for item in cls._parse_deepdiff_items(diff, prev_fac, curr_fac):
-                    normalized_path = item.path[4:] if item.path.startswith('root') else item.path
-                    full_path = f"root['facility_reports']['{fac_name}']{normalized_path}"
-                    changes.append(
-                        cls.process_change(
-                            full_path, item.old_value, item.new_value, item.change_type, serialized_data=current
-                        )
-                    )
+        changes.extend(cls._detect_modified_facilities(prev_facilities, curr_facilities, current))
 
         # --- Compliance products added/removed/modified ---
         prev_products = {
@@ -422,16 +390,7 @@ class ReportReviewChangesService:
             )
 
         # Modified products
-        for name in prev_products.keys() & curr_products.keys():
-            prev_p = prev_products[name]
-            curr_p = curr_products[name]
-            diff = DeepDiff(prev_p, curr_p, ignore_order=True)
-            for item in cls._parse_deepdiff_items(diff, prev_p, curr_p):
-                # Keep the product name as key in path
-                field = f"root['report_compliance_summary']['products']['{name}']{item.path[4:]}"
-                changes.append(
-                    cls.process_change(field, item.old_value, item.new_value, item.change_type, serialized_data=current)
-                )
+        changes.extend(cls.detect_modified_products(prev_products, curr_products, current))
 
         # --- Top-level diff excluding facility_reports (products handled separately) ---
         diff = DeepDiff(previous, current, ignore_order=True, exclude_regex_paths=[r".*?facility_reports.*"])
@@ -442,5 +401,80 @@ class ReportReviewChangesService:
             changes.append(
                 cls.process_change(item.path, item.old_value, item.new_value, item.change_type, serialized_data=current)
             )
+
+        return changes
+
+    # --- Facility helper methods ---
+    @staticmethod
+    def _detect_removed_and_added_facilities(
+        prev_facilities: Dict[str, dict], curr_facilities: Dict[str, dict]
+    ) -> List[Dict[str, Any]]:
+        """Detect removed facilities. Returns list of removed facility change dicts."""
+        changes: List[Dict[str, Any]] = []
+
+        for fac_name, prev_fac in list(prev_facilities.items()):
+            if fac_name not in curr_facilities:
+                changes.append(
+                    {
+                        "field": f"root['facility_reports']['{fac_name}']",
+                        "old_value": prev_fac,
+                        "new_value": None,
+                        "change_type": "removed",
+                    }
+                )
+
+        for fac_name, curr_fac in curr_facilities.items():
+            if fac_name not in prev_facilities:
+                changes.append(
+                    {
+                        "field": f"root['facility_reports']['{fac_name}']",
+                        "old_value": None,
+                        "new_value": curr_fac,
+                        "change_type": "added",
+                    }
+                )
+
+        return changes
+
+    @classmethod
+    def _detect_modified_facilities(
+        cls, prev_facilities: Dict[str, dict], curr_facilities: Dict[str, dict], current: dict
+    ) -> List[Dict[str, Any]]:
+        """Detect modified facilities. Returns list of modified facility change dicts."""
+        changes: List[Dict[str, Any]] = []
+
+        for fac_name, curr_fac in curr_facilities.items():
+            if fac_name in prev_facilities:
+                prev_fac = prev_facilities[fac_name]
+                diff = DeepDiff(prev_fac, curr_fac, ignore_order=True, exclude_regex_paths=[r".*?id'\]$"])
+                for item in cls._parse_deepdiff_items(diff, prev_fac, curr_fac):
+                    normalized_path = item.path[4:] if item.path.startswith('root') else item.path
+                    full_path = f"root['facility_reports']['{fac_name}']{normalized_path}"
+                    changes.append(
+                        cls.process_change(
+                            full_path, item.old_value, item.new_value, item.change_type, serialized_data=current
+                        )
+                    )
+
+        return changes
+
+    # --- Product helper methods ---
+    @classmethod
+    def detect_modified_products(
+        cls, prev_products: Dict[str, dict], curr_products: Dict[str, dict], current: dict
+    ) -> List[Dict[str, Any]]:
+        """Detect modified products. Returns list of modified product change dicts."""
+        changes: List[Dict[str, Any]] = []
+
+        for name in prev_products.keys() & curr_products.keys():
+            prev_p = prev_products[name]
+            curr_p = curr_products[name]
+            diff = DeepDiff(prev_p, curr_p, ignore_order=True)
+            for item in cls._parse_deepdiff_items(diff, prev_p, curr_p):
+                # Keep the product name as key in path
+                field = f"root['report_compliance_summary']['products']['{name}']{item.path[4:]}"
+                changes.append(
+                    cls.process_change(field, item.old_value, item.new_value, item.change_type, serialized_data=current)
+                )
 
         return changes


### PR DESCRIPTION
Third batch addressing bcgov/cas-compliance#532, specifically Maintainability issues of High level. Bundled together mostly by file name.

## Refactors 🚧

- bc_obps/.../tests/endpoints/user/test_user_app_role.py
	- [x] [[Add a nested comment explaining why this method is empty, or complete the implementation.](https://sonarcloud.io/project/issues?open=AZVxd70ijyYZCE8l87fz&id=bcgov_cas-registration)](https://sonarcloud.io/project/issues?open=AZVxd70ijyYZCE8l87fz&id=bcgov_cas-registration)
- bc_obps/registration/tests/utils/helpers.py
	- [x] [[Rename "facility" to "self" or add the missing "self" parameter.](https://sonarcloud.io/project/issues?open=AZFNxZKtBmdcFqO8zxz3&id=bcgov_cas-registration)](https://sonarcloud.io/project/issues?open=AZFNxZKtBmdcFqO8zxz3&id=bcgov_cas-registration)
- bc_obps/registration/utils.py
	- [x] [[Refactor this function to reduce its Cognitive Complexity from 16 to the 15 allowed.](https://sonarcloud.io/project/issues?open=AYwYYhy3KDO-b4XUy4YM&id=bcgov_cas-registration)](https://sonarcloud.io/project/issues?open=AYwYYhy3KDO-b4XUy4YM&id=bcgov_cas-registration)
- bc_obps/reporting/models/report_activity.py
	- [x] [[Define a constant instead of duplicating this literal "%(class)s_records" 3 times.](https://sonarcloud.io/project/issues?open=AZTyF26rIpSM0VzUgQPO&id=bcgov_cas-registration)](https://sonarcloud.io/project/issues?open=AZTyF26rIpSM0VzUgQPO&id=bcgov_cas-registration) Dropped per comment
- bc_obps/reporting/models/report_emission.py
	- [x] [[Define a constant instead of duplicating this literal "%(class)s_records" 4 times.](https://sonarcloud.io/project/issues?open=AZEupCa-poT9LTUYXlQR&id=bcgov_cas-registration)](https://sonarcloud.io/project/issues?open=AZEupCa-poT9LTUYXlQR&id=bcgov_cas-registration) Dropped per comment
- bc_obps/reporting/models/report_fuel.py
	- [x] [[Define a constant instead of duplicating this literal "%(class)s_records" 3 times.](https://sonarcloud.io/project/issues?open=AZEupCanpoT9LTUYXlQQ&id=bcgov_cas-registration)](https://sonarcloud.io/project/issues?open=AZEupCanpoT9LTUYXlQQ&id=bcgov_cas-registration) Dropped per comment
- bc_obps/reporting/models/report_product_emission_allocation.py
	- [x] [[Define a constant instead of duplicating this literal "%(class)s_records" 4 times.](https://sonarcloud.io/project/issues?open=AZOtNoBQ_EH9KHLoedZN&id=bcgov_cas-registration)](https://sonarcloud.io/project/issues?open=AZOtNoBQ_EH9KHLoedZN&id=bcgov_cas-registration) Dropped per comment
- bc_obps/reporting/models/report_source_type.py
	- [x] [[Define a constant instead of duplicating this literal "%(class)s_records" 3 times.](https://sonarcloud.io/project/issues?open=AZEupCaFpoT9LTUYXlQP&id=bcgov_cas-registration)](https://sonarcloud.io/project/issues?open=AZEupCaFpoT9LTUYXlQP&id=bcgov_cas-registration) Dropped per comment
- bc_obps/reporting/service/report_review_changes_service.py
	- [x] [[Refactor this function to reduce its Cognitive Complexity from 29 to the 15 allowed.](https://sonarcloud.io/project/issues?open=AZlO_3SKs0wI32IrSdxW&id=bcgov_cas-registration)](https://sonarcloud.io/project/issues?open=AZlO_3SKs0wI32IrSdxW&id=bcgov_cas-registration)