### PR TITLE
fix: remove unevaluated methodology fields in activity raw fixture + re-enable report_validation for e2e tests

### DIFF
--- a/bc_obps/reporting/fixtures/mock/report_raw_activity_data.json
+++ b/bc_obps/reporting/fixtures/mock/report_raw_activity_data.json
@@ -15,7 +15,6 @@
                   {
                     "fuelType": {
                       "fuelName": "Diesel",
-                      "fuelUnit": "kilolitres",
                       "fuelClassification": "Non-biomass"
                     },
                     "emissions": [
@@ -62,7 +61,6 @@
                   {
                     "fuelType": {
                       "fuelName": "Diesel",
-                      "fuelUnit": "kilolitres",
                       "fuelClassification": "Non-biomass"
                     },
                     "emissions": [
@@ -109,7 +107,6 @@
                   {
                     "fuelType": {
                       "fuelName": "Diesel",
-                      "fuelUnit": "kilolitres",
                       "fuelClassification": "Non-biomass"
                     },
                     "emissions": [

--- a/bc_obps/reporting/fixtures/mock/report_raw_activity_data.json
+++ b/bc_obps/reporting/fixtures/mock/report_raw_activity_data.json
@@ -23,9 +23,7 @@
                         "gasType": "CO2",
                         "emission": 11000,
                         "methodology": {
-                          "methodology": "Default EF",
-                          "unitFuelCo2DefaultEf": 1,
-                          "unitFuelCo2DefaultEfFieldUnits": "kg/fuel units"
+                          "methodology": "Default EF"
                         }
                       }
                     ],
@@ -72,9 +70,7 @@
                         "gasType": "CO2",
                         "emission": 250000,
                         "methodology": {
-                          "methodology": "Default EF",
-                          "unitFuelCo2DefaultEf": 1,
-                          "unitFuelCo2DefaultEfFieldUnits": "kg/fuel units"
+                          "methodology": "Default EF"
                         }
                       }
                     ],
@@ -121,9 +117,7 @@
                         "gasType": "CO2",
                         "emission": 0.0,
                         "methodology": {
-                          "methodology": "Default EF",
-                          "unitFuelCo2DefaultEf": 1,
-                          "unitFuelCo2DefaultEfFieldUnits": "kg/fuel units"
+                          "methodology": "Default EF"
                         }
                       }
                     ],

--- a/bc_obps/reporting/service/report_validation/report_validation_error.py
+++ b/bc_obps/reporting/service/report_validation/report_validation_error.py
@@ -28,6 +28,7 @@ class ReportValidationErrorKey(StrEnum):
     REPORT_DATA_OUT_OF_BOUNDS_BY_REPORTING_FIELD = "report_data_out_of_bounds_by_reporting_field"
     ACTIVITY_DATA_COVERAGE = "activity_data_coverage"
     ERROR_REQUIRED_FIELDS = "error_required_fields"
+    ACTIVITY_JSON_SCHEMA_VALIDATION_ERROR = "activity_json_schema_validation_error"
 
 
 class ErrorContext(BaseModel):

--- a/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
+++ b/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
@@ -40,11 +40,6 @@ def enable_jsonschema_draft_2020_validation(schema: Any) -> None:
 
 
 def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    logger.warning(
-        "Report activity json validation has been suspended until the jsonschema draft2020 can be fully implemented."
-    )
-    return {}
-
     errors = {}
 
     for facility_report in report_version.facility_reports.all():

--- a/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
+++ b/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
@@ -6,6 +6,7 @@ from reporting.models.report_version import ReportVersion
 from reporting.models.source_type import SourceType
 from reporting.service.report_validation.report_validation_error import (
     ReportValidationError,
+    ReportValidationErrorKey,
     Severity,
 )
 from service.form_builder_service import FormBuilderService
@@ -71,6 +72,7 @@ def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
                     ReportValidationError(
                         severity=Severity.ERROR,
                         message=f"Validation error: {e.message} at: {' > '.join(str(elt) for elt in e.path)}",
+                        key=ReportValidationErrorKey.ACTIVITY_JSON_SCHEMA_VALIDATION_ERROR,
                     )
                 )
 

--- a/bc_obps/reporting/tests/service/report_validation/validators/test_report_activity_json_validator.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/test_report_activity_json_validator.py
@@ -216,7 +216,6 @@ class TestReportActivityJsonValidator:
                                 {
                                     "fuelType": {
                                         "fuelName": "Acid Gas",
-                                        "fuelUnit": "Sm^3",
                                         "fuelClassification": "Non-biomass",
                                     },
                                     "emissions": [
@@ -250,7 +249,6 @@ class TestReportActivityJsonValidator:
                                 {
                                     "fuelType": {
                                         "fuelName": "Diesel",
-                                        "fuelUnit": "kilolitres",
                                         "fuelClassification": "Non-biomass",
                                     },
                                     "emissions": [


### PR DESCRIPTION
fixes [941](https://github.com/bcgov/cas-reporting/issues/941)