### PR TITLE
4478: Add production unit in FinalReview page

### DIFF
--- a/bc_obps/reporting/schema/compliance_data.py
+++ b/bc_obps/reporting/schema/compliance_data.py
@@ -12,6 +12,7 @@ class RegulatoryValuesSchema(Schema):
 
 class ReportProductComplianceSchema(Schema):
     name: str
+    unit: str
     annual_production: float
     jan_mar_production: Optional[float] = None
     apr_dec_production: float

--- a/bc_obps/reporting/schema/report_final_review.py
+++ b/bc_obps/reporting/schema/report_final_review.py
@@ -44,11 +44,16 @@ class EmissionCategorySchema(ModelSchema):
 
 
 class ReportProductSchema(ModelSchema):
-    product: str
+    name: str
+    unit: str
 
     @staticmethod
-    def resolve_product(obj: ReportProduct) -> Optional[str]:
+    def resolve_name(obj: ReportProduct) -> Optional[str]:
         return obj.product.name if obj.product.name else None
+
+    @staticmethod
+    def resolve_unit(obj: ReportProduct) -> Optional[str]:
+        return obj.product.unit if obj.product.unit else None
 
     class Meta:
         model = ReportProduct

--- a/bc_obps/reporting/service/compliance_service/compliance_service.py
+++ b/bc_obps/reporting/service/compliance_service/compliance_service.py
@@ -38,6 +38,7 @@ from reporting.service.report_operation_opt_out_service import (
 @dataclass
 class ReportProductComplianceData:
     name: str
+    unit: str
     product_id: int
     annual_production: Decimal
     jan_mar_production: Optional[Decimal]
@@ -48,8 +49,10 @@ class ReportProductComplianceData:
     reduction_factor_override: Decimal | None
     tightening_rate_override: Decimal | None
 
-    def as_record_defaults(self) -> dict[str, Decimal | None]:
+    def as_record_defaults(self) -> dict[str, Decimal | str | None]:
         return {
+            "name": self.name,
+            "unit": self.unit,
             "annual_production": ComplianceParameters.round(self.annual_production),
             "jan_mar_production": (
                 ComplianceParameters.round(self.jan_mar_production) if self.jan_mar_production is not None else None
@@ -290,6 +293,7 @@ class ComplianceService:
             compliance_product_list.append(
                 ReportProductComplianceData(
                     name=rp.product.name,
+                    unit=rp.product.unit,
                     product_id=rp.product_id,
                     annual_production=production_totals["annual_amount"],
                     jan_mar_production=production_totals["jan_mar"] if include_jan_mar else None,

--- a/bc_obps/reporting/service/compliance_service/compliance_service.py
+++ b/bc_obps/reporting/service/compliance_service/compliance_service.py
@@ -51,8 +51,6 @@ class ReportProductComplianceData:
 
     def as_record_defaults(self) -> dict[str, Decimal | str | None]:
         return {
-            "name": self.name,
-            "unit": self.unit,
             "annual_production": ComplianceParameters.round(self.annual_production),
             "jan_mar_production": (
                 ComplianceParameters.round(self.jan_mar_production) if self.jan_mar_production is not None else None

--- a/bc_obps/reporting/tests/api_v2/forms/test_report_compliance_summary_data_endpoint.py
+++ b/bc_obps/reporting/tests/api_v2/forms/test_report_compliance_summary_data_endpoint.py
@@ -52,6 +52,7 @@ class TestComplianceSummaryFormV2Endpoints(CommonTestSetup):
 
         mock_product = ReportProductComplianceData(
             name="Test Product",
+            unit="tonnes of product",
             product_id=1,
             annual_production=Decimal("5000.0"),
             jan_mar_production=None,
@@ -115,6 +116,7 @@ class TestComplianceSummaryFormV2Endpoints(CommonTestSetup):
         assert len(payload["products"]) == 1
         product = payload["products"][0]
         assert product["name"] == "Test Product"
+        assert product["unit"] == "tonnes of product"
         assert product["reduction_factor"] == approx(0.9)
         assert product["tightening_rate"] == approx(0.01)
 

--- a/bc_obps/reporting/tests/schema/test_compliance_data_schema.py
+++ b/bc_obps/reporting/tests/schema/test_compliance_data_schema.py
@@ -26,6 +26,7 @@ class TestComplianceDataSchema(SimpleTestCase):
             products=[
                 ReportProductComplianceData(
                     name="product 1",
+                    unit="production unit",
                     product_id=999,
                     annual_production=Decimal("1"),
                     jan_mar_production=Decimal("0.2"),
@@ -38,6 +39,7 @@ class TestComplianceDataSchema(SimpleTestCase):
                 ),
                 ReportProductComplianceData(
                     name="product 2",
+                    unit="production unit",
                     product_id=992,
                     annual_production=Decimal("5"),
                     jan_mar_production=Decimal("1"),
@@ -74,9 +76,11 @@ class TestComplianceDataSchema(SimpleTestCase):
             "allocated_compliance_emissions": 567.89,
             "reduction_factor": 2.34,  # Defaulting to industry values
             "tightening_rate": 5.55,  # Defaulting to industry values
+            "unit": "production unit",
         }
         assert dict(schema_under_test.products[1]) == {
             "name": "product 2",
+            "unit": "production unit",
             "annual_production": 5.0,
             "jan_mar_production": 1.0,
             "apr_dec_production": 4.0,

--- a/bc_obps/reporting/tests/service/test_compliance_service/test_compliance_service_class.py
+++ b/bc_obps/reporting/tests/service/test_compliance_service/test_compliance_service_class.py
@@ -297,6 +297,7 @@ class TestComplianceSummaryServiceClass(TestCase):
                     'product_id': 3,
                     'reduction_factor_override': None,
                     'tightening_rate_override': None,
+                    'unit': 'Tonne pure hydrogen peroxide',
                 },
                 {
                     'allocated_compliance_emissions': Decimal('8000.0280'),
@@ -309,6 +310,7 @@ class TestComplianceSummaryServiceClass(TestCase):
                     'product_id': 16,
                     'reduction_factor_override': None,
                     'tightening_rate_override': None,
+                    'unit': 'Tonne saleable dry chemical pulp',
                 },
                 {
                     'allocated_compliance_emissions': Decimal('16000.9708'),
@@ -321,6 +323,7 @@ class TestComplianceSummaryServiceClass(TestCase):
                     'product_id': 41,
                     'reduction_factor_override': Decimal('0.9000'),
                     'tightening_rate_override': Decimal('0.0100'),
+                    'unit': 'Tonnes dry recovered lime (calcium oxide)',
                 },
             ],
             'reporting_only_emissions': Decimal('10500.0500'),

--- a/bc_obps/service/report_version_service.py
+++ b/bc_obps/service/report_version_service.py
@@ -1,5 +1,6 @@
 from django.db import transaction
 
+from reporting.models.report_product import ReportProduct
 from registration.models import Operation
 from registration.models.contact import Contact
 from reporting.models.report import Report
@@ -176,13 +177,16 @@ class ReportVersionService:
             "report_electricity_import_data",
             "report_new_entrant",
             "report_compliance_summary",
-            "report_products",
             "report_operation_representatives",
             Prefetch(
                 "report_non_attributable_emissions",
                 queryset=ReportNonAttributableEmissions.objects.select_related("emission_category").prefetch_related(
                     "gas_type"
                 ),
+            ),
+            Prefetch(
+                "report_products",
+                queryset=ReportProduct.objects.select_related("product"),
             ),
             "report_operation__activities",
             "report_operation__regulated_products",

--- a/bciers/apps/reporting-e2e/poms/production-data.ts
+++ b/bciers/apps/reporting-e2e/poms/production-data.ts
@@ -52,11 +52,15 @@ export class ProductionDataPOM {
       await checkCheckboxByLabel(this.page, product);
     }
 
-    // Verify unit text for each selected product (ReadOnlyWidget renders a div, not an input)
-    for (const product of productsToSelect) {
+    // Verify unit text for each selected product (InlineFieldTemplate renders unit as <p>)
+    // Use nth(i) to target the unit in the specific product row
+    const unitTexts = this.page.locator("p");
+    for (const [i, product] of productsToSelect.entries()) {
       const unit = PRODUCT_UNITS[product];
       if (unit) {
-        await expect(this.page.getByText(unit, { exact: true })).toBeVisible();
+        // Find the nth occurrence of the unit text within the product data section
+        const unitElement = unitTexts.filter({ hasText: unit }).nth(i);
+        await expect(unitElement).toBeVisible();
       }
     }
 

--- a/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummaryForm.tsx
+++ b/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummaryForm.tsx
@@ -30,8 +30,6 @@ const ComplianceSummaryForm: React.FC<Props> = ({
     displayJanMarProduction,
   );
 
-  console.log(summaryFormData);
-
   const complianceSummaryUiSchema = createComplianceSummaryUiSchema(
     summaryFormData.reporting_year,
   );

--- a/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummaryForm.tsx
+++ b/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummaryForm.tsx
@@ -12,6 +12,7 @@ import ReportingStepButtons from "@bciers/components/form/components/ReportingSt
 import { NavigationInformation } from "@reporting/src/app/components/taskList/types";
 import { ComplianceSummaryFormPayload } from "@reporting/src/app/components/complianceSummary/types";
 import { hasJanMarProduction } from "@reporting/src/app/utils/hasJanMarProduction";
+import { createFormContext } from "../shared/formContextHelpers";
 
 interface Props {
   summaryFormData: ComplianceSummaryFormPayload;
@@ -51,10 +52,7 @@ const ComplianceSummaryForm: React.FC<Props> = ({
             schema={complianceSummarySchema}
             uiSchema={complianceSummaryUiSchema}
             formData={summaryFormData}
-            formContext={{
-              ...summaryFormData,
-              getProductByIndex: (i: number) => summaryFormData.products[i],
-            }}
+            formContext={createFormContext(summaryFormData)}
           >
             <ReportingStepButtons
               backUrl={navigationInformation.backUrl}

--- a/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummaryForm.tsx
+++ b/bciers/apps/reporting/src/app/components/complianceSummary/ComplianceSummaryForm.tsx
@@ -29,6 +29,8 @@ const ComplianceSummaryForm: React.FC<Props> = ({
     displayJanMarProduction,
   );
 
+  console.log(summaryFormData);
+
   const complianceSummaryUiSchema = createComplianceSummaryUiSchema(
     summaryFormData.reporting_year,
   );
@@ -49,6 +51,10 @@ const ComplianceSummaryForm: React.FC<Props> = ({
             schema={complianceSummarySchema}
             uiSchema={complianceSummaryUiSchema}
             formData={summaryFormData}
+            formContext={{
+              ...summaryFormData,
+              getProductByIndex: (i: number) => summaryFormData.products[i],
+            }}
           >
             <ReportingStepButtons
               backUrl={navigationInformation.backUrl}

--- a/bciers/apps/reporting/src/app/components/complianceSummary/types.ts
+++ b/bciers/apps/reporting/src/app/components/complianceSummary/types.ts
@@ -3,6 +3,7 @@ export type ComplianceSummaryFormProduct = {
   annual_production: string;
   jan_mar_production?: string;
   apr_dec_production?: string;
+  unit: string;
   emission_intensity: string;
   allocated_industrial_process_emissions: string;
   allocated_compliance_emissions: string;

--- a/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FinalReviewForm.tsx
@@ -36,6 +36,7 @@ export const FinalReviewForm: React.FC<Props> = ({
     }
     fetchData();
   }, [version_id]);
+
   return (
     <div className="p-6">
       <div className="container mx-auto p-4" data-testid="facility-review">

--- a/bciers/apps/reporting/src/app/components/finalReview/finalReviewFields.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/finalReviewFields.ts
@@ -327,11 +327,12 @@ export const complianceSummaryFields = (products: any[] = []) => {
         {
           label: "Annual production",
           key: `products.${index}.annual_production`,
-          unit: "production unit",
+          unit: product.unit,
         },
         {
           label: "Production data for Apr 1 - Dec 31 2024",
           key: `products.${index}.apr_dec_production`,
+          unit: product.unit,
           reporting_years: [2024],
         },
         ...(product.jan_mar_production !== null &&
@@ -340,7 +341,7 @@ export const complianceSummaryFields = (products: any[] = []) => {
               {
                 label: "Production data for Jan 1 - Mar 31 2025",
                 key: `products.${index}.jan_mar_production`,
-                unit: "production unit",
+                unit: product.unit,
                 reporting_years: [2025],
               },
             ]
@@ -348,7 +349,7 @@ export const complianceSummaryFields = (products: any[] = []) => {
         {
           label: "Production-weighted average emission intensity",
           key: `products.${index}.emission_intensity`,
-          unit: "tCO2e/production unit",
+          unit: `tCO2e/${product.unit}`,
         },
         {
           label: "Allocated industrial process emissions",

--- a/bciers/apps/reporting/src/app/components/finalReview/finalReviewFields.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/finalReviewFields.ts
@@ -387,14 +387,18 @@ export const emissionsSummaryFields = [
 export const productionDataFields = (product: any = []) => {
   return [
     { heading: product.product },
-    { label: "Unit", key: "unit" },
-    { label: "Annual Production", key: "annual_production" },
+    {
+      label: "Annual Production",
+      key: "annual_production",
+      unit: product.unit,
+    },
     ...(product.production_data_apr_dec !== null &&
     product.production_data_apr_dec !== undefined
       ? [
           {
             label: "Production Data for Apr 1 - Dec 31 2024",
             key: "production_data_apr_dec",
+            unit: product.unit,
           },
         ]
       : []),
@@ -404,6 +408,7 @@ export const productionDataFields = (product: any = []) => {
           {
             label: "Production Data for Jan 1 - Mar 31 2025",
             key: "production_data_jan_mar",
+            unit: product.unit,
           },
         ]
       : []),
@@ -424,21 +429,25 @@ export const productionDataFields = (product: any = []) => {
       label:
         "Quantity in storage at the beginning of the compliance period [Jan 1], if applicable",
       key: FIELD_KEYS.storageQuantityStart,
+      unit: product.unit,
     },
     {
       label:
         "Quantity in storage at the end of the compliance period [Dec 31], if applicable",
       key: FIELD_KEYS.storageQuantityEnd,
+      unit: product.unit,
     },
     {
       label:
         "Quantity sold during compliance period [Jan 1 - Dec 31], if applicable",
       key: FIELD_KEYS.quantitySold,
+      unit: product.unit,
     },
     {
       label:
         "Quantity of throughput at point of sale during compliance period [Jan 1 - Dec 31], if applicable",
       key: FIELD_KEYS.quantityThroughput,
+      unit: product.unit,
     },
   ];
 };

--- a/bciers/apps/reporting/src/app/components/finalReview/reportTypes.ts
+++ b/bciers/apps/reporting/src/app/components/finalReview/reportTypes.ts
@@ -62,6 +62,7 @@ export interface ComplianceProduct {
   emission_intensity: number;
   allocated_industrial_process_emissions: number;
   allocated_compliance_emissions: number;
+  unit: string;
 }
 export interface ReportProduct {
   product: string;

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -31,6 +31,7 @@ const ProductionDataForm: React.FC<Props> = ({
   facility_id,
   facilityType,
   reportingYear,
+  allowedProducts,
   schema,
   initialData,
   navigationInformation,
@@ -92,14 +93,11 @@ const ProductionDataForm: React.FC<Props> = ({
     product_selection: string[];
     production_data: ProductData[];
   }) => {
-    // const updatedSelection = newFormData.product_selection.map(
-    //   (product_name) =>
-    //     newFormData.production_data.find(
-    //       (item) => item.product_name === product_name,
-    //     ) ?? allowedProducts.find((p) => p.product_name === product_name),
-    // );
-    const updatedSelection = newFormData.production_data.filter((item) =>
-      newFormData.product_selection.includes(item.product_name),
+    const updatedSelection = newFormData.product_selection.map(
+      (product_name) =>
+        newFormData.production_data.find(
+          (item) => item.product_name === product_name,
+        ) ?? allowedProducts.find((p) => p.product_name === product_name),
     );
 
     setFormData({

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -32,7 +32,6 @@ const ProductionDataForm: React.FC<Props> = ({
   facilityType,
   reportingYear,
   schema,
-  allowedProducts,
   initialData,
   navigationInformation,
   isPulpAndPaper,

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -10,6 +10,7 @@ import {
   FieldTemplate,
   TitleOnlyFieldTemplate,
 } from "@bciers/components/form/fields";
+import { createFormContext } from "../shared/formContextHelpers";
 
 interface Props {
   report_version_id: number;
@@ -92,11 +93,14 @@ const ProductionDataForm: React.FC<Props> = ({
     product_selection: string[];
     production_data: ProductData[];
   }) => {
-    const updatedSelection = newFormData.product_selection.map(
-      (product_name) =>
-        newFormData.production_data.find(
-          (item) => item.product_name === product_name,
-        ) ?? allowedProducts.find((p) => p.product_name === product_name),
+    // const updatedSelection = newFormData.product_selection.map(
+    //   (product_name) =>
+    //     newFormData.production_data.find(
+    //       (item) => item.product_name === product_name,
+    //     ) ?? allowedProducts.find((p) => p.product_name === product_name),
+    // );
+    const updatedSelection = newFormData.production_data.filter((item) =>
+      newFormData.product_selection.includes(item.product_name),
     );
 
     setFormData({
@@ -151,6 +155,7 @@ const ProductionDataForm: React.FC<Props> = ({
       schema={schema}
       uiSchema={buildProductionDataUiSchema(reportingYear, isOptedOut)}
       formData={formData}
+      formContext={createFormContext(formData)}
       baseUrl={"#"}
       cancelUrl={"#"}
       backUrl={navigationInformation.backUrl}

--- a/bciers/apps/reporting/src/app/components/shared/formContextHelpers.ts
+++ b/bciers/apps/reporting/src/app/components/shared/formContextHelpers.ts
@@ -1,0 +1,8 @@
+export const createFormContext = (formData: any) => ({
+  ...formData,
+  getArrayItem: (path: string, index: number) => {
+    const arr = formData?.[path];
+    if (!Array.isArray(arr)) return undefined;
+    return arr[index];
+  },
+});

--- a/bciers/apps/reporting/src/data/jsonSchema/2024/complianceSummary.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/2024/complianceSummary.ts
@@ -142,17 +142,17 @@ export const complianceSummaryUiSchema2024 = {
       },
       annual_production: {
         "ui:options": {
-          displayUnit: "production unit",
+          unit: { source: "product", field: "unit" },
         },
       },
       apr_dec_production: {
         "ui:options": {
-          displayUnit: "production unit",
+          unit: { source: "product", field: "unit" },
         },
       },
       emission_intensity: {
         "ui:options": {
-          displayUnit: "tCO2e/production unit",
+          unit: ["tCO2e/", { source: "product", field: "unit" }],
         },
       },
       allocated_industrial_process_emissions: {

--- a/bciers/apps/reporting/src/data/jsonSchema/2024/complianceSummary.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/2024/complianceSummary.ts
@@ -143,16 +143,19 @@ export const complianceSummaryUiSchema2024 = {
       annual_production: {
         "ui:options": {
           unit: { source: "product", field: "unit" },
+          arrayPath: "products",
         },
       },
       apr_dec_production: {
         "ui:options": {
           unit: { source: "product", field: "unit" },
+          arrayPath: "products",
         },
       },
       emission_intensity: {
         "ui:options": {
           unit: ["tCO2e/", { source: "product", field: "unit" }],
+          arrayPath: "products",
         },
       },
       allocated_industrial_process_emissions: {

--- a/bciers/apps/reporting/src/data/jsonSchema/2024/productionData.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/2024/productionData.tsx
@@ -4,7 +4,6 @@ import {
   InlineFieldTemplate,
   TitleOnlyFieldTemplate,
 } from "@bciers/components/form/fields";
-import { ReadOnlyWidget } from "@bciers/components/form/widgets/readOnly";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import { ProductionDataTitleWidget } from "@reporting/src/data/jsonSchema/commonSchema/productionDataTitleWidget";
 

--- a/bciers/apps/reporting/src/data/jsonSchema/2024/productionData.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/2024/productionData.tsx
@@ -1,6 +1,7 @@
 import {
   ArrayFieldTemplate,
   FieldTemplate,
+  InlineFieldTemplate,
   TitleOnlyFieldTemplate,
 } from "@bciers/components/form/fields";
 import { ReadOnlyWidget } from "@bciers/components/form/widgets/readOnly";
@@ -61,11 +62,6 @@ export const buildProductionDataSchema2024 = (
             title: "Name",
             type: "string",
             default: "custom value",
-          },
-          unit: {
-            title: "Unit",
-            type: "string",
-            readOnly: true,
           },
           annual_production: {
             title: "Annual Production",
@@ -149,7 +145,6 @@ export const productionDataUiSchema2024 = (): UiSchema => {
         "ui:order": [
           "product_id",
           "product_name",
-          "unit",
           "annual_production",
           "production_data_apr_dec",
           "production_methodology",
@@ -167,8 +162,47 @@ export const productionDataUiSchema2024 = (): UiSchema => {
             label: false,
           },
         },
-        unit: {
-          "ui:widget": ReadOnlyWidget,
+        annual_production: {
+          "ui:FieldTemplate": InlineFieldTemplate,
+          "ui:options": {
+            unit: { source: "product", field: "unit" },
+            arrayPath: "production_data",
+          },
+        },
+        production_data_apr_dec: {
+          "ui:FieldTemplate": InlineFieldTemplate,
+          "ui:options": {
+            unit: { source: "product", field: "unit" },
+            arrayPath: "production_data",
+          },
+        },
+        storage_quantity_start_of_period: {
+          "ui:FieldTemplate": InlineFieldTemplate,
+          "ui:options": {
+            unit: { source: "product", field: "unit" },
+            arrayPath: "production_data",
+          },
+        },
+        storage_quantity_end_of_period: {
+          "ui:FieldTemplate": InlineFieldTemplate,
+          "ui:options": {
+            unit: { source: "product", field: "unit" },
+            arrayPath: "production_data",
+          },
+        },
+        quantity_sold_during_period: {
+          "ui:FieldTemplate": InlineFieldTemplate,
+          "ui:options": {
+            unit: { source: "product", field: "unit" },
+            arrayPath: "production_data",
+          },
+        },
+        quantity_throughput_during_period: {
+          "ui:FieldTemplate": InlineFieldTemplate,
+          "ui:options": {
+            unit: { source: "product", field: "unit" },
+            arrayPath: "production_data",
+          },
         },
       },
     },

--- a/bciers/apps/reporting/src/data/jsonSchema/2025/complianceSummary.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/2025/complianceSummary.ts
@@ -150,17 +150,20 @@ export const complianceSummaryUiSchema2025 = {
       },
       annual_production: {
         "ui:options": {
-          displayUnit: "production unit",
+          unit: { source: "product", field: "unit" },
+          arrayPath: "products",
         },
       },
       jan_mar_production: {
         "ui:options": {
-          displayUnit: "production unit",
+          unit: { source: "product", field: "unit" },
+          arrayPath: "products",
         },
       },
       emission_intensity: {
         "ui:options": {
-          displayUnit: "tCO2e/production unit",
+          unit: ["tCO2e/", { source: "product", field: "unit" }],
+          arrayPath: "products",
         },
       },
       allocated_industrial_process_emissions: {

--- a/bciers/apps/reporting/src/data/jsonSchema/2025/productionData.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/2025/productionData.tsx
@@ -58,11 +58,6 @@ export const buildProductionDataSchema2025 = (
             type: "string",
             default: "custom value",
           },
-          unit: {
-            title: "Unit",
-            type: "string",
-            readOnly: true,
-          },
           annual_production: {
             title: "Annual Production",
             type: "number",
@@ -182,12 +177,42 @@ export const productionDataUiSchema2025 = (isOptedOut: boolean): UiSchema => ({
         "ui:FieldTemplate": InlineFieldTemplate,
         "ui:options": {
           unit: { source: "product", field: "unit" },
+          arrayPath: "production_data",
         },
       },
       production_data_jan_mar: {
         "ui:FieldTemplate": InlineFieldTemplate,
         "ui:options": {
           unit: { source: "product", field: "unit" },
+          arrayPath: "production_data",
+        },
+      },
+      storage_quantity_start_of_period: {
+        "ui:FieldTemplate": InlineFieldTemplate,
+        "ui:options": {
+          unit: { source: "product", field: "unit" },
+          arrayPath: "production_data",
+        },
+      },
+      storage_quantity_end_of_period: {
+        "ui:FieldTemplate": InlineFieldTemplate,
+        "ui:options": {
+          unit: { source: "product", field: "unit" },
+          arrayPath: "production_data",
+        },
+      },
+      quantity_sold_during_period: {
+        "ui:FieldTemplate": InlineFieldTemplate,
+        "ui:options": {
+          unit: { source: "product", field: "unit" },
+          arrayPath: "production_data",
+        },
+      },
+      quantity_throughput_during_period: {
+        "ui:FieldTemplate": InlineFieldTemplate,
+        "ui:options": {
+          unit: { source: "product", field: "unit" },
+          arrayPath: "production_data",
         },
       },
     },

--- a/bciers/apps/reporting/src/data/jsonSchema/2025/productionData.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/2025/productionData.tsx
@@ -1,9 +1,9 @@
 import {
   ArrayFieldTemplate,
   FieldTemplate,
+  InlineFieldTemplate,
   TitleOnlyFieldTemplate,
 } from "@bciers/components/form/fields";
-import { ReadOnlyWidget } from "@bciers/components/form/widgets/readOnly";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import { ProductionDataTitleWidget } from "@reporting/src/data/jsonSchema/commonSchema/productionDataTitleWidget";
 
@@ -161,7 +161,6 @@ export const productionDataUiSchema2025 = (isOptedOut: boolean): UiSchema => ({
       "ui:order": [
         "product_id",
         "product_name",
-        "unit",
         "annual_production",
         ...(isOptedOut ? ["production_data_jan_mar"] : []),
         "production_methodology",
@@ -179,8 +178,17 @@ export const productionDataUiSchema2025 = (isOptedOut: boolean): UiSchema => ({
           label: false,
         },
       },
-      unit: {
-        "ui:widget": ReadOnlyWidget,
+      annual_production: {
+        "ui:FieldTemplate": InlineFieldTemplate,
+        "ui:options": {
+          unit: { source: "product", field: "unit" },
+        },
+      },
+      production_data_jan_mar: {
+        "ui:FieldTemplate": InlineFieldTemplate,
+        "ui:options": {
+          unit: { source: "product", field: "unit" },
+        },
       },
     },
   },

--- a/bciers/apps/reporting/src/data/jsonSchema/productionData.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/productionData.tsx
@@ -198,6 +198,7 @@ const productionDataUiSchemaDefault = (): UiSchema => ({
         "ui:FieldTemplate": InlineFieldTemplate,
         "ui:options": {
           unit: { source: "product", field: "unit" },
+          arrayPath: "production_data",
         },
       },
     },

--- a/bciers/apps/reporting/src/data/jsonSchema/productionData.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/productionData.tsx
@@ -1,9 +1,9 @@
 import {
   ArrayFieldTemplate,
   FieldTemplate,
+  InlineFieldTemplate,
   TitleOnlyFieldTemplate,
 } from "@bciers/components/form/fields";
-import { ReadOnlyWidget } from "@bciers/components/form/widgets/readOnly";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import { ProductionDataTitleWidget } from "@reporting/src/data/jsonSchema/commonSchema/productionDataTitleWidget";
 import {
@@ -65,11 +65,6 @@ const buildProductionDataSchemaDefault = (
             title: "Name",
             type: "string",
             default: "custom value",
-          },
-          unit: {
-            title: "Unit",
-            type: "string",
-            readOnly: true,
           },
           annual_production: {
             title: "Annual Production",
@@ -183,7 +178,6 @@ const productionDataUiSchemaDefault = (): UiSchema => ({
       "ui:order": [
         "product_id",
         "product_name",
-        "unit",
         "annual_production",
         "production_methodology",
         "production_methodology_description",
@@ -200,8 +194,11 @@ const productionDataUiSchemaDefault = (): UiSchema => ({
           label: false,
         },
       },
-      unit: {
-        "ui:widget": ReadOnlyWidget,
+      annual_production: {
+        "ui:FieldTemplate": InlineFieldTemplate,
+        "ui:options": {
+          unit: { source: "product", field: "unit" },
+        },
       },
     },
   },

--- a/bciers/apps/reporting/src/tests/components/finalReview/FinalReviewForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/finalReview/FinalReviewForm.test.tsx
@@ -33,6 +33,74 @@ vi.mock(
   }),
 );
 
+const mockData = {
+  report_operation: {
+    activities: "Test Activities",
+    regulated_products: "Test Products",
+    representatives: "Test Reps",
+    operator_legal_name: "Test Legal Name",
+    operator_trade_name: "Test Trade Name",
+    operation_name: "Test Operation",
+    operation_type: "SFO",
+    operation_bcghgid: "123456",
+    bc_obps_regulated_operation_id: "REG123",
+    registration_purpose: "REPORTING_OPERATION",
+  },
+  report_person_responsible: {
+    first_name: "John",
+    last_name: "Doe",
+    position_title: "Manager",
+    business_role: "Owner",
+    email: "john@example.com",
+    phone_number: "555-1234",
+    street_address: "123 Main St",
+    municipality: "Vancouver",
+    province: "BC",
+    postal_code: "V6B 1A1",
+  },
+  facility_reports: [
+    {
+      facility: "facility-1",
+      facility_name: "Test Facility",
+      activity_data: [],
+      emission_summary: {},
+      reportnonattributableemissions_records: [],
+    },
+  ],
+  report_additional_data: {
+    capture_emissions: false,
+    emissions_on_site_use: "100",
+    emissions_on_site_sequestration: "50",
+    emissions_off_site_transfer: "25",
+    electricity_generated: 1000,
+  },
+  report_compliance_summary: {
+    emissions_attributable_for_reporting: "1000",
+    reporting_only_emissions: "500",
+    emissions_attributable_for_compliance: "800",
+    emissions_limit: "1200",
+    excess_emissions: "0",
+    credited_emissions: "200",
+    regulatory_values: {
+      initial_compliance_period: 2021,
+      compliance_period: 2024,
+    },
+    products: [
+      {
+        name: "Cement equivalent",
+        unit: "Tonnes",
+        annual_production: 45.0,
+        apr_dec_production: 2.0,
+        emission_intensity: 0.6262,
+        allocated_industrial_process_emissions: 0.0,
+        allocated_compliance_emissions: 0.0,
+        reduction_factor: 0.65,
+        tightening_rate: 0.01,
+      },
+    ],
+  },
+};
+
 describe("The FinalReviewForm component", () => {
   const mockNavigationInformation = {
     headerStepIndex: 4,
@@ -87,73 +155,6 @@ describe("The FinalReviewForm component", () => {
   });
 
   it("renders all components when data is provided", async () => {
-    const mockData = {
-      report_operation: {
-        activities: "Test Activities",
-        regulated_products: "Test Products",
-        representatives: "Test Reps",
-        operator_legal_name: "Test Legal Name",
-        operator_trade_name: "Test Trade Name",
-        operation_name: "Test Operation",
-        operation_type: "SFO",
-        operation_bcghgid: "123456",
-        bc_obps_regulated_operation_id: "REG123",
-        registration_purpose: "REPORTING_OPERATION",
-      },
-      report_person_responsible: {
-        first_name: "John",
-        last_name: "Doe",
-        position_title: "Manager",
-        business_role: "Owner",
-        email: "john@example.com",
-        phone_number: "555-1234",
-        street_address: "123 Main St",
-        municipality: "Vancouver",
-        province: "BC",
-        postal_code: "V6B 1A1",
-      },
-      facility_reports: [
-        {
-          facility: "facility-1",
-          facility_name: "Test Facility",
-          activity_data: [],
-          emission_summary: {},
-          reportnonattributableemissions_records: [],
-        },
-      ],
-      report_additional_data: {
-        capture_emissions: false,
-        emissions_on_site_use: "100",
-        emissions_on_site_sequestration: "50",
-        emissions_off_site_transfer: "25",
-        electricity_generated: 1000,
-      },
-      report_compliance_summary: {
-        emissions_attributable_for_reporting: "1000",
-        reporting_only_emissions: "500",
-        emissions_attributable_for_compliance: "800",
-        emissions_limit: "1200",
-        excess_emissions: "0",
-        credited_emissions: "200",
-        regulatory_values: {
-          initial_compliance_period: 2021,
-          compliance_period: 2024,
-        },
-        products: [
-          {
-            name: "Cement equivalent",
-            annual_production: 45.0,
-            apr_dec_production: 0.0,
-            emission_intensity: 0.6262,
-            allocated_industrial_process_emissions: 0.0,
-            allocated_compliance_emissions: 0.0,
-            reduction_factor: 0.65,
-            tightening_rate: 0.01,
-          },
-        ],
-      },
-    };
-
     (getFinalReviewData as any).mockResolvedValue(mockData);
 
     render(
@@ -165,19 +166,61 @@ describe("The FinalReviewForm component", () => {
     );
 
     await waitFor(async () => {
-      expect(screen.getByTestId("facility-review")).toBeInTheDocument();
-      expect(screen.getByTestId("multi-step-header")).toBeInTheDocument();
-      expect(screen.getByTestId("reporting-task-list")).toBeInTheDocument();
-      expect(screen.getByTestId("reporting-step-buttons")).toBeInTheDocument();
+      expect(screen.getByTestId("facility-review")).toBeVisible();
+      expect(screen.getByTestId("multi-step-header")).toBeVisible();
+      expect(screen.getByTestId("reporting-task-list")).toBeVisible();
+      expect(screen.getByTestId("reporting-step-buttons")).toBeVisible();
     });
 
     const user = userEvent.setup();
     const printButton = screen.getByRole("button", {
       name: /save as pdf|print/i,
     });
-    expect(printButton).toBeInTheDocument();
+    expect(printButton).toBeVisible();
 
     await user.click(printButton);
     expect(window.print).toHaveBeenCalled();
+  });
+
+  it("should display production units in Compliance Summary section", async () => {
+    (getFinalReviewData as any).mockResolvedValue(mockData);
+
+    render(
+      <FinalReviewForm
+        navigationInformation={mockNavigationInformation}
+        version_id={1}
+        flow={ReportingFlow.SFO}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("facility-review")).toBeVisible();
+    });
+
+    // Annual production
+    const annualProdLabel = screen.getByText(/annual production/i);
+    // get the div for the entire row (the parent of the label's div)
+    const annualRowContainer = annualProdLabel.closest("div")?.parentElement;
+    expect(annualRowContainer).toBeTruthy();
+    const input = annualRowContainer!.querySelector(
+      'input[type="text"]',
+    ) as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.value).toBe("45");
+    expect(annualRowContainer).toHaveTextContent(/tonnes/i);
+
+    // Apr-Dec production
+    const aprDecLabel = screen.getByText(
+      /production data for apr 1 - dec 31 2024/i,
+    );
+    // get the div for the entire row (the parent of the label's div)
+    const aprDecContainer = aprDecLabel.closest("div")?.parentElement;
+    expect(aprDecContainer).toBeTruthy();
+    const aprDecInput = aprDecContainer!.querySelector(
+      'input[type="text"]',
+    ) as HTMLInputElement;
+    expect(aprDecInput).toBeTruthy();
+    expect(aprDecInput.value).toBe("2");
+    expect(aprDecContainer).toHaveTextContent(/tonnes/i);
   });
 });

--- a/bciers/apps/reporting/src/tests/components/finalReview/FinalReviewForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/finalReview/FinalReviewForm.test.tsx
@@ -90,7 +90,7 @@ const mockData = {
         name: "Cement equivalent",
         unit: "Tonnes",
         annual_production: 45.0,
-        apr_dec_production: 2.0,
+        apr_dec_production: 2.1,
         emission_intensity: 0.6262,
         allocated_industrial_process_emissions: 0.0,
         allocated_compliance_emissions: 0.0,
@@ -220,7 +220,7 @@ describe("The FinalReviewForm component", () => {
       'input[type="text"]',
     ) as HTMLInputElement;
     expect(aprDecInput).toBeTruthy();
-    expect(aprDecInput.value).toBe("2");
+    expect(aprDecInput.value).toBe("2.1");
     expect(aprDecContainer).toHaveTextContent(/tonnes/i);
   });
 });

--- a/bciers/apps/reporting/src/tests/components/finalReview/finalReviewFields.test.ts
+++ b/bciers/apps/reporting/src/tests/components/finalReview/finalReviewFields.test.ts
@@ -151,6 +151,7 @@ describe("complianceSummaryFields", () => {
       {
         name: "Product A",
         jan_mar_production: 123,
+        unit: "production unit",
       },
     ]);
 
@@ -167,6 +168,7 @@ describe("complianceSummaryFields", () => {
       {
         name: "Product A",
         jan_mar_production: null,
+        unit: "production unit",
       },
     ]);
 

--- a/bciers/apps/reporting/src/tests/components/finalReview/finalReviewFields.test.ts
+++ b/bciers/apps/reporting/src/tests/components/finalReview/finalReviewFields.test.ts
@@ -5,7 +5,6 @@ import {
 
 describe("productionDataFields", () => {
   const alwaysPresentKeys = [
-    "unit",
     "annual_production",
     "production_methodology",
     "storage_quantity_start_of_period",

--- a/bciers/apps/reporting/src/tests/components/products/ProductionDataPage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/products/ProductionDataPage.test.tsx
@@ -108,10 +108,10 @@ describe("The Production Data component", () => {
     expect(screen.getAllByText(/production data/i)).toHaveLength(1);
     expect(
       screen.getByText("Select the products that apply to this facility:"),
-    ).toBeInTheDocument();
+    ).toBeVisible();
     expect(screen.getAllByRole("checkbox")).toHaveLength(2);
-    expect(screen.getByText(/testProduct/)).toBeInTheDocument();
-    expect(screen.getByText(/otherProduct/)).toBeInTheDocument();
+    expect(screen.getByText(/testProduct/)).toBeVisible();
+    expect(screen.getByText(/otherProduct/)).toBeVisible();
   });
   it("renders the form with the right form elements except apr-dec production", async () => {
     getProductionDataMock.mockReturnValue({
@@ -132,15 +132,15 @@ describe("The Production Data component", () => {
     });
 
     render(await ProductionDataPage(props));
-    expect(screen.getByText("testProduct")).toBeInTheDocument();
-    expect(screen.getByText("Unit")).toBeInTheDocument();
-    expect(screen.getByText("tonnes of tests")).toBeInTheDocument();
+    expect(screen.getByText("testProduct")).toBeVisible();
     expect(
       screen.queryByLabelText("Production data for Apr 1 - Dec 31, 2024*"),
     ).not.toBeInTheDocument();
     expect(
       screen.getByLabelText("Production Quantification Methodology*"),
     ).toHaveRole("combobox");
+    expect(screen.getByLabelText("annual_production")).toHaveRole("textbox");
+    expect(screen.getByText("tonnes of tests")).toBeVisible();
     expect(
       screen.getByLabelText(
         "Quantity in storage at the beginning of the compliance period [Jan 1], if applicable",

--- a/bciers/libs/components/src/form/fields/InlineFieldTemplate.test.tsx
+++ b/bciers/libs/components/src/form/fields/InlineFieldTemplate.test.tsx
@@ -4,6 +4,13 @@ import FormBase from "../FormBase";
 import InlineFieldTemplate from "./InlineFieldTemplate";
 
 describe("InlineFieldTemplate", () => {
+  const createGetArrayItem =
+    (data: Record<string, unknown>) => (path: string, index: number) => {
+      const arr = data[path];
+      if (!Array.isArray(arr)) return undefined;
+      return arr[index];
+    };
+
   it("renders a static unit from displayUnit", () => {
     const schema: RJSFSchema = {
       type: "object",
@@ -45,12 +52,6 @@ describe("InlineFieldTemplate", () => {
       ],
     };
 
-    const getArrayItem = (path: string, index: number) => {
-      const arr = (data as Record<string, unknown[]>)[path];
-      if (!Array.isArray(arr)) return undefined;
-      return arr[index];
-    };
-
     const schema: RJSFSchema = {
       type: "object",
       properties: {
@@ -88,7 +89,7 @@ describe("InlineFieldTemplate", () => {
         schema={schema}
         uiSchema={uiSchema}
         formData={data}
-        formContext={{ getArrayItem }}
+        formContext={{ getArrayItem: createGetArrayItem(data) }}
       />,
     );
 
@@ -103,12 +104,6 @@ describe("InlineFieldTemplate", () => {
           unit: "tonnes of tests",
         },
       ],
-    };
-
-    const getArrayItem = (path: string, index: number) => {
-      const arr = (data as Record<string, unknown[]>)[path];
-      if (!Array.isArray(arr)) return undefined;
-      return arr[index];
     };
 
     const schema: RJSFSchema = {
@@ -148,7 +143,7 @@ describe("InlineFieldTemplate", () => {
         schema={schema}
         uiSchema={uiSchema}
         formData={data}
-        formContext={{ getArrayItem }}
+        formContext={{ getArrayItem: createGetArrayItem(data) }}
       />,
     );
 

--- a/bciers/libs/components/src/form/fields/InlineFieldTemplate.test.tsx
+++ b/bciers/libs/components/src/form/fields/InlineFieldTemplate.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen } from "@testing-library/react";
+import { RJSFSchema } from "@rjsf/utils";
+import FormBase from "../FormBase";
+import InlineFieldTemplate from "./InlineFieldTemplate";
+
+describe("InlineFieldTemplate", () => {
+  it("renders a static unit from displayUnit", () => {
+    const schema: RJSFSchema = {
+      type: "object",
+      properties: {
+        annual_production: {
+          type: "number",
+          title: "Annual Production",
+        },
+      },
+    };
+
+    const uiSchema = {
+      annual_production: {
+        "ui:FieldTemplate": InlineFieldTemplate,
+        "ui:options": {
+          displayUnit: "tCO2e",
+        },
+      },
+    };
+
+    render(
+      <FormBase
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={{ annual_production: 123 }}
+      />,
+    );
+
+    expect(screen.getByText("tCO2e")).toBeVisible();
+  });
+
+  it("resolves unit from array item using arrayPath and field", () => {
+    const data = {
+      production_data: [
+        {
+          annual_production: 123,
+          unit: "tonnes of tests",
+        },
+      ],
+    };
+
+    const getArrayItem = (path: string, index: number) => {
+      const arr = (data as Record<string, unknown[]>)[path];
+      if (!Array.isArray(arr)) return undefined;
+      return arr[index];
+    };
+
+    const schema: RJSFSchema = {
+      type: "object",
+      properties: {
+        production_data: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              annual_production: {
+                type: "number",
+                title: "Annual Production",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const uiSchema = {
+      production_data: {
+        items: {
+          annual_production: {
+            "ui:FieldTemplate": InlineFieldTemplate,
+            "ui:options": {
+              unit: { field: "unit" },
+              arrayPath: "production_data",
+            },
+          },
+        },
+      },
+    };
+
+    render(
+      <FormBase
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={data}
+        formContext={{ getArrayItem }}
+      />,
+    );
+
+    expect(screen.getByText("tonnes of tests")).toBeVisible();
+  });
+
+  it("renders a composed unit from mixed static and dynamic tokens", () => {
+    const data = {
+      products: [
+        {
+          emission_intensity: 3.14,
+          unit: "tonnes of tests",
+        },
+      ],
+    };
+
+    const getArrayItem = (path: string, index: number) => {
+      const arr = (data as Record<string, unknown[]>)[path];
+      if (!Array.isArray(arr)) return undefined;
+      return arr[index];
+    };
+
+    const schema: RJSFSchema = {
+      type: "object",
+      properties: {
+        products: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              emission_intensity: {
+                type: "number",
+                title: "Production-weighted average emission intensity",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const uiSchema = {
+      products: {
+        items: {
+          emission_intensity: {
+            "ui:FieldTemplate": InlineFieldTemplate,
+            "ui:options": {
+              unit: ["tCO2e/", { field: "unit" }],
+              arrayPath: "products",
+            },
+          },
+        },
+      },
+    };
+
+    render(
+      <FormBase
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={data}
+        formContext={{ getArrayItem }}
+      />,
+    );
+
+    expect(screen.getByText("tCO2e/tonnes of tests")).toBeVisible();
+  });
+
+  it("falls back to root formContext lookup when arrayPath is not provided", () => {
+    const schema: RJSFSchema = {
+      type: "object",
+      properties: {
+        annual_production: {
+          type: "number",
+          title: "Annual Production",
+        },
+      },
+    };
+
+    const uiSchema = {
+      annual_production: {
+        "ui:FieldTemplate": InlineFieldTemplate,
+        "ui:options": {
+          unit: { field: "globalUnit" },
+        },
+      },
+    };
+
+    render(
+      <FormBase
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={{ annual_production: 123 }}
+        formContext={{ globalUnit: "kg" }}
+      />,
+    );
+
+    expect(screen.getByText("kg")).toBeVisible();
+  });
+
+  it("does not render unit text when neither unit nor displayUnit is configured", () => {
+    const schema: RJSFSchema = {
+      type: "object",
+      properties: {
+        annual_production: {
+          type: "number",
+          title: "Annual Production",
+        },
+      },
+    };
+
+    const uiSchema = {
+      annual_production: {
+        "ui:FieldTemplate": InlineFieldTemplate,
+      },
+    };
+
+    render(
+      <FormBase
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={{ annual_production: 123 }}
+        formContext={{ globalUnit: "unit-that-should-not-render" }}
+      />,
+    );
+
+    expect(
+      screen.queryByText("unit-that-should-not-render"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FieldTemplateProps } from "@rjsf/utils";
+import { FieldTemplateProps, Registry } from "@rjsf/utils";
 import AlertIcon from "@bciers/components/icons/AlertIcon";
 
 type UnitOption =
@@ -11,12 +11,14 @@ type UnitOption =
 const resolveUnit = (
   unitOption: UnitOption | undefined,
   id: string,
-  formContext: any,
+  registry?: Registry,
+  options?: any,
 ): string | undefined => {
   if (!unitOption) return;
 
   // normalize to array if it isn't already
   const parts = Array.isArray(unitOption) ? unitOption : [unitOption];
+  const arrayPath = options?.arrayPath;
 
   return parts
     .map((part) => {
@@ -24,15 +26,17 @@ const resolveUnit = (
         return part;
       }
       if (part.source === "product") {
-        // regex search for correct product in array of products
-        const match = id.match(/products_(\d+)_/);
+        // regex search - generic index extraction
+        const match = id.match(/_(\d+)_/);
         const index = match ? Number(match[1]) : null;
+
         if (index !== null) {
-          return formContext?.getProductByIndex?.(index)?.[part.field];
+          const item = registry?.formContext?.getArrayItem?.(arrayPath, index);
+          return item?.[part.field];
         }
       }
       if (part.source === "form") {
-        return formContext?.[part.field];
+        return registry?.formContext?.[part.field];
       }
       return "";
     })
@@ -63,7 +67,7 @@ function InlineFieldTemplate({
   const labelClassNames = (options?.labelClassNames as string) ?? "lg:w-3/12";
   const unitOption = options.unit ?? options.displayUnit;
 
-  const resolvedUnit = resolveUnit(unitOption, id, registry?.formContext);
+  const resolvedUnit = resolveUnit(unitOption, id, registry, options);
 
   let cellWidth = "lg:w-4/12";
   if (options?.inline) cellWidth = "lg:w-full";

--- a/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
@@ -5,27 +5,54 @@ import AlertIcon from "@bciers/components/icons/AlertIcon";
 
 type UnitOption =
   | string
-  | { source: "product" | "form"; field: string }
-  | Array<string | { source: "product" | "form"; field: string }>;
+  | { field: string; source?: "product" | "form" }
+  | Array<string | { field: string; source?: "product" | "form" }>;
 
+/**
+ * Resolves the display unit text for a field from a configured `unit` option.
+ *
+ * Supported token shapes:
+ * - `"tCO2e"` (static text)
+ * - `{ field: "unit" }` (dynamic value)
+ * - `["tCO2e/", { field: "unit" }]` (composed string)
+ *
+ * Resolution order for dynamic tokens:
+ * - If `options.arrayPath` is provided, extract the row index from the RJSF `id`
+ *   and read from `formContext.getArrayItem(arrayPath, index)[field]`.
+ * - Otherwise read from `formContext[field]`.
+ *
+ * Returns `undefined` when no unit option is configured.
+ *
+ * Example usage:
+ *    annual_production: {
+        "ui:FieldTemplate": InlineFieldTemplate,
+        "ui:options": {
+          unit: { source: "product", field: "unit" },
+          arrayPath: "production_data",
+        },
+      }
+    ^ this will examine the "production_data" array in the RJSF form data, and for the
+    "product" object being rendered, will display the value in the "unit" attribute.
+ */
 const resolveUnit = (
   unitOption: UnitOption | undefined,
   id: string,
   registry?: Registry,
-  options?: any,
+  options?: Record<string, unknown>,
 ): string | undefined => {
   if (!unitOption) return;
 
   // normalize to array if it isn't already
   const parts = Array.isArray(unitOption) ? unitOption : [unitOption];
-  const arrayPath = options?.arrayPath;
+  const arrayPath =
+    typeof options?.arrayPath === "string" ? options.arrayPath : undefined;
 
   return parts
     .map((part) => {
       if (typeof part === "string") {
         return part;
       }
-      if (part.source === "product") {
+      if (arrayPath) {
         // regex search - generic index extraction
         const match = id.match(/_(\d+)_/);
         const index = match ? Number(match[1]) : null;
@@ -35,10 +62,7 @@ const resolveUnit = (
           return item?.[part.field];
         }
       }
-      if (part.source === "form") {
-        return registry?.formContext?.[part.field];
-      }
-      return "";
+      return registry?.formContext?.[part.field];
     })
     .join("");
 };

--- a/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
@@ -65,7 +65,9 @@ function InlineFieldTemplate({
   const options = uiSchema?.["ui:options"] || {};
   const isLabel = options?.label !== false;
   const labelClassNames = (options?.labelClassNames as string) ?? "lg:w-3/12";
-  const unitOption = (options.unit ?? options.displayUnit) as UnitOption | undefined;
+  const unitOption = (options.unit ?? options.displayUnit) as
+    | UnitOption
+    | undefined;
 
   const resolvedUnit = resolveUnit(unitOption, id, registry, options);
 

--- a/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
@@ -54,7 +54,7 @@ const resolveUnit = (
       }
       if (arrayPath) {
         // regex search - generic index extraction
-        const match = id.match(/_(\d+)_/);
+        const match = /_(\d+)_/.exec(id);
         const index = match ? Number(match[1]) : null;
 
         if (index !== null) {

--- a/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
@@ -65,7 +65,7 @@ function InlineFieldTemplate({
   const options = uiSchema?.["ui:options"] || {};
   const isLabel = options?.label !== false;
   const labelClassNames = (options?.labelClassNames as string) ?? "lg:w-3/12";
-  const unitOption = options.unit ?? options.displayUnit;
+  const unitOption = (options.unit ?? options.displayUnit) as UnitOption | undefined;
 
   const resolvedUnit = resolveUnit(unitOption, id, registry, options);
 

--- a/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
+++ b/bciers/libs/components/src/form/fields/InlineFieldTemplate.tsx
@@ -3,6 +3,42 @@
 import { FieldTemplateProps } from "@rjsf/utils";
 import AlertIcon from "@bciers/components/icons/AlertIcon";
 
+type UnitOption =
+  | string
+  | { source: "product" | "form"; field: string }
+  | Array<string | { source: "product" | "form"; field: string }>;
+
+const resolveUnit = (
+  unitOption: UnitOption | undefined,
+  id: string,
+  formContext: any,
+): string | undefined => {
+  if (!unitOption) return;
+
+  // normalize to array if it isn't already
+  const parts = Array.isArray(unitOption) ? unitOption : [unitOption];
+
+  return parts
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      if (part.source === "product") {
+        // regex search for correct product in array of products
+        const match = id.match(/products_(\d+)_/);
+        const index = match ? Number(match[1]) : null;
+        if (index !== null) {
+          return formContext?.getProductByIndex?.(index)?.[part.field];
+        }
+      }
+      if (part.source === "form") {
+        return formContext?.[part.field];
+      }
+      return "";
+    })
+    .join("");
+};
+
 function InlineFieldTemplate({
   id,
   label,
@@ -13,6 +49,7 @@ function InlineFieldTemplate({
   children,
   uiSchema,
   classNames,
+  registry,
 }: FieldTemplateProps) {
   const isHidden = uiSchema?.["ui:widget"] === "hidden";
   if (isHidden) return null;
@@ -24,6 +61,9 @@ function InlineFieldTemplate({
   const options = uiSchema?.["ui:options"] || {};
   const isLabel = options?.label !== false;
   const labelClassNames = (options?.labelClassNames as string) ?? "lg:w-3/12";
+  const unitOption = options.unit ?? options.displayUnit;
+
+  const resolvedUnit = resolveUnit(unitOption, id, registry?.formContext);
 
   let cellWidth = "lg:w-4/12";
   if (options?.inline) cellWidth = "lg:w-full";
@@ -51,11 +91,11 @@ function InlineFieldTemplate({
         <div className={`relative flex items-center w-full ${cellWidth}`}>
           {children}
         </div>
-        {options.displayUnit && (
+        {resolvedUnit && (
           <div
             className={`relative flex items-center w-full ml-2 text-bc-bg-blue ${cellWidth}`}
           >
-            <p>{options.displayUnit as any}</p>
+            <p>{resolvedUnit}</p>
           </div>
         )}
         {isErrors && (


### PR DESCRIPTION
ISSUE #4478 

### Changes Made

- went rogue from ticket AC. Instead of inserting the literal "production unit" I added each product's assigned unit at the end of every input field related to the product using InlineFieldTemplate. This involved expanding our template to take params from "ui:options" to specify where the template can find the unit (if any) from the formData (in json format). 
- changes made to InlineFieldTemplate are backward-compatible with the `displayUnit` that we have been using previously
- changes visible in reporting pages: production-data, compliance-summary, final-review, and review-changes

### Sample Screenshots

- Production Data page for RY24 report
<img width="757" height="713" alt="Screenshot 2026-05-06 at 1 58 56 PM" src="https://github.com/user-attachments/assets/ea30c716-d02f-4a25-8abb-043bfb4e8275" />

- Compliance Summary page for RY24 report
<img width="800" height="720" alt="Screenshot 2026-05-06 at 2 42 29 PM" src="https://github.com/user-attachments/assets/73de008f-46fc-41ba-a0fb-9c67236c4884" />

- Final Review page for RY24 report
<img width="992" height="652" alt="Screenshot 2026-05-06 at 2 45 21 PM" src="https://github.com/user-attachments/assets/04e1cd6b-17e9-49ed-87b3-aca95fb5c249" />
<img width="902" height="897" alt="Screenshot 2026-05-06 at 2 46 07 PM" src="https://github.com/user-attachments/assets/b4da1224-5941-4694-b85d-060232b8e5cd" />

- Production Data page for RY25 report
<img width="927" height="700" alt="Screenshot 2026-05-06 at 2 52 49 PM" src="https://github.com/user-attachments/assets/e4fff2bd-95c6-4c41-8c1d-03e54e60c978" />

- Compliance Summary page for RY25 report
<img width="802" height="655" alt="Screenshot 2026-05-06 at 2 55 38 PM" src="https://github.com/user-attachments/assets/57209e89-3aaa-4c2f-85a0-7617d08a85b5" />

- Final Review page for RY25 report
<img width="936" height="556" alt="Screenshot 2026-05-06 at 2 56 40 PM" src="https://github.com/user-attachments/assets/2039cfd8-057f-4854-86a4-0a57e162d141" />
<img width="968" height="585" alt="Screenshot 2026-05-06 at 2 57 01 PM" src="https://github.com/user-attachments/assets/79dd109c-6d10-47d9-84ff-f6fd48b0100f" />

