### PR TITLE
Chore/batch 4 sonarqube high maintainability fixes

### DIFF
--- a/bc_obps/reporting/tests/service/test_compliance_service/infrastructure.py
+++ b/bc_obps/reporting/tests/service/test_compliance_service/infrastructure.py
@@ -14,6 +14,20 @@ from reporting.models.reporting_year import ReportingYear
 from reporting.models.emission_category import EmissionCategory
 from model_bakery.baker import make_recipe
 
+# String constants for deduplication
+REGISTRATION_OPERATION_RECIPE_NAME = "registration.tests.utils.operation"
+REPORTING_REPORT_RECIPE_NAME = "reporting.tests.utils.report"
+REPORTING_REPORT_VERSION_RECIPE_NAME = "reporting.tests.utils.report_version"
+REPORTING_REPORT_OPERATION_RECIPE_NAME = "reporting.tests.utils.report_operation"
+REPORTING_REPORT_EMISSION_RECIPE_NAME = "reporting.tests.utils.report_emission"
+REPORTING_REPORT_PRODUCT_RECIPE_NAME = "reporting.tests.utils.report_product"
+REPORTING_REPORT_EMISSION_ALLOCATION_RECIPE_NAME = "reporting.tests.utils.report_emission_allocation"
+REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME = "reporting.tests.utils.report_product_emission_allocation"
+
+# Mock data constants for deduplication
+MOCK_SFO_NAME = "test sfo"
+MOCK_SFO_TYPE = "Single Facility Operation"
+
 
 class ComplianceTestInfrastructure:
     operation_1: Operation
@@ -53,37 +67,39 @@ class ComplianceTestInfrastructure:
     def build(cls):
         t = ComplianceTestInfrastructure()
         t.operation_1 = make_recipe(
-            'registration.tests.utils.operation',
-            name='test sfo',
+            REGISTRATION_OPERATION_RECIPE_NAME,
+            name=MOCK_SFO_NAME,
             naics_code=NaicsCode.objects.get(pk=1),
-            type='Single Facility Operation',
+            type=MOCK_SFO_TYPE,
         )
         t.report_1 = make_recipe(
-            "reporting.tests.utils.report", operation=t.operation_1, reporting_year=ReportingYear.objects.get(pk=2024)
+            REPORTING_REPORT_RECIPE_NAME,
+            operation=t.operation_1,
+            reporting_year=ReportingYear.objects.get(pk=2024),
         )
-        t.report_version_1 = make_recipe("reporting.tests.utils.report_version", report=t.report_1)
+        t.report_version_1 = make_recipe(REPORTING_REPORT_VERSION_RECIPE_NAME, report=t.report_1)
         # Create ReportOperation for the report_version
-        t.report_operation_1 = make_recipe("reporting.tests.utils.report_operation", report_version=t.report_version_1)
+        t.report_operation_1 = make_recipe(REPORTING_REPORT_OPERATION_RECIPE_NAME, report_version=t.report_version_1)
         t.report_emission_1 = make_recipe(
-            "reporting.tests.utils.report_emission",
+            REPORTING_REPORT_EMISSION_RECIPE_NAME,
             report_version=t.report_version_1,
             gas_type_id=1,
             json_data={"equivalentEmission": 10000.0001},
         )
         t.report_emission_2 = make_recipe(
-            "reporting.tests.utils.report_emission",
+            REPORTING_REPORT_EMISSION_RECIPE_NAME,
             report_version=t.report_version_1,
             gas_type_id=2,
             json_data={"equivalentEmission": 10000.9988},
         )
         t.report_emission_3 = make_recipe(
-            "reporting.tests.utils.report_emission",
+            REPORTING_REPORT_EMISSION_RECIPE_NAME,
             report_version=t.report_version_1,
             gas_type_id=2,
             json_data={"equivalentEmission": 100000.0088},
         )
         t.report_emission_4 = make_recipe(
-            "reporting.tests.utils.report_emission",
+            REPORTING_REPORT_EMISSION_RECIPE_NAME,
             report_version=t.report_version_1,
             gas_type_id=3,
             json_data={"equivalentEmission": 3000.05},
@@ -95,21 +111,21 @@ class ComplianceTestInfrastructure:
         t.report_emission_4.emission_categories.set([5, 12])
 
         t.report_product_1 = make_recipe(
-            "reporting.tests.utils.report_product",
+            REPORTING_REPORT_PRODUCT_RECIPE_NAME,
             report_version=t.report_version_1,
             product_id=1,
             annual_production=Decimal('100000'),
             production_data_apr_dec=Decimal('50000'),
         )
         t.report_product_2 = make_recipe(
-            "reporting.tests.utils.report_product",
+            REPORTING_REPORT_PRODUCT_RECIPE_NAME,
             report_version=t.report_version_1,
             product_id=2,
             annual_production=Decimal('100000'),
             production_data_apr_dec=Decimal('25000'),
         )
         t.report_product_3 = make_recipe(
-            "reporting.tests.utils.report_product",
+            REPORTING_REPORT_PRODUCT_RECIPE_NAME,
             report_version=t.report_version_1,
             product_id=3,
             annual_production=Decimal('20000'),
@@ -117,10 +133,10 @@ class ComplianceTestInfrastructure:
         )
 
         t.report_emission_allocation = make_recipe(
-            "reporting.tests.utils.report_emission_allocation", report_version=t.report_version_1
+            REPORTING_REPORT_EMISSION_ALLOCATION_RECIPE_NAME, report_version=t.report_version_1
         )
         t.allocation_1 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             report_product=t.report_product_1,
@@ -128,7 +144,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('10000.0001'),
         )
         t.allocation_2 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             emission_category=EmissionCategory.objects.get(pk=3),  # Industrial Process Product 2
