### PR TITLE
Fix false positive changes when creating supplementary report with no changes

### DIFF
--- a/bc_obps/reporting/api/report_review_changes.py
+++ b/bc_obps/reporting/api/report_review_changes.py
@@ -10,6 +10,16 @@ from .permissions import approved_industry_user_report_version_composite_auth
 from service.report_version_service import ReportVersionService
 from reporting.service.review_changes_service.report_review_changes_service import ReportReviewChangesService
 
+EXCLUDE_REPORT_PRODUCT_ID = {
+    "facility_reports": {
+        "__all__": {
+            "report_emission_allocation": {
+                "report_product_emission_allocations": {"__all__": {"products": {"__all__": {"report_product_id"}}}},
+            }
+        }
+    }
+}
+
 
 @router.get(
     "/report-version/{version_id}/diff-data",
@@ -38,8 +48,8 @@ def get_report_version_diff_data(request: HttpRequest, version_id: int) -> tuple
     previous_version = ReportVersionService.fetch_full_report_version(
         previous_version_id, prefetch_full_facility_report=True
     )
-    current_data = ReviewChangesVersionSchema.from_orm(current_version).dict()
-    previous_data = ReviewChangesVersionSchema.from_orm(previous_version).dict()
+    current_data = ReviewChangesVersionSchema.from_orm(current_version).dict(exclude=EXCLUDE_REPORT_PRODUCT_ID)
+    previous_data = ReviewChangesVersionSchema.from_orm(previous_version).dict(exclude=EXCLUDE_REPORT_PRODUCT_ID)
 
     changed = ReportReviewChangesService.get_report_version_diff_changes(previous_data, current_data)
 

--- a/bc_obps/reporting/schema/report_product_emission_allocation.py
+++ b/bc_obps/reporting/schema/report_product_emission_allocation.py
@@ -34,6 +34,7 @@ class ReportProductEmissionAllocationsSchemaIn(Schema):
 
 class ReportProductEmissionAllocationSchemaOut(Schema):
     report_product_id: int
+    product_id: int
     product_name: str
     allocated_quantity: float
 

--- a/bc_obps/reporting/service/report_emission_allocation_service.py
+++ b/bc_obps/reporting/service/report_emission_allocation_service.py
@@ -24,6 +24,7 @@ class ReportProductEmissionAllocationData:
     """
 
     report_product_id: int
+    product_id: int
     product_name: str
     allocated_quantity: Decimal | int
 
@@ -115,6 +116,7 @@ class ReportEmissionAllocationService:
                 ).first()
                 product = ReportProductEmissionAllocationData(
                     report_product_id=rp.pk,
+                    product_id=rp.product_id,
                     product_name=rp.product.name,
                     allocated_quantity=product_emission.allocated_quantity if product_emission else 0,
                 )
@@ -275,6 +277,7 @@ class ReportEmissionAllocationService:
             report_product_emission_allocation_totals.append(
                 ReportProductEmissionAllocationData(
                     report_product_id=rp.pk,
+                    product_id=rp.product_id,
                     product_name=rp.product.name,
                     allocated_quantity=allocated_quantity if allocated_quantity else 0,
                 )

--- a/bc_obps/reporting/tests/api/test_report_emission_allocation_api.py
+++ b/bc_obps/reporting/tests/api/test_report_emission_allocation_api.py
@@ -36,6 +36,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -43,6 +44,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -60,6 +62,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -67,6 +70,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -84,6 +88,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -91,6 +96,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -108,6 +114,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -115,6 +122,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -132,6 +140,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 100000.0000,
                                     }
@@ -139,6 +148,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 400000.0000,
                                     }
@@ -156,6 +166,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -163,6 +174,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -180,6 +192,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -187,6 +200,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -204,6 +218,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -211,6 +226,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -228,6 +244,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -235,6 +252,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -252,6 +270,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -259,6 +278,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -276,6 +296,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -283,6 +304,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -300,6 +322,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
+                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -307,6 +330,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
+                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -320,6 +344,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                     ReportProductEmissionAllocationData(
                         **{
                             'report_product_id': 1,
+                            'product_id': 2,
                             'product_name': 'Cement equivalent',
                             'allocated_quantity': 100000.0000,
                         }
@@ -327,6 +352,7 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                     ReportProductEmissionAllocationData(
                         **{
                             'report_product_id': 2,
+                            'product_id': 6,
                             'product_name': 'Gypsum wallboard',
                             'allocated_quantity': 400000.0000,
                         }


### PR DESCRIPTION
fixes [4542](https://github.com/bcgov/cas-registration/issues/4542)

Problem:
- On Creating of supplementary report, new `report_product`s are created. When checking diffs in each facility, deep diffs sees something like `{"allocated_quantity": 32.0, "report_product_id": 9},` vs `{"allocated_quantity": 32.0, "report_product_id": 7}`. 

Solution:
- I've added product_id to the schema to keep the comparison of product_id allocations consistent
- Excluded report_product_id ONLY on the review-changes page because the allocation schema is used on the final review page as well