### PR TITLE
4582 Fix Non attributable emissions page required fields

### DIFF
--- a/bc_obps/reporting/api/report_non_attributable_emissions.py
+++ b/bc_obps/reporting/api/report_non_attributable_emissions.py
@@ -1,16 +1,14 @@
 from typing import Literal, List
 from uuid import UUID
-
 from django.http import HttpRequest
-
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
 from service.error_service.custom_codes_4xx import custom_codes_4xx
-
 from .router import router
 from ..models import ReportNonAttributableEmissions
 from ..schema.report_non_attributable_emissions import (
     ReportNonAttributableOut,
+    ReportNonAttributableActivityOut,
     ReportNonAttributableSchema,
 )
 from ..service.report_non_attributable_service import ReportNonAttributableService
@@ -19,23 +17,23 @@ from reporting.api.permissions import approved_industry_user_report_version_comp
 
 @router.get(
     "/report-version/{version_id}/facilities/{facility_id}/non-attributable",
-    response={200: List[ReportNonAttributableOut], custom_codes_4xx: Message},
+    response={200: ReportNonAttributableOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Takes version_id (primary key of Report_Version model) and returns all non-attributable emissions for that report version.""",
     auth=approved_industry_user_report_version_composite_auth,
 )
 def get_report_non_attributable_by_version_id(
     request: HttpRequest, version_id: int, facility_id: UUID
-) -> tuple[Literal[200], list[ReportNonAttributableEmissions]]:
+) -> tuple[Literal[200], dict]:
     emissions = ReportNonAttributableService.get_report_non_attributable_by_version_id(
         version_id, facility_id=facility_id
     )
-    return 200, emissions
+    return 200, {"emissions_exceeded": emissions.exists(), "activities": emissions}
 
 
 @router.post(
     "/report-version/{version_id}/facilities/{facility_id}/non-attributable",
-    response={201: List[ReportNonAttributableOut], custom_codes_4xx: Message},
+    response={201: List[ReportNonAttributableActivityOut], custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="""Handles updating or deleting non-attributable emissions data for a specified facility and report
     version. If `emissions_exceeded` is `false`, all existing non-attributable emissions data is deleted for the
@@ -45,7 +43,7 @@ def get_report_non_attributable_by_version_id(
 )
 def save_report(
     request: HttpRequest, version_id: int, facility_id: UUID, payload: ReportNonAttributableSchema
-) -> tuple[Literal[201], list[ReportNonAttributableEmissions]]:
+) -> tuple[Literal[201], List[ReportNonAttributableEmissions]]:
     saved_reports = []
 
     # If emissions_exceeded is false, delete existing data

--- a/bc_obps/reporting/models/report_non_attributable_emissions.py
+++ b/bc_obps/reporting/models/report_non_attributable_emissions.py
@@ -1,5 +1,4 @@
 from django.db import models
-
 from registration.models import TimeStampedModel
 from reporting.models import ReportVersion, FacilityReport
 from reporting.models.emission_category import EmissionCategory

--- a/bc_obps/reporting/schema/facility_report.py
+++ b/bc_obps/reporting/schema/facility_report.py
@@ -1,18 +1,8 @@
 from typing import Annotated, List, Optional
 from uuid import UUID
-
 from ninja import Field, FilterSchema, ModelSchema
 from pydantic import alias_generators
-
 from reporting.models import FacilityReport
-
-
-def to_camel(string: str) -> str:
-    return alias_generators.to_camel(string)
-
-
-def to_snake(string: str) -> str:
-    return alias_generators.to_snake(string)
 
 
 class FacilityReportOut(ModelSchema):
@@ -25,7 +15,7 @@ class FacilityReportOut(ModelSchema):
         return str(obj.facility)
 
     class Meta:
-        alias_generator = to_snake
+        alias_generator = alias_generators.to_snake
         model = FacilityReport
         fields = ['facility_name', 'facility_type', 'facility_bcghgid', 'activities', 'facility']
 
@@ -44,14 +34,14 @@ class FacilityReportIn(ModelSchema):
     activities: List[int]
 
     class Meta:
-        alias_generator = to_snake
+        alias_generator = alias_generators.to_snake
         model = FacilityReport
         fields = ['facility_name', 'facility_type', 'facility_bcghgid', 'activities']
 
 
 class FacilityReportListSchema(ModelSchema):
     class Meta:
-        alias_generator = to_snake
+        alias_generator = alias_generators.to_snake
         model = FacilityReport
         fields = ['id', 'facility_name', 'facility', 'facility_bcghgid', 'is_completed']
 
@@ -61,7 +51,7 @@ class FacilityReportListInSchema(ModelSchema):
     is_completed: bool
 
     class Meta:
-        alias_generator = to_snake
+        alias_generator = alias_generators.to_snake
         model = FacilityReport
         fields = ['is_completed']
 

--- a/bc_obps/reporting/schema/report_additional_data.py
+++ b/bc_obps/reporting/schema/report_additional_data.py
@@ -1,18 +1,12 @@
 from typing import Optional
-
 from ninja import ModelSchema
 from pydantic import alias_generators
-
 from reporting.models import ReportAdditionalData
-
-
-def to_snake(string: str) -> str:
-    return alias_generators.to_snake(string)
 
 
 class ReportAdditionalDataOut(ModelSchema):
     class Meta:
-        alias_generator = to_snake
+        alias_generator = alias_generators.to_snake
         model = ReportAdditionalData
         fields = [
             'capture_emissions',
@@ -36,7 +30,7 @@ class ReportAdditionalDataIn(ModelSchema):
     electricity_generated: Optional[int] = None
 
     class Meta:
-        alias_generator = to_snake
+        alias_generator = alias_generators.to_snake
         model = ReportAdditionalData
         fields = [
             'capture_emissions',

--- a/bc_obps/reporting/schema/report_non_attributable_emissions.py
+++ b/bc_obps/reporting/schema/report_non_attributable_emissions.py
@@ -39,7 +39,7 @@ class ReportNonAttributableIn(ModelSchema):
 
     id: Optional[int] = Field(None)
     emission_category: str
-    gas_type: List[str]
+    gas_type: List[str] = Field(min_length=1)
 
     class Meta:
         alias_generator = alias_generators.to_snake

--- a/bc_obps/reporting/schema/report_non_attributable_emissions.py
+++ b/bc_obps/reporting/schema/report_non_attributable_emissions.py
@@ -1,26 +1,35 @@
 from typing import List, Optional
 from ninja import ModelSchema, Schema, Field
+from common.exceptions import UserError
 from reporting.models import ReportNonAttributableEmissions
-from pydantic import alias_generators
+from pydantic import alias_generators, field_validator, model_validator, ValidationInfo
 
 
-def to_camel(string: str) -> str:
-    return alias_generators.to_camel(string)
-
-
-def to_snake(string: str) -> str:
-    return alias_generators.to_snake(string)
-
-
-class ReportNonAttributableOut(ModelSchema):
+class ReportNonAttributableActivityOut(ModelSchema):
     """
-    Schema for the get report operation endpoint request output
+    Schema for a single non-attributable emission activity.
     """
+
+    emission_category: str = Field(..., alias="emission_category.category_name")
+    gas_type: List[str]
 
     class Meta:
-        alias_generator = to_snake
+        alias_generator = alias_generators.to_snake
         model = ReportNonAttributableEmissions
-        fields = ['id', 'activity', 'source_type', 'emission_category', 'gas_type']
+        fields = ['id', 'activity', 'source_type']
+
+    @staticmethod
+    def resolve_gas_type(obj: ReportNonAttributableEmissions) -> List[str]:
+        return list(obj.gas_type.values_list('chemical_formula', flat=True))
+
+
+class ReportNonAttributableOut(Schema):
+    """
+    Schema for the non-attributable emissions endpoint response.
+    """
+
+    emissions_exceeded: bool
+    activities: List[ReportNonAttributableActivityOut]
 
 
 class ReportNonAttributableIn(ModelSchema):
@@ -29,15 +38,13 @@ class ReportNonAttributableIn(ModelSchema):
     """
 
     id: Optional[int] = Field(None)
-    activity: str
-    source_type: str
     emission_category: str
     gas_type: List[str]
 
     class Meta:
-        alias_generator = to_snake
+        alias_generator = alias_generators.to_snake
         model = ReportNonAttributableEmissions
-        fields = ['id', 'activity', 'source_type', 'emission_category', 'gas_type']
+        fields = ['id', 'activity', 'source_type']
 
 
 class ReportNonAttributableSchema(Schema):
@@ -46,4 +53,17 @@ class ReportNonAttributableSchema(Schema):
     """
 
     emissions_exceeded: bool = Field(..., description="Indicates if emissions exceeded the threshold.")
-    activities: List[ReportNonAttributableIn] = Field(..., description="List of activities in the report.")
+    activities: List[ReportNonAttributableIn] = Field(default=[], description="List of activities in the report.")
+
+    @field_validator("activities", mode="before")
+    @classmethod
+    def clear_activities_when_not_exceeded(cls, v: list, info: ValidationInfo) -> list:
+        if not info.data.get("emissions_exceeded"):
+            return []
+        return v
+
+    @model_validator(mode="after")
+    def activities_required_when_emissions_exceeded(self) -> "ReportNonAttributableSchema":
+        if self.emissions_exceeded and not self.activities:
+            raise UserError("At least one activity is required when emissions are exceeded.")
+        return self

--- a/bc_obps/reporting/schema/report_operation.py
+++ b/bc_obps/reporting/schema/report_operation.py
@@ -1,20 +1,10 @@
 from uuid import UUID
-
 from ninja import ModelSchema, Schema
-
 from registration.schema import RegulatedProductSchema
 from reporting.models import ReportOperationRepresentative
 from reporting.models.report_operation import ReportOperation
 from pydantic import alias_generators
 from typing import List, Optional
-
-
-def to_camel(string: str) -> str:
-    return alias_generators.to_camel(string)
-
-
-def to_snake(string: str) -> str:
-    return alias_generators.to_snake(string)
 
 
 class ReportOperationOut(ModelSchema):
@@ -23,7 +13,7 @@ class ReportOperationOut(ModelSchema):
     """
 
     class Meta:
-        alias_generator = to_snake
+        alias_generator = alias_generators.to_snake
         model = ReportOperation
         fields = [
             'operator_legal_name',

--- a/bc_obps/reporting/schema/report_person_responsible.py
+++ b/bc_obps/reporting/schema/report_person_responsible.py
@@ -4,10 +4,6 @@ from pydantic import alias_generators, ConfigDict
 from reporting.models import ReportPersonResponsible
 
 
-def to_snake(string: str) -> str:
-    return alias_generators.to_snake(string)
-
-
 class ReportPersonResponsibleOut(ModelSchema):
     """
     Schema for the get report operation endpoint response output
@@ -46,7 +42,7 @@ class ReportPersonResponsibleIn(ModelSchema):
     contact_id: Optional[int] = None
 
     class Meta:
-        alias_generator = to_snake
+        alias_generator = alias_generators.to_snake
         model = ReportPersonResponsible
         fields = [
             'street_address',

--- a/bc_obps/reporting/service/report_non_attributable_service.py
+++ b/bc_obps/reporting/service/report_non_attributable_service.py
@@ -1,8 +1,7 @@
 from typing import List
 from uuid import UUID
-
+from django.db.models import QuerySet
 from reporting.models import ReportNonAttributableEmissions, EmissionCategory, ReportVersion, FacilityReport, GasType
-
 from reporting.schema.report_non_attributable_emissions import ReportNonAttributableIn
 
 
@@ -10,9 +9,11 @@ class ReportNonAttributableService:
     @classmethod
     def get_report_non_attributable_by_version_id(
         cls, report_version_id: int, facility_id: UUID
-    ) -> List[ReportNonAttributableEmissions]:
-        facility_report = FacilityReport.objects.get(report_version_id=report_version_id, facility_id=facility_id)
-        return list(ReportNonAttributableEmissions.objects.filter(facility_report=facility_report))
+    ) -> QuerySet[ReportNonAttributableEmissions]:
+        return ReportNonAttributableEmissions.objects.filter(
+            facility_report__facility_id=facility_id,
+            facility_report__report_version_id=report_version_id,
+        )
 
     @classmethod
     def save_report_non_attributable_emissions(
@@ -37,13 +38,13 @@ class ReportNonAttributableService:
             emission_category = EmissionCategory.objects.get(category_name=emission_category_name)
 
             # Using the object attributes instead of .get()
-            report_non_attributable, created = ReportNonAttributableEmissions.objects.update_or_create(
+            report_non_attributable, _ = ReportNonAttributableEmissions.objects.update_or_create(
                 id=activity_data.id,
                 defaults={
                     "report_version": report_version,
                     "facility_report": facility_report,
-                    "activity": activity_data.activity,
-                    "source_type": activity_data.source_type,
+                    "activity": activity_data.activity,  # type: ignore[attr-defined] # mypy not aware of model schema field
+                    "source_type": activity_data.source_type,  # type: ignore[attr-defined] # mypy not aware of model schema field
                     "emission_category": emission_category,
                 },
             )

--- a/bc_obps/reporting/tests/endpoints/test_report_non_attributable_emissions_endpoint.py
+++ b/bc_obps/reporting/tests/endpoints/test_report_non_attributable_emissions_endpoint.py
@@ -25,34 +25,60 @@ class TestReportNonAttributableEndpoints(CommonTestSetup):
         emission_category = make(EmissionCategory)
         gas_type = make(GasType)
 
-        mock_emissions = [
-            ReportNonAttributableEmissions(
-                facility_report=self.facility_report,
-                emission_category=emission_category,
-                activity="Activity Type",
-                source_type="Source Type",
-                report_version=self.facility_report.report_version,
-            )
-        ]
+        record = ReportNonAttributableEmissions(
+            facility_report=self.facility_report,
+            emission_category=emission_category,
+            activity="Activity Type",
+            source_type="Source Type",
+            report_version=self.facility_report.report_version,
+        )
+        record.save()
+        record.gas_type.set([gas_type])
 
-        mock_emissions[0].save()
-
-        mock_emissions[0].gas_type.set([gas_type])
-
-        mock_get_emissions.return_value = mock_emissions
+        mock_qs = MagicMock()
+        mock_qs.exists.return_value = True
+        mock_qs.__iter__ = MagicMock(return_value=iter([record]))
+        mock_get_emissions.return_value = mock_qs
 
         response = TestUtils.mock_get_with_auth_role(self, "industry_user", self.endpoint_under_test)
 
         assert response.status_code == 200
-        assert response.json() == [
-            {
-                "id": mock_emissions[0].id,
-                "activity": mock_emissions[0].activity,
-                "source_type": mock_emissions[0].source_type,
-                "emission_category": mock_emissions[0].emission_category.id,
-                "gas_type": [gas.id for gas in mock_emissions[0].gas_type.all()],
-            }
-        ]
+        assert response.json() == {
+            "emissions_exceeded": True,
+            "activities": [
+                {
+                    "id": record.id,
+                    "activity": record.activity,
+                    "source_type": record.source_type,
+                    "emission_category": emission_category.category_name,
+                    "gas_type": [gas_type.chemical_formula],
+                }
+            ],
+        }
+
+    def test_post_with_emissions_not_exceeded_ignores_activities(self):
+        TestUtils.authorize_current_user_as_operator_user(
+            self, operator=self.facility_report.report_version.report.operator
+        )
+        payload = {
+            "emissions_exceeded": False,
+            "activities": [{"gas_type": []}],  # incomplete item — should be cleared by schema
+        }
+        response = TestUtils.mock_post_with_auth_role(
+            self, "industry_user", "application/json", payload, self.endpoint_under_test
+        )
+        assert response.status_code == 201
+        assert response.json() == []
+
+    def test_post_with_emissions_exceeded_and_no_activities_returns_400(self):
+        TestUtils.authorize_current_user_as_operator_user(
+            self, operator=self.facility_report.report_version.report.operator
+        )
+        payload = {"emissions_exceeded": True, "activities": []}
+        response = TestUtils.mock_post_with_auth_role(
+            self, "industry_user", "application/json", payload, self.endpoint_under_test
+        )
+        assert response.status_code == 400
 
     def test_validates_report_version_id(self):
         assert_report_version_ownership_is_validated("get_report_non_attributable_by_version_id", facility_id="uuid")

--- a/bc_obps/reporting/tests/endpoints/test_report_non_attributable_emissions_endpoint.py
+++ b/bc_obps/reporting/tests/endpoints/test_report_non_attributable_emissions_endpoint.py
@@ -1,4 +1,3 @@
-from unittest.mock import patch, MagicMock
 from model_bakery.baker import make
 from model_bakery.baker import make_recipe
 from registration.tests.utils.helpers import CommonTestSetup, TestUtils
@@ -14,10 +13,7 @@ class TestReportNonAttributableEndpoints(CommonTestSetup):
 
         return super().setup_method()
 
-    @patch(
-        "reporting.service.report_non_attributable_service.ReportNonAttributableService.get_report_non_attributable_by_version_id"
-    )
-    def test_get_returns_the_right_data(self, mock_get_emissions: MagicMock):
+    def test_get_returns_the_right_data(self):
         TestUtils.authorize_current_user_as_operator_user(
             self, operator=self.facility_report.report_version.report.operator
         )
@@ -34,11 +30,6 @@ class TestReportNonAttributableEndpoints(CommonTestSetup):
         )
         record.save()
         record.gas_type.set([gas_type])
-
-        mock_qs = MagicMock()
-        mock_qs.exists.return_value = True
-        mock_qs.__iter__ = MagicMock(return_value=iter([record]))
-        mock_get_emissions.return_value = mock_qs
 
         response = TestUtils.mock_get_with_auth_role(self, "industry_user", self.endpoint_under_test)
 

--- a/bc_obps/reporting/tests/endpoints/test_report_non_attributable_emissions_endpoint.py
+++ b/bc_obps/reporting/tests/endpoints/test_report_non_attributable_emissions_endpoint.py
@@ -71,6 +71,26 @@ class TestReportNonAttributableEndpoints(CommonTestSetup):
         )
         assert response.status_code == 400
 
+    def test_post_with_empty_gas_type_returns_422(self):
+        TestUtils.authorize_current_user_as_operator_user(
+            self, operator=self.facility_report.report_version.report.operator
+        )
+        payload = {
+            "emissions_exceeded": True,
+            "activities": [
+                {
+                    "activity": "Some Activity",
+                    "source_type": "Some Source",
+                    "emission_category": "Some Category",
+                    "gas_type": [],
+                }
+            ],
+        }
+        response = TestUtils.mock_post_with_auth_role(
+            self, "industry_user", "application/json", payload, self.endpoint_under_test
+        )
+        assert response.status_code == 422
+
     def test_validates_report_version_id(self):
         assert_report_version_ownership_is_validated("get_report_non_attributable_by_version_id", facility_id="uuid")
         assert_report_version_ownership_is_validated("save_report", method="post", facility_id="uuid")

--- a/bc_obps/reporting/tests/service/test_report_non_attributable_service.py
+++ b/bc_obps/reporting/tests/service/test_report_non_attributable_service.py
@@ -51,8 +51,15 @@ class TestReportNonAttributableService:
             self.report_version_id, self.facility_id
         )
 
-        assert len(result) == len(self.test_data)
-        assert all(isinstance(emission, ReportNonAttributableEmissions) for emission in result)
+        assert result.count() == len(self.test_data)
+        assert all(isinstance(e, ReportNonAttributableEmissions) for e in result)
+
+    def test_get_returns_empty_queryset_when_no_records(self):
+        result = ReportNonAttributableService.get_report_non_attributable_by_version_id(
+            self.report_version_id, self.facility_id
+        )
+
+        assert result.count() == 0
 
     def test_save_report_non_attributable_emissions(self):
         new_data = [

--- a/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.tsx
+++ b/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.tsx
@@ -9,22 +9,46 @@ import {
 import { actionHandler } from "@bciers/actions";
 import { NavigationInformation } from "../../taskList/types";
 
-interface ActivityData {
+export interface GasType {
+  id: number;
+  chemical_formula: string;
+}
+
+export interface EmissionCategory {
+  id: number;
+  category_name: string;
+}
+
+export interface NonAttributableEmissionRecord {
   id: number;
   activity: string;
   source_type: string;
-  emission_category: number;
-  gas_type: number[];
+  emission_category: string;
+  gas_type: string[];
 }
 
-interface NonAttributableEmissionsProps {
+interface ActivityFormItem {
+  id?: number;
+  activity?: string;
+  source_type?: string;
+  emission_category?: string;
+  gas_type: string[];
+}
+
+interface NonAttributableFormData {
+  emissions_exceeded: boolean;
+  activities: ActivityFormItem[];
+}
+
+interface NonAttributableEmissionsFormProps {
   versionId: number;
   facilityId: string;
-  emissionFormData: ActivityData[]; // Define emissionFormData as an array of ActivityData
-  gasTypes: { id: number; chemical_formula: string }[];
-  emissionCategories: { id: number; category_name: string }[];
-  gasTypeMap: Record<number, string>;
-  emissionCategoryMap: Record<number, string>;
+  emissionFormData: {
+    emissions_exceeded: boolean;
+    activities: NonAttributableEmissionRecord[];
+  };
+  gasTypes: GasType[];
+  emissionCategories: EmissionCategory[];
   navigationInformation: NavigationInformation;
 }
 
@@ -34,38 +58,18 @@ export default function NonAttributableEmissionsForm({
   emissionFormData,
   gasTypes,
   emissionCategories,
-  gasTypeMap,
-  emissionCategoryMap,
   navigationInformation,
-}: NonAttributableEmissionsProps & {
-  gasTypeMap: Record<number, string>;
-  emissionCategoryMap: Record<number, string>;
-}) {
+}: NonAttributableEmissionsFormProps) {
   const [errors, setErrors] = useState<string[]>();
-  const [formData, setFormData] = useState(
-    emissionFormData.length
-      ? {
-          activities: emissionFormData.map((item) => ({
-            id: item.id,
-            activity: item.activity,
-            source_type: item.source_type,
-            emission_category: emissionCategoryMap[item.emission_category],
-            gas_type: item.gas_type.map((id) => gasTypeMap[id]),
-          })),
-          emissions_exceeded: true,
-        }
-      : {
-          activities: [
-            {
-              activity: "",
-              source_type: "",
-              gas_type: [],
-              emission_category: "",
-            },
-          ],
-          emissions_exceeded: false,
-        },
-  );
+  const [formData, setFormData] = useState<NonAttributableFormData>({
+    emissions_exceeded: emissionFormData.emissions_exceeded,
+    // Seed one empty row so the form renders a first entry when the user switches to "Yes",
+    // since RJSF does not auto-populate array rows inside a conditional schema branch.
+    activities:
+      emissionFormData.activities.length > 0
+        ? emissionFormData.activities
+        : [{ gas_type: [] }],
+  });
 
   const schema = generateUpdatedSchema(gasTypes, emissionCategories);
 
@@ -94,7 +98,9 @@ export default function NonAttributableEmissionsForm({
       uiSchema={nonAttributableEmissionUiSchema}
       formData={formData}
       cancelUrl="#"
-      onChange={(data: any) => setFormData((data as any).formData)}
+      onChange={(data) =>
+        setFormData((data as { formData: NonAttributableFormData }).formData)
+      }
       onSubmit={handleSubmit}
       backUrl={navigationInformation.backUrl}
       continueUrl={navigationInformation.continueUrl}

--- a/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsPage.tsx
+++ b/bciers/apps/reporting/src/app/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsPage.tsx
@@ -12,18 +12,19 @@ export default async function NonAttributableEmissionsPage({
   version_id,
   facility_id,
 }: HasFacilityId) {
-  const gasTypes = await getBasicGasTypes();
-  const emissionCategories = await getAllEmissionCategories();
-  const emissionFormData = await getNonAttributableEmissionsData(
-    version_id,
-    facility_id,
-  );
-
-  const tasklistData = await getReportInformationTasklist(
-    version_id,
-    facility_id,
-  );
-  const orderedActivities = await getOrderedActivities(version_id, facility_id);
+  const [
+    gasTypes,
+    emissionCategories,
+    emissionFormData,
+    tasklistData,
+    orderedActivities,
+  ] = await Promise.all([
+    getBasicGasTypes(),
+    getAllEmissionCategories(),
+    getNonAttributableEmissionsData(version_id, facility_id),
+    getReportInformationTasklist(version_id, facility_id),
+    getOrderedActivities(version_id, facility_id),
+  ]);
 
   const navigationInformation = await getNavigationInformation(
     HeaderStep.ReportInformation,
@@ -36,28 +37,6 @@ export default async function NonAttributableEmissionsPage({
     },
   );
 
-  const gasTypeMap = gasTypes.reduce(
-    (
-      acc: { [x: string]: any },
-      gas: { id: string | number; chemical_formula: any },
-    ) => {
-      acc[gas.id] = gas.chemical_formula;
-      return acc;
-    },
-    {} as Record<number, string>,
-  );
-
-  const emissionCategoryMap = emissionCategories.reduce(
-    (
-      acc: { [x: string]: any },
-      category: { id: string | number; category_name: any },
-    ) => {
-      acc[category.id] = category.category_name;
-      return acc;
-    },
-    {} as Record<number, string>,
-  );
-
   return (
     <NonAttributableEmissionsForm
       versionId={version_id}
@@ -65,8 +44,6 @@ export default async function NonAttributableEmissionsPage({
       emissionFormData={emissionFormData}
       gasTypes={gasTypes}
       emissionCategories={emissionCategories}
-      gasTypeMap={gasTypeMap}
-      emissionCategoryMap={emissionCategoryMap}
       navigationInformation={navigationInformation}
     />
   );

--- a/bciers/apps/reporting/src/data/jsonSchema/nonAttributableEmissions/nonAttributableEmissions.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/nonAttributableEmissions/nonAttributableEmissions.ts
@@ -75,6 +75,7 @@ export const generateUpdatedSchema = (
               type: "array",
               items: {
                 type: "object",
+                required: ["activity", "source_type", "emission_category"],
                 properties: {
                   activity: { type: "string", title: "Activity Name" },
                   source_type: { type: "string", title: "Source Type" },

--- a/bciers/apps/reporting/src/data/jsonSchema/nonAttributableEmissions/nonAttributableEmissions.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/nonAttributableEmissions/nonAttributableEmissions.ts
@@ -75,13 +75,19 @@ export const generateUpdatedSchema = (
               type: "array",
               items: {
                 type: "object",
-                required: ["activity", "source_type", "emission_category"],
+                required: [
+                  "activity",
+                  "source_type",
+                  "emission_category",
+                  "gas_type",
+                ],
                 properties: {
                   activity: { type: "string", title: "Activity Name" },
                   source_type: { type: "string", title: "Source Type" },
                   gas_type: {
                     type: "array",
                     title: "Gas Type",
+                    minItems: 1,
                     items: {
                       type: "string",
                       enum: gasTypes.map((gas) => gas.chemical_formula),

--- a/bciers/apps/reporting/src/tests/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.test.tsx
@@ -20,6 +20,19 @@ describe("NonAttributableEmissionsForm Component", () => {
   const facilityId = "some-uuid" as UUID;
   const gasTypes = [{ id: 1, chemical_formula: "CO2" }];
   const emissionCategories = [{ id: 1, category_name: "Direct" }];
+  const emptyFormData = { emissions_exceeded: false, activities: [] };
+  const existingFormData = {
+    emissions_exceeded: true,
+    activities: [
+      {
+        id: 1,
+        activity: "Test Activity",
+        source_type: "Test Source",
+        emission_category: "Direct",
+        gas_type: ["CO2"],
+      },
+    ],
+  };
   const mockPush = vi.fn();
 
   beforeEach(() => {
@@ -40,96 +53,102 @@ describe("NonAttributableEmissionsForm Component", () => {
     vi.clearAllMocks();
   });
 
-  it("updates form data when the 'emissions exceeded' radio button is clicked", async () => {
+  it("renders the initial question field", async () => {
     render(
       <NonAttributableEmissionsForm
         versionId={versionId}
         facilityId={facilityId}
-        emissionFormData={[]}
+        emissionFormData={emptyFormData}
         gasTypes={gasTypes}
         emissionCategories={emissionCategories}
-        gasTypeMap={{ 1: "CO2" }}
-        emissionCategoryMap={{ 1: "Direct" }}
         navigationInformation={dummyNavigationInformation}
       />,
     );
 
-    const yesRadioButton = screen.getByLabelText("Yes");
-    fireEvent.click(yesRadioButton);
-    expect(yesRadioButton).toBeChecked();
-
-    const activityNameField = await screen.findByText("Activity Name"); // Ensure the correct text matches
-    expect(activityNameField).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Did your non-attributable emissions exceed 100 tCO2e?",
+      ),
+    ).toBeVisible();
   });
 
-  it("renders the form with the correct initial fields", async () => {
+  it("shows activity fields when 'Yes' is selected", async () => {
     render(
       <NonAttributableEmissionsForm
         versionId={versionId}
         facilityId={facilityId}
-        emissionFormData={[]}
+        emissionFormData={emptyFormData}
         gasTypes={gasTypes}
         emissionCategories={emissionCategories}
-        gasTypeMap={{ 1: "CO2" }}
-        emissionCategoryMap={{ 1: "Direct" }}
         navigationInformation={dummyNavigationInformation}
       />,
     );
 
-    const emissionExceededText = await screen.findByText(
-      "Did your non-attributable emissions exceed 100 tCO2e?",
-    );
-    expect(emissionExceededText).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Yes"));
+
+    expect(await screen.findByText("Activity Name")).toBeVisible();
+    expect(await screen.findByText("Source Type")).toBeVisible();
+    expect(await screen.findByText("Emission Category")).toBeVisible();
   });
 
-  it("submits form data and redirects to summary page on successful submission", async () => {
+  it("renders existing emission data when provided", async () => {
     render(
       <NonAttributableEmissionsForm
         versionId={versionId}
         facilityId={facilityId}
-        emissionFormData={[]}
+        emissionFormData={existingFormData}
         gasTypes={gasTypes}
         emissionCategories={emissionCategories}
-        gasTypeMap={{ 1: "CO2" }}
-        emissionCategoryMap={{ 1: "Direct" }}
         navigationInformation={dummyNavigationInformation}
       />,
     );
 
-    const submitButton = await screen.findByRole("button", {
-      name: /Save & Continue/i,
-    });
-    expect(submitButton).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("Test Activity")).toBeVisible();
+    expect(await screen.findByDisplayValue("Test Source")).toBeVisible();
+  });
 
-    fireEvent.click(submitButton);
+  it("submits form data and navigates on successful submission", async () => {
+    render(
+      <NonAttributableEmissionsForm
+        versionId={versionId}
+        facilityId={facilityId}
+        emissionFormData={emptyFormData}
+        gasTypes={gasTypes}
+        emissionCategories={emissionCategories}
+        navigationInformation={dummyNavigationInformation}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Save & Continue/i }),
+    );
 
     await waitFor(() => expect(actionHandler).toHaveBeenCalled());
-    expect(mockPush).toHaveBeenCalledWith(`continue`);
+    expect(mockPush).toHaveBeenCalledWith("continue");
   });
 
-  it("handles submission failure gracefully", async () => {
+  it("displays error message on submission failure", async () => {
     (actionHandler as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      success: false,
+      error: "Something went wrong",
     });
 
     render(
       <NonAttributableEmissionsForm
         versionId={versionId}
         facilityId={facilityId}
-        emissionFormData={[]}
+        emissionFormData={emptyFormData}
         gasTypes={gasTypes}
         emissionCategories={emissionCategories}
-        gasTypeMap={{ 1: "CO2" }}
-        emissionCategoryMap={{ 1: "Direct" }}
         navigationInformation={dummyNavigationInformation}
       />,
     );
 
-    const submitButton = await screen.findByRole("button", {
-      name: /Save & Continue/i,
-    });
-    fireEvent.click(submitButton);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Save & Continue/i }),
+    );
 
-    await waitFor(() => expect(actionHandler).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByText("Something went wrong")).toBeVisible(),
+    );
   });
 });

--- a/bciers/apps/reporting/src/tests/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.test.tsx
@@ -89,7 +89,7 @@ describe("NonAttributableEmissionsForm Component", () => {
     expect(screen.getByText(/activity name\*/i)).toBeVisible();
     expect(screen.getByText(/source type\*/i)).toBeVisible();
     expect(screen.getByText(/emission category\*/i)).toBeVisible();
-    expect(screen.getByText(/gas type/i)).toBeVisible();
+    expect(screen.getByText(/gas type\*/i)).toBeVisible();
     // MUI's CheckboxGroupWidget is always visually hidden via CSS so we check the if the checkbox is in the document
     // and then check the label by text
     expect(
@@ -113,6 +113,25 @@ describe("NonAttributableEmissionsForm Component", () => {
 
     expect(await screen.findByDisplayValue("Test Activity")).toBeVisible();
     expect(await screen.findByDisplayValue("Test Source")).toBeVisible();
+    expect(screen.getByRole("checkbox", { name: /co2/i })).toBeChecked();
+  });
+
+  it("shows validation error when saving without selecting a gas type", async () => {
+    render(
+      <NonAttributableEmissionsForm
+        versionId={versionId}
+        facilityId={facilityId}
+        emissionFormData={emptyFormData}
+        gasTypes={gasTypes}
+        emissionCategories={emissionCategories}
+        navigationInformation={dummyNavigationInformation}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Yes"));
+    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }));
+
+    expect(await screen.findByText("Select at least one option")).toBeVisible();
   });
 
   it("submits form data and navigates on successful submission", async () => {

--- a/bciers/apps/reporting/src/tests/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/reportInformation/nonAttributableEmissions/NonAttributableEmissionsForm.test.tsx
@@ -86,9 +86,17 @@ describe("NonAttributableEmissionsForm Component", () => {
 
     fireEvent.click(screen.getByLabelText("Yes"));
 
-    expect(await screen.findByText("Activity Name")).toBeVisible();
-    expect(await screen.findByText("Source Type")).toBeVisible();
-    expect(await screen.findByText("Emission Category")).toBeVisible();
+    expect(screen.getByText(/activity name\*/i)).toBeVisible();
+    expect(screen.getByText(/source type\*/i)).toBeVisible();
+    expect(screen.getByText(/emission category\*/i)).toBeVisible();
+    expect(screen.getByText(/gas type/i)).toBeVisible();
+    // MUI's CheckboxGroupWidget is always visually hidden via CSS so we check the if the checkbox is in the document
+    // and then check the label by text
+    expect(
+      screen.getByRole("checkbox", { name: /co2 co2/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("CO2")).toBeVisible();
+    expect(screen.getByRole("button", { name: /add activity/i })).toBeVisible();
   });
 
   it("renders existing emission data when provided", async () => {

--- a/bciers/libs/components/src/form/widgets/CheckboxGroupWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/CheckboxGroupWidget.tsx
@@ -9,7 +9,6 @@ const CheckboxGroupWidget: React.FC<WidgetProps> = ({
   id,
   onChange,
   value = [],
-  required,
   options,
   uiSchema,
   readonly,
@@ -46,7 +45,6 @@ const CheckboxGroupWidget: React.FC<WidgetProps> = ({
                 onChange={handleCheckboxChange(option.value)}
                 disabled={disabled}
                 id={`${id}_${index}`}
-                required={required}
                 aria-label={option.label || option.value}
                 readOnly={readonly}
               />

--- a/bciers/libs/utils/src/customTransformErrors.test.ts
+++ b/bciers/libs/utils/src/customTransformErrors.test.ts
@@ -459,6 +459,44 @@ describe("customTransformErrors", () => {
     expect(transformedErrors[0].message).toBe(customFormatsErrorMessages.phone);
   });
 
+  // activities array field vs sub-field required error distinction
+  it("returns 'Select at least one option' for a required error on the activities array itself", () => {
+    const activitiesArrayError = [
+      {
+        name: "required",
+        property: ".activities",
+        message: "must have required property 'activities'",
+        params: { missingProperty: "activities" },
+        stack: "must have required property 'activities'",
+        schemaPath: "#/required",
+      },
+    ];
+    const transformedErrors = customTransformErrors(
+      activitiesArrayError,
+      customFormatsErrorMessages,
+    );
+    expect(transformedErrors[0].message).toBe("Select at least one option");
+  });
+
+  it("returns a field-level required message for a sub-field inside activities, not 'Select at least one option'", () => {
+    const activitySubFieldError = [
+      {
+        name: "required",
+        property: ".activities.0.activity",
+        message: "must have required property 'Activity Name'",
+        params: { missingProperty: "activity" },
+        stack: "must have required property 'Activity Name'",
+        schemaPath: "#/properties/activities/items/required",
+      },
+    ];
+    const transformedErrors = customTransformErrors(
+      activitySubFieldError,
+      customFormatsErrorMessages,
+    );
+    expect(transformedErrors[0].message).toBe("Activity Name is required");
+    expect(transformedErrors[0].message).not.toBe("Select at least one option");
+  });
+
   // Emissions, methodology and gas type filtering tests
   describe("emissions methodology and gas type filtering", () => {
     it("filters out oneOf errors at the emission level", () => {

--- a/bciers/libs/utils/src/customTransformErrors.ts
+++ b/bciers/libs/utils/src/customTransformErrors.ts
@@ -17,10 +17,14 @@ const transformPropertyError = (
   error: RJSFValidationError,
 ): RJSFValidationError | null => {
   if (
-    // we use some because fields can be nested in sections
+    // Match the array field itself (e.g. `.activities`), not sub-fields within it
+    // (e.g. `.activities.0.activity`), to avoid misclassifying required field errors
     ["activities", "regulated_products"].some((field) => {
-      // @ts-expect-error - we already checked for error.property's existence above
-      return error?.name === "required" && error.property.includes(field);
+      return (
+        error?.name === "required" &&
+        // @ts-expect-error - we already checked for error.property's existence above
+        new RegExp(`(^|\\.)${field}$`).test(error.property)
+      );
     })
   ) {
     error.message = "Select at least one option";


### PR DESCRIPTION
[ISSUE 4582](https://github.com/bcgov/cas-registration/issues/4582)


## Summary

- **Bug fix**: Required fields (`activity`, `source_type`, `emission_category`) on the non-attributable emissions form were not highlighted when left blank. Added `required` to the activity items in the frontend JSON schema so RJSF highlights missing fields client-side before the form reaches the backend.
- **`gas_type` now required**: Added `gas_type` as a required field with `minItems: 1` in the frontend JSON schema so RJSF fires a "Select at least one option" validation error when no gas type is selected. Added `Field(min_length=1)` to `ReportNonAttributableIn` so the backend independently rejects empty gas type lists with a 422. Fixed `CheckboxGroupWidget` to not pass `required` down to individual `<Checkbox>` elements (which caused asterisks to appear on each option instead of just the field label).
- **Backend GET response**: Refactored the `GET` endpoint to return `{ emissions_exceeded, activities }` instead of a flat list, so the frontend can correctly initialise `emissions_exceeded` from the server rather than inferring it from array length.
- **`customTransformErrors` fix**: The regex matching for array-level required errors (e.g. `.activities`) was too broad — it also matched sub-field errors (e.g. `.activities.0.activity`), causing them to display "Select at least one option" instead of a field-level message. Tightened the regex to match only the array field itself.
- **Schema cleanup**: Removed redundant `to_camel`/`to_snake` wrapper functions across multiple schema files and replaced with `alias_generators` directly. Cleaned up `ReportNonAttributableIn` to remove manually re-declared fields that `ModelSchema` already provides.
- **Frontend refactor**: Moved `gasTypeMap`/`emissionCategoryMap` computation from `NonAttributableEmissionsPage` into `NonAttributableEmissionsForm` (they are only consumed there), added explicit types (`ActivityFormItem`, `NonAttributableFormData`), and used a lazy `useState` initializer so map computation only runs once on mount. Simplified the Page to use `Promise.all` for parallel data fetching.

## Test plan

Follow steps in the issue.
