### PR TITLE
995 fix validators

### DIFF
--- a/bc_obps/reporting/schema/report_validation_data.py
+++ b/bc_obps/reporting/schema/report_validation_data.py
@@ -22,6 +22,9 @@ class ErrorContextSchema(Schema):
     section_title: str | None = None
     missing_fields: list[str] | None = None
 
+    expected_range: str | None = None
+    user_input: str | None = None
+
 
 class ReportValidationErrorDetailSchema(Schema):
     severity: str

--- a/bc_obps/reporting/service/report_validation/report_validation_error.py
+++ b/bc_obps/reporting/service/report_validation/report_validation_error.py
@@ -52,6 +52,8 @@ class ErrorContext(BaseModel):
     section: Optional[str] = None
     section_title: Optional[str] = None
     missing_fields: list[str] | None = None
+    expected_range: Optional[str] = None
+    user_input: Optional[str] = None
 
 
 @dataclass

--- a/bc_obps/reporting/service/report_validation/validators/report_data_by_fuel_type_validator.py
+++ b/bc_obps/reporting/service/report_validation/validators/report_data_by_fuel_type_validator.py
@@ -13,22 +13,35 @@ from reporting.service.report_validation.report_validation_error import (
 )
 
 from reporting.service.report_validation.report_validation_tags import ValidationTags
+from reporting.models.reporting_field import ReportingField
+from functools import lru_cache
 
 TAGS = [ValidationTags.REPORT_VALIDATION]
+
+
+@lru_cache
+def get_reporting_field_display_name(slug: str, default: str) -> str:
+    return ReportingField.objects.filter(slug=slug).values_list("field_display_title", flat=True).first() or default
 
 
 def validate_fuel_amount(
     fuel_record: ReportFuel, activity_name: str, source_type_name: str, fuel_type_name: str
 ) -> dict[str, ReportValidationError]:
     fuel_amount = fuel_record.json_data['annualFuelAmount']
+    reporting_field_display_name = (
+        ReportingField.objects.filter(slug="annualFuelAmount").values_list("field_display_title", flat=True).first()
+        or "Annual Fuel Amount"
+    )
     validation_record = ExpectedValueRangeFuelAmount.objects.get(fuel_type=fuel_record.fuel_type)
     fuel_amount_errors: dict[str, ReportValidationError] = {}
     # Validate annualFuelAmount value against lower/upper bounds of expected value
