### PR TITLE
Fix/increment chart with release

### DIFF
--- a/.bin/release-bump-chart-version.sh
+++ b/.bin/release-bump-chart-version.sh
@@ -3,19 +3,21 @@
 set -euxo pipefail
 
 VERSION=$1
+BCIERS_CHART="helm/cas-bciers/Chart.yaml"
+MIGRATION_TEST_CHART="helm/migration-test/cas-obps-backend-migration-test/Chart.yaml"
 
 # Bump app versions in charts for BCIERS
-sed -i '' "s/^appVersion:.*/appVersion: \"${VERSION}\"/" helm/cas-bciers/Chart.yaml
-sed -i '' "s/^appVersion:.*/appVersion: \"${VERSION}\"/" helm/migration-test/cas-obps-backend-migration-test/Chart.yaml
+sed -i '' "s/^appVersion:.*/appVersion: \"${VERSION}\"/" $BCIERS_CHART
+sed -i '' "s/^appVersion:.*/appVersion: \"${VERSION}\"/" $MIGRATION_TEST_CHART
 
 # Bump chart version in test chart
-CURRENT_TEST_CHART_VERSION=$(grep -Po '(?<=^version: )[^ "]+' helm/migration-test/cas-obps-backend-migration-test/Chart.yaml)
+CURRENT_TEST_CHART_VERSION=$(grep -Po '(?<=^version: )[^ "]+' $MIGRATION_TEST_CHART)
 MAJOR_MINOR_TEST_CHART_VERSION=${echo "$CURRENT_TEST_CHART_VERSION" | grep -Po '.*(?=\.\d+)'}
 PATCH_TEST_CHART_VERSION=${echo "$CURRENT_TEST_CHART_VERSION" | grep -Po '\d+$'}
 NEW_TEST_CHART_VERSION="${MAJOR_MINOR_TEST_CHART_VERSION}.$((PATCH_TEST_CHART_VERSION + 1))"
 
-sed -i '' "s/^version:.*/version: ${NEW_TEST_CHART_VERSION}/" helm/migration-test/cas-obps-backend-migration-test/Chart.yaml
+sed -i '' "s/^version:.*/version: ${NEW_TEST_CHART_VERSION}/" $MIGRATION_TEST_CHART
 
 # Commit changes
-git add helm/cas-bciers/Chart.yaml
-git add helm/migration-test/cas-obps-backend-migration-test/Chart.yaml
+git add $BCIERS_CHART
+git add $MIGRATION_TEST_CHART

--- a/.bin/release-bump-chart-version.sh
+++ b/.bin/release-bump-chart-version.sh
@@ -4,7 +4,18 @@ set -euxo pipefail
 
 VERSION=$1
 
+# Bump app versions in charts for BCIERS
 sed -i '' "s/^appVersion:.*/appVersion: \"${VERSION}\"/" helm/cas-bciers/Chart.yaml
 sed -i '' "s/^appVersion:.*/appVersion: \"${VERSION}\"/" helm/migration-test/cas-obps-backend-migration-test/Chart.yaml
+
+# Bump chart version in test chart
+CURRENT_TEST_CHART_VERSION=$(grep -Po '(?<=^version: )[^ "]+' helm/migration-test/cas-obps-backend-migration-test/Chart.yaml)
+MAJOR_MINOR_TEST_CHART_VERSION=${echo "$CURRENT_TEST_CHART_VERSION" | grep -Po '.*(?=\.\d+)'}
+PATCH_TEST_CHART_VERSION=${echo "$CURRENT_TEST_CHART_VERSION" | grep -Po '\d+$'}
+NEW_TEST_CHART_VERSION="${MAJOR_MINOR_TEST_CHART_VERSION}.$((PATCH_TEST_CHART_VERSION + 1))"
+
+sed -i '' "s/^version:.*/version: ${NEW_TEST_CHART_VERSION}/" helm/migration-test/cas-obps-backend-migration-test/Chart.yaml
+
+# Commit changes
 git add helm/cas-bciers/Chart.yaml
 git add helm/migration-test/cas-obps-backend-migration-test/Chart.yaml


### PR DESCRIPTION
Addresses release bug. Increments the Backend Migration Test Chart's `version` when running _release-it_. It previously only updated the `appVersion` along with the `cas-bciers` chart, causing the _chart release_ action to fail due to the "new" chart.

## Changes 🚧

- Update the chart version bump (on release) to also bump the `version` by a patch.
