### PR TITLE
Chore/precommit ci better eslint

### DIFF
--- a/.bin/pre-commit-lint.sh
+++ b/.bin/pre-commit-lint.sh
@@ -12,4 +12,4 @@ fi
 
 # Use stream output style to avoid TTY requirements entirely.
 # See: https://github.com/nrwl/nx/issues/31484
-NODE_OPTIONS="--max-old-space-size=5120" yarn nx affected --base=origin/develop --target=lint --parallel --output-style=stream
+NODE_OPTIONS="--max-old-space-size=5120" yarn nx affected --base=origin/develop --target=lint --parallel --output-style=stream --quiet


### PR DESCRIPTION
Addresses #4606. Modifies pre-commit script for linting in CI to ensure only `errors` are shown.

## Changes 🚧

- Conditionally add `--quiet` to pre-commit lint script. 

## To test 🔬

- A linting error was intentionally introduced and run through CI here: https://github.com/bcgov/cas-registration/actions/runs/25453364544/job/74676514199?pr=4607. Only blocking `errors` show up now!