-    if fuel_amount < validation_record.lower_bound or fuel_amount > validation_record.upper_bound:
+    lower_bound = validation_record.lower_bound
+    upper_bound = validation_record.upper_bound
+    if fuel_amount < lower_bound or fuel_amount > upper_bound:
         fuel_amount_errors[f"report_fuel_fuel_amount_value_outside_expected_bounds_{fuel_record.id}"] = (
             ReportValidationError(
                 Severity.WARNING,
-                f"Fuel Amount value ({fuel_record.json_data['annualFuelAmount']}) is outside of the expected range ({validation_record.lower_bound} - {validation_record.upper_bound}) for Activity: {activity_name}, Source Type: {source_type_name}, Fuel Type: {fuel_type_name}",
+                f"Fuel Amount value ({fuel_amount}) is outside of the expected range ({lower_bound} - {upper_bound}) for Activity: {activity_name}, Source Type: {source_type_name}, Fuel Type: {fuel_type_name}",
                 key=ReportValidationErrorKey.REPORT_DATA_OUT_OF_BOUNDS_BY_FUEL_TYPE,
                 context=ErrorContext(
                     report_version_id=fuel_record.report_version.id,
@@ -39,9 +52,13 @@ def validate_fuel_amount(
                     source_type_id=fuel_record.report_source_type.source_type_id,
                     source_type_name=source_type_name,
                     fuel_type_name=fuel_type_name,
+                    reporting_field=reporting_field_display_name,
+                    expected_range=f"{lower_bound} - {upper_bound}",
+                    user_input=str(fuel_amount),
                 ),
             )
         )
+
     return fuel_amount_errors
 
 
@@ -62,14 +79,16 @@ def validate_methodology_reporting_fields(
                 fuel_type=fuel_record.fuel_type, methodology=methodology_record.methodology, reporting_field__slug=k
             )
             # Validate report_methodology json_data <key> value against upper/lower bounds of expected value
-            if v < methodology_field_validation.lower_bound or v > methodology_field_validation.upper_bound:
+            lower_bound = methodology_field_validation.lower_bound
+            upper_bound = methodology_field_validation.upper_bound
+            if v < lower_bound or v > upper_bound:
                 gas_type_name = methodology_record.report_emission.gas_type.chemical_formula
                 reporting_field_display_name = methodology_field_validation.reporting_field.field_display_title
                 methodology_field_errors[
                     f"report_methodology_{k}_value_outside_expected_bounds_{methodology_record.id}"
                 ] = ReportValidationError(
                     Severity.WARNING,
-                    f"Methodology Field ({reporting_field_display_name}) with value ({v}) is outside of the expected range ({methodology_field_validation.lower_bound} - {methodology_field_validation.upper_bound}) for Activity: {activity_name}, Source Type: {source_type_name}, Fuel Type: {fuel_type_name}, Gas Type: {gas_type_name}",
+                    f"Methodology Field ({reporting_field_display_name}) with value ({v}) is outside of the expected range ({lower_bound} - {upper_bound}) for Activity: {activity_name}, Source Type: {source_type_name}, Fuel Type: {fuel_type_name}, Gas Type: {gas_type_name}",
                     key=ReportValidationErrorKey.REPORT_DATA_OUT_OF_BOUNDS_BY_REPORTING_FIELD,
                     context=ErrorContext(
                         report_version_id=methodology_record.report_version.id,
@@ -83,8 +102,11 @@ def validate_methodology_reporting_fields(
                         gas_type_name=gas_type_name,
                         methodology_name=methodology_record.methodology.name,
                         reporting_field=reporting_field_display_name,
+                        expected_range=f"{lower_bound} - {upper_bound}",
+                        user_input=str(v),
                     ),
                 )
+
     return methodology_field_errors
 
 

--- a/bc_obps/reporting/service/report_validation/validators/report_data_by_fuel_type_validator.py
+++ b/bc_obps/reporting/service/report_validation/validators/report_data_by_fuel_type_validator.py
@@ -28,9 +28,9 @@ def validate_fuel_amount(
     fuel_record: ReportFuel, activity_name: str, source_type_name: str, fuel_type_name: str
 ) -> dict[str, ReportValidationError]:
     fuel_amount = fuel_record.json_data['annualFuelAmount']
-    reporting_field_display_name = (
-        ReportingField.objects.filter(slug="annualFuelAmount").values_list("field_display_title", flat=True).first()
-        or "Annual Fuel Amount"
+    reporting_field_display_name = get_reporting_field_display_name(
+        "annualFuelAmount",
+        "Annual Fuel Amount",
     )
     validation_record = ExpectedValueRangeFuelAmount.objects.get(fuel_type=fuel_record.fuel_type)
     fuel_amount_errors: dict[str, ReportValidationError] = {}

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/base_required_fields_validator.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/base_required_fields_validator.py
@@ -1,0 +1,97 @@
+from typing import Any, ClassVar
+
+from reporting.models.report_version import ReportVersion
+from reporting.service.report_validation.report_validation_error import (
+    ErrorContext,
+    ReportValidationError,
+    ReportValidationErrorKey,
+    Severity,
+)
+from reporting.service.report_validation.validators.required_fields.types import (
+    RequiredFieldConfig,
+)
+from reporting.service.report_validation.validators.required_fields.utils import (
+    applies_to_section,
+    collect_missing_fields,
+)
+from reporting.service.reporting_flow_service import ReportingFlow
+
+
+class BaseRequiredFieldsValidator:
+    SECTION: ClassVar[str]
+    SECTION_TITLE: ClassVar[str]
+    REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]]
+
+    @classmethod
+    def applies(cls, flow: ReportingFlow) -> bool:
+        return applies_to_section(flow, cls.SECTION)
+
+    @classmethod
+    def get_required_fields(
+        cls,
+        report_version: ReportVersion,
+        flow: ReportingFlow,
+    ) -> list[RequiredFieldConfig]:
+        return cls.REQUIRED_FIELDS
+
+    @classmethod
+    def get_object_to_validate(cls, report_version: ReportVersion) -> Any:
+        raise NotImplementedError
+
+    @classmethod
+    def get_custom_missing_fields(
+        cls,
+        report_version: ReportVersion,
+    ) -> list[str]:
+        return []
+
+    @classmethod
+    def build_error(
+        cls,
+        *,
+        report_version_id: int,
+        missing_field_labels: list[str],
+    ) -> ReportValidationError:
+        return ReportValidationError(
+            severity=Severity.ERROR,
+            message="Required fields are empty.",
+            key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
+            context=ErrorContext(
+                report_version_id=report_version_id,
+                missing_fields=missing_field_labels,
+                section=cls.SECTION,
+                section_title=cls.SECTION_TITLE,
+            ),
+        )
+
+    @classmethod
+    def validate(
+        cls,
+        report_version: ReportVersion,
+        flow: ReportingFlow,
+    ) -> dict[str, ReportValidationError]:
+        required_fields = cls.get_required_fields(report_version, flow)
+
+        try:
+            obj = cls.get_object_to_validate(report_version)
+        except Exception:
+            return {
+                f"error_required_fields_{cls.SECTION}": cls.build_error(
+                    report_version_id=report_version.id,
+                    missing_field_labels=[field["label"] for field in required_fields]
+                    + cls.get_custom_missing_fields(report_version),
+                )
+            }
+
+        missing_field_labels = collect_missing_fields(obj, required_fields)
+        missing_field_labels += cls.get_custom_missing_fields(report_version)
+
+        if not missing_field_labels:
+            return {}
+
+        return {
+            f"error_required_fields_{cls.SECTION}": cls.build_error(
+                report_version_id=report_version.id,
+                missing_field_labels=missing_field_labels,
+            )
+        }

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/base_required_fields_validator.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/base_required_fields_validator.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar
 from uuid import UUID
-
+from django.core.exceptions import ObjectDoesNotExist
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_error import (
     ErrorContext,
@@ -79,7 +79,7 @@ class BaseRequiredFieldsValidator:
 
         try:
             obj = cls.get_object_to_validate(report_version)
-        except Exception:
+        except ObjectDoesNotExist:
             return {
                 f"error_required_fields_{cls.SECTION}": cls.build_error(
                     report_version_id=report_version.id,

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/base_required_fields_validator.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/base_required_fields_validator.py
@@ -1,4 +1,5 @@
 from typing import Any, ClassVar
+from uuid import UUID
 
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_error import (
@@ -51,6 +52,8 @@ class BaseRequiredFieldsValidator:
         *,
         report_version_id: int,
         missing_field_labels: list[str],
+        facility_id: UUID | None = None,
+        facility_name: str | None = None,
     ) -> ReportValidationError:
         return ReportValidationError(
             severity=Severity.ERROR,
@@ -58,6 +61,8 @@ class BaseRequiredFieldsValidator:
             key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
             context=ErrorContext(
                 report_version_id=report_version_id,
+                facility_id=facility_id,
+                facility_name=facility_name,
                 missing_fields=missing_field_labels,
                 section=cls.SECTION,
                 section_title=cls.SECTION_TITLE,

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/base_required_fields_validator.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/base_required_fields_validator.py
@@ -1,6 +1,8 @@
 from typing import Any, ClassVar
 from uuid import UUID
+
 from django.core.exceptions import ObjectDoesNotExist
+
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_error import (
     ErrorContext,
@@ -30,8 +32,7 @@ class BaseRequiredFieldsValidator:
     @classmethod
     def get_required_fields(
         cls,
-        report_version: ReportVersion,
-        flow: ReportingFlow,
+        flow: ReportingFlow | None = None,
     ) -> list[RequiredFieldConfig]:
         return cls.REQUIRED_FIELDS
 
@@ -73,9 +74,11 @@ class BaseRequiredFieldsValidator:
     def validate(
         cls,
         report_version: ReportVersion,
-        flow: ReportingFlow,
+        flow: ReportingFlow | None = None,
     ) -> dict[str, ReportValidationError]:
-        required_fields = cls.get_required_fields(report_version, flow)
+        required_fields = cls.get_required_fields(
+            flow,
+        )
 
         try:
             obj = cls.get_object_to_validate(report_version)
@@ -88,7 +91,10 @@ class BaseRequiredFieldsValidator:
                 )
             }
 
-        missing_field_labels = collect_missing_fields(obj, required_fields)
+        missing_field_labels = collect_missing_fields(
+            obj,
+            required_fields,
+        )
         missing_field_labels += cls.get_custom_missing_fields(report_version)
 
         if not missing_field_labels:

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_activity_data.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_activity_data.py
@@ -1,76 +1,70 @@
-from uuid import UUID
+from typing import ClassVar
+
 from django.db.models import Count
+
 from reporting.models.facility_report import FacilityReport
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_error import (
     ReportValidationError,
 )
 from reporting.service.report_validation.report_validation_tags import ValidationTags
-from reporting.service.report_validation.validators.required_fields.utils import (
-    build_required_fields_error,
+from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
+    BaseRequiredFieldsValidator,
 )
-
-from reporting.service.report_validation.validators.required_fields.utils import applies_to_section
+from reporting.service.report_validation.validators.required_fields.types import (
+    RequiredFieldConfig,
+)
 from reporting.service.reporting_flow_service import ReportingFlow
 
 
 TAGS = [ValidationTags.REPORT_VALIDATION]
-SECTION = "activity_data"
-SECTION_TITLE = "Activity data"
+
+
+ACTIVITY_DATA_LABEL = "Activity data"
+
+
+class RequiredFieldsActivityDataValidator(BaseRequiredFieldsValidator):
+    SECTION: ClassVar[str] = "activity_data"
+    SECTION_TITLE: ClassVar[str] = ACTIVITY_DATA_LABEL
+
+    REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]] = [
+        {
+            "field": "activity_data",
+            "label": ACTIVITY_DATA_LABEL,
+            "field_type": "scalar",
+        },
+    ]
+
+    @classmethod
+    def validate(
+        cls,
+        report_version: ReportVersion,
+        flow: ReportingFlow | None = None,
+    ) -> dict[str, ReportValidationError]:
+        errors: dict[str, ReportValidationError] = {}
+
+        facility_reports = (
+            FacilityReport.objects.filter(report_version=report_version)
+            .annotate(activity_count=Count("reportactivity_records"))
+            .filter(activity_count=0)
+        )
+
+        for facility_report in facility_reports:
+            error_key = f"error_required_fields_{cls.SECTION}_facility_{facility_report.facility_id}"
+
+            errors[error_key] = cls.build_error(
+                report_version_id=report_version.id,
+                facility_id=facility_report.facility_id,
+                facility_name=facility_report.facility_name,
+                missing_field_labels=["Activity data"],
+            )
+
+        return errors
 
 
 def applies(flow: ReportingFlow) -> bool:
-    return applies_to_section(flow, SECTION)
-
-
-def _build_error(
-    *,
-    report_version_id: int,
-    facility_id: UUID,
-    facility_name: str,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return build_required_fields_error(
-        report_version_id=report_version_id,
-        facility_id=facility_id,
-        facility_name=facility_name,
-        section=SECTION,
-        section_title=SECTION_TITLE,
-        missing_field_labels=missing_field_labels,
-    )
-
-
-def _build_facility_error(
-    *,
-    report_version: ReportVersion,
-    facility_report: FacilityReport,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return _build_error(
-        report_version_id=report_version.id,
-        facility_id=facility_report.facility_id,
-        facility_name=facility_report.facility_name,
-        missing_field_labels=missing_field_labels,
-    )
+    return RequiredFieldsActivityDataValidator.applies(flow)
 
 
 def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    errors: dict[str, ReportValidationError] = {}
-
-    # use Count for existence check
-    facility_reports = (
-        FacilityReport.objects.filter(report_version=report_version)
-        .annotate(activity_count=Count("reportactivity_records"))
-        .filter(activity_count=0)
-    )
-
-    for facility_report in facility_reports:
-        error_key = f"error_required_fields_{SECTION}_facility_{facility_report.facility_id}"
-
-        errors[error_key] = _build_facility_error(
-            report_version=report_version,
-            facility_report=facility_report,
-            missing_field_labels=["Activity data"],
-        )
-
-    return errors
+    return RequiredFieldsActivityDataValidator.validate(report_version)

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_additional_data.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_additional_data.py
@@ -1,94 +1,92 @@
+from typing import ClassVar
+
+from django.core.exceptions import ObjectDoesNotExist
+
 from reporting.models.report_additional_data import ReportAdditionalData
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_error import (
-    ErrorContext,
     ReportValidationError,
-    ReportValidationErrorKey,
-    Severity,
 )
 from reporting.service.report_validation.report_validation_tags import (
     ValidationTags,
 )
+from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
+    BaseRequiredFieldsValidator,
+)
 from reporting.service.report_validation.validators.required_fields.types import (
     RequiredFieldConfig,
 )
-from reporting.service.report_validation.validators.required_fields.utils import (
-    collect_missing_fields,
-)
-
-from reporting.service.report_validation.validators.required_fields.utils import applies_to_section
 from reporting.service.reporting_flow_service import ReportingFlow
 
 TAGS = [ValidationTags.REPORT_VALIDATION]
 
-SECTION = "additional_reporting_data"
-SECTION_TITLE = "Additional reporting data"
-REQUIRED_FIELDS: list[RequiredFieldConfig] = []
 
+class RequiredFieldsAdditionalReportingDataValidator(BaseRequiredFieldsValidator):
+    SECTION: ClassVar[str] = "additional_reporting_data"
+    SECTION_TITLE: ClassVar[str] = "Additional reporting data"
 
-def applies(flow: ReportingFlow) -> bool:
-    return applies_to_section(flow, SECTION)
+    REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]] = []
 
+    @classmethod
+    def get_object_to_validate(
+        cls,
+        report_version: ReportVersion,
+    ) -> ReportAdditionalData:
+        return report_version.report_additional_data
 
-def _build_error(
-    *,
-    report_version_id: int,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return ReportValidationError(
-        severity=Severity.ERROR,
-        message="Required fields are empty.",
-        key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
-        context=ErrorContext(
-            report_version_id=report_version_id,
-            missing_fields=missing_field_labels,
-            section=SECTION,
-            section_title=SECTION_TITLE,
-        ),
-    )
+    @classmethod
+    def get_custom_missing_fields(
+        cls,
+        report_version: ReportVersion,
+    ) -> list[str]:
+        report_additional_data = report_version.report_additional_data
 
+        if not report_additional_data.capture_emissions:
+            return []
 
-def _get_missing_additional_reporting_fields(
-    report_additional_data: ReportAdditionalData,
-) -> list[str]:
-    if not report_additional_data.capture_emissions:
+        capture_fields = [
+            report_additional_data.emissions_on_site_use,
+            report_additional_data.emissions_on_site_sequestration,
+            report_additional_data.emissions_off_site_transfer,
+        ]
+
+        if all(field is None for field in capture_fields):
+            return ["At least one emissions capture type must be provided"]
+
         return []
 
-    capture_fields = [
-        report_additional_data.emissions_on_site_use,
-        report_additional_data.emissions_on_site_sequestration,
-        report_additional_data.emissions_off_site_transfer,
-    ]
+    @classmethod
+    def validate(
+        cls,
+        report_version: ReportVersion,
+        flow: ReportingFlow | None = None,
+    ) -> dict[str, ReportValidationError]:
+        try:
+            cls.get_object_to_validate(report_version)
+        except ObjectDoesNotExist:
+            return {
+                f"error_required_fields_{cls.SECTION}": cls.build_error(
+                    report_version_id=report_version.id,
+                    missing_field_labels=[cls.SECTION_TITLE],
+                )
+            }
 
-    if all(field is None for field in capture_fields):
-        return ["At least one emissions capture type must be provided"]
+        missing_field_labels = cls.get_custom_missing_fields(report_version)
 
-    return []
+        if not missing_field_labels:
+            return {}
 
-
-def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    try:
-        report_additional_data: ReportAdditionalData = report_version.report_additional_data
-    except ReportAdditionalData.DoesNotExist:
         return {
-            f"error_required_fields_{SECTION}": _build_error(
+            f"error_required_fields_{cls.SECTION}": cls.build_error(
                 report_version_id=report_version.id,
-                missing_field_labels=[SECTION_TITLE],
+                missing_field_labels=missing_field_labels,
             )
         }
 
-    missing_field_labels = collect_missing_fields(
-        report_additional_data,
-        REQUIRED_FIELDS,
-    )
-    missing_field_labels.extend(_get_missing_additional_reporting_fields(report_additional_data))
 
-    if not missing_field_labels:
-        return {}
+def applies(flow: ReportingFlow) -> bool:
+    return RequiredFieldsAdditionalReportingDataValidator.applies(flow)
 
-    return {
-        f"error_required_fields_{SECTION}": _build_error(
-            report_version_id=report_version.id,
-            missing_field_labels=missing_field_labels,
-        )
-    }
+
+def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
+    return RequiredFieldsAdditionalReportingDataValidator.validate(report_version)

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_electricity_import_data.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_electricity_import_data.py
@@ -1,123 +1,94 @@
-from reporting.models.report_electricity_import_data import ReportElectricityImportData
+from typing import ClassVar
+
+from reporting.models.report_electricity_import_data import (
+    ReportElectricityImportData,
+)
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_error import (
-    ErrorContext,
     ReportValidationError,
-    ReportValidationErrorKey,
-    Severity,
 )
 from reporting.service.report_validation.report_validation_tags import (
     ValidationTags,
 )
-from reporting.service.report_validation.validators.required_fields.utils import (
-    RequiredFieldConfig,
-    collect_missing_fields,
+from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
+    BaseRequiredFieldsValidator,
 )
-
-from reporting.service.report_validation.validators.required_fields.utils import applies_to_section
+from reporting.service.report_validation.validators.required_fields.types import (
+    RequiredFieldConfig,
+)
 from reporting.service.reporting_flow_service import ReportingFlow
 
 TAGS = [ValidationTags.REPORT_VALIDATION]
-SECTION = "electricity_import_data"
-SECTION_TITLE = "Electricity Import Data"
-REQUIRED_FIELDS: list[RequiredFieldConfig] = [
-    {
-        "field": "import_specified_electricity",
-        "label": "Amount of imported electricity - specified sources",
-        "field_type": "scalar",
-    },
-    {
-        "field": "import_specified_emissions",
-        "label": "Emissions from specified imports",
-        "field_type": "scalar",
-    },
-    {
-        "field": "import_unspecified_electricity",
-        "label": "Amount of imported electricity - unspecified sources",
-        "field_type": "scalar",
-    },
-    {
-        "field": "import_unspecified_emissions",
-        "label": "Emissions from unspecified imports",
-        "field_type": "scalar",
-    },
-    {
-        "field": "export_specified_electricity",
-        "label": "Amount of exported electricity - specified sources",
-        "field_type": "scalar",
-    },
-    {
-        "field": "export_specified_emissions",
-        "label": "Emissions from specified exports",
-        "field_type": "scalar",
-    },
-    {
-        "field": "export_unspecified_electricity",
-        "label": "Amount of exported electricity - unspecified sources",
-        "field_type": "scalar",
-    },
-    {
-        "field": "export_unspecified_emissions",
-        "label": "Emissions from unspecified exports",
-        "field_type": "scalar",
-    },
-    {
-        "field": "canadian_entitlement_electricity",
-        "label": "Amount of electricity categorized as Canadian Entitlement Power",
-        "field_type": "scalar",
-    },
-    {
-        "field": "canadian_entitlement_emissions",
-        "label": "Emissions from Canadian Entitlement Power",
-        "field_type": "scalar",
-    },
-]
+
+
+class RequiredFieldsElectricityImportDataValidator(BaseRequiredFieldsValidator):
+    SECTION: ClassVar[str] = "electricity_import_data"
+    SECTION_TITLE: ClassVar[str] = "Electricity Import Data"
+
+    REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]] = [
+        {
+            "field": "import_specified_electricity",
+            "label": "Amount of imported electricity - specified sources",
+            "field_type": "scalar",
+        },
+        {
+            "field": "import_specified_emissions",
+            "label": "Emissions from specified imports",
+            "field_type": "scalar",
+        },
+        {
+            "field": "import_unspecified_electricity",
+            "label": "Amount of imported electricity - unspecified sources",
+            "field_type": "scalar",
+        },
+        {
+            "field": "import_unspecified_emissions",
+            "label": "Emissions from unspecified imports",
+            "field_type": "scalar",
+        },
+        {
+            "field": "export_specified_electricity",
+            "label": "Amount of exported electricity - specified sources",
+            "field_type": "scalar",
+        },
+        {
+            "field": "export_specified_emissions",
+            "label": "Emissions from specified exports",
+            "field_type": "scalar",
+        },
+        {
+            "field": "export_unspecified_electricity",
+            "label": "Amount of exported electricity - unspecified sources",
+            "field_type": "scalar",
+        },
+        {
+            "field": "export_unspecified_emissions",
+            "label": "Emissions from unspecified exports",
+            "field_type": "scalar",
+        },
+        {
+            "field": "canadian_entitlement_electricity",
+            "label": "Amount of electricity categorized as Canadian Entitlement Power",
+            "field_type": "scalar",
+        },
+        {
+            "field": "canadian_entitlement_emissions",
+            "label": "Emissions from Canadian Entitlement Power",
+            "field_type": "scalar",
+        },
+    ]
+
+    @classmethod
+    def get_object_to_validate(
+        cls,
+        report_version: ReportVersion,
+    ) -> ReportElectricityImportData:
+        return report_version.report_electricity_import_data.get()
 
 
 def applies(flow: ReportingFlow) -> bool:
-    return applies_to_section(flow, SECTION)
-
-
-def _build_error(
-    *,
-    report_version_id: int,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return ReportValidationError(
-        severity=Severity.ERROR,
-        message="Required fields are empty.",
-        key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
-        context=ErrorContext(
-            report_version_id=report_version_id,
-            missing_fields=missing_field_labels,
-            section=SECTION,
-            section_title=SECTION_TITLE,
-        ),
-    )
+    return RequiredFieldsElectricityImportDataValidator.applies(flow)
 
 
 def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    try:
-        electricity_import_data: ReportElectricityImportData = report_version.report_electricity_import_data.get()
-    except ReportElectricityImportData.DoesNotExist:
-        return {
-            f"error_required_fields_{SECTION}": _build_error(
-                report_version_id=report_version.id,
-                missing_field_labels=[item["label"] for item in REQUIRED_FIELDS],
-            )
-        }
-
-    missing_field_labels = collect_missing_fields(
-        electricity_import_data,
-        REQUIRED_FIELDS,
-    )
-
-    if not missing_field_labels:
-        return {}
-
-    return {
-        f"error_required_fields_{SECTION}": _build_error(
-            report_version_id=report_version.id,
-            missing_field_labels=missing_field_labels,
-        )
-    }
+    return RequiredFieldsElectricityImportDataValidator.validate(report_version)

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_emission_allocation.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_emission_allocation.py
@@ -1,5 +1,7 @@
-from uuid import UUID
+from typing import ClassVar
+
 from django.db.models import Count, Prefetch
+
 from reporting.models.facility_report import FacilityReport
 from reporting.models.report_emission_allocation import ReportEmissionAllocation
 from reporting.models.report_version import ReportVersion
@@ -7,117 +9,98 @@ from reporting.service.report_validation.report_validation_error import (
     ReportValidationError,
 )
 from reporting.service.report_validation.report_validation_tags import ValidationTags
+from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
+    BaseRequiredFieldsValidator,
+)
 from reporting.service.report_validation.validators.required_fields.types import (
     RequiredFieldConfig,
 )
 from reporting.service.report_validation.validators.required_fields.utils import (
-    build_required_fields_error,
     collect_missing_fields,
 )
-
-from reporting.service.report_validation.validators.required_fields.utils import applies_to_section
 from reporting.service.reporting_flow_service import ReportingFlow
 
-
 TAGS = [ValidationTags.REPORT_VALIDATION]
-SECTION = "allocation_of_emissions"
-SECTION_TITLE = "Allocation of emissions"
-REQUIRED_FIELDS: list[RequiredFieldConfig] = [
-    {
-        "field": "allocation_methodology",
-        "label": "Allocation methodology",
-        "field_type": "scalar",
-    },
-]
+
+
+class RequiredFieldsAllocationOfEmissionsValidator(BaseRequiredFieldsValidator):
+    SECTION: ClassVar[str] = "allocation_of_emissions"
+    SECTION_TITLE: ClassVar[str] = "Allocation of emissions"
+
+    REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]] = [
+        {
+            "field": "allocation_methodology",
+            "label": "Allocation methodology",
+            "field_type": "scalar",
+        },
+    ]
+
+    @classmethod
+    def get_allocation_missing_fields(
+        cls,
+        allocation_record: ReportEmissionAllocation,
+    ) -> list[str]:
+        missing_fields = collect_missing_fields(allocation_record, cls.REQUIRED_FIELDS)
+
+        if (
+            allocation_record.allocation_methodology == ReportEmissionAllocation.AllocationMethodologyChoices.OTHER
+            and not allocation_record.allocation_other_methodology_description
+        ):
+            missing_fields.append("Allocation other methodology description")
+
+        return sorted(set(missing_fields))
+
+    @classmethod
+    def validate(
+        cls,
+        report_version: ReportVersion,
+        flow: ReportingFlow | None = None,
+    ) -> dict[str, ReportValidationError]:
+        errors: dict[str, ReportValidationError] = {}
+
+        facility_reports = (
+            FacilityReport.objects.filter(report_version=report_version)
+            .annotate(allocation_count=Count("reportemissionallocation_records"))
+            .prefetch_related(
+                Prefetch(
+                    "reportemissionallocation_records",
+                    queryset=ReportEmissionAllocation.objects.filter(
+                        report_version=report_version,
+                    ),
+                    to_attr="emission_allocation_records",
+                )
+            )
+        )
+
+        for facility_report in facility_reports:
+            error_key = f"error_required_fields_{cls.SECTION}_facility_{facility_report.facility_id}"
+
+            if facility_report.allocation_count == 0:
+                errors[error_key] = cls.build_error(
+                    report_version_id=report_version.id,
+                    facility_id=facility_report.facility_id,
+                    facility_name=facility_report.facility_name,
+                    missing_field_labels=[item["label"] for item in cls.REQUIRED_FIELDS],
+                )
+                continue
+
+            allocation_record = facility_report.emission_allocation_records[0]
+            missing_field_labels = cls.get_allocation_missing_fields(allocation_record)
+
+            if missing_field_labels:
+                errors[error_key] = cls.build_error(
+                    report_version_id=report_version.id,
+                    facility_id=facility_report.facility_id,
+                    facility_name=facility_report.facility_name,
+                    missing_field_labels=missing_field_labels,
+                )
+
+        return errors
 
 
 def applies(flow: ReportingFlow) -> bool:
-    return applies_to_section(flow, SECTION)
-
-
-def _build_error(
-    *,
-    report_version_id: int,
-    facility_id: UUID,
-    facility_name: str,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return build_required_fields_error(
-        report_version_id=report_version_id,
-        facility_id=facility_id,
-        facility_name=facility_name,
-        section=SECTION,
-        section_title=SECTION_TITLE,
-        missing_field_labels=missing_field_labels,
-    )
-
-
-def _build_facility_error(
-    *,
-    report_version: ReportVersion,
-    facility_report: FacilityReport,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return _build_error(
-        report_version_id=report_version.id,
-        facility_id=facility_report.facility_id,
-        facility_name=facility_report.facility_name,
-        missing_field_labels=missing_field_labels,
-    )
-
-
-def _get_allocation_missing_fields(
-    allocation_record: ReportEmissionAllocation,
-) -> list[str]:
-    missing_fields = collect_missing_fields(allocation_record, REQUIRED_FIELDS)
-
-    if (
-        allocation_record.allocation_methodology == ReportEmissionAllocation.AllocationMethodologyChoices.OTHER
-        and not allocation_record.allocation_other_methodology_description
-    ):
-        missing_fields.append("Allocation other methodology description")
-
-    return sorted(set(missing_fields))
+    return RequiredFieldsAllocationOfEmissionsValidator.applies(flow)
 
 
 def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    errors: dict[str, ReportValidationError] = {}
-
-    # use Count for existence check
-    # use Prefetch for_related records
-    facility_reports = (
-        FacilityReport.objects.filter(report_version=report_version)
-        .annotate(allocation_count=Count("reportemissionallocation_records"))
-        .prefetch_related(
-            Prefetch(
-                "reportemissionallocation_records",
-                queryset=ReportEmissionAllocation.objects.filter(
-                    report_version=report_version,
-                ),
-                to_attr="emission_allocation_records",
-            )
-        )
-    )
-
-    for facility_report in facility_reports:
-        error_key = f"error_required_fields_{SECTION}_facility_{facility_report.facility_id}"
-
-        if facility_report.allocation_count == 0:
-            errors[error_key] = _build_facility_error(
-                report_version=report_version,
-                facility_report=facility_report,
-                missing_field_labels=[item["label"] for item in REQUIRED_FIELDS],
-            )
-            continue
-
-        allocation_record = facility_report.emission_allocation_records[0]
-        missing_field_labels = _get_allocation_missing_fields(allocation_record)
-
-        if missing_field_labels:
-            errors[error_key] = _build_facility_error(
-                report_version=report_version,
-                facility_report=facility_report,
-                missing_field_labels=missing_field_labels,
-            )
-
-    return errors
+    return RequiredFieldsAllocationOfEmissionsValidator.validate(report_version)

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_new_entrant_information.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_new_entrant_information.py
@@ -1,90 +1,57 @@
+from typing import ClassVar
+
 from reporting.models.report_new_entrant import ReportNewEntrant
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_error import (
-    ErrorContext,
     ReportValidationError,
-    ReportValidationErrorKey,
-    Severity,
 )
 from reporting.service.report_validation.report_validation_tags import (
     ValidationTags,
 )
+from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
+    BaseRequiredFieldsValidator,
+)
 from reporting.service.report_validation.validators.required_fields.types import (
     RequiredFieldConfig,
 )
-from reporting.service.report_validation.validators.required_fields.utils import (
-    collect_missing_fields,
-)
-
-from reporting.service.report_validation.validators.required_fields.utils import applies_to_section
 from reporting.service.reporting_flow_service import ReportingFlow
 
 TAGS = [ValidationTags.REPORT_VALIDATION]
-SECTION = "new_entrant_information"
-SECTION_TITLE = "New entrant information"
-REQUIRED_FIELDS: list[RequiredFieldConfig] = [
-    {
-        "field": "authorization_date",
-        "label": "Authorization date",
-        "field_type": "scalar",
-    },
-    {
-        "field": "first_shipment_date",
-        "label": "Date of first shipment",
-        "field_type": "scalar",
-    },
-    {
-        "field": "new_entrant_period_start",
-        "label": "Date new entrant period began",
-        "field_type": "scalar",
-    },
-]
+
+
+class RequiredFieldsNewEntrantInformationValidator(BaseRequiredFieldsValidator):
+    SECTION: ClassVar[str] = "new_entrant_information"
+    SECTION_TITLE: ClassVar[str] = "New entrant information"
+
+    REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]] = [
+        {
+            "field": "authorization_date",
+            "label": "Authorization date",
+            "field_type": "scalar",
+        },
+        {
+            "field": "first_shipment_date",
+            "label": "Date of first shipment",
+            "field_type": "scalar",
+        },
+        {
+            "field": "new_entrant_period_start",
+            "label": "Date new entrant period began",
+            "field_type": "scalar",
+        },
+    ]
+
+    @classmethod
+    def get_object_to_validate(
+        cls,
+        report_version: ReportVersion,
+    ) -> ReportNewEntrant:
+        return report_version.report_new_entrant.get()
 
 
 def applies(flow: ReportingFlow) -> bool:
-    return applies_to_section(flow, SECTION)
-
-
-def _build_error(
-    *,
-    report_version_id: int,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return ReportValidationError(
-        severity=Severity.ERROR,
-        message="Required fields are empty.",
-        key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
-        context=ErrorContext(
-            report_version_id=report_version_id,
-            missing_fields=missing_field_labels,
-            section=SECTION,
-            section_title=SECTION_TITLE,
-        ),
-    )
+    return RequiredFieldsNewEntrantInformationValidator.applies(flow)
 
 
 def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    try:
-        report_new_entrant: ReportNewEntrant = report_version.report_new_entrant.get()
-    except ReportNewEntrant.DoesNotExist:
-        return {
-            f"error_required_fields_{SECTION}": _build_error(
-                report_version_id=report_version.id,
-                missing_field_labels=[item["label"] for item in REQUIRED_FIELDS],
-            )
-        }
-
-    missing_field_labels = collect_missing_fields(
-        report_new_entrant,
-        REQUIRED_FIELDS,
-    )
-
-    if not missing_field_labels:
-        return {}
-
-    return {
-        f"error_required_fields_{SECTION}": _build_error(
-            report_version_id=report_version.id,
-            missing_field_labels=missing_field_labels,
-        )
-    }
+    return RequiredFieldsNewEntrantInformationValidator.validate(report_version)

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_non_attributable_emissions.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_non_attributable_emissions.py
@@ -1,114 +1,88 @@
-from uuid import UUID
+from typing import ClassVar
+
 from django.db.models import Prefetch
+
 from reporting.models.facility_report import FacilityReport
 from reporting.models.report_non_attributable_emissions import (
     ReportNonAttributableEmissions,
 )
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_error import (
-    ErrorContext,
     ReportValidationError,
-    ReportValidationErrorKey,
-    Severity,
 )
 from reporting.service.report_validation.report_validation_tags import ValidationTags
-from reporting.service.report_validation.validators.required_fields.types import RequiredFieldConfig
-from reporting.service.report_validation.validators.required_fields.utils import collect_missing_fields_many
-
-
-from reporting.service.report_validation.validators.required_fields.utils import applies_to_section
+from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
+    BaseRequiredFieldsValidator,
+)
+from reporting.service.report_validation.validators.required_fields.types import (
+    RequiredFieldConfig,
+)
+from reporting.service.report_validation.validators.required_fields.utils import (
+    collect_missing_fields_many,
+)
 from reporting.service.reporting_flow_service import ReportingFlow
 
-
 TAGS = [ValidationTags.REPORT_VALIDATION]
