### PR TITLE
chore: use reporting_field.slug in form_builder service

### DIFF
--- a/bc_obps/service/form_builder_service.py
+++ b/bc_obps/service/form_builder_service.py
@@ -19,12 +19,6 @@ from django.db.models import Prefetch
 from service.data_access_service.fuel_service import FuelTypeDataAccessService
 
 
-# Helper function to dynamically set the RJSF property value of a field from a Title cased name
-def str_to_camel_case(st: str) -> str:
-    output = "".join(x for x in st.title() if x.isalnum())
-    return output[0].lower() + output[1:]
-
-
 def get_custom_methodology_schema_by_id(schema_id: int) -> Dict[str, Any]:
     custom_schema = CustomMethodologySchema.objects.get(id=schema_id)
     return custom_schema.json_schema  # type: ignore[no-any-return]

--- a/bc_obps/service/form_builder_service.py
+++ b/bc_obps/service/form_builder_service.py
@@ -80,7 +80,7 @@ def handle_methodologies(
 
         else:
             for reporting_field in reporting_fields:
-                property_field = str_to_camel_case(reporting_field.field_name)
+                property_field = reporting_field.slug
                 methodology_object["properties"][property_field] = {
                     "type": reporting_field.field_type,
                     "title": reporting_field.field_display_title or reporting_field.field_name,


### PR DESCRIPTION
Quick follow up to the work in #4411 which added a `slug` column to the reporting_field table. This should be a more stable identifier for the reporting_field record and should be used in the form_builder service rather than camel-casing the field name.