@@ -136,7 +152,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('10000.9988'),
         )
         t.allocation_3 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             emission_category=EmissionCategory.objects.get(pk=4),  # Mobile Product 3
@@ -144,7 +160,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('75000.0088'),
         )
         t.allocation_4 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             emission_category=EmissionCategory.objects.get(pk=5),  # GSC Product 1
@@ -152,7 +168,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('3000.05'),
         )
         t.allocation_5 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             emission_category=EmissionCategory.objects.get(pk=12),  # Excluded nonbio Product 1
@@ -160,7 +176,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('3000.05'),
         )
         t.allocation_6 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             report_product=t.report_product_2,
@@ -235,7 +251,7 @@ class ComplianceTestInfrastructure:
     def unregulated_product_and_funny_category_13(cls):
         t = cls.build()
         t.report_emission_5 = make_recipe(
-            "reporting.tests.utils.report_emission",
+            REPORTING_REPORT_EMISSION_RECIPE_NAME,
             report_version=t.report_version_1,
             gas_type_id=3,
             json_data={"equivalentEmission": 55.55},
@@ -243,14 +259,14 @@ class ComplianceTestInfrastructure:
         t.report_emission_5.emission_categories.set([5, 13])
 
         t.report_product_4 = make_recipe(
-            "reporting.tests.utils.report_product",
+            REPORTING_REPORT_PRODUCT_RECIPE_NAME,
             report_version=t.report_version_1,
             product_id=40,  # Unregulated product
             annual_production=Decimal('500'),
             production_data_apr_dec=Decimal('300'),
         )
         t.allocation_7 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             report_product=t.report_product_4,
@@ -263,19 +279,21 @@ class ComplianceTestInfrastructure:
     def decimal_places(cls):
         t = ComplianceTestInfrastructure()
         t.operation_1 = make_recipe(
-            'registration.tests.utils.operation',
-            name='test sfo',
+            REGISTRATION_OPERATION_RECIPE_NAME,
+            name=MOCK_SFO_NAME,
             naics_code=NaicsCode.objects.get(pk=1),
-            type='Single Facility Operation',
+            type=MOCK_SFO_TYPE,
         )
         t.report_1 = make_recipe(
-            "reporting.tests.utils.report", operation=t.operation_1, reporting_year=ReportingYear.objects.get(pk=2024)
+            REPORTING_REPORT_RECIPE_NAME,
+            operation=t.operation_1,
+            reporting_year=ReportingYear.objects.get(pk=2024),
         )
-        t.report_version_1 = make_recipe("reporting.tests.utils.report_version", report=t.report_1)
+        t.report_version_1 = make_recipe(REPORTING_REPORT_VERSION_RECIPE_NAME, report=t.report_1)
         # Create ReportOperation for the report_version
-        t.report_operation_1 = make_recipe("reporting.tests.utils.report_operation", report_version=t.report_version_1)
+        t.report_operation_1 = make_recipe(REPORTING_REPORT_OPERATION_RECIPE_NAME, report_version=t.report_version_1)
         t.report_emission_1 = make_recipe(
-            "reporting.tests.utils.report_emission",
+            REPORTING_REPORT_EMISSION_RECIPE_NAME,
             report_version=t.report_version_1,
             gas_type_id=1,
             json_data={"equivalentEmission": 10000.555555555555},
@@ -283,17 +301,17 @@ class ComplianceTestInfrastructure:
         t.report_emission_1.emission_categories.set([1])
 
         t.report_product_1 = make_recipe(
-            "reporting.tests.utils.report_product",
+            REPORTING_REPORT_PRODUCT_RECIPE_NAME,
             report_version=t.report_version_1,
             product_id=1,
             annual_production=Decimal('100000'),
             production_data_apr_dec=Decimal('50000'),
         )
         t.report_emission_allocation = make_recipe(
-            "reporting.tests.utils.report_emission_allocation", report_version=t.report_version_1
+            REPORTING_REPORT_EMISSION_ALLOCATION_RECIPE_NAME, report_version=t.report_version_1
         )
         t.allocation_1 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             report_product=t.report_product_1,
@@ -307,19 +325,19 @@ class ComplianceTestInfrastructure:
     def build_pulp_and_paper_2025(cls):
         t = ComplianceTestInfrastructure()
         t.operation_1 = make_recipe(
-            'registration.tests.utils.operation',
-            name='test sfo',
-            naics_code=NaicsCode.objects.get(naics_code='322112'),
-            type='Single Facility Operation',
+            REGISTRATION_OPERATION_RECIPE_NAME,
+            name=MOCK_SFO_NAME,
+            naics_code=NaicsCode.objects.get(naics_code="322112"),
+            type=MOCK_SFO_TYPE,
         )
         t.report_1 = make_recipe(
-            "reporting.tests.utils.report",
+            REPORTING_REPORT_RECIPE_NAME,
             operation=t.operation_1,
             reporting_year_id=2025,
         )
-        t.report_version_1 = make_recipe("reporting.tests.utils.report_version", report=t.report_1)
+        t.report_version_1 = make_recipe(REPORTING_REPORT_VERSION_RECIPE_NAME, report=t.report_1)
         # Create ReportOperation for the report_version
-        t.report_operation_1 = make_recipe("reporting.tests.utils.report_operation", report_version=t.report_version_1)
+        t.report_operation_1 = make_recipe(REPORTING_REPORT_OPERATION_RECIPE_NAME, report_version=t.report_version_1)
 
         t.report_activity = make_recipe(
             "reporting.tests.utils.report_activity",
@@ -338,7 +356,7 @@ class ComplianceTestInfrastructure:
 
         ## 4 Emissions, 2 GSC and 2 industrial process
         t.report_emission_1 = make_recipe(
-            "reporting.tests.utils.report_emission",
+            REPORTING_REPORT_EMISSION_RECIPE_NAME,
             report_version=t.report_version_1,
             gas_type_id=1,
             json_data={"equivalentEmission": 10000.0001},
@@ -347,7 +365,7 @@ class ComplianceTestInfrastructure:
         t.report_emission_1.emission_categories.set([5])
 
         t.report_emission_2 = make_recipe(
-            "reporting.tests.utils.report_emission",
+            REPORTING_REPORT_EMISSION_RECIPE_NAME,
             report_version=t.report_version_1,
             report_source_type__report_activity=t.report_activity,
             gas_type_id=1,
@@ -357,7 +375,7 @@ class ComplianceTestInfrastructure:
         t.report_emission_2.emission_categories.set([3])
 
         t.report_emission_3 = make_recipe(
-            "reporting.tests.utils.report_emission",
+            REPORTING_REPORT_EMISSION_RECIPE_NAME,
             report_version=t.report_version_1,
             report_source_type__report_activity=t.report_activity,
             gas_type_id=1,
@@ -367,7 +385,7 @@ class ComplianceTestInfrastructure:
         t.report_emission_3.emission_categories.set([3, 10])
 
         t.report_emission_4 = make_recipe(
-            "reporting.tests.utils.report_emission",
+            REPORTING_REPORT_EMISSION_RECIPE_NAME,
             report_version=t.report_version_1,
             report_source_type__report_activity=t.report_activity,
             gas_type_id=1,
@@ -378,29 +396,29 @@ class ComplianceTestInfrastructure:
         t.report_emission_4.emission_categories.set([5, 11])
 
         t.report_product_1 = make_recipe(
-            "reporting.tests.utils.report_product",
+            REPORTING_REPORT_PRODUCT_RECIPE_NAME,
             report_version=t.report_version_1,
             product=RegulatedProduct.objects.get(name='Pulp and paper: chemical pulp'),
             annual_production=Decimal('10000'),
         )
         t.report_product_2 = make_recipe(
-            "reporting.tests.utils.report_product",
+            REPORTING_REPORT_PRODUCT_RECIPE_NAME,
             report_version=t.report_version_1,
             product=RegulatedProduct.objects.get(name='Pulp and paper: lime recovered by kiln'),
             annual_production=Decimal('15000'),
         )
         t.report_product_3 = make_recipe(
-            "reporting.tests.utils.report_product",
+            REPORTING_REPORT_PRODUCT_RECIPE_NAME,
             report_version=t.report_version_1,
             product_id=3,  # PWAEI = 1.07
             annual_production=Decimal('200'),
         )
 
         t.report_emission_allocation = make_recipe(
-            "reporting.tests.utils.report_emission_allocation", report_version=t.report_version_1
+            REPORTING_REPORT_EMISSION_ALLOCATION_RECIPE_NAME, report_version=t.report_version_1
         )
         t.allocation_1 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             report_product=t.report_product_1,
@@ -408,7 +426,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('10000.048'),
         )
         t.allocation_1_2 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             report_product=t.report_product_1,
@@ -416,7 +434,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('2100'),
         )
         t.allocation_2 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             emission_category=EmissionCategory.objects.get(pk=3),  # Industrial Process
@@ -424,7 +442,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('20001.0008'),
         )
         t.allocation_2_2 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             emission_category=EmissionCategory.objects.get(pk=5),  # GSC (both taxable and excluded)
@@ -432,7 +450,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('2100'),
         )
         t.allocation_3 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             emission_category=EmissionCategory.objects.get(pk=5),  # GSC (both taxable and excluded)
@@ -440,7 +458,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('6300.0001'),
         )
         t.allocation_4 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             emission_category=EmissionCategory.objects.get(pk=10),  # Excluded woody biomass
@@ -448,7 +466,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('4100.02'),  # Industrial emission + GSC both from woody biomass
         )
         t.allocation_5 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             emission_category=EmissionCategory.objects.get(pk=10),  # Excluded woody biomass
@@ -456,7 +474,7 @@ class ComplianceTestInfrastructure:
             allocated_quantity=Decimal('6100.03'),  # Industrial emission + GSC both from woody biomass
         )
         t.allocation_6 = make_recipe(
-            "reporting.tests.utils.report_product_emission_allocation",
+            REPORTING_REPORT_PRODUCT_EMISSION_ALLOCATION_RECIPE_NAME,
             report_emission_allocation=t.report_emission_allocation,
             report_version=t.report_version_1,
             report_product=t.report_product_3,

--- a/bc_obps/reporting/tests/service/test_report_activity_save_service/data.py
+++ b/bc_obps/reporting/tests/service/test_report_activity_save_service/data.py
@@ -1,3 +1,5 @@
+KG_GJ_UNITS = "kg/GJ"
+
 test_data = {
     "test_activity_number": 12345,
     "test_activity_bool": True,
@@ -34,7 +36,7 @@ test_data = {
                                         "methodology": "Default HHV/Default EF",
                                         "fuelDefaultHighHeatingValue": 10,
                                         "unitFuelCo2DefaultEmissionFactor": 20,
-                                        "unitFuelCo2DefaultEmissionFactorFieldUnits": "kg/GJ",
+                                        "unitFuelCo2DefaultEmissionFactorFieldUnits": KG_GJ_UNITS,
                                     },
                                 },
                             ],