-SECTION = "non_attributable_emissions"
-SECTION_TITLE = "Non-attributable emissions"
-REQUIRED_FIELDS: list[RequiredFieldConfig] = [
-    {
-        "field": "activity",
-        "label": "Activity name",
-        "field_type": "scalar",
-    },
-    {
-        "field": "source_type",
-        "label": "Source type",
-        "field_type": "scalar",
-    },
-    {
-        "field": "emission_category",
-        "label": "Emission category",
-        "field_type": "scalar",
-    },
-    {
-        "field": "gas_type",
-        "label": "Gas type",
-        "field_type": "m2m",
-    },
-]
+
+
+class RequiredFieldsNonAttributableEmissionsValidator(BaseRequiredFieldsValidator):
+    SECTION: ClassVar[str] = "non_attributable_emissions"
+    SECTION_TITLE: ClassVar[str] = "Non-attributable emissions"
+
+    REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]] = [
+        {"field": "activity", "label": "Activity name", "field_type": "scalar"},
+        {"field": "source_type", "label": "Source type", "field_type": "scalar"},
+        {"field": "emission_category", "label": "Emission category", "field_type": "scalar"},
+        {"field": "gas_type", "label": "Gas type", "field_type": "m2m"},
+    ]
+
+    @classmethod
+    def validate(
+        cls,
+        report_version: ReportVersion,
+        flow: ReportingFlow | None = None,
+    ) -> dict[str, ReportValidationError]:
+        errors: dict[str, ReportValidationError] = {}
+
+        facility_reports = FacilityReport.objects.filter(
+            report_version=report_version,
+        ).prefetch_related(
+            Prefetch(
+                "reportnonattributableemissions_records",
+                queryset=ReportNonAttributableEmissions.objects.filter(
+                    report_version=report_version,
+                ),
+                to_attr="non_attributable_emission_records",
+            )
+        )
+
+        for facility_report in facility_reports:
+            records = facility_report.non_attributable_emission_records
+
+            if not records:
+                continue
+
+            missing_field_labels = collect_missing_fields_many(
+                records,
+                cls.REQUIRED_FIELDS,
+            )
+
+            if missing_field_labels:
+                error_key = f"error_required_fields_{cls.SECTION}_facility_{facility_report.facility_id}"
+
+                errors[error_key] = cls.build_error(
+                    report_version_id=report_version.id,
+                    facility_id=facility_report.facility_id,
+                    facility_name=facility_report.facility_name,
+                    missing_field_labels=sorted(set(missing_field_labels)),
+                )
+
+        return errors
 
 
 def applies(flow: ReportingFlow) -> bool:
-    return applies_to_section(flow, SECTION)
-
-
-def _build_error(
-    *,
-    report_version_id: int,
-    facility_id: UUID,
-    facility_name: str,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return ReportValidationError(
-        severity=Severity.ERROR,
-        message="Required fields are empty.",
-        key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
-        context=ErrorContext(
-            report_version_id=report_version_id,
-            facility_id=facility_id,
-            facility_name=facility_name,
-            missing_fields=missing_field_labels,
-            section=SECTION,
-            section_title=SECTION_TITLE,
-        ),
-    )
+    return RequiredFieldsNonAttributableEmissionsValidator.applies(flow)
 
 
 def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    errors: dict[str, ReportValidationError] = {}
-
-    # use Prefetch for_related records
-    facility_reports = FacilityReport.objects.filter(
-        report_version=report_version,
-    ).prefetch_related(
-        Prefetch(
-            "reportnonattributableemissions_records",
-            queryset=ReportNonAttributableEmissions.objects.filter(
-                report_version=report_version,
-            ),
-            to_attr="non_attributable_emission_records",
-        )
-    )
-
-    for facility_report in facility_reports:
-        records = facility_report.non_attributable_emission_records
-
-        # only validate required fields when a record exists
-        if not records:
-            continue
-
-        missing_field_labels = collect_missing_fields_many(
-            records,
-            REQUIRED_FIELDS,
-        )
-
-        if missing_field_labels:
-            error_key = f"error_required_fields_{SECTION}_facility_{facility_report.facility_id}"
-
-            errors[error_key] = _build_error(
-                report_version_id=report_version.id,
-                facility_id=facility_report.facility_id,
-                facility_name=facility_report.facility_name,
-                missing_field_labels=sorted(set(missing_field_labels)),
-            )
-
-    return errors
+    return RequiredFieldsNonAttributableEmissionsValidator.validate(report_version)

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_operation_information.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_operation_information.py
@@ -1,108 +1,71 @@
+from typing import ClassVar
+from reporting.service.report_validation.report_validation_error import ReportValidationError
+from reporting.service.report_validation.report_validation_tags import ValidationTags
 from reporting.models.report_operation import ReportOperation
 from reporting.models.report_operation_representative import (
     ReportOperationRepresentative,
 )
 from reporting.models.report_version import ReportVersion
-from reporting.service.report_validation.report_validation_error import (
-    ErrorContext,
-    ReportValidationError,
-    ReportValidationErrorKey,
-    Severity,
-)
-from reporting.service.report_validation.report_validation_tags import (
-    ValidationTags,
+from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
+    BaseRequiredFieldsValidator,
 )
 from reporting.service.report_validation.validators.required_fields.types import (
     RequiredFieldConfig,
 )
-from reporting.service.report_validation.validators.required_fields.utils import (
-    collect_missing_fields,
-)
-
-from reporting.service.report_validation.validators.required_fields.utils import applies_to_section
-from reporting.service.reporting_flow_service import ReportingFlow
+from reporting.service.reporting_flow_service import ReportingFlow, resolve_flow
 
 TAGS = [ValidationTags.REPORT_VALIDATION]
-SECTION = "review_operation_information"
-SECTION_TITLE = "Review operation information"
-REQUIRED_FIELDS: list[RequiredFieldConfig] = [
-    {
-        "field": "operation_name",
-        "label": "Operation name",
-        "field_type": "scalar",
-    },
-    {
-        "field": "operator_legal_name",
-        "label": "Operator legal name",
-        "field_type": "scalar",
-    },
-    {
-        "field": "activities",
-        "label": "Activities",
-        "field_type": "m2m",
-    },
-    {
-        "field": "regulated_products",
-        "label": "Regulated products",
-        "field_type": "m2m",
-    },
-]
+
+OPERATION_REPRESENTATIVE_LABEL = "Operation representative name"
+
+
+class RequiredFieldsReportOperationInformationValidator(BaseRequiredFieldsValidator):
+    SECTION: ClassVar[str] = "review_operation_information"
+    SECTION_TITLE: ClassVar[str] = "Review operation information"
+    REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]] = [
+        {"field": "operation_name", "label": "Operation name", "field_type": "scalar"},
+        {"field": "operator_legal_name", "label": "Operator legal name", "field_type": "scalar"},
+        {"field": "activities", "label": "Activities", "field_type": "m2m"},
+        {"field": "regulated_products", "label": "Regulated products", "field_type": "m2m"},
+    ]
+
+    @classmethod
+    def get_required_fields(
+        cls,
+        report_version: ReportVersion,
+        flow: ReportingFlow,
+    ) -> list[RequiredFieldConfig]:
+        if flow == ReportingFlow.EIO:
+            return [
+                field for field in cls.REQUIRED_FIELDS if field["field"] not in {"activities", "regulated_products"}
+            ]
+
+        return cls.REQUIRED_FIELDS
+
+    @classmethod
+    def get_object_to_validate(cls, report_version: ReportVersion) -> ReportOperation:
+        return report_version.report_operation
+
+    @classmethod
+    def get_custom_missing_fields(cls, report_version: ReportVersion) -> list[str]:
+        has_selected_representative = ReportOperationRepresentative.objects.filter(
+            report_version__id=report_version.id,
+            selected_for_report=True,
+        ).exists()
+
+        if has_selected_representative:
+            return []
+
+        return [OPERATION_REPRESENTATIVE_LABEL]
 
 
 def applies(flow: ReportingFlow) -> bool:
-    return applies_to_section(flow, SECTION)
-
-
-def _build_error(
-    *,
-    report_version_id: int,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return ReportValidationError(
-        severity=Severity.ERROR,
-        message="Required fields are empty.",
-        key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
-        context=ErrorContext(
-            report_version_id=report_version_id,
-            missing_fields=missing_field_labels,
-            section=SECTION,
-            section_title=SECTION_TITLE,
-        ),
-    )
-
-
-def _is_missing_operation_representative(report_version_id: int) -> bool:
-    return not ReportOperationRepresentative.objects.filter(
-        report_version__id=report_version_id,
-        selected_for_report=True,
-    ).exists()
+    return RequiredFieldsReportOperationInformationValidator.applies(flow)
 
 
 def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    try:
-        report_operation: ReportOperation = report_version.report_operation
-    except ReportOperation.DoesNotExist:
-        return {
-            f"error_required_fields_{SECTION}": _build_error(
-                report_version_id=report_version.id,
-                missing_field_labels=[item["label"] for item in REQUIRED_FIELDS] + ["Operation representative name"],
-            )
-        }
-
-    missing_field_labels = collect_missing_fields(
-        report_operation,
-        REQUIRED_FIELDS,
+    flow = resolve_flow(report_version)
+    return RequiredFieldsReportOperationInformationValidator.validate(
+        report_version,
+        flow,
     )
-
-    if _is_missing_operation_representative(report_version.id):
-        missing_field_labels.append("Operation representative name")
-
-    if not missing_field_labels:
-        return {}
-
-    return {
-        f"error_required_fields_{SECTION}": _build_error(
-            report_version_id=report_version.id,
-            missing_field_labels=missing_field_labels,
-        )
-    }

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_operation_information.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_operation_information.py
@@ -1,11 +1,12 @@
 from typing import ClassVar
-from reporting.service.report_validation.report_validation_error import ReportValidationError
-from reporting.service.report_validation.report_validation_tags import ValidationTags
+
 from reporting.models.report_operation import ReportOperation
 from reporting.models.report_operation_representative import (
     ReportOperationRepresentative,
 )
 from reporting.models.report_version import ReportVersion
+from reporting.service.report_validation.report_validation_error import ReportValidationError
+from reporting.service.report_validation.report_validation_tags import ValidationTags
 from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
     BaseRequiredFieldsValidator,
 )
@@ -22,6 +23,7 @@ OPERATION_REPRESENTATIVE_LABEL = "Operation representative name"
 class RequiredFieldsReportOperationInformationValidator(BaseRequiredFieldsValidator):
     SECTION: ClassVar[str] = "review_operation_information"
     SECTION_TITLE: ClassVar[str] = "Review operation information"
+
     REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]] = [
         {"field": "operation_name", "label": "Operation name", "field_type": "scalar"},
         {"field": "operator_legal_name", "label": "Operator legal name", "field_type": "scalar"},
@@ -32,8 +34,7 @@ class RequiredFieldsReportOperationInformationValidator(BaseRequiredFieldsValida
     @classmethod
     def get_required_fields(
         cls,
-        report_version: ReportVersion,
-        flow: ReportingFlow,
+        flow: ReportingFlow | None = None,
     ) -> list[RequiredFieldConfig]:
         if flow == ReportingFlow.EIO:
             return [

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_person_responsible.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_person_responsible.py
@@ -1,119 +1,50 @@
+from typing import ClassVar
+
 from reporting.models.report_person_responsible import ReportPersonResponsible
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_error import (
-    ErrorContext,
     ReportValidationError,
-    ReportValidationErrorKey,
-    Severity,
 )
 from reporting.service.report_validation.report_validation_tags import ValidationTags
+from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
+    BaseRequiredFieldsValidator,
+)
 from reporting.service.report_validation.validators.required_fields.types import (
     RequiredFieldConfig,
 )
-from reporting.service.report_validation.validators.required_fields.utils import (
-    collect_missing_fields,
-)
-
-from reporting.service.report_validation.validators.required_fields.utils import applies_to_section
 from reporting.service.reporting_flow_service import ReportingFlow
 
 
 TAGS = [ValidationTags.REPORT_VALIDATION]
-SECTION = "person_responsible"
-SECTION_TITLE = "Person responsible"
-REQUIRED_FIELDS: list[RequiredFieldConfig] = [
-    {
-        "field": "first_name",
-        "label": "First name",
-        "field_type": "scalar",
-    },
-    {
-        "field": "last_name",
-        "label": "Last name",
-        "field_type": "scalar",
-    },
-    {
-        "field": "email",
-        "label": "Business email address",
-        "field_type": "scalar",
-    },
-    {
-        "field": "phone_number",
-        "label": "Business telephone number",
-        "field_type": "scalar",
-    },
-    {
-        "field": "street_address",
-        "label": "Business mailing address",
-        "field_type": "scalar",
-    },
-    {
-        "field": "municipality",
-        "label": "Municipality",
-        "field_type": "scalar",
-    },
-    {
-        "field": "province",
-        "label": "Province",
-        "field_type": "scalar",
-    },
-    {
-        "field": "postal_code",
-        "label": "Postal code",
-        "field_type": "scalar",
-    },
-    {
-        "field": "business_role",
-        "label": "Job title / position",
-        "field_type": "scalar",
-    },
-]
+
+
+class RequiredFieldsPersonResponsibleValidator(BaseRequiredFieldsValidator):
+    SECTION: ClassVar[str] = "person_responsible"
+    SECTION_TITLE: ClassVar[str] = "Person responsible"
+
+    REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]] = [
+        {"field": "first_name", "label": "First name", "field_type": "scalar"},
+        {"field": "last_name", "label": "Last name", "field_type": "scalar"},
+        {"field": "email", "label": "Business email address", "field_type": "scalar"},
+        {"field": "phone_number", "label": "Business telephone number", "field_type": "scalar"},
+        {"field": "street_address", "label": "Business mailing address", "field_type": "scalar"},
+        {"field": "municipality", "label": "Municipality", "field_type": "scalar"},
+        {"field": "province", "label": "Province", "field_type": "scalar"},
+        {"field": "postal_code", "label": "Postal code", "field_type": "scalar"},
+        {"field": "business_role", "label": "Job title / position", "field_type": "scalar"},
+    ]
+
+    @classmethod
+    def get_object_to_validate(
+        cls,
+        report_version: ReportVersion,
+    ) -> ReportPersonResponsible:
+        return report_version.report_person_responsible
 
 
 def applies(flow: ReportingFlow) -> bool:
