### PR TITLE
Task/add reporting year attachments page/4455

### DIFF
--- a/bc_obps/reporting/api/report_attachments.py
+++ b/bc_obps/reporting/api/report_attachments.py
@@ -116,7 +116,7 @@ def get_all_attachments(
             mapped_sort_field = "report_version__report__operator__legal_name"
         case "operation":
             mapped_sort_field = "report_version__report__operation__name"
-        case "reporting_year":
+        case "reporting_year_id":
             mapped_sort_field = "report_version__report__reporting_year_id"
         case _:
             mapped_sort_field = sort_field or "id"

--- a/bc_obps/reporting/api/report_attachments.py
+++ b/bc_obps/reporting/api/report_attachments.py
@@ -1,4 +1,5 @@
 from typing import List, Literal, Optional, Tuple
+from reporting.models.report_attachment import ReportAttachment
 from common.api.utils.current_user_utils import get_current_user_guid
 from common.permissions import authorize
 from django.db import transaction
@@ -8,8 +9,6 @@ from ninja import File, Form, Query, UploadedFile
 from ninja.pagination import paginate
 from registration.utils import CustomPagination
 from reporting.constants import EMISSIONS_REPORT_TAGS
-from reporting.models.report_attachment import ReportAttachment
-from reporting.models.report_version import ReportVersion
 from reporting.schema.generic import Message
 from reporting.schema.report_attachment import (
     AttachmentsWithConfirmationOut,
@@ -23,6 +22,16 @@ from reporting.api.permissions import (
     approved_industry_user_report_version_composite_auth,
     approved_authorized_roles_report_version_composite_auth,
 )
+
+# Mapping of filter field names to model lookup paths
+FILTER_LOOKUPS = {
+    "operator": "report_version__report__operator__legal_name__icontains",
+    "operation": "report_version__report__operation__name__icontains",
+    "report_version_id": "report_version__id",
+    "reporting_year_id": "report_version__report__reporting_year__reporting_year",
+    "attachment_type": "attachment_type__icontains",
+    "attachment_name": "attachment_name__icontains",
+}
 
 
 @router.post(
@@ -74,7 +83,7 @@ def get_report_attachments(
     request: HttpRequest,
     version_id: int,
 ) -> Tuple[int, dict]:
-    attachments = ReportAttachmentService.get_attachments(version_id)
+    attachments = ReportAttachmentService.get_attachments_by_version(version_id)
     confirmation = ReportAttachmentService.get_attachment_confirmation(version_id)
 
     response_data = {
@@ -97,7 +106,7 @@ def get_report_attachment_url(request: HttpRequest, version_id: int, file_id: in
 
 @router.get(
     "attachments",
-    response={200: list[InternalReportAttachmentOut], custom_codes_4xx: Message},
+    response={200: List[InternalReportAttachmentOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Returns the list of all attachments for all reports.""",
     auth=authorize("authorized_irc_user"),
@@ -111,27 +120,10 @@ def get_all_attachments(
     paginate_result: bool = Query(True, description="Whether to paginate the results"),
 ) -> QuerySet[ReportAttachment]:
 
-    match sort_field:
-        case "operator":
-            mapped_sort_field = "report_version__report__operator__legal_name"
-        case "operation":
-            mapped_sort_field = "report_version__report__operation__name"
-        case "reporting_year_id":
-            mapped_sort_field = "report_version__report__reporting_year_id"
-        case _:
-            mapped_sort_field = sort_field or "report_version_id"
+    filter_params = {
+        FILTER_LOOKUPS[field]: value
+        for field, value in filters.model_dump(exclude_none=True).items()
+        if value is not None
+    }
 
-    sort_direction = "-" if sort_order == "desc" else ""
-    sort_by = f"{sort_direction}{mapped_sort_field}"
-
-    attachments_query = ReportAttachment.objects.select_related(
-        "report_version",
-        "report_version__report__operation",
-        "report_version__report__operator",
-        "report_version__report__reporting_year",
-    ).filter(
-        report_version__status=ReportVersion.ReportVersionStatus.Submitted,
-        report_version__report__reporting_year__isnull=False,
-    )
-
-    return filters.filter(attachments_query).order_by(sort_by)
+    return ReportAttachmentService.get_all_attachments(filter_params, sort_field, sort_order)

--- a/bc_obps/reporting/api/report_attachments.py
+++ b/bc_obps/reporting/api/report_attachments.py
@@ -105,7 +105,7 @@ def get_report_attachment_url(request: HttpRequest, version_id: int, file_id: in
 def get_all_attachments(
     request: HttpRequest,
     filters: InternalReportAttachmentFilterSchema = Query(...),
-    sort_field: Optional[str] | Optional[(str)] = "report_version_id",
+    sort_field: Optional[str] = "report_version_id",
     sort_order: Optional[Literal["desc", "asc"]] = "desc",
     paginate_result: bool = Query(True, description="Whether to paginate the results"),
 ) -> QuerySet[ReportAttachment]:

--- a/bc_obps/reporting/api/report_attachments.py
+++ b/bc_obps/reporting/api/report_attachments.py
@@ -106,23 +106,25 @@ def get_report_attachment_url(request: HttpRequest, version_id: int, file_id: in
 def get_all_attachments(
     request: HttpRequest,
     filters: InternalReportAttachmentFilterSchema = Query(...),
-    sort_field: Optional[str] = "id",
+    sort_field: Optional[str] | Optional[(str)] = "id",
     sort_order: Optional[Literal["desc", "asc"]] = "desc",
     paginate_result: bool = Query(True, description="Whether to paginate the results"),
 ) -> QuerySet[ReportAttachment]:
 
-    match sort_field:
-        case "operator":
-            mapped_sort_field = "report_version__report__operator__legal_name"
-        case "operation":
-            mapped_sort_field = "report_version__report__operation__name"
-        case "reporting_year_id":
-            mapped_sort_field = "report_version__report__reporting_year_id"
-        case _:
-            mapped_sort_field = sort_field or "id"
+    # match sort_field:
+    #     case "operator":
+    #         mapped_sort_field = "report_version__report__operator__legal_name"
+    #     case "operation":
+    #         mapped_sort_field = "report_version__report__operation__name"
+    #     case "reporting_year_id":
+    #         mapped_sort_field = "report_version__report__reporting_year_id"
+    #     case _:
+    #         mapped_sort_field = sort_field or "reporting_year_id"
 
-    sort_direction = "-" if sort_order == "desc" else ""
-    sort_by = f"{sort_direction}{mapped_sort_field}"
+    # sort_direction = "-" if sort_order == "desc" else ""
+    # sort_by = f"{sort_direction}{mapped_sort_field}"
+
+    sort_by = ["-report_version__report__reporting_year_id", "-report_version_id"]
 
     attachments_query = ReportAttachment.objects.select_related(
         "report_version",
@@ -134,4 +136,6 @@ def get_all_attachments(
         report_version__report__reporting_year__isnull=False,
     )
 
-    return filters.filter(attachments_query).order_by(sort_by)
+    print(f"\n\n\nsort_by = {sort_by}\n\n\n")
+
+    return filters.filter(attachments_query).order_by(*sort_by)

--- a/bc_obps/reporting/api/report_attachments.py
+++ b/bc_obps/reporting/api/report_attachments.py
@@ -111,11 +111,15 @@ def get_all_attachments(
     paginate_result: bool = Query(True, description="Whether to paginate the results"),
 ) -> QuerySet[ReportAttachment]:
 
-    mapped_sort_field = (
-        "report_version__report__operator__legal_name"
-        if sort_field == "operator"
-        else "report_version__report__operation__name" if sort_field == "operation" else sort_field
-    )
+    match sort_field:
+        case "operator":
+            mapped_sort_field = "report_version__report__operator__legal_name"
+        case "operation":
+            mapped_sort_field = "report_version__report__operation__name"
+        case "reporting_year":
+            mapped_sort_field = "report_version__report__reporting_year_id"
+        case _:
+            mapped_sort_field = sort_field or "id"
 
     sort_direction = "-" if sort_order == "desc" else ""
     sort_by = f"{sort_direction}{mapped_sort_field}"
@@ -124,6 +128,10 @@ def get_all_attachments(
         "report_version",
         "report_version__report__operation",
         "report_version__report__operator",
-    ).filter(report_version__status=ReportVersion.ReportVersionStatus.Submitted)
+        "report_version__report__reporting_year",
+    ).filter(
+        report_version__status=ReportVersion.ReportVersionStatus.Submitted,
+        report_version__report__reporting_year__isnull=False,
+    )
 
     return filters.filter(attachments_query).order_by(sort_by)

--- a/bc_obps/reporting/api/report_attachments.py
+++ b/bc_obps/reporting/api/report_attachments.py
@@ -106,25 +106,23 @@ def get_report_attachment_url(request: HttpRequest, version_id: int, file_id: in
 def get_all_attachments(
     request: HttpRequest,
     filters: InternalReportAttachmentFilterSchema = Query(...),
-    sort_field: Optional[str] | Optional[(str)] = "id",
+    sort_field: Optional[str] | Optional[(str)] = "report_version_id",
     sort_order: Optional[Literal["desc", "asc"]] = "desc",
     paginate_result: bool = Query(True, description="Whether to paginate the results"),
 ) -> QuerySet[ReportAttachment]:
 
-    # match sort_field:
-    #     case "operator":
-    #         mapped_sort_field = "report_version__report__operator__legal_name"
-    #     case "operation":
-    #         mapped_sort_field = "report_version__report__operation__name"
-    #     case "reporting_year_id":
-    #         mapped_sort_field = "report_version__report__reporting_year_id"
-    #     case _:
-    #         mapped_sort_field = sort_field or "reporting_year_id"
+    match sort_field:
+        case "operator":
+            mapped_sort_field = "report_version__report__operator__legal_name"
+        case "operation":
+            mapped_sort_field = "report_version__report__operation__name"
+        case "reporting_year_id":
+            mapped_sort_field = "report_version__report__reporting_year_id"
+        case _:
+            mapped_sort_field = sort_field or "report_version_id"
 
-    # sort_direction = "-" if sort_order == "desc" else ""
-    # sort_by = f"{sort_direction}{mapped_sort_field}"
-
-    sort_by = ["-report_version__report__reporting_year_id", "-report_version_id"]
+    sort_direction = "-" if sort_order == "desc" else ""
+    sort_by = f"{sort_direction}{mapped_sort_field}"
 
     attachments_query = ReportAttachment.objects.select_related(
         "report_version",
@@ -136,6 +134,4 @@ def get_all_attachments(
         report_version__report__reporting_year__isnull=False,
     )
 
-    print(f"\n\n\nsort_by = {sort_by}\n\n\n")
-
-    return filters.filter(attachments_query).order_by(*sort_by)
+    return filters.filter(attachments_query).order_by(sort_by)

--- a/bc_obps/reporting/api/report_attachments.py
+++ b/bc_obps/reporting/api/report_attachments.py
@@ -23,16 +23,6 @@ from reporting.api.permissions import (
     approved_authorized_roles_report_version_composite_auth,
 )
 
-# Mapping of filter field names to model lookup paths
-FILTER_LOOKUPS = {
-    "operator": "report_version__report__operator__legal_name__icontains",
-    "operation": "report_version__report__operation__name__icontains",
-    "report_version_id": "report_version__id",
-    "reporting_year_id": "report_version__report__reporting_year__reporting_year",
-    "attachment_type": "attachment_type__icontains",
-    "attachment_name": "attachment_name__icontains",
-}
-
 
 @router.post(
     "report-version/{version_id}/attachments",
@@ -120,10 +110,4 @@ def get_all_attachments(
     paginate_result: bool = Query(True, description="Whether to paginate the results"),
 ) -> QuerySet[ReportAttachment]:
 
-    filter_params = {
-        FILTER_LOOKUPS[field]: value
-        for field, value in filters.model_dump(exclude_none=True).items()
-        if value is not None
-    }
-
-    return ReportAttachmentService.get_all_attachments(filter_params, sort_field, sort_order)
+    return ReportAttachmentService.get_all_attachments(filters, sort_field, sort_order)

--- a/bc_obps/reporting/management/commands/utils.py
+++ b/bc_obps/reporting/management/commands/utils.py
@@ -21,7 +21,7 @@ def submit_report_from_fixture(report_version: ReportVersion, submitting_user: U
         "verification_statement",
         ContentFile(b"data1", "file1.pdf"),
     )
-    verification_statement = ReportAttachmentService.get_attachments(report_version.id).first()
+    verification_statement = ReportAttachmentService.get_attachments_by_version(report_version.id).first()
     verification_statement.status = 'Clean'
     verification_statement.save()
 

--- a/bc_obps/reporting/schema/report_attachment.py
+++ b/bc_obps/reporting/schema/report_attachment.py
@@ -44,6 +44,8 @@ class InternalReportAttachmentFilterSchema(FilterSchema):
     operator: Annotated[str | None, Field(q="report_version__report__operator__legal_name__icontains")] = None
     operation: Annotated[str | None, Field(q="report_version__report__operation__name__icontains")] = None
     report_version_id: Annotated[int | None, Field(q="report_version__id")] = None
-    reporting_year_id: Annotated[int | None, Field(q="report_version__report__reporting_year__reporting_year")] = None
+    reporting_year_id: Annotated[
+        int | None, Field(q="report_version__report__reporting_year__reporting_year__icontains")
+    ] = None
     attachment_type: Annotated[str | None, Field(q="attachment_type__icontains")] = None
     attachment_name: Annotated[str | None, Field(q="attachment_name__icontains")] = None

--- a/bc_obps/reporting/schema/report_attachment.py
+++ b/bc_obps/reporting/schema/report_attachment.py
@@ -29,6 +29,7 @@ class InternalReportAttachmentOut(ModelSchema):
     operator: str = Field(..., alias="report_version.report.operator.legal_name")
     operation: str = Field(..., alias="report_version.report.operation.name")
     report_version_id: int = Field(..., alias="report_version.id")
+    reporting_year_id: Optional[int] = Field(None, alias="report_version.report.reporting_year.reporting_year")
 
     class Meta:
         model = ReportAttachment
@@ -43,5 +44,6 @@ class InternalReportAttachmentFilterSchema(FilterSchema):
     operator: Annotated[str | None, Field(q="report_version__report__operator__legal_name__icontains")] = None
     operation: Annotated[str | None, Field(q="report_version__report__operation__name__icontains")] = None
     report_version_id: Annotated[int | None, Field(q="report_version__id")] = None
+    reporting_year_id: Annotated[int | None, Field(q="report_version__report__reporting_year__reporting_year")] = None
     attachment_type: Annotated[str | None, Field(q="attachment_type__icontains")] = None
     attachment_name: Annotated[str | None, Field(q="attachment_name__icontains")] = None

--- a/bc_obps/reporting/service/report_attachment_service.py
+++ b/bc_obps/reporting/service/report_attachment_service.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import UploadedFile
@@ -6,6 +6,7 @@ from django.db.models import QuerySet
 from reporting.constants import MAX_UPLOAD_SIZE
 from reporting.models.report_attachment import ReportAttachment
 from reporting.models.report_attachment_confirmation import ReportAttachmentConfirmation
+from reporting.models.report_version import ReportVersion
 
 
 class ReportAttachmentService:
@@ -39,12 +40,48 @@ class ReportAttachmentService:
         attachment.save()
 
     @classmethod
-    def get_attachments(cls, report_version_id: int) -> QuerySet[ReportAttachment]:
+    def get_attachments_by_version(cls, report_version_id: int) -> QuerySet[ReportAttachment]:
         return ReportAttachment.objects.filter(report_version_id=report_version_id).all()
 
     @classmethod
     def get_attachment(cls, report_version_id: int, attachment_id: int) -> ReportAttachment:
         return ReportAttachment.objects.get(report_version_id=report_version_id, id=attachment_id)
+
+    @classmethod
+    def get_all_attachments(
+        cls,
+        filter_params: dict,
+        sort_field: Optional[str] | Optional[(str)] = "report_version_id",
+        sort_order: Optional[Literal["desc", "asc"]] = "desc",
+    ) -> QuerySet[ReportAttachment]:
+
+        match sort_field:
+            case "operator":
+                mapped_sort_field = "report_version__report__operator__legal_name"
+            case "operation":
+                mapped_sort_field = "report_version__report__operation__name"
+            case "reporting_year_id":
+                mapped_sort_field = "report_version__report__reporting_year_id"
+            case _:
+                mapped_sort_field = sort_field or "report_version_id"
+
+        sort_direction = "-" if sort_order == "desc" else ""
+        sort_by = f"{sort_direction}{mapped_sort_field}"
+
+        query = ReportAttachment.objects.select_related(
+            "report_version",
+            "report_version__report",
+            "report_version__report__operation",
+            "report_version__report__operator",
+            "report_version__report__reporting_year",
+        ).filter(
+            report_version__status=ReportVersion.ReportVersionStatus.Submitted,
+        )
+
+        if filter_params:
+            query = query.filter(**filter_params)
+
+        return query.order_by(sort_by)
 
     @classmethod
     def save_attachment_confirmation(

--- a/bc_obps/reporting/service/report_attachment_service.py
+++ b/bc_obps/reporting/service/report_attachment_service.py
@@ -1,8 +1,10 @@
 from typing import Literal, Optional
 from uuid import UUID
+from ninja import Query
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import UploadedFile
 from django.db.models import QuerySet
+from reporting.schema.report_attachment import InternalReportAttachmentFilterSchema
 from reporting.constants import MAX_UPLOAD_SIZE
 from reporting.models.report_attachment import ReportAttachment
 from reporting.models.report_attachment_confirmation import ReportAttachmentConfirmation
@@ -50,7 +52,7 @@ class ReportAttachmentService:
     @classmethod
     def get_all_attachments(
         cls,
-        filter_params: Optional[dict] = {},
+        filters: InternalReportAttachmentFilterSchema = Query(...),
         sort_field: Optional[str] | Optional[(str)] = "report_version_id",
         sort_order: Optional[Literal["desc", "asc"]] = "desc",
     ) -> QuerySet[ReportAttachment]:
@@ -68,7 +70,7 @@ class ReportAttachmentService:
         sort_direction = "-" if sort_order == "desc" else ""
         sort_by = f"{sort_direction}{mapped_sort_field}"
 
-        query = ReportAttachment.objects.select_related(
+        queryset = ReportAttachment.objects.select_related(
             "report_version",
             "report_version__report",
             "report_version__report__operation",
@@ -78,10 +80,10 @@ class ReportAttachmentService:
             report_version__status=ReportVersion.ReportVersionStatus.Submitted,
         )
 
-        if filter_params:
-            query = query.filter(**filter_params)
+        if filters:
+            queryset = filters.filter(queryset)
 
-        return query.order_by(sort_by)
+        return queryset.order_by(sort_by)
 
     @classmethod
     def save_attachment_confirmation(

--- a/bc_obps/reporting/service/report_attachment_service.py
+++ b/bc_obps/reporting/service/report_attachment_service.py
@@ -50,7 +50,7 @@ class ReportAttachmentService:
     @classmethod
     def get_all_attachments(
         cls,
-        filter_params: dict,
+        filter_params: Optional[dict] = {},
         sort_field: Optional[str] | Optional[(str)] = "report_version_id",
         sort_order: Optional[Literal["desc", "asc"]] = "desc",
     ) -> QuerySet[ReportAttachment]:

--- a/bc_obps/reporting/service/report_attachment_service.py
+++ b/bc_obps/reporting/service/report_attachment_service.py
@@ -1,6 +1,5 @@
 from typing import Literal, Optional
 from uuid import UUID
-from ninja import Query
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import UploadedFile
 from django.db.models import QuerySet
@@ -52,7 +51,7 @@ class ReportAttachmentService:
     @classmethod
     def get_all_attachments(
         cls,
-        filters: InternalReportAttachmentFilterSchema = Query(...),
+        filters: Optional[InternalReportAttachmentFilterSchema] = None,
         sort_field: Optional[str] | Optional[(str)] = "report_version_id",
         sort_order: Optional[Literal["desc", "asc"]] = "desc",
     ) -> QuerySet[ReportAttachment]:

--- a/bc_obps/reporting/tests/api/test_report_attachment_api.py
+++ b/bc_obps/reporting/tests/api/test_report_attachment_api.py
@@ -21,7 +21,9 @@ class TestReportAttachmentEndpoints(CommonTestSetup):
         "reporting.service.report_attachment_service.ReportAttachmentService.save_attachment_confirmation",
         autospec=True,
     )
-    @patch("reporting.service.report_attachment_service.ReportAttachmentService.get_attachments", autospec=True)
+    @patch(
+        "reporting.service.report_attachment_service.ReportAttachmentService.get_attachments_by_version", autospec=True
+    )
     @patch(
         "reporting.service.report_attachment_service.ReportAttachmentService.get_attachment_confirmation", autospec=True
     )
@@ -85,7 +87,9 @@ class TestReportAttachmentEndpoints(CommonTestSetup):
             },
         }
 
-    @patch("reporting.service.report_attachment_service.ReportAttachmentService.get_attachments", autospec=True)
+    @patch(
+        "reporting.service.report_attachment_service.ReportAttachmentService.get_attachments_by_version", autospec=True
+    )
     @patch(
         "reporting.service.report_attachment_service.ReportAttachmentService.get_attachment_confirmation", autospec=True
     )

--- a/bc_obps/reporting/tests/endpoints/test_report_attachment_internal_endpoint.py
+++ b/bc_obps/reporting/tests/endpoints/test_report_attachment_internal_endpoint.py
@@ -57,20 +57,22 @@ class TestReportAttachmentInternalEndpoints(CommonTestSetup):
             "count": 2,
             "items": [
                 {
-                    "attachment_name": "test_conf_req.txt",
-                    "attachment_type": "confidentiality_request",
-                    "id": attachment2.id,
-                    "operation": "test operation",
-                    "operator": "test operator",
-                    "report_version_id": report_version.id,
-                },
-                {
                     "attachment_name": "test_attachment.txt",
                     "attachment_type": "verification_statement",
                     "id": attachment.id,
                     "operation": "test operation",
                     "operator": "test operator",
                     "report_version_id": report_version.id,
+                    "reporting_year_id": report_version.report.reporting_year.reporting_year,
+                },
+                {
+                    "attachment_name": "test_conf_req.txt",
+                    "attachment_type": "confidentiality_request",
+                    "id": attachment2.id,
+                    "operation": "test operation",
+                    "operator": "test operator",
+                    "report_version_id": report_version.id,
+                    "reporting_year_id": report_version.report.reporting_year.reporting_year,
                 },
             ],
         }

--- a/bc_obps/reporting/tests/service/test_report_attachment_service.py
+++ b/bc_obps/reporting/tests/service/test_report_attachment_service.py
@@ -6,6 +6,7 @@ from model_bakery.baker import make_recipe
 from ninja import UploadedFile
 import pytest
 from registration.models.user import User
+from reporting.models.report_version import ReportVersion
 from reporting.models.report_attachment import ReportAttachment
 from reporting.service.report_attachment_service import ReportAttachmentService
 from reporting.models.report_attachment_confirmation import ReportAttachmentConfirmation
@@ -85,33 +86,189 @@ class TestReportAttachmentService:
         response = ReportAttachmentService.get_attachments_by_version(self.report_version.id)
         assert list(response.all()) == [r, r2]
 
-    def test_get_all_attachments(self):
-        uploaded_files = []
-        for i in range(5):
-            file = ContentFile(b"asdhfjh", f"test_file_{i}.txt")
-            uploaded_file = InMemoryUploadedFile(
-                file,
-                size=file.size,
-                field_name='attachment',
-                name=f"test_file_{i}.txt",
-                content_type="a",
-                charset="utf-8",
-            )
-            uploaded_files.append(uploaded_file)
+    def test_get_all_attachments_filters(self):
+        # ARRANGE
+        rv1 = self.report_version
+        rv2 = make_recipe("reporting.tests.utils.report_version")
 
-        attachments = []
-        for i in range(5):
-            r = ReportAttachment(
-                report_version=self.report_version,
-                attachment=uploaded_files[i],
-                attachment_type="verification_statement",
-                attachment_name=f"some_test_file_{i}.pdf",
-            )
-            r.save()
-            attachments.append(r)
+        file = ContentFile(b"fasjdfh", "test_file.txt")
 
-        response = ReportAttachmentService.get_all_attachments()
-        assert list(response.all()) == attachments
+        up_file1 = InMemoryUploadedFile(
+            file, size=file.size, field_name='attachment', name="test_file_1.txt", content_type='a', charset='utf-8'
+        )
+        up_file2 = InMemoryUploadedFile(
+            file, size=file.size, field_name='attachment', name="test_file_2.txt", content_type='a', charset='utf-8'
+        )
+
+        a1 = baker.make(
+            ReportAttachment,
+            report_version=rv1,
+            attachment=up_file1,
+            attachment_type="verification_statement",
+            attachment_name="test_file_1.pdf",
+        )
+        a2 = baker.make(
+            ReportAttachment,
+            report_version=rv2,
+            attachment=up_file2,
+            attachment_type="verification_statement",
+            attachment_name="test_file_2.pdf",
+        )
+
+        a1.save()
+        a2.save()
+        rv1.status = ReportVersion.ReportVersionStatus.Submitted
+        rv2.status = ReportVersion.ReportVersionStatus.Submitted
+        rv1.save(update_fields=['status'])
+        rv2.save(update_fields=['status'])
+
+        # ACT/ASSERT
+        # first try with no filters
+        result = ReportAttachmentService.get_all_attachments()
+        assert list(result) == [a2, a1]
+
+        # now filter by report_version_id
+        result = ReportAttachmentService.get_all_attachments(filter_params={"report_version_id": rv1.id})
+        assert list(result) == [a1]
+
+    def test_get_all_attachments_default_sort_by_report_version_id(self):
+        # ARRANGE
+        rv1 = self.report_version
+        rv2 = make_recipe("reporting.tests.utils.report_version")
+
+        file = ContentFile(b"fasjdfh", "test_file.txt")
+
+        up_file1 = InMemoryUploadedFile(
+            file, size=file.size, field_name='attachment', name="test_file_1.txt", content_type='a', charset='utf-8'
+        )
+        up_file2 = InMemoryUploadedFile(
+            file, size=file.size, field_name='attachment', name="test_file_2.txt", content_type='a', charset='utf-8'
+        )
+
+        a1 = baker.make(
+            ReportAttachment,
+            report_version=rv1,
+            attachment=up_file1,
+            attachment_type="verification_statement",
+            attachment_name="test_file_1.pdf",
+        )
+        a2 = baker.make(
+            ReportAttachment,
+            report_version=rv2,
+            attachment=up_file2,
+            attachment_type="verification_statement",
+            attachment_name="test_file_2.pdf",
+        )
+
+        a1.save()
+        a2.save()
+        rv1.status = ReportVersion.ReportVersionStatus.Submitted
+        rv2.status = ReportVersion.ReportVersionStatus.Submitted
+        rv1.save(update_fields=['status'])
+        rv2.save(update_fields=['status'])
+
+        # ACT/ASSERT
+        # first test default sort order (desc)
+        result = list(ReportAttachmentService.get_all_attachments({}, "report_version_id", "desc"))
+        assert result == sorted([a1, a2], key=lambda x: x.report_version_id, reverse=True)
+
+        # now test ascending sort order
+        result = list(ReportAttachmentService.get_all_attachments({}, "report_version_id", "asc"))
+        assert result == sorted([a1, a2], key=lambda x: x.report_version_id)
+
+    def test_get_all_attachments_sort_by_operation_name(self):
+        # ARRANGE
+        op_a = make_recipe("reporting.tests.utils.report_operation", operation_name="Chocolate Factory")
+        op_b = make_recipe("reporting.tests.utils.report_operation", operation_name="Licorice Factory")
+
+        rv1 = make_recipe("reporting.tests.utils.report_version", report_operation=op_a)
+        rv2 = make_recipe("reporting.tests.utils.report_version", report_operation=op_b)
+
+        file = ContentFile(b"fasjdfh", "test_file.txt")
+
+        up_file1 = InMemoryUploadedFile(
+            file, size=file.size, field_name='attachment', name="test_file_1.txt", content_type='a', charset='utf-8'
+        )
+        up_file2 = InMemoryUploadedFile(
+            file, size=file.size, field_name='attachment', name="test_file_2.txt", content_type='a', charset='utf-8'
+        )
+
+        a1 = baker.make(
+            ReportAttachment,
+            report_version=rv1,
+            attachment=up_file1,
+            attachment_type="verification_statement",
+            attachment_name="test_file_1.pdf",
+        )
+        a2 = baker.make(
+            ReportAttachment,
+            report_version=rv2,
+            attachment=up_file2,
+            attachment_type="verification_statement",
+            attachment_name="test_file_2.pdf",
+        )
+
+        a1.save()
+        a2.save()
+        rv1.status = ReportVersion.ReportVersionStatus.Submitted
+        rv2.status = ReportVersion.ReportVersionStatus.Submitted
+        rv1.save(update_fields=['status'])
+        rv2.save(update_fields=['status'])
+
+        # ACT
+        result = list(ReportAttachmentService.get_all_attachments({}, "operation", "asc"))
+
+        # ASSERT
+        assert result == [a1, a2]  # Chocolate Factory before Licorice Factory
+
+    def test_get_all_attachments_only_returns_submitted_ones(self):
+        # ARRANGE
+        # need to first set status to Draft so we can still make attachments to it
+        submitted_rv = make_recipe(
+            "reporting.tests.utils.report_version", status=ReportVersion.ReportVersionStatus.Draft
+        )
+        draft_rv = make_recipe("reporting.tests.utils.report_version", status=ReportVersion.ReportVersionStatus.Draft)
+
+        file = ContentFile(b"fasjdfh", "test_file.txt")
+
+        up_file1 = InMemoryUploadedFile(
+            file, size=file.size, field_name='attachment', name="test_file_1.txt", content_type='a', charset='utf-8'
+        )
+        up_file2 = InMemoryUploadedFile(
+            file, size=file.size, field_name='attachment', name="test_file_2.txt", content_type='a', charset='utf-8'
+        )
+
+        a1 = baker.make(
+            ReportAttachment,
+            report_version=submitted_rv,
+            attachment=up_file1,
+            attachment_type="wci_352_362",
+            attachment_name="test_file_1.pdf",
+        )
+        baker.make(
+            ReportAttachment,
+            report_version=draft_rv,
+            attachment=up_file2,
+            attachment_type="confidentiality_request",
+            attachment_name="test_file_2.pdf",
+        )
+
+        submitted_rv.status = ReportVersion.ReportVersionStatus.Submitted
+        submitted_rv.save(update_fields=['status'])
+
+        # ACT
+        result = list(ReportAttachmentService.get_all_attachments())
+
+        # ASSERT
+        assert result == [a1]
+
+    def test_get_all_attachments_empty(self):
+        result = list(ReportAttachmentService.get_all_attachments())
+        assert result == []
+
+    def test_get_all_attachments_invalid_sort_field(self):
+        with pytest.raises(Exception):
+            ReportAttachmentService.get_all_attachments({}, "silly_field", "desc")
 
     def test_get_attachment_returns_the_right_record(self):
         file = ContentFile(b"somedefinitelyrandombytes", "test_file.txt")

--- a/bc_obps/reporting/tests/service/test_report_attachment_service.py
+++ b/bc_obps/reporting/tests/service/test_report_attachment_service.py
@@ -58,7 +58,7 @@ class TestReportAttachmentService:
         assert r.attachment_name == "test_file.txt"
         assert r.attachment is not None
 
-    def test_get_attachments(self):
+    def test_get_attachments_by_report_version(self):
         file = ContentFile(b"abvedseqwe", "test_file.txt")
         uploadedFile1 = InMemoryUploadedFile(
             file, size=file.size, field_name='attachment', name="test_file.txt", content_type="a", charset='utf-8'
@@ -82,8 +82,36 @@ class TestReportAttachmentService:
         )
         r2.save()
 
-        response = ReportAttachmentService.get_attachments(self.report_version.id)
+        response = ReportAttachmentService.get_attachments_by_version(self.report_version.id)
         assert list(response.all()) == [r, r2]
+
+    def test_get_all_attachments(self):
+        uploaded_files = []
+        for i in range(5):
+            file = ContentFile(b"asdhfjh", f"test_file_{i}.txt")
+            uploaded_file = InMemoryUploadedFile(
+                file,
+                size=file.size,
+                field_name='attachment',
+                name=f"test_file_{i}.txt",
+                content_type="a",
+                charset="utf-8",
+            )
+            uploaded_files.append(uploaded_file)
+
+        attachments = []
+        for i in range(5):
+            r = ReportAttachment(
+                report_version=self.report_version,
+                attachment=uploaded_files[i],
+                attachment_type="verification_statement",
+                attachment_name=f"some_test_file_{i}.pdf",
+            )
+            r.save()
+            attachments.append(r)
+
+        response = ReportAttachmentService.get_all_attachments()
+        assert list(response.all()) == attachments
 
     def test_get_attachment_returns_the_right_record(self):
         file = ContentFile(b"somedefinitelyrandombytes", "test_file.txt")

--- a/bc_obps/reporting/tests/service/test_report_attachment_service.py
+++ b/bc_obps/reporting/tests/service/test_report_attachment_service.py
@@ -1,6 +1,7 @@
 from django.core.files.base import ContentFile
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import InMemoryUploadedFile
+from reporting.schema.report_attachment import InternalReportAttachmentFilterSchema
 from model_bakery import baker
 from model_bakery.baker import make_recipe
 from ninja import UploadedFile
@@ -128,7 +129,8 @@ class TestReportAttachmentService:
         assert list(result) == [a2, a1]
 
         # now filter by report_version_id
-        result = ReportAttachmentService.get_all_attachments(filter_params={"report_version_id": rv1.id})
+        filters = InternalReportAttachmentFilterSchema(report_version_id=rv1.id)
+        result = ReportAttachmentService.get_all_attachments(filters=filters)
         assert list(result) == [a1]
 
     def test_get_all_attachments_default_sort_by_report_version_id(self):
@@ -257,13 +259,13 @@ class TestReportAttachmentService:
         submitted_rv.save(update_fields=['status'])
 
         # ACT
-        result = list(ReportAttachmentService.get_all_attachments())
+        result = list(ReportAttachmentService.get_all_attachments({}))
 
         # ASSERT
         assert result == [a1]
 
     def test_get_all_attachments_empty(self):
-        result = list(ReportAttachmentService.get_all_attachments())
+        result = list(ReportAttachmentService.get_all_attachments({}))
         assert result == []
 
     def test_get_all_attachments_invalid_sort_field(self):

--- a/bciers/apps/reporting/src/app/components/attachments/attachmentsList/AttachmentsListPage.tsx
+++ b/bciers/apps/reporting/src/app/components/attachments/attachmentsList/AttachmentsListPage.tsx
@@ -5,6 +5,7 @@ import AttachmentsListGrid from "./AttachmentsListGrid";
 
 export type Attachment = {
   id: number;
+  reporting_year: number;
   operator: string;
   operation: string;
   report_version_id: number;

--- a/bciers/apps/reporting/src/app/components/attachments/attachmentsList/columns.tsx
+++ b/bciers/apps/reporting/src/app/components/attachments/attachmentsList/columns.tsx
@@ -23,6 +23,11 @@ const AttachmentDownloadCell = (params: GridRenderCellParams) => {
 
 export const attachmentsGridColumns: GridColDef[] = [
   {
+    field: "reporting_year_id",
+    headerName: "Reporting Year",
+    flex: 1,
+  },
+  {
     field: "operator",
     headerName: "Operator",
     flex: 1,

--- a/bciers/apps/reporting/src/tests/components/attachments/attachmentsList/AttachmentListGrid.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/attachments/attachmentsList/AttachmentListGrid.test.tsx
@@ -57,7 +57,7 @@ describe("The AttachmentsListGrid component", () => {
         rows: [
           {
             id: 1,
-            reporting_year_id: 2024,
+            reporting_year: 2024,
             operator: "Operator 1",
             operation: "Operaion 1",
             report_version_id: 123,
@@ -66,7 +66,7 @@ describe("The AttachmentsListGrid component", () => {
           },
           {
             id: 2,
-            reporting_year_id: 2025,
+            reporting_year: 2025,
             operator: "Operator 2",
             operation: "Operation 2",
             report_version_id: 456,
@@ -100,6 +100,7 @@ describe("The AttachmentsListGrid component", () => {
             report_version_id: 123,
             attachment_type: "verification_statement",
             attachment_name: "somefile.pdf",
+            reporting_year: 2024,
           },
         ],
         row_count: 2,

--- a/bciers/apps/reporting/src/tests/components/attachments/attachmentsList/AttachmentListGrid.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/attachments/attachmentsList/AttachmentListGrid.test.tsx
@@ -47,8 +47,8 @@ describe("The AttachmentsListGrid component", () => {
       expect(screen.getByRole("columnheader", { name: column })).toBeVisible();
     }
 
-    // 5 for the headers and 5 for the search cells
-    expect(screen.queryAllByRole("columnheader")).toHaveLength(10);
+    // 6 for the headers and 6 for the search cells
+    expect(screen.queryAllByRole("columnheader")).toHaveLength(12);
   });
 
   it("Displays one row per attachment returned by the server", async () => {

--- a/bciers/apps/reporting/src/tests/components/attachments/attachmentsList/AttachmentListGrid.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/attachments/attachmentsList/AttachmentListGrid.test.tsx
@@ -37,15 +37,14 @@ describe("The AttachmentsListGrid component", () => {
     render(<AttachmentsListGrid {...props} />);
 
     for (const column of [
+      "Reporting Year",
       "Operator",
       "Operation",
       "Version ID",
       "Type",
       "Download",
     ]) {
-      expect(
-        screen.getByRole("columnheader", { name: column }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: column })).toBeVisible();
     }
 
     // 5 for the headers and 5 for the search cells
@@ -58,6 +57,7 @@ describe("The AttachmentsListGrid component", () => {
         rows: [
           {
             id: 1,
+            reporting_year_id: 2024,
             operator: "Operator 1",
             operation: "Operaion 1",
             report_version_id: 123,
@@ -66,6 +66,7 @@ describe("The AttachmentsListGrid component", () => {
           },
           {
             id: 2,
+            reporting_year_id: 2025,
             operator: "Operator 2",
             operation: "Operation 2",
             report_version_id: 456,


### PR DESCRIPTION
Card: #4455 

#### Changes made:

- added Reporting Year column (with search bar) to grid for Report Attachments Download (CAS internal users only)
- changed default sorting behaviour of grid so that it's in descending order by report_version_id (because report versions are number sequentially, this automatically means that more recent reporting years will be displayed first, and that supplementary versions of a report will appear before their originals)
- replaced a chain of if/else statements to a match case to make Pierre happier 😺 
- refactored the relevant API endpoint to instead use a new function I created in the ReportAttachmentService - better code practices

#### Changes not made:

- didn't add E2E tests because we don't have any pre-created poms/E2E infrastructure for this page. Made new ticket #4516 instead
- didn't update user access permissions, so despite what ticket #4455  says, cas-view-only users will not be able to access this page. I figured that changing user permissions was beyond the scope of this ticket 