### PR TITLE
1009 report validation error structure

### DIFF
--- a/bciers/apps/reporting/src/app/components/shared/validation/ReportValidationSummary.tsx
+++ b/bciers/apps/reporting/src/app/components/shared/validation/ReportValidationSummary.tsx
@@ -1,0 +1,121 @@
+import Link from "next/link";
+import AlertNote, {
+  AlertType,
+} from "@bciers/components/form/components/AlertNote";
+
+import type {
+  ReportValidationError,
+  ReportValidationErrors,
+  ReportValidationMessageKey,
+  ValidationSeverity,
+} from "./types";
+import {
+  getFormattedValidationMessage,
+  getValidationErrorHref,
+  getValidationErrorLabel,
+  getValidationUIConfig,
+} from "./utils";
+
+type ReportValidationSummaryProps = {
+  errors?: ReportValidationErrors;
+};
+
+// Maps backend severity to AlertNote type
+function toAlertType(severity: ValidationSeverity): AlertType {
+  switch (severity) {
+    case "error":
+      return "ERROR";
+    case "warning":
+      return "ALERT";
+    default:
+      return "DEFAULT";
+  }
+}
+
+// Replaces label text in message with a clickable link (inline)
+// Note: validationUIConfig label must exactly match the text in the validationUIConfig message
+function renderMessageWithInlineLink(
+  text: string,
+  label?: string,
+  href?: string,
+) {
+  if (!label || !href || !text.includes(label)) {
+    return <span>{text}</span>;
+  }
+
+  const [before, ...rest] = text.split(label);
+  const after = rest.join(label);
+
+  return (
+    <span>
+      {before}
+      <Link href={href} className="underline">
+        {label}
+      </Link>
+      {after}
+    </span>
+  );
+}
+
+// Renders message based on config-defined render mode
+function renderValidationMessage(
+  key: ReportValidationMessageKey,
+  error: ReportValidationError,
+) {
+  const config = getValidationUIConfig(key);
+  const label = getValidationErrorLabel(key, error);
+  const href = getValidationErrorHref(key, error);
+  const message = getFormattedValidationMessage(key, error);
+
+  switch (config?.renderMode) {
+    case "inline_link":
+      return renderMessageWithInlineLink(message, label, href);
+
+    case "label_then_message":
+      if (!label || !href) {
+        return <span>{message}</span>;
+      }
+
+      return (
+        <span>
+          <Link href={href} className="underline">
+            {label}
+          </Link>
+          : {message}
+        </span>
+      );
+
+    case "message_only":
+    default:
+      return <span>{message}</span>;
+  }
+}
+
+export default function ReportValidationSummary({
+  errors,
+}: Readonly<ReportValidationSummaryProps>) {
+  if (!errors?.length) return null;
+
+  const severityOrder: Record<ValidationSeverity, number> = {
+    error: 0,
+    warning: 1,
+  };
+
+  const sortedEntries = [...errors].sort(
+    (a, b) => severityOrder[a.error.severity] - severityOrder[b.error.severity],
+  );
+
+  return (
+    <div className="space-y-3">
+      {sortedEntries.map(({ key, error }, index) => (
+        <AlertNote
+          key={`${key}-${index}`}
+          id={`report-validation-${key}-${index}`}
+          alertType={toAlertType(error.severity)}
+        >
+          {renderValidationMessage(key, error)}
+        </AlertNote>
+      ))}
+    </div>
+  );
+}