-    return applies_to_section(flow, SECTION)
-
-
-def _build_error(
-    *,
-    report_version_id: int,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return ReportValidationError(
-        severity=Severity.ERROR,
-        message="Required fields are empty.",
-        key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
-        context=ErrorContext(
-            report_version_id=report_version_id,
-            missing_fields=missing_field_labels,
-            section=SECTION,
-            section_title=SECTION_TITLE,
-        ),
-    )
+    return RequiredFieldsPersonResponsibleValidator.applies(flow)
 
 
 def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    try:
-        report_person_responsible: ReportPersonResponsible = report_version.report_person_responsible
-    except ReportPersonResponsible.DoesNotExist:
-        return {
-            f"error_required_fields_{SECTION}": _build_error(
-                report_version_id=report_version.id,
-                missing_field_labels=[item["label"] for item in REQUIRED_FIELDS],
-            )
-        }
-
-    missing_field_labels = collect_missing_fields(
-        report_person_responsible,
-        REQUIRED_FIELDS,
-    )
-
-    if not missing_field_labels:
-        return {}
-
-    return {
-        f"error_required_fields_{SECTION}": _build_error(
-            report_version_id=report_version.id,
-            missing_field_labels=missing_field_labels,
-        )
-    }
+    return RequiredFieldsPersonResponsibleValidator.validate(report_version)

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_production_data.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_production_data.py
@@ -1,183 +1,182 @@
-from uuid import UUID
+from typing import ClassVar
+
 from django.db.models import Count, Prefetch
+from reporting.service.report_product_service import ReportProductService
+
+from registration.models.operation import Operation
 from reporting.models.facility_report import FacilityReport
 from reporting.models.report_product import ReportProduct
 from reporting.models.report_version import ReportVersion
-from registration.models.operation import Operation
 from reporting.service.report_validation.report_validation_error import (
     ReportValidationError,
 )
 from reporting.service.report_validation.report_validation_tags import ValidationTags
+from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
+    BaseRequiredFieldsValidator,
+)
 from reporting.service.report_validation.validators.required_fields.types import (
     RequiredFieldConfig,
 )
 from reporting.service.report_validation.validators.required_fields.utils import (
-    build_required_fields_error,
     collect_missing_fields_many,
 )
-
-from reporting.service.report_validation.validators.required_fields.utils import applies_to_section
 from reporting.service.reporting_flow_service import ReportingFlow
 
-
 TAGS = [ValidationTags.REPORT_VALIDATION]
-SECTION = "production_data"
-SECTION_TITLE = "Production data"
 OPTED_IN_OPERATION = Operation.Purposes.OPTED_IN_OPERATION
-REQUIRED_FIELDS: list[RequiredFieldConfig] = [
-    {
-        "field": "product",
-        "label": "Product",
-        "field_type": "scalar",
-    },
-    {
-        "field": "annual_production",
-        "label": "Annual production",
-        "field_type": "scalar",
-    },
-    {
-        "field": "production_methodology",
-        "label": "Production methodology",
-        "field_type": "scalar",
-    },
-]
+
+
+class RequiredFieldsProductionDataValidator(BaseRequiredFieldsValidator):
+    SECTION: ClassVar[str] = "production_data"
+    SECTION_TITLE: ClassVar[str] = "Production data"
+
+    REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]] = [
+        {"field": "product", "label": "Product", "field_type": "scalar"},
+        {"field": "annual_production", "label": "Annual production", "field_type": "scalar"},
+        {"field": "production_methodology", "label": "Production methodology", "field_type": "scalar"},
+    ]
+
+    @classmethod
+    def requires_jan_mar(cls, report_version: ReportVersion) -> bool:
+        report = report_version.report
+        operation = report.operation
+
+        result = (
+            report.reporting_year_id == 2025
+            and operation.registration_purpose == OPTED_IN_OPERATION
+            and operation.opted_in_operation is not None
+            and operation.opted_in_operation.final_reporting_year_id == 2025
+        )
+
+        print(f"[JAN-MAR CHECK] result={result}")
+        return result
+
+    @classmethod
+    def get_product_missing_fields(
+        cls,
+        *,
+        report_product: ReportProduct,
+        reporting_year_id: int,
+        requires_jan_mar: bool,
+    ) -> list[str]:
+        missing_fields: list[str] = []
+
+        if reporting_year_id == 2024 and report_product.production_data_apr_dec is None:
+            missing_fields.append("Apr-Dec production data")
+
+        if requires_jan_mar and report_product.production_data_jan_mar is None:
+            missing_fields.append("Jan-Mar production data")
+
+        if (
+            report_product.production_methodology == ReportProduct.ProductionMethodologyChoices.OTHER
+            and not report_product.production_methodology_description
+        ):
+            missing_fields.append("Production methodology description")
+
+        return missing_fields
+
+    @classmethod
+    def get_facility_missing_fields(
+        cls,
+        *,
+        queryset: list[ReportProduct],
+        report_version: ReportVersion,
+        requires_jan_mar: bool,
+    ) -> list[str]:
+        missing_field_labels = collect_missing_fields_many(
+            queryset,
+            cls.REQUIRED_FIELDS,
+        )
+
+        for report_product in queryset:
+            print(
+                f"[PRODUCT] id={report_product.id}, "
+                f"annual={report_product.annual_production}, "
+                f"apr_dec={report_product.production_data_apr_dec}, "
+                f"jan_mar={getattr(report_product, 'production_data_jan_mar', None)}"
+            )
+
+            missing_field_labels.extend(
+                cls.get_product_missing_fields(
+                    report_product=report_product,
+                    reporting_year_id=report_version.report.reporting_year_id,
+                    requires_jan_mar=requires_jan_mar,
+                )
+            )
+
+        return sorted(set(missing_field_labels))
+
+    @classmethod
+    def validate(
+        cls,
+        report_version: ReportVersion,
+        flow: ReportingFlow | None = None,
+    ) -> dict[str, ReportValidationError]:
+
+        errors: dict[str, ReportValidationError] = {}
+        allowed_products = ReportProductService.get_allowed_products(report_version.id)
+
+        # Skip if nothing should be reported
+        if not allowed_products:
+            return errors
+
+        requires_jan_mar = cls.requires_jan_mar(report_version)
+
+        facility_reports = (
+            FacilityReport.objects.filter(report_version=report_version)
+            .annotate(product_count=Count("report_products"))
+            .prefetch_related(
+                Prefetch(
+                    "report_products",
+                    queryset=ReportProduct.objects.filter(report_version=report_version),
+                    to_attr="prefetched_report_products",
+                )
+            )
+        )
+
+        for facility_report in facility_reports:
+            error_key = f"error_required_fields_{cls.SECTION}_facility_{facility_report.facility_id}"
+
+            # No ReportProduct rows
+            if facility_report.product_count == 0:
+                missing_fields = [item["label"] for item in cls.REQUIRED_FIELDS]
+
+                if report_version.report.reporting_year_id == 2024:
+                    missing_fields.append("Apr-Dec production data")
+
+                if requires_jan_mar:
+                    missing_fields.append("Jan-Mar production data")
+
+                errors[error_key] = cls.build_error(
+                    report_version_id=report_version.id,
+                    facility_id=facility_report.facility_id,
+                    facility_name=facility_report.facility_name,
+                    missing_field_labels=missing_fields,
+                )
+                continue
+
+            # Validate actual products
+
+            missing_field_labels = cls.get_facility_missing_fields(
+                queryset=facility_report.prefetched_report_products,
+                report_version=report_version,
+                requires_jan_mar=requires_jan_mar,
+            )
+
+            if missing_field_labels:
+                errors[error_key] = cls.build_error(
+                    report_version_id=report_version.id,
+                    facility_id=facility_report.facility_id,
+                    facility_name=facility_report.facility_name,
+                    missing_field_labels=missing_field_labels,
+                )
+
+        return errors
 
 
 def applies(flow: ReportingFlow) -> bool:
-    return applies_to_section(flow, SECTION)
-
-
-def _requires_jan_mar(report_version: ReportVersion) -> bool:
-    report = report_version.report
-    operation = report.operation
-
-    if report.reporting_year_id != 2025:
-        return False
-
-    if operation.registration_purpose != OPTED_IN_OPERATION:
-        return False
-
-    opted_in_operation = operation.opted_in_operation
-    if opted_in_operation is None:
-        return False
-
-    return opted_in_operation.final_reporting_year_id == 2025
-
-
-def _build_error(
-    *,
-    report_version_id: int,
-    facility_id: UUID,
-    facility_name: str,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return build_required_fields_error(
-        report_version_id=report_version_id,
-        facility_id=facility_id,
-        facility_name=facility_name,
-        section=SECTION,
-        section_title=SECTION_TITLE,
-        missing_field_labels=missing_field_labels,
-    )
-
-
-def _build_facility_error(
-    *,
-    report_version: ReportVersion,
-    facility_report: FacilityReport,
-    missing_field_labels: list[str],
-) -> ReportValidationError:
-    return _build_error(
-        report_version_id=report_version.id,
-        facility_id=facility_report.facility_id,
-        facility_name=facility_report.facility_name,
-        missing_field_labels=missing_field_labels,
-    )
-
-
-def _get_product_missing_fields(
-    *,
-    report_product: ReportProduct,
-    reporting_year_id: int,
-    requires_jan_mar: bool,
-) -> list[str]:
-    missing_fields: list[str] = []
-
-    if reporting_year_id == 2024 and report_product.production_data_apr_dec is None:
-        missing_fields.append("Apr-Dec production data")
-
-    if requires_jan_mar and report_product.production_data_jan_mar is None:
-        missing_fields.append("Jan-Mar production data")
-
-    if (
-        report_product.production_methodology == ReportProduct.ProductionMethodologyChoices.OTHER
-        and not report_product.production_methodology_description
-    ):
-        missing_fields.append("Production methodology description")
-
-    return missing_fields
-
-
-def _get_facility_missing_fields(
-    *,
-    queryset: list[ReportProduct],
-    report_version: ReportVersion,
-    requires_jan_mar: bool,
-) -> list[str]:
-    missing_field_labels = collect_missing_fields_many(queryset, REQUIRED_FIELDS)
-
-    for report_product in queryset:
-        missing_field_labels.extend(
-            _get_product_missing_fields(
-                report_product=report_product,
-                reporting_year_id=report_version.report.reporting_year_id,
-                requires_jan_mar=requires_jan_mar,
-            )
-        )
-
-    return sorted(set(missing_field_labels))
+    return RequiredFieldsProductionDataValidator.applies(flow)
 
 
 def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    errors: dict[str, ReportValidationError] = {}
-    requires_jan_mar = _requires_jan_mar(report_version)
-
-    # use Count for existence check
-    # use Prefetch for_related records
-    facility_reports = (
-        FacilityReport.objects.filter(report_version=report_version)
-        .annotate(product_count=Count("report_products"))
-        .prefetch_related(
-            Prefetch(
-                "report_products",
-                queryset=ReportProduct.objects.filter(report_version=report_version),
-                to_attr="prefetched_report_products",
-            )
-        )
-    )
-
-    for facility_report in facility_reports:
-        error_key = f"error_required_fields_{SECTION}_facility_{facility_report.facility_id}"
-
-        if facility_report.product_count == 0:
-            errors[error_key] = _build_facility_error(
-                report_version=report_version,
-                facility_report=facility_report,
-                missing_field_labels=[item["label"] for item in REQUIRED_FIELDS],
-            )
-            continue
-
-        missing_field_labels = _get_facility_missing_fields(
-            queryset=facility_report.prefetched_report_products,
-            report_version=report_version,
-            requires_jan_mar=requires_jan_mar,
-        )
-
-        if missing_field_labels:
-            errors[error_key] = _build_facility_error(
-                report_version=report_version,
-                facility_report=facility_report,
-                missing_field_labels=missing_field_labels,
-            )
-
-    return errors
+    return RequiredFieldsProductionDataValidator.validate(report_version)

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_production_data.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_production_data.py
@@ -47,8 +47,6 @@ class RequiredFieldsProductionDataValidator(BaseRequiredFieldsValidator):
             and operation.opted_in_operation is not None
             and operation.opted_in_operation.final_reporting_year_id == 2025
         )
-
-        print(f"[JAN-MAR CHECK] result={result}")
         return result
 
     @classmethod
@@ -89,13 +87,6 @@ class RequiredFieldsProductionDataValidator(BaseRequiredFieldsValidator):
         )
 
         for report_product in queryset:
