### PR TITLE
3198 - playwright accessibility issues

### DIFF
--- a/bciers/apps/administration-e2e/tests/workflows/contacts.spec.ts
+++ b/bciers/apps/administration-e2e/tests/workflows/contacts.spec.ts
@@ -63,7 +63,7 @@ test.describe("Test add/edit contact", () => {
       component: "Contacts grid",
       variant: "filled",
     });
-    await analyzeAccessibility(page);
+    await analyzeAccessibility(page, "Contacts grid", ["empty-table-header"]);
 
     await viewDetails.click();
     // Check for presence of heading

--- a/bciers/apps/administration-e2e/tests/workflows/contacts.spec.ts
+++ b/bciers/apps/administration-e2e/tests/workflows/contacts.spec.ts
@@ -63,8 +63,7 @@ test.describe("Test add/edit contact", () => {
       component: "Contacts grid",
       variant: "filled",
     });
-    // TODO: investigate accessibility failing
-    // await analyzeAccessibility(page);
+    await analyzeAccessibility(page);
 
     await viewDetails.click();
     // Check for presence of heading

--- a/bciers/apps/administration-e2e/tests/workflows/issue-boro-bcghg-id.spec.ts
+++ b/bciers/apps/administration-e2e/tests/workflows/issue-boro-bcghg-id.spec.ts
@@ -13,6 +13,7 @@ import {
   assertSuccessfulSnackbar,
   clickButton,
   urlIsCorrect,
+  waitForSnackbarToHide,
 } from "@bciers/e2e/utils/helpers";
 
 const test = setupBeforeAllTest(UserRole.CAS_DIRECTOR);
@@ -58,6 +59,9 @@ test.describe("Issue BCGHG and BORO ID", () => {
       component: "BORO ID and BCGHG ID issued",
       variant: "default",
     });
+
+    await waitForSnackbarToHide(page, SnackbarMessages.ISSUED_BCGHG_ID);
+    await waitForSnackbarToHide(page, SnackbarMessages.ISSUED_BORO_ID);
     await analyzeAccessibility(page);
   });
 });

--- a/bciers/apps/registration-e2e/tests/register-an-operation.spec.ts
+++ b/bciers/apps/registration-e2e/tests/register-an-operation.spec.ts
@@ -78,8 +78,7 @@ test.describe("Test register operations", () => {
       variant: "filled",
     });
     await clickButton(registrationPage.page, /save operation representative/i);
-    // TODO fix the accessibility errors and uncomment:  https://github.com/bcgov/cas-registration/issues/3198
-    // await analyzeAccessibility(page, componentName);
+    await analyzeAccessibility(page, componentName);
     await clickButton(registrationPage.page, /continue/i); // button on this form is `Continue` instead of `Save and Continue`
     await registrationPage.waitForRegistrationUrl(5);
 
@@ -134,8 +133,7 @@ test.describe("Test register operations", () => {
       component: componentName,
       variant: "filled",
     });
-    // TODO fix the accessibility errors and uncomment:  https://github.com/bcgov/cas-registration/issues/3198
-    // await analyzeAccessibility(page, componentName);
+    await analyzeAccessibility(page, componentName);
     await clickButton(registrationPage.page, /continue/i); // button on this form is `Continue` instead of `Save and Continue`
     await registrationPage.waitForRegistrationUrl(3);
 

--- a/bciers/libs/e2e/src/utils/helpers.ts
+++ b/bciers/libs/e2e/src/utils/helpers.ts
@@ -17,14 +17,16 @@ import path from "node:path";
 export async function analyzeAccessibility(
   page: Page,
   description: string = "",
+  disableRules?: string[],
 ) {
-  const accessibilityScanResults = await new AxeBuilder({
+  const builder = new AxeBuilder({
     page,
-    // ignore empty-table-headers since our search bar action cell is intenionally empty
-  })
-    .withTags(["wcag2aa", "wcag22aa", "best-practice"])
-    .disableRules(["empty-table-header"])
-    .analyze();
+  });
+
+  if (disableRules && disableRules.length > 0)
+    builder.disableRules(disableRules);
+
+  const accessibilityScanResults = await builder.analyze();
 
   if (accessibilityScanResults.violations.length > 0) {
     // eslint-disable-next-line no-console

--- a/bciers/libs/e2e/src/utils/helpers.ts
+++ b/bciers/libs/e2e/src/utils/helpers.ts
@@ -20,7 +20,11 @@ export async function analyzeAccessibility(
 ) {
   const accessibilityScanResults = await new AxeBuilder({
     page,
-  }).analyze();
+    // ignore empty-table-headers since our search bar action cell is intenionally empty
+  })
+    .withTags(["wcag2aa", "wcag22aa", "best-practice"])
+    .disableRules(["empty-table-header"])
+    .analyze();
 
   if (accessibilityScanResults.violations.length > 0) {
     // eslint-disable-next-line no-console
@@ -447,6 +451,15 @@ export async function assertSuccessfulSnackbar(
     .getByText(message);
   await snackbarLocator.waitFor();
   await expect(snackbarLocator).toBeVisible();
+}
+
+export async function waitForSnackbarToHide(
+  page: Page,
+  message: string | RegExp,
+) {
+  const snackbar = page.locator(".MuiSnackbarContent-root").getByText(message);
+
+  await snackbar.waitFor({ state: "detached" });
 }
 
 export async function clickWithRetry(


### PR DESCRIPTION
Resolves: [3198](https://github.com/bcgov/cas-registration/issues/3198)

- Uncommented the analyzeAccessibility() lines that were causing errors. One error was no longer there, the color-contrast was still there.
- I've added the tags 'wcag2aa', 'wcag22aa', and 'best-practice' according to @fviduya 's suggestion in the original ticket
        - This is still reporting the issues of empty-table-header, color-contrast, 

- The empty-table-header alert described here:
`https://dequeuniversity.com/rules/axe/4.9/empty-table-header?application=playwright`
        - Our action column header leaf cell is empty purposefully, so this will be excluded

- The color-contrast error is to do with the snackbar disappearing I'm assuming. Adding a function to wait for it to disappear seems to have resolved this issue