### PR TITLE
fix error message handling for validation errors

### DIFF
--- a/bc_obps/registration/tests/test_utils.py
+++ b/bc_obps/registration/tests/test_utils.py
@@ -123,6 +123,16 @@ class TestGenerateUsefulError:
         expected_error = "Field1: Error message 1 for field1"
         assert useful_error == expected_error
 
+    def test_generate_useful_error_plain_string(self):
+        error = ValidationError("Something went wrong.")
+        useful_error = generate_useful_error(error)
+        assert useful_error == "Something went wrong."
+
+    def test_generate_useful_error_empty_messages(self):
+        error = ValidationError([])
+        useful_error = generate_useful_error(error)
+        assert useful_error is None
+
 
 class TestCheckIfRoleAuthorized(TestCase):
     def setup_method(self, *args, **kwargs):

--- a/bc_obps/registration/utils.py
+++ b/bc_obps/registration/utils.py
@@ -72,22 +72,24 @@ def generate_useful_error(error: Union[ValidationError, NinjaValidationError]) -
     if isinstance(error, NinjaValidationError):
         # Just return the first error message if it is a NinjaValidationError (Like Unprocessable Entity)
         errors_list = error.__dict__['errors']
-        if errors_list and isinstance(errors_list, list):
-            first_error = errors_list[0]
-            if 'loc' in first_error and 'msg' in first_error:
-                # Extract field name from loc tuple and capitalize it
-                field_path = first_error['loc']
-                field_name = field_path[-1]  # Last item in loc tuple is the field name
-                formatted_key = ' '.join(word.capitalize() for word in field_name.split('_'))
-                return f"{formatted_key}: {first_error['msg']}"
-        return None
-    else:
+        if not errors_list or not isinstance(errors_list, list):
+            return None
+        first_error = errors_list[0]
+        if 'loc' not in first_error or 'msg' not in first_error:
+            return None
+        # Extract field name from loc tuple and capitalize it
+        field_name = first_error['loc'][-1]  # Last item in loc tuple is the field name
+        formatted_key = ' '.join(word.capitalize() for word in field_name.split('_'))
+        return f"{formatted_key}: {first_error['msg']}"
+    if hasattr(error, 'message_dict'):
         for key, value in error.message_dict.items():
             if key == '__all__':  # ignore adding formatted key for general error message like constraints
                 return value[0]  # Return the general error message directly
             formatted_key = ' '.join(word.capitalize() for word in key.split('_'))
             return f"{formatted_key}: {value[0]}"
         return None
+    messages = error.messages
+    return messages[0] if messages else None
 
 
 # File helpers


### PR DESCRIPTION
## Summary

- `generate_useful_error` in `registration/utils.py` raised `AttributeError: 'ValidationError' object has no attribute 'error_dict'` when a Django `ValidationError` was constructed with a plain string or list instead of a dictionary. Only dict-form `ValidationError`s have `message_dict`; string/list forms do not.
- Fixed by guarding with `hasattr(error, 'message_dict')` and adding an `else` branch that falls back to `error.messages`, which is always available regardless of how the error was raised.
- Refactored the function using early returns to flatten nested `if` blocks, reducing Cognitive Complexity from 17 to 15.