-            print(
-                f"[PRODUCT] id={report_product.id}, "
-                f"annual={report_product.annual_production}, "
-                f"apr_dec={report_product.production_data_apr_dec}, "
-                f"jan_mar={getattr(report_product, 'production_data_jan_mar', None)}"
-            )
-
             missing_field_labels.extend(
                 cls.get_product_missing_fields(
                     report_product=report_product,

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_review_facilities.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_review_facilities.py
@@ -1,49 +1,49 @@
+from typing import ClassVar
+
 from reporting.models.facility_report import FacilityReport
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_error import (
-    ErrorContext,
     ReportValidationError,
-    ReportValidationErrorKey,
-    Severity,
 )
 from reporting.service.report_validation.report_validation_tags import (
     ValidationTags,
 )
-
-from reporting.service.report_validation.validators.required_fields.utils import applies_to_section
+from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
+    BaseRequiredFieldsValidator,
+)
 from reporting.service.reporting_flow_service import ReportingFlow
 
 TAGS = [ValidationTags.REPORT_VALIDATION]
-SECTION = "review_facilities"
-SECTION_TITLE = "Review facilities"
+
+
+class RequiredFieldsReviewFacilitiesValidator(BaseRequiredFieldsValidator):
+    SECTION: ClassVar[str] = "review_facilities"
+    SECTION_TITLE: ClassVar[str] = "Review facilities"
+
+    @classmethod
+    def validate(
+        cls,
+        report_version: ReportVersion,
+        flow: ReportingFlow | None = None,
+    ) -> dict[str, ReportValidationError]:
+        has_selected_facilities = FacilityReport.objects.filter(
+            report_version=report_version,
+        ).exists()
+
+        if has_selected_facilities:
+            return {}
+
+        return {
+            f"error_required_fields_{cls.SECTION}": cls.build_error(
+                report_version_id=report_version.id,
+                missing_field_labels=["Facilities"],
+            )
+        }
 
 
 def applies(flow: ReportingFlow) -> bool:
-    return applies_to_section(flow, SECTION)
-
-
-def _build_error(*, report_version_id: int) -> ReportValidationError:
-    return ReportValidationError(
-        severity=Severity.ERROR,
-        message="No facilities selected.",
-        key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
-        context=ErrorContext(
-            report_version_id=report_version_id,
-            missing_fields=["Facilities"],
-            section=SECTION,
-            section_title=SECTION_TITLE,
-        ),
-    )
+    return RequiredFieldsReviewFacilitiesValidator.applies(flow)
 
 
 def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    has_selected_facilities = FacilityReport.objects.filter(report_version=report_version).exists()
-
-    if has_selected_facilities:
-        return {}
-
-    return {
-        f"error_required_fields_{SECTION}": _build_error(
-            report_version_id=report_version.id,
-        )
-    }
+    return RequiredFieldsReviewFacilitiesValidator.validate(report_version)

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_review_facility_information.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_review_facility_information.py
@@ -1,3 +1,6 @@
+from typing import ClassVar
+from uuid import UUID
+
 from reporting.models.facility_report import FacilityReport
 from reporting.models.report_version import ReportVersion
 from reporting.service.report_validation.report_validation_error import (
@@ -9,40 +12,24 @@ from reporting.service.report_validation.report_validation_error import (
 from reporting.service.report_validation.report_validation_tags import (
     ValidationTags,
 )
+from reporting.service.report_validation.validators.required_fields.base_required_fields_validator import (
+    BaseRequiredFieldsValidator,
+)
 from reporting.service.report_validation.validators.required_fields.types import (
     RequiredFieldConfig,
 )
 from reporting.service.report_validation.validators.required_fields.utils import (
     collect_missing_fields_many,
-    applies_to_section,
 )
-from reporting.service.reporting_flow_service import resolve_flow, ReportingFlow
+from reporting.service.reporting_flow_service import (
+    ReportingFlow,
+    resolve_flow,
+)
 
 TAGS = [ValidationTags.REPORT_VALIDATION]
 
-SECTION = "review_facility_information"
-SECTION_TITLE = "Review facility"
-
 REVIEW_FACILITIES_SECTION = "review_facility_report_information"
 REVIEW_FACILITIES_SECTION_TITLE = "Report Information"
-
-REQUIRED_FIELDS: list[RequiredFieldConfig] = [
-    {
-        "field": "facility_name",
-        "label": "Facility name",
-        "field_type": "scalar",
-    },
-    {
-        "field": "facility_type",
-        "label": "Facility type",
-        "field_type": "scalar",
-    },
-    {
-        "field": "activities",
-        "label": "Activities",
-        "field_type": "m2m",
-    },
-]
 
 LFO_COMPLETION_REQUIRED_FLOWS = {
     ReportingFlow.LFO,
@@ -51,65 +38,107 @@ LFO_COMPLETION_REQUIRED_FLOWS = {
 }
 
 
-def applies(flow: ReportingFlow) -> bool:
-    return applies_to_section(flow, SECTION)
+class RequiredFieldsReviewFacilityInformationValidator(BaseRequiredFieldsValidator):
+    SECTION: ClassVar[str] = "review_facility_information"
+    SECTION_TITLE: ClassVar[str] = "Review facility"
 
+    REQUIRED_FIELDS: ClassVar[list[RequiredFieldConfig]] = [
+        {
+            "field": "facility_name",
+            "label": "Facility name",
+            "field_type": "scalar",
+        },
+        {
+            "field": "facility_type",
+            "label": "Facility type",
+            "field_type": "scalar",
+        },
+        {
+            "field": "activities",
+            "label": "Activities",
+            "field_type": "m2m",
+        },
+    ]
 
-def _build_error(
-    *,
-    report_version_id: int,
-    missing_field_labels: list[str],
-    section: str = SECTION,
-    section_title: str = SECTION_TITLE,
-) -> ReportValidationError:
-    return ReportValidationError(
-        severity=Severity.ERROR,
-        message="Required fields are empty.",
-        key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
-        context=ErrorContext(
-            report_version_id=report_version_id,
-            missing_fields=missing_field_labels,
-            section=section,
-            section_title=section_title,
-        ),
-    )
-
-
-def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
-    errors: dict[str, ReportValidationError] = {}
-
-    facility_reports = list(FacilityReport.objects.filter(report_version=report_version))
-
-    if not facility_reports:
-        return {
-            f"error_required_fields_{SECTION}": _build_error(
-                report_version_id=report_version.id,
-                missing_field_labels=[item["label"] for item in REQUIRED_FIELDS],
-            )
-        }
-
-    missing_field_labels = collect_missing_fields_many(
-        facility_reports,
-        REQUIRED_FIELDS,
-    )
-
-    if missing_field_labels:
-        errors[f"error_required_fields_{SECTION}"] = _build_error(
-            report_version_id=report_version.id,
-            missing_field_labels=sorted(set(missing_field_labels)),
+    @classmethod
+    def build_error(
+        cls,
+        *,
+        report_version_id: int,
+        missing_field_labels: list[str],
+        facility_id: UUID | None = None,
+        facility_name: str | None = None,
+        section: str | None = None,
+        section_title: str | None = None,
+    ) -> ReportValidationError:
+        return ReportValidationError(
+            severity=Severity.ERROR,
+            message="Required fields are empty.",
+            key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
+            context=ErrorContext(
+                report_version_id=report_version_id,
+                facility_id=facility_id,
+                facility_name=facility_name,
+                missing_fields=missing_field_labels,
+                section=section or cls.SECTION,
+                section_title=section_title or cls.SECTION_TITLE,
+            ),
         )
 
-    flow = resolve_flow(report_version)
+    @classmethod
+    def validate(
+        cls,
+        report_version: ReportVersion,
+        flow: ReportingFlow | None = None,
+    ) -> dict[str, ReportValidationError]:
+        errors: dict[str, ReportValidationError] = {}
 
-    if flow in LFO_COMPLETION_REQUIRED_FLOWS:
-        has_incomplete_facility = any(not facility_report.is_completed for facility_report in facility_reports)
+        facility_reports = list(
+            FacilityReport.objects.filter(
+                report_version=report_version,
+            )
+        )
 
-        if has_incomplete_facility:
-            errors[f"error_required_fields_{REVIEW_FACILITIES_SECTION}"] = _build_error(
+        if not facility_reports:
+            return {
+                f"error_required_fields_{cls.SECTION}": cls.build_error(
+                    report_version_id=report_version.id,
+                    missing_field_labels=[item["label"] for item in cls.REQUIRED_FIELDS],
+                )
+            }
+
+        missing_field_labels = collect_missing_fields_many(
+            facility_reports,
+            cls.REQUIRED_FIELDS,
+        )
+
+        if missing_field_labels:
+            errors[f"error_required_fields_{cls.SECTION}"] = cls.build_error(
                 report_version_id=report_version.id,
-                missing_field_labels=["All facilities must be marked complete"],
-                section=REVIEW_FACILITIES_SECTION,
-                section_title=REVIEW_FACILITIES_SECTION_TITLE,
+                missing_field_labels=sorted(set(missing_field_labels)),
             )
 
-    return errors
+        resolved_flow = flow or resolve_flow(report_version)
+
+        if resolved_flow in LFO_COMPLETION_REQUIRED_FLOWS:
+            has_incomplete_facility = any(not facility_report.is_completed for facility_report in facility_reports)
+
+            if has_incomplete_facility:
+                errors[f"error_required_fields_{REVIEW_FACILITIES_SECTION}"] = cls.build_error(
+                    report_version_id=report_version.id,
+                    missing_field_labels=["All facilities must be marked complete"],
+                    section=REVIEW_FACILITIES_SECTION,
+                    section_title=REVIEW_FACILITIES_SECTION_TITLE,
+                )
+
+        return errors
+
+
+def applies(flow: ReportingFlow) -> bool:
+    return RequiredFieldsReviewFacilityInformationValidator.applies(flow)
+
+
+def validate(
+    report_version: ReportVersion,
+) -> dict[str, ReportValidationError]:
+    return RequiredFieldsReviewFacilityInformationValidator.validate(report_version)

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/utils.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/utils.py
@@ -1,12 +1,5 @@
 from typing import Any, Iterable
-from uuid import UUID
 
-from reporting.service.report_validation.report_validation_error import (
-    ErrorContext,
-    ReportValidationError,
-    ReportValidationErrorKey,
-    Severity,
-)
 from reporting.service.report_validation.validators.required_fields.types import (
     RequiredFieldConfig,
 )
@@ -66,27 +59,3 @@ def collect_missing_fields_many(
                 missing.add(item["label"])
 
     return sorted(missing)
-
-
-def build_required_fields_error(
-    *,
-    report_version_id: int,
-    section: str,
-    section_title: str,
-    missing_field_labels: list[str],
-    facility_id: UUID | None = None,
-    facility_name: str | None = None,
-) -> ReportValidationError:
-    return ReportValidationError(
-        severity=Severity.ERROR,
-        message="Required fields are empty.",
-        key=ReportValidationErrorKey.ERROR_REQUIRED_FIELDS,
-        context=ErrorContext(
-            report_version_id=report_version_id,
-            facility_id=facility_id,
-            facility_name=facility_name,
-            missing_fields=missing_field_labels,
-            section=section,
-            section_title=section_title,
-        ),
-    )

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_activity_data.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_activity_data.py
@@ -6,14 +6,16 @@ from reporting.service.report_validation.report_validation_error import (
     Severity,
 )
 from reporting.service.report_validation.validators.required_fields.required_fields_report_activity_data import (
-    SECTION,
+    RequiredFieldsActivityDataValidator,
     applies,
     validate,
 )
-
 from reporting.service.reporting_flow_service import ReportingFlow
 
 pytestmark = pytest.mark.django_db
+
+SECTION = RequiredFieldsActivityDataValidator.SECTION
+SECTION_TITLE = RequiredFieldsActivityDataValidator.SECTION_TITLE
 
 BASE_PATH = "reporting.service.report_validation.validators.required_fields.required_fields_report_activity_data"
 APPLIES_TO_SECTION_PATH = f"{BASE_PATH}.applies_to_section"
@@ -48,7 +50,7 @@ class TestRequiredFieldsActivityDataValidator:
         assert error.context.facility_id == self.facility_report.facility_id
         assert error.context.facility_name == self.facility_report.facility_name
         assert error.context.section == SECTION
-        assert error.context.section_title == "Activity data"
+        assert error.context.section_title == SECTION_TITLE
         assert error.context.missing_fields == ["Activity data"]
 
     def test_validate_returns_no_error_when_facility_has_activity_data(self):

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_additional_data.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_additional_data.py
@@ -8,8 +8,7 @@ from reporting.service.report_validation.report_validation_error import (
     Severity,
 )
 from reporting.service.report_validation.validators.required_fields.required_fields_report_additional_data import (
-    SECTION,
-    SECTION_TITLE,
+    RequiredFieldsAdditionalReportingDataValidator,
     applies,
     validate,
 )
@@ -17,6 +16,9 @@ from reporting.service.reporting_flow_service import ReportingFlow
 
 
 pytestmark = pytest.mark.django_db
+
+SECTION = RequiredFieldsAdditionalReportingDataValidator.SECTION
+SECTION_TITLE = RequiredFieldsAdditionalReportingDataValidator.SECTION_TITLE
 
 BASE_PATH = "reporting.service.report_validation.validators.required_fields.required_fields_report_additional_data"
 APPLIES_TO_SECTION_PATH = f"{BASE_PATH}.applies_to_section"
@@ -90,9 +92,7 @@ class TestRequiredFieldsReportAdditionalDataValidator:
 
         assert result == {}
 
-    def test_validate_returns_empty_dict_when_capture_emissions_fields_are_present(
-        self,
-    ):
+    def test_validate_returns_empty_dict_when_capture_emissions_fields_are_present(self):
         baker.make_recipe(
             "reporting.tests.utils.report_additional_data",
             report_version=self.report_version,

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_electricity_import_data.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_electricity_import_data.py
@@ -8,15 +8,16 @@ from reporting.service.report_validation.report_validation_error import (
     Severity,
 )
 from reporting.service.report_validation.validators.required_fields.required_fields_report_electricity_import_data import (
-    SECTION,
-    SECTION_TITLE,
+    RequiredFieldsElectricityImportDataValidator,
     applies,
     validate,
 )
-
 from reporting.service.reporting_flow_service import ReportingFlow
 
 pytestmark = pytest.mark.django_db
+
+SECTION = RequiredFieldsElectricityImportDataValidator.SECTION
+SECTION_TITLE = RequiredFieldsElectricityImportDataValidator.SECTION_TITLE
 
 BASE_PATH = (
     "reporting.service.report_validation.validators.required_fields.required_fields_report_electricity_import_data"

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_emission_allocation.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_emission_allocation.py
@@ -9,8 +9,7 @@ from reporting.service.report_validation.report_validation_error import (
     Severity,
 )
 from reporting.service.report_validation.validators.required_fields.required_fields_report_emission_allocation import (
-    SECTION,
-    SECTION_TITLE,
+    RequiredFieldsAllocationOfEmissionsValidator,
     applies,
     validate,
 )
@@ -18,6 +17,9 @@ from reporting.service.reporting_flow_service import ReportingFlow
 
 
 pytestmark = pytest.mark.django_db
+
+SECTION = RequiredFieldsAllocationOfEmissionsValidator.SECTION
+SECTION_TITLE = RequiredFieldsAllocationOfEmissionsValidator.SECTION_TITLE
 
 BASE_PATH = "reporting.service.report_validation.validators.required_fields.required_fields_report_emission_allocation"
 APPLIES_TO_SECTION_PATH = f"{BASE_PATH}.applies_to_section"

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_new_entrant_information.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_new_entrant_information.py
@@ -8,8 +8,7 @@ from reporting.service.report_validation.report_validation_error import (
     Severity,
 )
 from reporting.service.report_validation.validators.required_fields.required_fields_report_new_entrant_information import (
-    SECTION,
-    SECTION_TITLE,
+    RequiredFieldsNewEntrantInformationValidator,
     applies,
     validate,
 )
@@ -17,6 +16,9 @@ from reporting.service.reporting_flow_service import ReportingFlow
 
 
 pytestmark = pytest.mark.django_db
+
+SECTION = RequiredFieldsNewEntrantInformationValidator.SECTION
+SECTION_TITLE = RequiredFieldsNewEntrantInformationValidator.SECTION_TITLE
 
 BASE_PATH = (
     "reporting.service.report_validation.validators.required_fields.required_fields_report_new_entrant_information"

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_non_attributable_emissions.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_non_attributable_emissions.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 from model_bakery import baker
 
@@ -10,18 +8,16 @@ from reporting.service.report_validation.report_validation_error import (
     Severity,
 )
 from reporting.service.report_validation.validators.required_fields.required_fields_report_non_attributable_emissions import (
-    SECTION,
-    SECTION_TITLE,
+    RequiredFieldsNonAttributableEmissionsValidator,
     applies,
     validate,
 )
+from reporting.service.reporting_flow_service import ReportingFlow
 
 pytestmark = pytest.mark.django_db
 
-BASE_PATH = (
-    "reporting.service.report_validation.validators.required_fields.required_fields_report_non_attributable_emissions"
-)
-APPLIES_TO_SECTION_PATH = f"{BASE_PATH}.applies_to_section"
+SECTION = RequiredFieldsNonAttributableEmissionsValidator.SECTION
+SECTION_TITLE = RequiredFieldsNonAttributableEmissionsValidator.SECTION_TITLE
 
 
 class TestRequiredFieldsReportNonAttributableEmissionsValidator:
@@ -35,18 +31,10 @@ class TestRequiredFieldsReportNonAttributableEmissionsValidator:
         self.error_key = f"error_required_fields_{SECTION}_facility_{self.facility_report.facility_id}"
 
     def test_applies_returns_true_when_flow_is_applicable(self):
-        with patch(APPLIES_TO_SECTION_PATH, return_value=True) as mock_applies:
-            result = applies(self.report_version)
-
-        assert result is True
-        mock_applies.assert_called_once_with(self.report_version, SECTION)
+        assert applies(ReportingFlow.SFO) is True
 
     def test_applies_returns_false_when_flow_is_not_applicable(self):
-        with patch(APPLIES_TO_SECTION_PATH, return_value=False) as mock_applies:
-            result = applies(self.report_version)
-
-        assert result is False
-        mock_applies.assert_called_once_with(self.report_version, SECTION)
+        assert applies(ReportingFlow.EIO) is False
 
     def test_validate_returns_empty_dict_when_facility_has_no_non_attributable_emissions(self):
         result = validate(self.report_version)

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_operation_information.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_operation_information.py
@@ -1,5 +1,6 @@
 import pytest
 from model_bakery import baker
+from unittest.mock import patch
 
 from reporting.service.report_validation.report_validation_error import (
     ErrorContext,
@@ -8,8 +9,7 @@ from reporting.service.report_validation.report_validation_error import (
     Severity,
 )
 from reporting.service.report_validation.validators.required_fields.required_fields_report_operation_information import (
-    SECTION,
-    SECTION_TITLE,
+    RequiredFieldsReportOperationInformationValidator,
     applies,
     validate,
 )
@@ -21,7 +21,10 @@ pytestmark = pytest.mark.django_db
 BASE_PATH = (
     "reporting.service.report_validation.validators.required_fields.required_fields_report_operation_information"
 )
-APPLIES_TO_SECTION_PATH = f"{BASE_PATH}.applies_to_section"
+RESOLVE_FLOW_PATH = f"{BASE_PATH}.resolve_flow"
+
+SECTION = RequiredFieldsReportOperationInformationValidator.SECTION
+SECTION_TITLE = RequiredFieldsReportOperationInformationValidator.SECTION_TITLE
 
 
 class TestRequiredFieldsReportOperationInformationValidator:
@@ -33,7 +36,8 @@ class TestRequiredFieldsReportOperationInformationValidator:
         assert applies(ReportingFlow.SFO) is True
 
     def test_validate_returns_error_when_report_operation_does_not_exist(self):
-        result = validate(self.report_version)
+        with patch(RESOLVE_FLOW_PATH, return_value=ReportingFlow.SFO):
+            result = validate(self.report_version)
 
         assert self.error_key in result
 
@@ -55,6 +59,20 @@ class TestRequiredFieldsReportOperationInformationValidator:
             "Operation representative name",
         ]
 
+    def test_validate_returns_error_when_report_operation_does_not_exist_for_eio(self):
+        with patch(RESOLVE_FLOW_PATH, return_value=ReportingFlow.EIO):
+            result = validate(self.report_version)
+
+        assert self.error_key in result
+
+        error = result[self.error_key]
+
+        assert error.context.missing_fields == [
+            "Operation name",
+            "Operator legal name",
+            "Operation representative name",
+        ]
+
     def test_validate_returns_empty_dict_when_required_fields_are_present(self):
         report_operation = baker.make_recipe(
             "reporting.tests.utils.report_operation",
@@ -73,6 +91,7 @@ class TestRequiredFieldsReportOperationInformationValidator:
             selected_for_report=True,
         )
 
-        result = validate(self.report_version)
+        with patch(RESOLVE_FLOW_PATH, return_value=ReportingFlow.SFO):
+            result = validate(self.report_version)
 
         assert result == {}

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_person_responsible.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_person_responsible.py
@@ -8,8 +8,7 @@ from reporting.service.report_validation.report_validation_error import (
     Severity,
 )
 from reporting.service.report_validation.validators.required_fields.required_fields_report_person_responsible import (
-    SECTION,
-    SECTION_TITLE,
+    RequiredFieldsPersonResponsibleValidator,
     applies,
     validate,
 )
@@ -17,6 +16,9 @@ from reporting.service.reporting_flow_service import ReportingFlow
 
 
 pytestmark = pytest.mark.django_db
+
+SECTION = RequiredFieldsPersonResponsibleValidator.SECTION
+SECTION_TITLE = RequiredFieldsPersonResponsibleValidator.SECTION_TITLE
 
 BASE_PATH = "reporting.service.report_validation.validators.required_fields.required_fields_report_person_responsible"
 APPLIES_TO_SECTION_PATH = f"{BASE_PATH}.applies_to_section"

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_production_data.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_production_data.py
@@ -1,5 +1,6 @@
 import pytest
 from model_bakery import baker
+from unittest.mock import patch
 
 from reporting.service.report_validation.report_validation_error import (
     ErrorContext,
@@ -8,8 +9,7 @@ from reporting.service.report_validation.report_validation_error import (
     Severity,
 )
 from reporting.service.report_validation.validators.required_fields.required_fields_report_production_data import (
-    SECTION,
-    SECTION_TITLE,
+    RequiredFieldsProductionDataValidator,
     applies,
     validate,
 )
@@ -18,8 +18,11 @@ from reporting.service.reporting_flow_service import ReportingFlow
 
 pytestmark = pytest.mark.django_db
 
+SECTION = RequiredFieldsProductionDataValidator.SECTION
+SECTION_TITLE = RequiredFieldsProductionDataValidator.SECTION_TITLE
+
 BASE_PATH = "reporting.service.report_validation.validators.required_fields.required_fields_report_production_data"
-APPLIES_TO_SECTION_PATH = f"{BASE_PATH}.applies_to_section"
+GET_ALLOWED_PRODUCTS_PATH = f"{BASE_PATH}.ReportProductService.get_allowed_products"
 
 
 class TestRequiredFieldsReportProductionDataValidator:
@@ -38,7 +41,10 @@ class TestRequiredFieldsReportProductionDataValidator:
     def test_applies_returns_false_for_non_applicable_flow(self):
         assert applies(ReportingFlow.EIO) is False
 
-    def test_validate_returns_error_when_facility_has_no_products(self):
+    @patch(GET_ALLOWED_PRODUCTS_PATH)
+    def test_validate_returns_error_when_facility_has_no_products(self, mock_allowed_products):
+        mock_allowed_products.return_value = [baker.make_recipe("reporting.tests.utils.regulated_product")]
+
         result = validate(self.report_version)
 
         assert self.error_key in result
@@ -61,14 +67,27 @@ class TestRequiredFieldsReportProductionDataValidator:
             "Production methodology",
         ]
 
-    def test_validate_returns_empty_dict_when_required_fields_are_present(self):
+    @patch(GET_ALLOWED_PRODUCTS_PATH)
+    def test_validate_returns_empty_dict_when_required_fields_are_present(self, mock_allowed_products):
+        product = baker.make_recipe("reporting.tests.utils.regulated_product")
+        mock_allowed_products.return_value = [product]
+
         baker.make_recipe(
             "reporting.tests.utils.report_product",
             report_version=self.report_version,
             facility_report=self.facility_report,
+            product=product,
             annual_production=100,
             production_data_apr_dec=50,
         )
+
+        result = validate(self.report_version)
+
+        assert result == {}
+
+    @patch(GET_ALLOWED_PRODUCTS_PATH)
+    def test_validate_skips_when_no_allowed_products(self, mock_allowed_products):
+        mock_allowed_products.return_value = []
 
         result = validate(self.report_version)
 

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_review_facilities.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_review_facilities.py
@@ -8,8 +8,7 @@ from reporting.service.report_validation.report_validation_error import (
     Severity,
 )
 from reporting.service.report_validation.validators.required_fields.required_fields_report_review_facilities import (
-    SECTION,
-    SECTION_TITLE,
+    RequiredFieldsReviewFacilitiesValidator,
     applies,
     validate,
 )
@@ -17,6 +16,9 @@ from reporting.service.reporting_flow_service import ReportingFlow
 
 
 pytestmark = pytest.mark.django_db
+
+SECTION = RequiredFieldsReviewFacilitiesValidator.SECTION
+SECTION_TITLE = RequiredFieldsReviewFacilitiesValidator.SECTION_TITLE
 
 BASE_PATH = "reporting.service.report_validation.validators.required_fields.required_fields_report_review_facilities"
 APPLIES_TO_SECTION_PATH = f"{BASE_PATH}.applies_to_section"

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_review_facility_information.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_review_facility_information.py
@@ -13,8 +13,7 @@ from reporting.service.reporting_flow_service import ReportingFlow
 from reporting.service.report_validation.validators.required_fields.required_fields_report_review_facility_information import (
     REVIEW_FACILITIES_SECTION,
     REVIEW_FACILITIES_SECTION_TITLE,
-    SECTION,
-    SECTION_TITLE,
+    RequiredFieldsReviewFacilityInformationValidator,
     applies,
     validate,
 )
@@ -22,12 +21,14 @@ from reporting.service.report_validation.validators.required_fields.required_fie
 
 pytestmark = pytest.mark.django_db
 
+SECTION = RequiredFieldsReviewFacilityInformationValidator.SECTION
+SECTION_TITLE = RequiredFieldsReviewFacilityInformationValidator.SECTION_TITLE
+
 BASE_PATH = (
     "reporting.service.report_validation.validators.required_fields."
     "required_fields_report_review_facility_information"
 )
 
-APPLIES_TO_SECTION_PATH = f"{BASE_PATH}.applies_to_section"
 RESOLVE_FLOW_PATH = f"{BASE_PATH}.resolve_flow"
 
 
@@ -99,9 +100,7 @@ class TestRequiredFieldsReportReviewFacilityInformationValidator:
             ]
         )
 
-    def test_validate_returns_review_facilities_error_when_lfo_facility_is_not_completed(
-        self,
-    ):
+    def test_validate_returns_review_facilities_error_when_lfo_facility_is_not_completed(self):
         facility_report = baker.make_recipe(
             "reporting.tests.utils.facility_report",
             report_version=self.report_version,
@@ -129,9 +128,7 @@ class TestRequiredFieldsReportReviewFacilityInformationValidator:
         assert error.context.section_title == REVIEW_FACILITIES_SECTION_TITLE
         assert error.context.missing_fields == ["All facilities must be marked complete"]
 
-    def test_validate_returns_both_errors_when_required_fields_are_missing_and_lfo_facility_is_not_completed(
-        self,
-    ):
+    def test_validate_returns_both_errors_when_required_fields_are_missing_and_lfo_facility_is_not_completed(self):
         facility_report = baker.make_recipe(
             "reporting.tests.utils.facility_report",
             report_version=self.report_version,

--- a/bc_obps/reporting/tests/service/report_validation/validators/test_report_data_by_fuel_type_validator.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/test_report_data_by_fuel_type_validator.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from django.test import TestCase
 from model_bakery.baker import make_recipe, make
 import pytest
@@ -20,6 +21,9 @@ from reporting.service.report_validation.validators.report_data_by_fuel_type_val
     validate,
 )
 from reporting.tests.service.test_report_activity_save_service.infrastructure import TestInfrastructure
+
+BASE_PATH = "reporting.service.report_validation.validators.report_data_by_fuel_type_validator"
+GET_REPORTING_FIELD_DISPLAY_NAME_PATH = f"{BASE_PATH}.get_reporting_field_display_name"
 
 
 @pytest.mark.django_db
@@ -79,7 +83,9 @@ class TestReportDataByFueltypeValidator(TestCase):
         result = validate(self.test_infrastructure.report_version)
         assert result == {}
 
-    def test_errors_when_fuel_amount_above_expected_bound(self):
+    @patch(GET_REPORTING_FIELD_DISPLAY_NAME_PATH)
+    def test_errors_when_fuel_amount_above_expected_bound(self, mock_reporting_field_display_name):
+        mock_reporting_field_display_name.return_value = "Annual Fuel Amount"
         ReportFuel.objects.update(json_data={"annualFuelAmount": 15000})
         report_fuel = ReportFuel.objects.first()
         result = validate(self.test_infrastructure.report_version)
@@ -97,11 +103,16 @@ class TestReportDataByFueltypeValidator(TestCase):
                     source_type_id=report_fuel.report_source_type.source_type_id,
                     source_type_name=report_fuel.report_source_type.source_type.name,
                     fuel_type_name=report_fuel.fuel_type.name,
+                    reporting_field="Annual Fuel Amount",
+                    expected_range="0.00 - 5000.00",
+                    user_input=str(report_fuel.json_data["annualFuelAmount"]),
                 ),
             )
         }
 
-    def test_errors_when_fuel_amount_below_expected_bound(self):
+    @patch(GET_REPORTING_FIELD_DISPLAY_NAME_PATH)
+    def test_errors_when_fuel_amount_below_expected_bound(self, mock_reporting_field_display_name):
+        mock_reporting_field_display_name.return_value = "Annual Fuel Amount"
         ReportFuel.objects.update(json_data={"annualFuelAmount": -15000})
         report_fuel = ReportFuel.objects.first()
         result = validate(self.test_infrastructure.report_version)
@@ -119,6 +130,9 @@ class TestReportDataByFueltypeValidator(TestCase):
                     source_type_id=report_fuel.report_source_type.source_type_id,
                     source_type_name=report_fuel.report_source_type.source_type.name,
                     fuel_type_name=report_fuel.fuel_type.name,
+                    reporting_field="Annual Fuel Amount",
+                    expected_range="0.00 - 5000.00",
+                    user_input=str(report_fuel.json_data["annualFuelAmount"]),
                 ),
             )
         }
@@ -146,6 +160,8 @@ class TestReportDataByFueltypeValidator(TestCase):
                     gas_type_name=report_methodology.report_emission.gas_type.chemical_formula,
                     methodology_name=report_methodology.methodology.name,
                     reporting_field=ReportingField.objects.get(slug='unitFuelCo2DefaultEf').field_display_title,
+                    expected_range="1000.0000 - 5000.0000",
+                    user_input=str(report_methodology.json_data["unitFuelCo2DefaultEf"]),
                 ),
             )
         }