--- a/bciers/apps/reporting/src/app/components/shared/validation/config.ts
+++ b/bciers/apps/reporting/src/app/components/shared/validation/config.ts
@@ -1,0 +1,136 @@
+import type { ReportValidationMessageKey, ValidationUIConfig } from "./types";
+
+// Frontend mapping of backend validation keys defining how each validation error is displayed in the UI
+export const validationUIConfig: Partial<
+  Record<ReportValidationMessageKey, ValidationUIConfig>
+> = {
+  missing_report_verification: {
+    label: "Verification page",
+    renderMode: "inline_link",
+    getHref: (ctx) =>
+      ctx?.reportVersionId
+        ? `/reports/${ctx.reportVersionId}/verification`
+        : undefined,
+    getMessage: () =>
+      "Verification information must be completed on the Verification page.",
+  },
+
+  verification_statement: {
+    label: "Attachments page",
+    renderMode: "inline_link",
+    getHref: (ctx) =>
+      ctx?.reportVersionId
+        ? `/reports/${ctx.reportVersionId}/attachments`
+        : undefined,
+    getMessage: () =>
+      "A verification statement must be uploaded with this report on the Attachments page.",
+  },
+
+  missing_supplementary_report_version_change: {
+    label: "Review Changes page",
+    renderMode: "inline_link",
+    getHref: (ctx) =>
+      ctx?.reportVersionId
+        ? `/reports/${ctx.reportVersionId}/review-changes`
+        : undefined,
+    getMessage: () =>
+      "A reason for the changes in this supplementary report must be added on the Review Changes page.",
+  },
+
+  missing_required_attachment_confirmation: {
+    label: "Attachments page",
+    renderMode: "inline_link",
+    getHref: (ctx) =>
+      ctx?.reportVersionId
+        ? `/reports/${ctx.reportVersionId}/attachments`
+        : undefined,
+    getMessage: () =>
+      "You must confirm that all required supplementary attachments have been uploaded on the Attachments page.",
+  },
+
+  missing_existing_attachment_confirmation: {
+    label: "Attachments page",
+    renderMode: "inline_link",
+    getHref: (ctx) =>
+      ctx?.reportVersionId
+        ? `/reports/${ctx.reportVersionId}/attachments`
+        : undefined,
+    getMessage: () =>
+      "You must confirm that all existing attachments are still relevant to the supplementary submission on the Attachments page.",
+  },
+
+  missing_supplementary_report_attachment_confirmation: {
+    label: "Attachments page",
+    renderMode: "inline_link",
+    getHref: (ctx) =>
+      ctx?.reportVersionId
+        ? `/reports/${ctx.reportVersionId}/attachments`
+        : undefined,
+    getMessage: () =>
+      "You must confirm that all required supplementary attachments have been uploaded and existing attachments are still relevant to the supplementary submission on the Attachments page.",
+  },
+
+  error_operation_information: {
+    label: "review operation information",
+    renderMode: "inline_link",
+    getHref: (ctx) =>
+      ctx?.reportVersionId
+        ? `/reports/${ctx.reportVersionId}/review-operation-information`
+        : undefined,
+    getMessage: () =>
+      "Required fields are empty on review operation information.",
+  },
+
+  error_activity_value: {
+    label: (error) => error.context?.activityName ?? "activity name",
+    renderMode: "inline_link",
+
+    getHref: (ctx) =>
+      ctx?.reportVersionId && ctx?.facilityId && ctx?.activityId !== undefined
+        ? `/reporting/reports/${ctx.reportVersionId}/facilities/${ctx.facilityId}/activities?activity_id=${ctx.activityId}`
+        : undefined,
+
+    getMessage: (error) => {
+      const ctx = error.context;
+
+      return `Unusual value detected for ${
+        ctx?.activityName ?? "[activity name]"
+      }. Expected ${ctx?.fuelType ?? "[fuel type]"} ${
+        ctx?.fieldName ?? "[field]"
+      } value to be between ${
+        ctx?.expectedRange ?? "[range]"
+      } but input was ${ctx?.userInput ?? "[user input]"}. Please ensure you have selected the correct fuel name and the value is accurate. If the value is accurate, you may save & continue.`;
+    },
+  },
+
+  allocation_mismatch: {
+    label: () => "allocation of emissions",
+    renderMode: "inline_link",
+    getHref: (ctx) =>
+      ctx?.reportVersionId && ctx?.facilityId
+        ? `/reporting/reports/${ctx.reportVersionId}/facilities/${ctx.facilityId}/allocation-of-emissions`
+        : undefined,
+    getMessage: (error) => {
+      const ctx = error.context;
+
+      return `Please review the allocation of emissions and ensure that emissions from ${
+        ctx?.sourceActivityName ?? "[activity type]"
+      } activities are allocated to the ${
+        ctx?.targetProductName ?? "[product]"
+      }. If they are allocated to the ${
+        ctx?.targetProductName ?? "[product]"
+      }, you may save & continue.`;
+    },
+  },
+
+  error_lime_kiln: {
+    label: "Pulp and Paper Production",
+    renderMode: "inline_link",
+    getHref: (ctx) =>
+      ctx?.reportVersionId && ctx?.facilityId
+        ? `/reports/${ctx.reportVersionId}/facilities/${ctx.facilityId}/production-data`
+        : undefined,
+    getMessage: () =>
+      'Error in Pulp and Paper Production. To proceed, select "Yes" to the question "Does this operation utilize a lime recovery kiln?"',
+  },
+};

