### PR TITLE
Fix/4592 allow lfo facility to continue without selecting a regulated product

### DIFF
--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -1,11 +1,15 @@
 "use client";
 import MultiStepFormWithTaskList from "@bciers/components/form/MultiStepFormWithTaskList";
 import { useState } from "react";
-import { RJSFSchema } from "@rjsf/utils";
+import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import { buildProductionDataUiSchema } from "@reporting/src/data/jsonSchema/productionData";
 import { ProductData } from "@reporting/src/app/components/products/types";
 import { postProductionData } from "@reporting/src/app/utils/productDataForm/postProductionData";
 import { NavigationInformation } from "@reporting/src/app/components/taskList/types";
+import {
+  FieldTemplate,
+  TitleOnlyFieldTemplate,
+} from "@bciers/components/form/fields";
 
 interface Props {
   report_version_id: number;
@@ -39,8 +43,50 @@ const ProductionDataForm: React.FC<Props> = ({
     production_data: initialData,
   };
 
+  const noRegulatedProductSchema: RJSFSchema = {
+    type: "object",
+    title: "Production Data",
+    properties: {
+      product_selection_title: {
+        title: "No Regulated Products to select",
+        type: "string",
+      },
+    },
+  };
+
+  const noRegulatedProductUiSchema: UiSchema = {
+    "ui:FieldTemplate": FieldTemplate,
+    "ui:classNames": "form-heading-label",
+    product_selection_title: {
+      "ui:FieldTemplate": TitleOnlyFieldTemplate,
+      "ui:classNames": "mt-2 mb-5 emission-array-header",
+    },
+  };
+
   const [formData, setFormData] = useState<any>(initialFormData);
   const [errors, setErrors] = useState<string[]>();
+
+  // Short circuit to allow LFO facilities to continue past this form without a regulated product selected
+  if (
+    ["Small Aggregate", "Medium Facility", "Large Facility"].includes(
+      facilityType,
+    ) &&
+    formData.product_selection.length < 1
+  ) {
+    return (
+      <MultiStepFormWithTaskList
+        taskListElements={navigationInformation.taskList}
+        schema={noRegulatedProductSchema}
+        uiSchema={noRegulatedProductUiSchema}
+        formData={formData}
+        backUrl={navigationInformation.backUrl}
+        continueUrl={navigationInformation.continueUrl}
+        steps={navigationInformation.headerSteps}
+        initialStep={navigationInformation.headerStepIndex}
+        saveButtonDisabled={true}
+      />
+    );
+  }
 
   const onChange = (newFormData: {
     product_selection: string[];
@@ -74,7 +120,9 @@ const ProductionDataForm: React.FC<Props> = ({
       }
     }
     if (
-      !["Small Aggregate", "Medium Facility"].includes(facilityType) &&
+      !["Small Aggregate", "Medium Facility", "Large Facility"].includes(
+        facilityType,
+      ) &&
       formData.product_selection.length < 1
     ) {
       setErrors(["A product must be selected."]);

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -66,12 +66,12 @@ const ProductionDataForm: React.FC<Props> = ({
   const [formData, setFormData] = useState<any>(initialFormData);
   const [errors, setErrors] = useState<string[]>();
 
-  // Short circuit to allow LFO facilities to continue past this form without a regulated product selected
+  // Short circuit to allow LFO facilities to continue past this form without a regulated product to select
   if (
     ["Small Aggregate", "Medium Facility", "Large Facility"].includes(
       facilityType,
     ) &&
-    formData.product_selection.length < 1
+    allowedProducts.length < 1
   ) {
     return (
       <MultiStepFormWithTaskList

--- a/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
@@ -58,7 +58,7 @@ describe("The ProductionDataForm component", () => {
     expect(mockPostProductionData).toHaveBeenCalledOnce();
   });
 
-  it("Allows an LFO facility to just continue when no regulated products are selected", async () => {
+  it("Allows an LFO facility to just continue when no regulated products are available to be selected", async () => {
     const mockPush = vi.fn();
     mockRouter.mockReturnValue({ push: mockPush });
 

--- a/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
@@ -32,13 +32,20 @@ describe("The ProductionDataForm component", () => {
 
     render(
       <ProductionDataForm
-        allowedProducts={[]}
-        initialData={[]}
+        allowedProducts={[{ product_id: 2024, product_name: "test" }]}
+        initialData={[
+          {
+            product_id: 2024,
+            product_name: "test",
+            production_methodology: "a",
+            unit: "unit",
+          },
+        ]}
         facility_id="abcd"
         report_version_id={1000}
         schema={{ testSchema: true }}
         navigationInformation={dummyNavigationInformation}
-        facilityType={"Small Aggregate"}
+        facilityType={""}
         isPulpAndPaper={false}
         overlappingIndustrialProcessEmissions={0}
         reportingYear={2024}
@@ -48,7 +55,36 @@ describe("The ProductionDataForm component", () => {
 
     const calledProps = mockMultiStepFormWithTaskList.mock.calls[0][0];
     await calledProps.onSubmit({ formData: { production_data: "test" } });
-    expect(mockPostProductionData).toHaveBeenCalledWith(1000, "abcd", "test");
+    expect(mockPostProductionData).toHaveBeenCalledOnce();
+  });
+
+  it("Allows an LFO facility to just continue when no regulated products are selected", async () => {
+    const mockPush = vi.fn();
+    mockRouter.mockReturnValue({ push: mockPush });
+
+    render(
+      <ProductionDataForm
+        allowedProducts={[]}
+        initialData={[]}
+        facility_id="abcd"
+        report_version_id={1000}
+        schema={{ testSchema: true }}
+        navigationInformation={dummyNavigationInformation}
+        facilityType={"Large Facility"}
+        isPulpAndPaper={false}
+        overlappingIndustrialProcessEmissions={0}
+        reportingYear={2024}
+        isOptedOut={false}
+      />,
+    );
+
+    const calledProps = mockMultiStepFormWithTaskList.mock.calls[0][0];
+    expect(
+      mockMultiStepFormWithTaskList.mock.calls[0][0].schema.properties
+        .product_selection_title.title == "No Regulated Products to select",
+    );
+    expect(calledProps.continueUrl == "Continue");
+    expect(calledProps.saveButtonDisabled == true);
   });
 
   it("on change, adds an item to the form data when a checkbox is checked", async () => {
@@ -60,7 +96,7 @@ describe("The ProductionDataForm component", () => {
         report_version_id={1000}
         schema={{ testSchema: true }}
         navigationInformation={dummyNavigationInformation}
-        facilityType={""}
+        facilityType={"Single Facility"}
         isPulpAndPaper={false}
         overlappingIndustrialProcessEmissions={0}
         reportingYear={2024}


### PR DESCRIPTION
#4592 LFO facilities can now continue past the ProductionDataForm without selecting any regulated products.

To test:

Scenario 1: A regulated product is available to select

- Start a report for an LFO operation
- Ensure both a regulated and non-regulated product is selected on the operation info page
- Go to the production data form
- Do not select the regulated product
- Click "Save & Continue"
- The page should not error & continue successfully to the next section

Scenario 2: no regulated product is available to select

- Start a report for an LFO operation
- Ensure only a non-regulated product is selected on the operation info page (ie: Refineries line tracing)
- Go to the production data form
- There should be no products to select & a message that says "No Regulated Products to select"
- Click "Continue"
- The page should not error & continue successfully to the next section