@@ -173,6 +189,8 @@ class TestReportDataByFueltypeValidator(TestCase):
                     gas_type_name=report_methodology.report_emission.gas_type.chemical_formula,
                     methodology_name=report_methodology.methodology.name,
                     reporting_field=ReportingField.objects.get(slug='unitFuelCo2DefaultEf').field_display_title,
+                    expected_range="1000.0000 - 5000.0000",
+                    user_input=str(report_methodology.json_data["unitFuelCo2DefaultEf"]),
                 ),
             )
         }

--- a/bciers/apps/reporting/src/app/components/shared/validation/config.ts
+++ b/bciers/apps/reporting/src/app/components/shared/validation/config.ts
@@ -142,7 +142,7 @@ export const validationUIConfig: Partial<
       const ctx = error.context;
 
       return `Unusual value detected for ${String(ctx?.facility_name ?? "facility")} ${label}.
-Expected ${String(ctx?.fuel_type_name ?? "fuel")} ${label} value to be between ${String(ctx?.expected_range ?? "the allowed range")} but input was ${String(ctx?.user_input ?? "the provided value")}.
+Expected ${String(ctx?.fuel_type_name ?? "fuel")} ${String(ctx?.reporting_field ?? "field")} value to be between ${String(ctx?.expected_range ?? "the allowed range")} but input was ${String(ctx?.user_input ?? "the provided value")}.
 Please ensure you have selected the correct fuel name and the value is accurate.
 If the value is accurate, you may save & continue.`;
     },