--- a/bciers/apps/reporting/src/app/components/shared/validation/types.ts
+++ b/bciers/apps/reporting/src/app/components/shared/validation/types.ts
@@ -1,0 +1,80 @@
+// Reflects backend Severity enum
+export type ValidationSeverity = "error" | "warning";
+
+// Keys used to identify validation errors returned from backend
+export type ReportValidationMessageKey =
+  // Missing required inputs / confirmations
+  | "missing_report_verification"
+  | "verification_statement"
+  | "missing_required_attachment_confirmation"
+  | "missing_existing_attachment_confirmation"
+  | "missing_supplementary_report_version_change"
+  | "missing_supplementary_report_attachment_confirmation"
+  // Errors (data issues / validation failures)
+  | "allocation_mismatch"
+  | "error_operation_information"
+  | "error_lime_kiln"
+  | "error_activity_value";
+
+// Additional metadata returned from backend used for dynamic content
+// (links, expected values, etc.)
+export interface ReportValidationErrorContext {
+  reportVersionId?: number;
+  facilityId?: string;
+  activityId?: number;
+
+  activityName?: string;
+  fuelType?: string;
+  fieldName?: string;
+  expectedRange?: string;
+  userInput?: string | number | null;
+
+  facilityName?: string;
+  emissionCategoryName?: string;
+  sourceActivityName?: string;
+  targetProductName?: string;
+}
+
+// Structured validation error stored in state and passed through components
+export interface ReportValidationError {
+  severity: ValidationSeverity;
+  message?: string;
+  context?: ReportValidationErrorContext;
+}
+
+// A single validation item combining the key and its error details
+export interface ReportValidationItem {
+  key: ReportValidationMessageKey;
+  error: ReportValidationError;
+}
+
+// A collection of validation items returned from backend / stored in state
+export type ReportValidationErrors = ReportValidationItem[];
+
+// Determines the layout strategy for rendering validation feedback in the UI
+export type ValidationRenderMode =
+  | "message_only"
+  | "label_then_message"
+  | "inline_link";
+
+// Arguments used when formatting validation messages
+export type ValidationTextArgs = {
+  label?: string;
+  message: string;
+  error: ReportValidationError;
+};
+
+/**
+ * UI configuration per validation key.
+ *
+ * Frontend mapping layer between:
+ * - backend validation keys
+ * - frontend rendering
+ */
+export type ValidationUIConfig = {
+  label?: string | ((error: ReportValidationError) => string | undefined);
+  getHref?: (ctx?: ReportValidationErrorContext) => string | undefined;
+  getMessage?: (error: ReportValidationError) => string;
+  renderMode?: ValidationRenderMode;
+  formatMessage?: (args: ValidationTextArgs) => string;
+};