@@ -59,7 +61,7 @@ test_data = {
                                         "methodology": "Default HHV/Default EF",
                                         "fuelDefaultHighHeatingValue": 11,
                                         "unitFuelCo2DefaultEmissionFactor": 23,
-                                        "unitFuelCo2DefaultEmissionFactorFieldUnits": "kg/GJ",
+                                        "unitFuelCo2DefaultEmissionFactorFieldUnits": KG_GJ_UNITS,
                                     },
                                 },
                                 {
@@ -68,7 +70,7 @@ test_data = {
                                     "methodology": {
                                         "methodology": "Default EF",
                                         "unitFuelCo2DefaultEmissionFactor": 3,
-                                        "unitFuelCo2DefaultEmissionFactorFieldUnits": "kg/GJ",
+                                        "unitFuelCo2DefaultEmissionFactorFieldUnits": KG_GJ_UNITS,
                                     },
                                 },
                             ],
@@ -84,7 +86,7 @@ test_data = {
                                     "methodology": {
                                         "methodology": "Measured HHV/Default EF",
                                         "unitFuelCo2DefaultEmissionFactor": 4,
-                                        "unitFuelCo2DefaultEmissionFactorFieldUnits": "kg/GJ",
+                                        "unitFuelCo2DefaultEmissionFactorFieldUnits": KG_GJ_UNITS,
                                         "fuelAnnualWeightedAverageHighHeatingValue": 4,
                                     },
                                 },
