### PR TITLE
Add preload attribute to header logo image for improved performance

### DIFF
--- a/bciers/libs/components/src/layout/Header.tsx
+++ b/bciers/libs/components/src/layout/Header.tsx
@@ -23,6 +23,7 @@ export default function Header() {
                 alt="Logo for Province of British Columbia CleanBC"
                 width="200"
                 height="43"
+                preload
               />
             </Link>
             <h1 className="text-white font-bold cursor-default ml-6 flex-grow text-xs p-1 sm:text-xl md:text-[28px] md:p-0">


### PR DESCRIPTION
[ISSUE 4626](https://github.com/bcgov/cas-registration/issues/4626)

To test this, just make sure you don’t see the following error in your browser console:
<img width="723" height="125" alt="Screenshot 2026-05-07 at 12 48 13 PM" src="https://github.com/user-attachments/assets/ca90903e-a57b-4368-b3b0-5714fc6a47e2" />

Or the following error in your frontend server logs:
<img width="747" height="87" alt="Screenshot 2026-05-07 at 12 48 25 PM" src="https://github.com/user-attachments/assets/780b6334-3f4f-45cd-93d4-7a1663449d0e" />