--- a/bciers/apps/reporting/src/app/components/shared/validation/utils.ts
+++ b/bciers/apps/reporting/src/app/components/shared/validation/utils.ts
@@ -1,0 +1,55 @@
+import { validationUIConfig } from "./config";
+import type {
+  ReportValidationError,
+  ReportValidationMessageKey,
+  ValidationUIConfig,
+} from "./types";
+
+// Returns full UI config for a validation key
+export function getValidationUIConfig(
+  key: ReportValidationMessageKey,
+): ValidationUIConfig | undefined {
+  return validationUIConfig[key];
+}
+
+// Returns navigation URL from config + error context
+export function getValidationErrorHref(
+  key: ReportValidationMessageKey,
+  error: ReportValidationError,
+): string | undefined {
+  return validationUIConfig[key]?.getHref?.(error.context);
+}
+
+// Resolves the display label for the validation error
+export function getValidationErrorLabel(
+  key: ReportValidationMessageKey,
+  error: ReportValidationError,
+): string | undefined {
+  const label = validationUIConfig[key]?.label;
+  return typeof label === "function" ? label(error) : label;
+}
+
+// Returns message
+export function getValidationErrorMessage(
+  key: ReportValidationMessageKey,
+  error: ReportValidationError,
+): string {
+  if (error.message) return error.message;
+  return validationUIConfig[key]?.getMessage?.(error) ?? key;
+}
+
+// Applies optional custom formatting to message
+export function getFormattedValidationMessage(
+  key: ReportValidationMessageKey,
+  error: ReportValidationError,
+): string {
+  const config = validationUIConfig[key];
+  const label = getValidationErrorLabel(key, error);
+  const message = getValidationErrorMessage(key, error);
+
+  if (config?.formatMessage) {
+    return config.formatMessage({ label, message, error });
+  }
+
+  return message;
+}

--- a/bciers/libs/components/src/form/FormAlerts.tsx
+++ b/bciers/libs/components/src/form/FormAlerts.tsx
@@ -10,6 +10,12 @@ const FormAlerts: React.FC<FormAlertsProps> = ({ errors }) => {
     return null; // Don't render anything if there are no errors
   }
 