@@ -162,12 +162,12 @@ If the value is accurate, you may save & continue.`;
           )
         : undefined,
 
-    formatMessage: ({ error }) => {
+    formatMessage: ({ label, error }) => {
       const ctx = error.context;
 
-      return `Unusual value detected for ${String(ctx?.facility_name ?? "facility")} ${String(ctx?.activity_name ?? "activity")}.
+      return `Unusual value detected for ${String(ctx?.facility_name ?? "facility")} ${label}.
 Expected ${String(ctx?.gas_type_name ?? "gas")} ${String(ctx?.reporting_field ?? "field")} value to be between ${String(ctx?.expected_range ?? "the allowed range")} but input was ${String(ctx?.user_input ?? "the provided value")}.
-Please ensure you have selected the correct value and the entry is accurate.
+Please ensure the value entered is accurate.
 If the value is accurate, you may save & continue.`;
     },
   }),

--- a/bciers/apps/reporting/src/app/components/shared/validation/config.ts
+++ b/bciers/apps/reporting/src/app/components/shared/validation/config.ts
@@ -141,11 +141,10 @@ export const validationUIConfig: Partial<
     formatMessage: ({ label, error }) => {
       const ctx = error.context;
 
-      return `Unusual value detected for fuel type for ${String(ctx?.facility_name ?? "facility")} in ${label}.
-Expected ${String(ctx?.fuel_type_name ?? "fuel")} value to be within the allowed range,
-but the input appears outside expected bounds.
-Please ensure you have selected the correct fuel type and entered an accurate value.
-If the value is correct, you may save & continue.`;
+      return `Unusual value detected for ${String(ctx?.facility_name ?? "facility")} ${label}.
+Expected ${String(ctx?.fuel_type_name ?? "fuel")} ${label} value to be between ${String(ctx?.expected_range ?? "the allowed range")} but input was ${String(ctx?.user_input ?? "the provided value")}.
+Please ensure you have selected the correct fuel name and the value is accurate.
+If the value is accurate, you may save & continue.`;
     },
   }),
 
@@ -166,11 +165,10 @@ If the value is correct, you may save & continue.`;
     formatMessage: ({ error }) => {
       const ctx = error.context;
 
-      return `Unusual value detected for reporting field for ${ctx?.facility_name ?? "facility"} ${ctx?.activity_name ?? "activity"}.
-Expected ${ctx?.reporting_field ?? "field"} value for ${ctx?.gas_type_name ?? "gas"} to be within the allowed range,
-but the input appears outside expected bounds.
-Please ensure the value entered is accurate.
-If the value is correct, you may save & continue.`;
+      return `Unusual value detected for ${String(ctx?.facility_name ?? "facility")} ${String(ctx?.activity_name ?? "activity")}.
+Expected ${String(ctx?.gas_type_name ?? "gas")} ${String(ctx?.reporting_field ?? "field")} value to be between ${String(ctx?.expected_range ?? "the allowed range")} but input was ${String(ctx?.user_input ?? "the provided value")}.
+Please ensure you have selected the correct value and the entry is accurate.
+If the value is accurate, you may save & continue.`;
     },
   }),
 


### PR DESCRIPTION

resolves errors in 995 https://github.com/bcgov/cas-reporting/issues/995#issuecomment-4374644335

####  
1. `required_fields_report_operation_information.py` 
   - when EIO operation
      **Expected:**
      Error message should not include `regulated products` and `reporting activities`

2. `required_fields_report_production_data.py` 
   - when RY 2024
      **Expected:**
     Error message should include Apr–Dec production data field.
   - when RY 2025, Opted-in with final year 2025 
      **Expected:**
      Error message should include Jan–Mar production data field.
   - when Unregulated products
      **Expected:**
      Error message should not be shown

3. `report_data_by_fuel_type_validator.py`
      **Expected:**
      Message reflects template:
```
Unusual value detected for [facility name] [activity name]. Expected [fuel name] [field] value to be between [range] but input was [user input]. Please ensure you have selected the correct fuel name and the value is accurate. If the value is accurate, you may save & continue. -
```


### 🚀 Impact
- Fixed operation information required fields when EIO

- Updated production data validator to include time-based requirements, Apr - Dec; Jan - Mar, when facility has zero ReportProduct records
- Fixed  production data validator when products are non-regulated

- Updated fuel type validator to include context for user message

- Added `BaseRequiredFieldsValidator`
- Updated required field validators to use `BaseRequiredFieldsValidator`
- Updated required field validators tests
---

### 🔬 Local Testing:  

#### Start Test Environment
1. Start the API server:  
   ```sh
   cd bc_obps
   make prepare_backend
   ```  
2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

---

#### Test: operation information validation when EIO

1. Log in using `bc-cas-dev`
2. Navigate to reporting
5. Start report for `Bojangles EIO - Registered - name from admin`
6. Navigate to `report-validation`
7. Validate the validation error messages
**Expected Results**
-  Operation information validation alert does display
<img width="1525" height="868" alt="image" src="https://github.com/user-attachments/assets/2e9482f0-3730-4d33-a653-b810376b0925" />


####  Test: operation information validation when missing operation representative
1. Complete `Test: EIO operation information validation` 
2. Update table to remove operation representative name
```
UPDATE erc.report_operation_representative
SET report_version_id=5
WHERE report_version_id=15;
```
3. Navigate to report http://localhost:3000/reporting/reports/15/review-operation-information
**Expected Results**
-  Operation representative is empty
<img width="1577" height="909" alt="image" src="https://github.com/user-attachments/assets/36fc23b5-4b84-4d4a-b256-e343b3404f25" />

4. Navigate to report http://localhost:3000/reporting/reports/15/report-validation
**Expected Results**
-  Operation information validation alert does display for Operation representative name.
-  Operation information validation alert does not display display  `regulated products` and `reporting activities`

<img width="1052" height="82" alt="image" src="https://github.com/user-attachments/assets/613740ab-00d6-488c-bb59-f19eb76038e3" />

---

#### Test:  production data validation when RY 2024 for Regulated operation

1. Log in using `bc-cas-dev`
2. Navigate to RY 2024 report http://localhost:3000/reporting/reports/1/report-validation

**Expected Results**
-  Production data validation alert includes ` Apr-Dec production data`
<img width="1052" height="69" alt="image" src="https://github.com/user-attachments/assets/1d2ff2e4-9ca2-4c0c-8504-3379da91f79d" />

---

#### Test: production data validation when RY 2025 for Opted-in operation which has opted out
- Create a report for RY 2025 for Opted-in operation which has opted out...
- Navigate to that report's `report-validation`

**Expected Results**
-  Production data validation alert includes `Apr-Dec production data`

<img width="1052" height="82" alt="image" src="https://github.com/user-attachments/assets/8999a930-4af5-4de8-a62e-164c7d6a6141" />



---

#### Test:  production data validation when unregulated products
1. Create an SFO report with unregulated product
<img width="1577" height="909" alt="image" src="https://github.com/user-attachments/assets/59c17997-0b0d-44a4-953c-d17a341dd956" />
<img width="1577" height="909" alt="image" src="https://github.com/user-attachments/assets/a3cd40d9-3598-404f-ac03-4fae14712af9" />

2. Navigate to that report's `report-validation`

**Expected Results**
-  Production data validation alert does NOT display
<img width="1577" height="909" alt="image" src="https://github.com/user-attachments/assets/32d505bf-4897-4d1d-beea-d384cc0b2fa6" />


---

#### Test: boundary checking message

1.  Navigate to report http://localhost:3000/reporting/reports/3/report-validation
**Expected Results**
-  Fuel type boundary error displays expected message
- Methodology boundary error displays expected message

<img width="1577" height="909" alt="image" src="https://github.com/user-attachments/assets/073616ca-9ae9-4c99-b8f2-78f61116aa8b" />