@@ -96,7 +98,7 @@ test_data = {
                                         "unitFuelAnnualSteamGenerated": 5,
                                         "boilerRatio": 5,
                                         "unitFuelCo2EmissionFactor": 5,
-                                        "unitFuelCo2EmissionFactorFieldUnits": "kg/GJ",
+                                        "unitFuelCo2EmissionFactorFieldUnits": KG_GJ_UNITS,
                                     },
                                 },
                             ],
@@ -146,7 +148,10 @@ test_data = {
                                 {
                                     "gasType": "N2O",
                                     "emission": 1,
-                                    "methodology": {"methodology": "Replacement Methodology", "description": "nine"},
+                                    "methodology": {
+                                        "methodology": "Replacement Methodology",
+                                        "description": "nine",
+                                    },
                                 },
                             ],
                         },

--- a/bc_obps/reporting/tests/service/test_report_activity_save_service/infrastructure.py
+++ b/bc_obps/reporting/tests/service/test_report_activity_save_service/infrastructure.py
@@ -11,6 +11,10 @@ from model_bakery.baker import make_recipe, make
 from reporting.models.report_version import ReportVersion
 from service.utils.get_report_valid_date_from_version_id import get_report_valid_date_from_version_id
 
+# String constants for deduplication
+REPORTING_FACILITY_REPORT_RECIPE_NAME = 'reporting.tests.utils.facility_report'
+REGISTRATION_INDUSTRY_OPERATOR_USER_RECIPE_NAME = 'registration.tests.utils.industry_operator_user'
+
 
 def get_report_unit_by_index(
     report_activity: ReportActivity, source_type_index: int, report_unit_index: int
@@ -44,12 +48,12 @@ class TestInfrastructure:
     def build(cls):
         t = TestInfrastructure()
         t.facility_report = make_recipe(
-            'reporting.tests.utils.facility_report',
+            REPORTING_FACILITY_REPORT_RECIPE_NAME,
             report_version__report__reporting_year_id=2025,
         )
         t.facility_report.refresh_from_db()
         t.report_version = t.facility_report.report_version
-        t.user = make_recipe('registration.tests.utils.industry_operator_user')
+        t.user = make_recipe(REGISTRATION_INDUSTRY_OPERATOR_USER_RECIPE_NAME)
         valid_date = get_report_valid_date_from_version_id(t.report_version.id)
         t.configuration = Configuration.objects.get(valid_from__lte=valid_date, valid_to__gte=valid_date)
         t.activity = make_recipe("reporting.tests.utils.activity")
@@ -72,12 +76,12 @@ class TestInfrastructure:
     def build_from_real_config(cls, activity_slug="gsc_non_compression_non_combustion"):
         t = TestInfrastructure()
         t.facility_report = make_recipe(
-            'reporting.tests.utils.facility_report',
+            REPORTING_FACILITY_REPORT_RECIPE_NAME,
             report_version__report__reporting_year_id=2025,
         )
         t.facility_report.refresh_from_db()
         t.report_version = t.facility_report.report_version
-        t.user = make_recipe('registration.tests.utils.industry_operator_user')
+        t.user = make_recipe(REGISTRATION_INDUSTRY_OPERATOR_USER_RECIPE_NAME)
         valid_date = get_report_valid_date_from_version_id(t.report_version.id)
         t.configuration = Configuration.objects.get(valid_from__lte=valid_date, valid_to__gte=valid_date)
         t.activity = Activity.objects.get(slug=activity_slug)
@@ -93,12 +97,12 @@ class TestInfrastructure:
     def build_with_defined_report_version(cls, report_version):
         t = TestInfrastructure()
         t.facility_report = make_recipe(
-            'reporting.tests.utils.facility_report',
+            REPORTING_FACILITY_REPORT_RECIPE_NAME,
             report_version=report_version,
         )
         t.facility_report.refresh_from_db()
         t.report_version = report_version
-        t.user = make_recipe('registration.tests.utils.industry_operator_user')
+        t.user = make_recipe(REGISTRATION_INDUSTRY_OPERATOR_USER_RECIPE_NAME)
         valid_date = get_report_valid_date_from_version_id(t.report_version.id)
         t.configuration = Configuration.objects.get(valid_from__lte=valid_date, valid_to__gte=valid_date)
         t.activity = Activity.objects.get(slug="gsc_non_compression_non_combustion")

--- a/bc_obps/reporting/tests/utils/immutable_report_version.py
+++ b/bc_obps/reporting/tests/utils/immutable_report_version.py
@@ -4,6 +4,9 @@ import pytest
 from decimal import Decimal
 
 
+IMMUTABLE_REPORT_ERROR_MESSAGE_MATCH = r".* record is immutable after a report version has been submitted"
+
+
 # Wrapping this in an atomic transaction
 def assert_immutable_report_version(
     recipe_path: str,
@@ -43,7 +46,7 @@ def assert_immutable_report_version(
     with transaction.atomic():
         with pytest.raises(
             ProgrammingError,
-            match=r".* record is immutable after a report version has been submitted",
+            match=IMMUTABLE_REPORT_ERROR_MESSAGE_MATCH,
         ):
             if decimal_value_to_update != Decimal('0'):
                 setattr(model_under_test, str_field_to_update, decimal_value_to_update)
@@ -55,7 +58,7 @@ def assert_immutable_report_version(
     with transaction.atomic():
         with pytest.raises(
             ProgrammingError,
-            match=r".* record is immutable after a report version has been submitted",
+            match=IMMUTABLE_REPORT_ERROR_MESSAGE_MATCH,
         ):
             model_under_test.delete()
 
@@ -68,7 +71,7 @@ def assert_immutable_report_version(
 
         with pytest.raises(
             ProgrammingError,
-            match=r".* record is immutable after a report version has been submitted",
+            match=IMMUTABLE_REPORT_ERROR_MESSAGE_MATCH,
         ):
             baker.make_recipe(
                 recipe_path,

--- a/bc_obps/rls/tests/helpers.py
+++ b/bc_obps/rls/tests/helpers.py
@@ -123,51 +123,50 @@ def assert_policies_for_industry_user(
     if not hasattr(model_name.Rls, 'enable_rls') or not model_name.Rls.enable_rls:
         return
 
+    rls_operation_to_functions_map = {
+        RlsOperations.SELECT: (select_function, forbidden_select_function),
+        RlsOperations.INSERT: (insert_function, forbidden_insert_function),
+        RlsOperations.UPDATE: (update_function, forbidden_update_function),
+        RlsOperations.DELETE: (delete_function, forbidden_delete_function),
+    }
+
     with connection.cursor() as cursor:
         RlsMiddleware._set_user_guid_and_role(cursor, user)
         operations = model_name.Rls.role_grants_mapping[RlsRoles.INDUSTRY_USER]
 
-        if RlsOperations.SELECT in operations:
-            if select_function is noop or forbidden_select_function is noop:
-                raise ValueError(
-                    "SELECT operation granted, but no select_function or forbidden_select_function provided."
-                )
-            run_with_rollback(cursor, select_function)
-            with pytest.raises(ObjectDoesNotExist):
-                run_with_rollback(cursor, forbidden_select_function)
+        for operation, (
+            function,
+            forbidden_function,
+        ) in rls_operation_to_functions_map.items():
+            if operation not in operations:
+                continue
 
-        if RlsOperations.INSERT in operations:
-            if insert_function is noop or forbidden_insert_function is noop:
+            if function is noop or forbidden_function is noop:
                 raise ValueError(
-                    "INSERT operation granted, but no insert_function or forbidden_insert_function provided."
-                )
-            run_with_rollback(cursor, insert_function)
-            with pytest.raises(
-                ProgrammingError,
-                match=r"new row violates row-level security policy for ",
-            ):
-                run_with_rollback(cursor, forbidden_insert_function)
-
-        if RlsOperations.UPDATE in operations:
-            if update_function is noop or forbidden_update_function is noop:
-                raise ValueError(
-                    "UPDATE operation granted, but no update_function or forbidden_update_function provided."
+                    f"{operation.name} operation granted, but no {operation.name.lower()}_function or {operation.name.lower()}_forbidden_function provided."
                 )
 
-            permitted_updated_records_count = run_with_rollback(cursor, update_function)
-            assert (
-                permitted_updated_records_count == 1
-            ), f"Expected 1 updated record, but got {permitted_updated_records_count} (did you remember to return in the update function?)"
+            if operation == RlsOperations.SELECT:
+                run_with_rollback(cursor, function)
+                with pytest.raises(ObjectDoesNotExist):
+                    run_with_rollback(cursor, forbidden_function)
+            elif operation == RlsOperations.INSERT:
+                run_with_rollback(cursor, function)
+                with pytest.raises(
+                    ProgrammingError,
+                    match=r"new row violates row-level security policy for ",
+                ):
+                    run_with_rollback(cursor, forbidden_function)
+            elif operation == RlsOperations.UPDATE:
+                permitted_updated_records_count = run_with_rollback(cursor, function)
+                assert (
+                    permitted_updated_records_count == 1
+                ), f"Expected 1 updated record, but got {permitted_updated_records_count} (did you remember to return in the update function?)"
 
-            forbidden_updated_records_count = run_with_rollback(cursor, forbidden_update_function)
-            assert (
-                forbidden_updated_records_count == 0
-            ), f"Expected 0 updated records, but got {permitted_updated_records_count} (did you remember to return in the update function?)"
-
-        if RlsOperations.DELETE in operations:
-            if delete_function is noop or forbidden_delete_function is noop:
-                raise ValueError(
-                    "DELETE operation granted, but no delete_function or forbidden_delete_function provided."
-                )
-            run_with_rollback(cursor, delete_function)
-            run_with_rollback(cursor, forbidden_delete_function)
+                forbidden_updated_records_count = run_with_rollback(cursor, forbidden_function)
+                assert (
+                    forbidden_updated_records_count == 0
+                ), f"Expected 0 updated records, but got {permitted_updated_records_count} (did you remember to return in the update function?)"
+            elif operation == RlsOperations.DELETE:
+                run_with_rollback(cursor, function)
+                run_with_rollback(cursor, forbidden_function)

--- a/bc_obps/rls/utils/m2m.py
+++ b/bc_obps/rls/utils/m2m.py
@@ -1,4 +1,4 @@
-from typing import Any, List, TypedDict
+from typing import Any, List, Optional, TypedDict
 from common.enums import Schemas
 from rls.utils.grant import RlsGrant
 from rls.utils.policy import RlsPolicy
@@ -17,13 +17,13 @@ class M2mRls:
     def __init__(
         self,
         grants: List[RlsGrant],
-        policies: List[RlsPolicy] = [],
+        policies: Optional[List[RlsPolicy]] = None,
         table: Any = None,
         enable_rls: bool = False,
         schema: Schemas = Schemas.ERC,
     ):
         self.grants = grants
-        self.policies = policies
+        self.policies = policies if policies is not None else []
         self.table = table.value if table is not None else None
         self.enable_rls = enable_rls
         self.schema = schema.value

--- a/bc_obps/rls/utils/manager.py
+++ b/bc_obps/rls/utils/manager.py
@@ -90,19 +90,19 @@ class RlsManager:
     @classmethod
     def apply_rls_for_model(cls, app_name: str, model_name: str) -> None:
         model = apps.all_models[app_name][model_name]
-        if hasattr(model, 'Rls'):
-            rls = model.Rls
-            with connection.cursor() as cursor:
-                if hasattr(rls, 'grants'):
-                    for grant in rls.grants:
-                        grant.apply_grant(cursor)
-                if hasattr(rls, 'm2m_rls_list'):
-                    for m2m_rls in rls.m2m_rls_list:
-                        cls.apply_m2m_rls(cursor, m2m_rls)
-                if hasattr(rls, 'enable_rls') and rls.enable_rls and hasattr(rls, 'policies'):
-                    cursor.execute(f'alter table {rls.schema}.{rls.table.value} enable row level security')
-                    for policy in rls.policies:
-                        policy.apply_policy(cursor)
+        if not hasattr(model, "Rls"):
+            return
+
+        rls = model.Rls
+        with connection.cursor() as cursor:
+            for grant in getattr(rls, "grants", []):
+                grant.apply_grant(cursor)
+            for m2m_rls in getattr(rls, "m2m_rls_list", []):
+                cls.apply_m2m_rls(cursor, m2m_rls)
+            if getattr(rls, "enable_rls", None) and getattr(rls, "policies", None):
+                cursor.execute(f"alter table {rls.schema}.{rls.table.value} enable row level security")
+                for policy in rls.policies:
+                    policy.apply_policy(cursor)
 
     @classmethod
     def drop_policies(cls) -> None:

--- a/bc_obps/task_scheduler/tests/utils/test_parameters.py
+++ b/bc_obps/task_scheduler/tests/utils/test_parameters.py
@@ -5,7 +5,7 @@ from task_scheduler.utils.parameters import extract_function_parameters
 class TestParameters(SimpleTestCase):
     def test_extract_function_parameters_kwargs_only(self):
         def test_function(param1, param2):
-            pass
+            pass  # This function intentionally passes to test parameter extraction
 
         args = ()
         kwargs = {"param1": "value1", "param2": "value2"}
@@ -17,7 +17,7 @@ class TestParameters(SimpleTestCase):
 
     def test_extract_function_parameters_positional_args(self):
         def test_function(param1, param2, param3):
-            pass
+            pass  # This function intentionally passes to test parameter extraction
 
         args = ("value1", "value2")
         kwargs = {"param3": "value3"}
@@ -29,7 +29,7 @@ class TestParameters(SimpleTestCase):
 
     def test_extract_function_parameters_mixed_args(self):
         def test_function(param1, param2, param3, param4):
-            pass
+            pass  # This function intentionally passes to test parameter extraction
 
         args = ("value1", "value2")
         kwargs = {"param3": "value3", "param4": "value4"}
@@ -41,7 +41,7 @@ class TestParameters(SimpleTestCase):
 
     def test_extract_function_parameters_extra_kwargs(self):
         def test_function(param1):
-            pass
+            pass  # This function intentionally passes to test parameter extraction
 
         args = ()
         kwargs = {"param1": "value1", "extra_param": "extra_value"}
@@ -53,7 +53,7 @@ class TestParameters(SimpleTestCase):
 
     def test_extract_function_parameters_more_args_than_params(self):
         def test_function(param1):
-            pass
+            pass  # This function intentionally passes to test parameter extraction
 
         args = ("value1", "extra_value")
         kwargs = {}

--- a/bc_obps/task_scheduler/tests/utils/test_paths.py
+++ b/bc_obps/task_scheduler/tests/utils/test_paths.py
@@ -6,7 +6,7 @@ from task_scheduler.utils.paths import get_function_path, resolve_function_from_
 class TestGetFunctionPath(SimpleTestCase):
     def test_get_function_path_regular_function(self):
         def test_function():
-            pass
+            pass  # This function intentionally passes to test path extraction
 
         result = get_function_path(test_function)
 
@@ -17,7 +17,7 @@ class TestGetFunctionPath(SimpleTestCase):
     def test_get_function_path_class_method(self):
         class TestClass:
             def test_method(self):
-                pass
+                pass  # This function intentionally passes to test path extraction
 
         result = get_function_path(TestClass.test_method)
 
@@ -28,7 +28,7 @@ class TestGetFunctionPath(SimpleTestCase):
         class TestClass:
             @staticmethod
             def test_static_method():
-                pass
+                pass  # This function intentionally passes to test path extraction
 
         result = get_function_path(TestClass.test_static_method)
 
@@ -38,7 +38,7 @@ class TestGetFunctionPath(SimpleTestCase):
     def test_get_function_path_bound_method(self):
         class TestClass:
             def test_method(self):
-                pass
+                pass  # This function intentionally passes to test path extraction
 
         instance = TestClass()
         result = get_function_path(instance.test_method)


### PR DESCRIPTION
First batch addressing bcgov/cas-compliance#532, specifically Maintainability issues of High level. Bundled together mostly by file name.

## Changes 🚧

- bc_obps/reporting/tests/service/test_compliance_service/infrastructure.py
	- [x] [Define a constant instead of duplicating this literal 'registration.tests.utils.operation' 3 times.](https://sonarcloud.io/project/issues?open=AZyN0G0Y2Ldy6XEgsuie&id=bcgov_cas-registration)
	- [x] [Define a constant instead of duplicating this literal 'test sfo' 3 times.](https://sonarcloud.io/project/issues?open=AZyN0G0Y2Ldy6XEgsuic&id=bcgov_cas-registration)
	- [x] [Define a constant instead of duplicating this literal 'Single Facility Operation' 3 times.](https://sonarcloud.io/project/issues?open=AZyN0G0Y2Ldy6XEgsuia&id=bcgov_cas-registration)
	- [x] [Define a constant instead of duplicating this literal "reporting.tests.utils.report" 3 times.](https://sonarcloud.io/project/issues?open=AZyN0G0Y2Ldy6XEgsuiZ&id=bcgov_cas-registration)
	- [x] [Define a constant instead of duplicating this literal "reporting.tests.utils.report_version" 3 times.](https://sonarcloud.io/project/issues?open=AZyN0G0Y2Ldy6XEgsuid&id=bcgov_cas-registration)
	- [x] [Define a constant instead of duplicating this literal "reporting.tests.utils.report_operation" 3 times.](https://sonarcloud.io/project/issues?open=AZyN0G0Y2Ldy6XEgsuib&id=bcgov_cas-registration)
	- [x] [Define a constant instead of duplicating this literal "reporting.tests.utils.report_emission" 10 times.](https://sonarcloud.io/project/issues?open=AZSKPNwZ6TPgdG-NIIA3&id=bcgov_cas-registration)
	- [x] [Define a constant instead of duplicating this literal "reporting.tests.utils.report_product" 8 times.](https://sonarcloud.io/project/issues?open=AZSKPNwZ6TPgdG-NIIA5&id=bcgov_cas-registration)
	- [x] [Define a constant instead of duplicating this literal "reporting.tests.utils.report_emission_allocation" 3 times.](https://sonarcloud.io/project/issues?open=AZyN0G0Y2Ldy6XEgsuif&id=bcgov_cas-registration)
	- [x] [Define a constant instead of duplicating this literal "reporting.tests.utils.report_product_emission_allocation" 16 times.](https://sonarcloud.io/project/issues?open=AZSKPNwZ6TPgdG-NIIA4&id=bcgov_cas-registration)
- bc_obps/reporting/tests/service/test_report_activity_save_service/data.py
	- [x] [Define a constant instead of duplicating this literal "kg/GJ" 5 times.](https://sonarcloud.io/project/issues?open=AZLjqOXfuQUMpDMLzqCs&id=bcgov_cas-registration)
- bc_obps/reporting/tests/service/test_report_activity_save_service/infrastructure.py
	- [x] [Define a constant instead of duplicating this literal 'reporting.tests.utils.facility_report' 3 times.](https://sonarcloud.io/project/issues?open=AZS-xwFsBa5yWLaqxRDw&id=bcgov_cas-registration)
	- [x] [Define a constant instead of duplicating this literal 'registration.tests.utils.industry_operator_user' 3 times.](https://sonarcloud.io/project/issues?open=AZS-xwFsBa5yWLaqxRDx&id=bcgov_cas-registration)
- bc_obps/reporting/tests/utils/immutable_report_version.py
	- [x] [Define a constant instead of duplicating this literal r".* record is immutable after a report version has been submitted" 3 times.](https://sonarcloud.io/project/issues?open=AZcjIRHDgmQUZRKYik6G&id=bcgov_cas-registration)
- bc_obps/rls/utils/m2m.py
	- [x] [Change this default value to "None" and initialize this parameter inside the function/method.](https://sonarcloud.io/project/issues?open=AZePjL8XXCx5wP8VKhuY&id=bcgov_cas-registration)
- bc_obps/rls/utils/manager.py
	- [x] [Refactor this function to reduce its Cognitive Complexity from 17 to the 15 allowed.](https://sonarcloud.io/project/issues?open=AZePjL8tXCx5wP8VKhuZ&id=bcgov_cas-registration)
- ~~bc_obps/service/form_builder_service.py~~ complexity load is low
	- [x] [Refactor this function to reduce its Cognitive Complexity from 16 to the 15 allowed.](https://sonarcloud.io/project/issues?open=AZcXqc2Pz23Vri0XqkWV&id=bcgov_cas-registration)
- ~~bc_obps/service/operation_service.py~~ complexity load is low
	- [x] [Refactor this function to reduce its Cognitive Complexity from 16 to the 15 allowed.](https://sonarcloud.io/project/issues?open=AZbQ-gsIzVtHS164hekS&id=bcgov_cas-registration)
- ~~bc_obps/service/transfer_event_service.py~~ complexity load is low
	- [x] [Refactor this function to reduce its Cognitive Complexity from 16 to the 15 allowed.](https://sonarcloud.io/project/issues?open=AZp6JlnzQ5pE8bHPMZ12&id=bcgov_cas-registration)
- bc_obps/task_scheduler/tests/utils/test_parameters.py
	- [x] [Add a nested comment explaining why this function is empty, or complete the implementation.](https://sonarcloud.io/project/issues?open=AZivX4mRNC-6zF-wfFZj&id=bcgov_cas-registration)
	- [x] [Add a nested comment explaining why this function is empty, or complete the implementation.](https://sonarcloud.io/project/issues?open=AZivX4mRNC-6zF-wfFZk&id=bcgov_cas-registration)
	- [x] [Add a nested comment explaining why this function is empty, or complete the implementation.](https://sonarcloud.io/project/issues?open=AZivX4mRNC-6zF-wfFZl&id=bcgov_cas-registration)
	- [x] [Add a nested comment explaining why this function is empty, or complete the implementation.](https://sonarcloud.io/project/issues?open=AZivX4mRNC-6zF-wfFZm&id=bcgov_cas-registration)
	- [x] [Add a nested comment explaining why this function is empty, or complete the implementation.](https://sonarcloud.io/project/issues?open=AZivX4mRNC-6zF-wfFZn&id=bcgov_cas-registration)
- bc_obps/task_scheduler/tests/utils/test_paths.py
	- [x] [Add a nested comment explaining why this function is empty, or complete the implementation.](https://sonarcloud.io/project/issues?open=AZivX4l4NC-6zF-wfFZf&id=bcgov_cas-registration)
	- [x] [Add a nested comment explaining why this method is empty, or complete the implementation.](https://sonarcloud.io/project/issues?open=AZivX4l4NC-6zF-wfFZg&id=bcgov_cas-registration)
	- [x] [Add a nested comment explaining why this method is empty, or complete the implementation.](https://sonarcloud.io/project/issues?open=AZivX4l4NC-6zF-wfFZh&id=bcgov_cas-registration)
	- [x] [Add a nested comment explaining why this method is empty, or complete the implementation.](https://sonarcloud.io/project/issues?open=AZivX4l4NC-6zF-wfFZi&id=bcgov_cas-registration)
- bc_obps/rls/tests/helpers.py
	- [x] [Add a nested comment explaining why this function is empty, or complete the implementation.](https://sonarcloud.io/project/issues?open=AZePjL9dXCx5wP8VKhug&id=bcgov_cas-registration)
	- [x] [Refactor this function to reduce its Cognitive Complexity from 23 to the 15 allowed.](https://sonarcloud.io/project/issues?open=AZePjL9dXCx5wP8VKhuh&id=bcgov_cas-registration)
	- [x] [Refactor this function to reduce its Cognitive Complexity from 18 to the 15 allowed.](https://sonarcloud.io/project/issues?open=AZlTkFeyGysxbmgSk01e&id=bcgov_cas-registration)