+  // If caller passed a single rendered component in an array
+  // (for example [<ReportValidationSummary />]), render it directly
+  if (errors.length === 1 && React.isValidElement(errors[0])) {
+    return <div className="mt-4">{errors[0]}</div>;
+  }
+
   return (
     <div className="min-h-[48px] box-border mt-4">
       {errors.map((error, index) => (

--- a/bciers/libs/components/src/form/components/AlertNote.tsx
+++ b/bciers/libs/components/src/form/components/AlertNote.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode, FC, PropsWithChildren } from "react";
 import { AlertIcon } from "@bciers/components/icons";
 import { Alert, SvgIconProps } from "@mui/material";
-import { BC_GOV_TEXT } from "@bciers/styles";
+import { BC_GOV_SEMANTICS_RED, BC_GOV_TEXT } from "@bciers/styles";
 import { ErrorRounded, InfoRounded, WarningRounded } from "@mui/icons-material";
 
 export type AlertType = "INFO" | "ALERT" | "ERROR" | "DEFAULT";
@@ -16,7 +16,7 @@ export interface AlertNoteProps {
 const bgClassMap: { [key in AlertType]: string } = {
   INFO: "bg-bc-light-blue",
   ALERT: "bg-bc-light-yellow",
-  ERROR: "bg-bc-error-red",
+  ERROR: "bg-bc-light-red border border-[#F1B5B8]",
   DEFAULT: "bg-bc-light-blue",
 };
 
@@ -27,7 +27,9 @@ const defaultIconProps: SvgIconProps = {
 const iconMap: { [key in AlertType]: ReactNode } = {
   INFO: <InfoRounded {...defaultIconProps} />,
   ALERT: <WarningRounded {...defaultIconProps} />,
-  ERROR: <ErrorRounded {...defaultIconProps} />,
+  ERROR: (
+    <ErrorRounded {...defaultIconProps} sx={{ color: BC_GOV_SEMANTICS_RED }} />
+  ),
   DEFAULT: <AlertIcon width="25" height="25" />,
 };
 
@@ -61,6 +63,16 @@ const AlertNote: FC<PropsWithChildren<AlertNoteProps>> = ({
       id={id}
       className={`${bgClassMap[alertType]} text-bc-text mb-2 items-center`}
       icon={defaultedIcon}
+      // MUI Alert applies its own default error background styles,
+      // so the ERROR state needs an sx override to render ERROR alertType background
+      sx={
+        alertType === "ERROR"
+          ? {
+              backgroundColor: "#FBEAEA",
+              border: "1px solid #F1B5B8",
+            }
+          : undefined
+      }
     >
       {children}
     </Alert>

--- a/docs/frontend/validation-error-guide.md
+++ b/docs/frontend/validation-error-guide.md
@@ -1,0 +1,146 @@
+# 📄 Validation Error System
+
+### Description
+
+The validation error system provides a **standardized way to handle and display validation errors** across reporting forms.
+
+Instead of passing string errors, the backend returns structured validation objects identified by a key
+typed with severity optionally including context data for the frontend which are rendered on the frontend using a shared, config-driven component.
+
+---
+
+### Usage
+
+Validation follows a simple flow:
+
+1. Backend returns structured validation errors
+2. Frontend stores them as `ReportValidationErrors`
+3. UI renders them using `ReportValidationSummary`
+4. Display behavior is controlled via `validationUIConfig`
+
+---
+
+### Example
+
+#### Backend response (array-based model)
+
+```json
+{
+  "error": [
+    {
+      "key": "missing_report_verification",
+      "error": {
+        "severity": "error",
+        "context": {
+          "reportVersionId": 123
+        }
+      }
+    },
+    // Multiple allocation_mismatch keys
+    {
+      "key": "allocation_mismatch",
+      "error": {
+        "severity": "error",
+        "context": {
+          "reportVersionId": 3,
+          "facilityId": "9f7b0848-021e-4d08-9852-10524c4e5457",
+          "facilityName": "Main Facility",
+          "emissionCategoryName": "Combustion",
+          "sourceActivityName": "non-processing and non-compression",
+          "targetProductName": "non-processing, non-compression product"
+        }
+      }
+    },
+    {
+      "key": "allocation_mismatch",
+      "error": {
+        "severity": "error",
+        "context": {
+          "reportVersionId": 3,
+          "facilityId": "9f7b0848-021e-4d08-9852-10524c4e5457",
+          "facilityName": "Main Facility",
+          "emissionCategoryName": "Flaring",
+          "sourceActivityName": "flaring",
+          "targetProductName": "flaring product"
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Frontend usage
+
+```ts
+const [validationErrors, setValidationErrors] =
+  useState<ReportValidationErrors>([]);
+```
+
+```ts
+if (response?.error) {
+  setValidationErrors(response.error);
+}
+```
+
+```tsx
+<ReportValidationSummary errors={validationErrors} />
+```
+
+---
+
+### Config-driven UI
+
+Each validation key is mapped in `validationUIConfig`:
+
+```ts
+missing_report_verification: {
+  label: "Verification page",
+  renderMode: "inline_link",
+  getHref: (ctx) =>
+    `/reporting/report-version/${ctx?.reportVersionId}/verification`,
+  getMessage: () =>
+    "Verification information must be completed on the Verification page.",
+}
+```
+
+This controls:
+
+- message text
+- navigation links
+- rendering style (inline, label, etc.)
+
+---
+
+### Adding a new validation
+
+1. Add a new key to `ReportValidationMessageKey`
+2. Return it from backend validation (posibley as an array item)
+3. Add config in `validationUIConfig`
+
+---
+
+### Context
+
+Validation errors may include optional context:
+
+```ts
+context: {
+  reportVersionId,
+  facilityId,
+  activityId,
+}
+```
+
+Used to:
+
+- build navigation URLs
+- customize messages dynamically
+
+---
+
+### Notes
+
+- Messages should include the label text when using `inline_link`
+- Errors are sorted by severity (errors before warnings)
+- UI is fully driven by config
+- Same validation key can appear multiple times (e.g., per activity)


### PR DESCRIPTION
resolves [1009](https://github.com/bcgov/cas-reporting/issues/1009)


### 🚀 Impact

- Added `ReportValidationErrors` and related types to handle severity, context, and messaging across the app
- Added `validationUIConfig` to map backend validation keys to frontend behaviour
- Added `ReportValidationSummary` to render validation errors with support of inline links, dynamic messages, and severity-based ordering



#### 🧩 Report Validation Flow


See `docs/frontend/validation-error-guide.md` for the full flow: Backend → ReportValidationErrors → validationUIConfig → ReportValidationSummary 

**Expected display:**

<img width="1123" height="438" alt="image" src="https://github.com/user-attachments/assets/54e42700-94ec-4f86-9474-65407269036d" />


