### PR TITLE
Chore/harden

### DIFF
--- a/.github/actions/nx-app-build/action.yaml
+++ b/.github/actions/nx-app-build/action.yaml
@@ -73,6 +73,12 @@ runs:
       run: |
         VERSION=$(grep '^appVersion:' helm/cas-bciers/Chart.yaml | sed 's/appVersion: "\(.*\)"/\1/')
         echo "value=${VERSION}" >> $GITHUB_OUTPUT
+    - name: Get Node version from .tool-versions
+      id: node_version
+      run: |
+        NODE_VERSION=$(grep '^nodejs ' ./.tool-versions | awk '{print $2}')
+        echo "value=${NODE_VERSION}" >> $GITHUB_OUTPUT
+      shell: bash
     - name: Build images
       shell: bash
       env:
@@ -93,7 +99,10 @@ runs:
           echo "Project not in allowed project list"
           exit 1
         fi
-        npx nx container $PROJECT --skip-nx-cache
+          npx nx container $PROJECT \
+            --build-args=application_path="$PROJECT" \
+            --build-args=NODE_VERSION="${{ steps.node_version.outputs.value }}" \
+            --skip-nx-cache
       working-directory: ./bciers
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/build-backend.yaml
+++ b/.github/workflows/build-backend.yaml
@@ -45,9 +45,16 @@ jobs:
           key: ${{ runner.os }}-buildx-bc_obps-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-bc_obps
+      - name: Get Python version from .tool-versions
+        id: python_version
+        run: |
+          PYTHON_VERSION=$(grep '^python ' ./bc_obps/.tool-versions | awk '{print $2}')
+          echo "value=${PYTHON_VERSION}" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Build image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
+          build-args: PYTHON_VERSION=${{ steps.python_version.outputs.value }}
           context: bc_obps
           builder: ${{ steps.buildx.outputs.name }}
           push: true

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 24.15.0
 gcloud 450.0.0
-python 3.12.11
+python 3.12.13

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-nodejs 24.14.1
+nodejs 24.15.0
 gcloud 450.0.0
 python 3.12.11

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-nodejs 24.15.0
+nodejs 24.16.0
 gcloud 450.0.0
 python 3.12.13

--- a/bc_obps/.tool-versions
+++ b/bc_obps/.tool-versions
@@ -1,3 +1,3 @@
-python 3.12.11
+python 3.12.13
 poetry 2.4.1
 postgres 16.2

--- a/bc_obps/Dockerfile
+++ b/bc_obps/Dockerfile
@@ -1,7 +1,10 @@
+# In CI, the Python version is specified in the build args, see .github/workflows/build-backend.yaml
+ARG PYTHON_VERSION
+
 ####################
 # Base Stage
 ####################
-FROM dhi.io/python:3.12.13-debian13-dev AS base
+FROM dhi.io/python:${PYTHON_VERSION}-debian13-dev AS base
 
 # Prevent Python from writing .pyc files to disk
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/bc_obps/Dockerfile
+++ b/bc_obps/Dockerfile
@@ -29,8 +29,6 @@ FROM base AS builder
 
 # Refresh package lists from repositories
 RUN apt-get update && \
-# Upgrade the installed system packages from apt-get update, making sure security is up to date
-    apt-get upgrade -y && \
 # Install minimal build tools required for asdf (git), curl for Poetry plugin, build-essential for compiling Python, and additional libs for Python
     apt-get install -y --no-install-recommends build-essential curl git libc6-dev libffi-dev libssl-dev zlib1g-dev && \
 # Remove apt cache to reduce image size
@@ -84,8 +82,6 @@ FROM base AS runner
 
 # Refresh package lists from repositories
 RUN apt-get update && \
-    # Upgrade the installed system packages from apt-get update, making sure security is up to date
-    apt-get upgrade -y && \
     # Install essential runner packages and WeasyPrint dependencies
     apt-get install -y --no-install-recommends \
     curl \

--- a/bc_obps/Dockerfile
+++ b/bc_obps/Dockerfile
@@ -1,7 +1,7 @@
 ####################
 # Base Stage
 ####################
-FROM python:3.12.11-slim AS base
+FROM dhi.io/python:3.12.13-debian13-dev AS base
 
 # Prevent Python from writing .pyc files to disk
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/bc_obps/Dockerfile
+++ b/bc_obps/Dockerfile
@@ -29,8 +29,8 @@ FROM base AS builder
 
 # Refresh package lists from repositories
 RUN apt-get update && \
-# Install minimal build tools required for asdf (git), curl for Poetry plugin, build-essential for compiling Python, and additional libs for Python
-    apt-get install -y --no-install-recommends build-essential curl git libc6-dev libffi-dev libssl-dev zlib1g-dev && \
+# Install minimal tools and dependencies
+    apt-get install -y --no-install-recommends build-essential curl && \
 # Remove apt cache to reduce image size
     apt-get clean && \
 # Delete package lists to further slim the image

--- a/bc_obps/Dockerfile
+++ b/bc_obps/Dockerfile
@@ -36,41 +36,28 @@ RUN apt-get update && \
 # Delete package lists to further slim the image
     rm -rf /var/lib/apt/lists/*
 
+# Add bin path for poetry
+ENV PATH="/app/.local/bin:${PATH}"
+
 # Copy version config and Poetry files with ownership set to numbered user
 COPY --chown=${USER_ID}:0 .tool-versions pyproject.toml poetry.lock ${HOME}/
 
 USER ${USER_ID}
 
-# Clone asdf shallowly from GitHub
-RUN git clone --depth 1 --branch v${ASDF_VERSION} https://github.com/asdf-vm/asdf.git ${HOME}/asdf
-
-# Ensure asdf is available in non-interactive shells
-ENV BASH_ENV="${HOME}/asdf/asdf.sh"
-
 # Use bash with environment sourcing for asdf commands
 SHELL ["/bin/bash", "-c"]
 
-# Filter .tool-versions for python and poetry
-RUN sed -i -nr '/python|poetry/p' ${HOME}/.tool-versions && \
-    # Add plugins for each tool listed in .tool-versions
-    cat ${HOME}/.tool-versions | cut -f 1 -d ' ' | xargs -n 1 asdf plugin add && \
-    # Update all plugins to latest versions
-    asdf plugin update --all && \
-    # Install tools (Python, Poetry) from .tool-versions
-    asdf install && \
-    # Regenerate shims for installed tools
-    asdf reshim
-
 # Configure Poetry and install dependencies
 # Extract Poetry version from .tool-versions
-RUN export POETRY_VERSION=$(grep '^poetry ' ${HOME}/.tool-versions | awk '{print $2}') && \
+RUN POETRY_VERSION=$(grep '^poetry ' ${HOME}/.tool-versions | awk '{print $2}') && \
+    # Use inbuilt Python to install Poetry
+    curl -sSL https://install.python-poetry.org | python3 - && \
     # Add Poetry to PATH in bashrc
-    echo "export PATH=${HOME}/.asdf/installs/poetry/${POETRY_VERSION}/bin:${PATH}" >> ${HOME}/.bashrc && \
     # Keep virtualenv in project directory (.venv)
-    poetry config virtualenvs.create true && \
-    poetry config virtualenvs.in-project true && \
+    ${HOME}/.local/bin/poetry config virtualenvs.create true && \
+    ${HOME}/.local/bin/poetry config virtualenvs.in-project true && \
     # Install dependencies without dev group, non-interactively
-    poetry install --without dev --no-root --no-interaction --no-ansi --compile
+    ${HOME}/.local/bin/poetry install --without dev --no-root --no-interaction --no-ansi --compile
 
 # Copy all remaining files, owned by numbered user
 COPY --chown=${USER_ID}:0 . ${HOME}/

--- a/bc_obps/Dockerfile
+++ b/bc_obps/Dockerfile
@@ -18,9 +18,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR ${HOME}
 
-# Recreate bc_obps user with bash shell
-RUN useradd -ms /bin/bash -d ${HOME} --uid ${USER_ID} -g root bc_obps && \
-    chown -R bc_obps:0 ${HOME} && \
+# Grant the numbered user complete access to the workspace root directory
+RUN chown -R ${USER_ID}:0 ${HOME} && \
     chmod -R g+rwX ${HOME}
 
 ####################
@@ -39,8 +38,8 @@ RUN apt-get update && \
 # Delete package lists to further slim the image
     rm -rf /var/lib/apt/lists/*
 
-# Copy version config and Poetry files with ownership set to bc_obps
-COPY --chown=bc_obps:0 .tool-versions pyproject.toml poetry.lock ${HOME}/
+# Copy version config and Poetry files with ownership set to numbered user
+COPY --chown=${USER_ID}:0 .tool-versions pyproject.toml poetry.lock ${HOME}/
 
 USER ${USER_ID}
 
@@ -75,8 +74,8 @@ RUN export POETRY_VERSION=$(grep '^poetry ' ${HOME}/.tool-versions | awk '{print
     # Install dependencies without dev group, non-interactively
     poetry install --without dev --no-root --no-interaction --no-ansi --compile
 
-# Copy all remaining files, owned by bc_obps
-COPY --chown=bc_obps:0 . ${HOME}/
+# Copy all remaining files, owned by numbered user
+COPY --chown=${USER_ID}:0 . ${HOME}/
 
 ####################
 # Runner Stage
@@ -103,7 +102,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy application from the builder stage
-COPY --from=builder --chown=bc_obps:0 ${HOME}/ ${HOME}/
+COPY --from=builder --chown=${USER_ID}:0 ${HOME}/ ${HOME}/
 
 # Remove asdf and Poetry files
 RUN rm .tool-versions pyproject.toml poetry.lock

--- a/bciers/Dockerfile
+++ b/bciers/Dockerfile
@@ -1,48 +1,57 @@
-# Dependencies built by Nx build
-# Production image, copy all the files and run next
-# DHI -dev image includes shell for setup
+####################
+# Bundler Stage
+# - Dependencies built by Nx build
+# - DockerHardenedImages (DHI.io)-dev image includes shell for setup
+####################
 FROM dhi.io/node:24.15.0-alpine3.23-dev AS bundler
 
 # nx/nextjs builds some files into subfolders based on project name. For a unified container, we supply the project name as a path.
 ARG application_path
 WORKDIR /usr/src/app
+
 COPY ./.next/standalone .
 COPY ./public ./apps/${application_path}/public
-COPY ./.next/static ./dist/${application_path}/.next/static
-RUN chmod -R g+rwX ./dist ./apps
-
 # Create a symlink so the entrypoint is ALWAYS at /usr/src/app/server.js
 RUN ln -s /usr/src/app/apps/${application_path}/server.js /usr/src/app/server.js
+COPY ./.next/static ./dist/${application_path}/.next/static
 
-# Build args
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+####################
+# Runner Stage
+# - Uses DHI.io runtime image which does not include shell
+# - Production image, copy all the files and run next
+####################
+FROM dhi.io/node:24.15.0-alpine3.23-dev AS runner
+
 # HOST variables are only used in test builds for running e2e in CI
 ARG HOST_ADMINISTRATION
 ARG HOST_COMPLIANCE
 ARG HOST_REGISTRATION
 ARG HOST_REPORTING
 
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 /usr/local/bin/dumb-init
-RUN chmod +x /usr/local/bin/dumb-init
-
-FROM dhi.io/node:24.15.0-alpine3.23 AS runner
 ENV HOST_ADMINISTRATION=${HOST_ADMINISTRATION}
 ENV HOST_COMPLIANCE=${HOST_COMPLIANCE}
 ENV HOST_REGISTRATION=${HOST_REGISTRATION}
 ENV HOST_REPORTING=${HOST_REPORTING}
 
-ENV NODE_ENV production
-ENV PORT 3000
+ENV NODE_ENV=production
+ENV PORT=3000
 
+WORKDIR /usr/src/app
+
+# Copy application and dumb-init from bundler
+# Writable .next directory: The .next directory is owned by the node user so the server can write prerender cache and optimized images at runtime
 COPY --from=bundler --chown=node:node /usr/src/app ./
-COPY --from=bundler /usr/local/bin/dumb-init /usr/local/bin/dumb-init
+COPY --from=bundler --chown=node:node /usr/local/bin/dumb-init /usr/local/bin/dumb-init
 
-ENTRYPOINT ["dumb-init", "--"]
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 
 USER node
 EXPOSE 3000
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry.
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 CMD ["node", "server.js"]

--- a/bciers/Dockerfile
+++ b/bciers/Dockerfile
@@ -11,28 +11,32 @@ COPY ./public ./apps/${application_path}/public
 COPY ./.next/static ./dist/${application_path}/.next/static
 RUN chmod -R g+rwX ./dist ./apps
 
+# Create a symlink so the entrypoint is ALWAYS at /usr/src/app/server.js
+RUN ln -s /usr/src/app/apps/${application_path}/server.js /usr/src/app/server.js
+
 # Build args
 # HOST variables are only used in test builds for running e2e in CI
 ARG HOST_ADMINISTRATION
 ARG HOST_COMPLIANCE
 ARG HOST_REGISTRATION
 ARG HOST_REPORTING
+
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+
+FROM dhi.io/node:24.15.0-alpine3.23 AS runner
 ENV HOST_ADMINISTRATION=${HOST_ADMINISTRATION}
 ENV HOST_COMPLIANCE=${HOST_COMPLIANCE}
 ENV HOST_REGISTRATION=${HOST_REGISTRATION}
 ENV HOST_REPORTING=${HOST_REPORTING}
-
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 /usr/local/bin/dumb-init
-RUN chmod +x /usr/local/bin/dumb-init
-ENTRYPOINT ["dumb-init", "--"]
-
-FROM dhi.io/node:24.15.0-alpine3.23 AS runner
 
 ENV NODE_ENV production
 ENV PORT 3000
 
 COPY --from=bundler --chown=node:node /usr/src/app ./
 COPY --from=bundler /usr/local/bin/dumb-init /usr/local/bin/dumb-init
+
+ENTRYPOINT ["dumb-init", "--"]
 
 USER node
 EXPOSE 3000
@@ -41,7 +45,4 @@ EXPOSE 3000
 # Uncomment the following line in case you want to disable telemetry.
 ENV NEXT_TELEMETRY_DISABLED 1
 
-# Add an ENV to preserve the build ARG
-ENV app_server=apps/${application_path}/server.js
-
-CMD node ${app_server}
+CMD ["node", "server.js"]

--- a/bciers/Dockerfile
+++ b/bciers/Dockerfile
@@ -1,9 +1,18 @@
+# In CI, the Node version is specified in the build args, taken from .tool-versions
+# TODO: Add docs for building locally
+ARG NODE_VERSION
+
+####################
+# Base Stage
+####################
+FROM dhi.io/node:${NODE_VERSION}-alpine3.23-dev AS base
+
 ####################
 # Bundler Stage
 # - Dependencies built by Nx build
 # - DockerHardenedImages (DHI.io)-dev image includes shell for setup
 ####################
-FROM dhi.io/node:24.15.0-alpine3.23-dev AS bundler
+FROM base AS bundler
 
 # nx/nextjs builds some files into subfolders based on project name. For a unified container, we supply the project name as a path.
 ARG application_path
@@ -22,7 +31,7 @@ RUN chmod +x /usr/local/bin/dumb-init
 # - Uses DHI.io runtime image which does not include shell
 # - Production image, copy all the files and run next
 ####################
-FROM dhi.io/node:24.15.0-alpine3.23-dev AS runner
+FROM base AS runner
 
 # HOST variables are only used in test builds for running e2e in CI
 ARG HOST_ADMINISTRATION

--- a/bciers/Dockerfile
+++ b/bciers/Dockerfile
@@ -1,6 +1,6 @@
 # Dependencies built by Nx build
 # Production image, copy all the files and run next
-FROM docker.io/node:24.11.1-alpine AS runner
+FROM docker.io/node:24.15.0-alpine AS runner
 
 # Apply patch to Apline's packages to address security issues that trivy found without caching (openssl and zlib)
 RUN apk update && apk upgrade --no-cache

--- a/bciers/Dockerfile
+++ b/bciers/Dockerfile
@@ -1,9 +1,6 @@
 # Dependencies built by Nx build
 # Production image, copy all the files and run next
-FROM docker.io/node:24.15.0-alpine AS runner
-
-# Apply patch to Apline's packages to address security issues that trivy found without caching (openssl and zlib)
-RUN apk update && apk upgrade --no-cache
+FROM dhi.io/node:24.15.0-alpine3.23 AS runner
 
 # nx/nextjs builds some files into subfolders based on project name. For a unified container, we supply the project name as a path.
 ARG application_path

--- a/bciers/Dockerfile
+++ b/bciers/Dockerfile
@@ -1,9 +1,15 @@
 # Dependencies built by Nx build
 # Production image, copy all the files and run next
-FROM dhi.io/node:24.15.0-alpine3.23 AS runner
+# DHI -dev image includes shell for setup
+FROM dhi.io/node:24.15.0-alpine3.23-dev AS bundler
 
 # nx/nextjs builds some files into subfolders based on project name. For a unified container, we supply the project name as a path.
 ARG application_path
+WORKDIR /usr/src/app
+COPY ./.next/standalone .
+COPY ./public ./apps/${application_path}/public
+COPY ./.next/static ./dist/${application_path}/.next/static
+RUN chmod -R g+rwX ./dist ./apps
 
 # Build args
 # HOST variables are only used in test builds for running e2e in CI
@@ -20,19 +26,16 @@ ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x
 RUN chmod +x /usr/local/bin/dumb-init
 ENTRYPOINT ["dumb-init", "--"]
 
+FROM dhi.io/node:24.15.0-alpine3.23 AS runner
+
 ENV NODE_ENV production
 ENV PORT 3000
-WORKDIR /usr/src/app
-COPY ./.next/standalone .
-COPY ./public ./apps/${application_path}/public
-COPY ./.next/static ./dist/${application_path}/.next/static
 
-RUN chmod -R g+rwX ./dist ./apps
+COPY --from=bundler --chown=node:node /usr/src/app ./
+COPY --from=bundler /usr/local/bin/dumb-init /usr/local/bin/dumb-init
 
 USER node
 EXPOSE 3000
-# COPY --chown=node:node ./tools/scripts/entrypoints/api.sh /usr/local/bin/docker-entrypoint.sh
-# ENTRYPOINT [ "docker-entrypoint.sh" ]
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry.

--- a/docs/developer-environment-setup-linux-os.md
+++ b/docs/developer-environment-setup-linux-os.md
@@ -182,7 +182,7 @@ This guide will help you set up the frontend development environment for the CAS
 ### Required Tools
 
 1. **Node.js**
-   - Version: 24.15.0 (as specified in `.tool-versions`)
+   - Version: 24.16.0 (as specified in `.tool-versions`)
    - Required for running the JavaScript/TypeScript codebase
 
 2. **Package Manager**
@@ -220,23 +220,23 @@ This guide will help you set up the frontend development environment for the CAS
 3. **Install Node.js**
 
    ```bash
-   asdf install nodejs 24.15.0
+   asdf install nodejs 24.16.0
    ```
 
 4. **Set Node.js version globally or locally**
    ```bash
-   asdf global nodejs 24.15.0  # for global setting
+   asdf global nodejs 24.16.0  # for global setting
    # OR
-   asdf local nodejs 24.15.0   # for project-specific setting
+   asdf local nodejs 24.16.0   # for project-specific setting
    ```
 
 ### Alternative Method (Without asdf)
 
-1. **Install Node.js 24.15.0**
+1. **Install Node.js 24.16.0**
    - Using nvm:
      ```bash
-     nvm install 24.15.0
-     nvm use 24.15.0
+     nvm install 24.16.0
+     nvm use 24.16.0
      ```
    - Or download directly from [Node.js website](https://nodejs.org/)
 
@@ -370,7 +370,7 @@ The shared libraries are automatically available to all applications in the mono
 
 ### Prerequisites
 
-- Node.js 24.15.0 (managed by asdf)
+- Node.js 24.16.0 (managed by asdf)
 - Yarn (via Node's Corepack)
 - Nx CLI (installed via project dependencies)
 
@@ -441,7 +441,7 @@ yarn nx run coam:test   # Run tests
      ```bash
      node --version
      ```
-   - Should output: v24.15.0
+   - Should output: v24.16.0
 
 2. **Yarn issues**
    - Clear yarn cache:
@@ -463,7 +463,7 @@ yarn nx run coam:test   # Run tests
 
 ## Additional Resources
 
-- [Node.js Documentation](https://nodejs.org/docs/v24.15.0/api/)
+- [Node.js Documentation](https://nodejs.org/docs/v24.16.0/api/)
 - [Yarn Documentation](https://yarnpkg.com/getting-started)
 - [Next.js Documentation](https://nextjs.org/docs)
 - [Nx Documentation](https://nx.dev/getting-started/intro)

--- a/docs/developer-environment-setup-linux-os.md
+++ b/docs/developer-environment-setup-linux-os.md
@@ -182,7 +182,7 @@ This guide will help you set up the frontend development environment for the CAS
 ### Required Tools
 
 1. **Node.js**
-   - Version: 24.11.1 (as specified in `.tool-versions`)
+   - Version: 24.15.0 (as specified in `.tool-versions`)
    - Required for running the JavaScript/TypeScript codebase
 
 2. **Package Manager**
@@ -220,23 +220,23 @@ This guide will help you set up the frontend development environment for the CAS
 3. **Install Node.js**
 
    ```bash
-   asdf install nodejs 24.11.1
+   asdf install nodejs 24.15.0
    ```
 
 4. **Set Node.js version globally or locally**
    ```bash
-   asdf global nodejs 24.11.1  # for global setting
+   asdf global nodejs 24.15.0  # for global setting
    # OR
-   asdf local nodejs 24.11.1   # for project-specific setting
+   asdf local nodejs 24.15.0   # for project-specific setting
    ```
 
 ### Alternative Method (Without asdf)
 
-1. **Install Node.js 24.11.1**
+1. **Install Node.js 24.15.0**
    - Using nvm:
      ```bash
-     nvm install 24.11.1
-     nvm use 24.11.1
+     nvm install 24.15.0
+     nvm use 24.15.0
      ```
    - Or download directly from [Node.js website](https://nodejs.org/)
 
@@ -370,7 +370,7 @@ The shared libraries are automatically available to all applications in the mono
 
 ### Prerequisites
 
-- Node.js 24.11.1 (managed by asdf)
+- Node.js 24.15.0 (managed by asdf)
 - Yarn (via Node's Corepack)
 - Nx CLI (installed via project dependencies)
 
@@ -441,7 +441,7 @@ yarn nx run coam:test   # Run tests
      ```bash
      node --version
      ```
-   - Should output: v24.11.1
+   - Should output: v24.15.0
 
 2. **Yarn issues**
    - Clear yarn cache:
@@ -463,11 +463,11 @@ yarn nx run coam:test   # Run tests
 
 ## Additional Resources
 
-- [Node.js Documentation](https://nodejs.org/docs/v24.11.1/api/)
+- [Node.js Documentation](https://nodejs.org/docs/v24.15.0/api/)
 - [Yarn Documentation](https://yarnpkg.com/getting-started)
 - [Next.js Documentation](https://nextjs.org/docs)
 - [Nx Documentation](https://nx.dev/getting-started/intro)
 
 ---
 
-_Last updated: February 3, 2025_
+_Last updated: February 10, 2026_

--- a/docs/docker-container-building.md
+++ b/docs/docker-container-building.md
@@ -1,0 +1,18 @@
+# Building docker containers locally
+
+Our `Dockerfile`s each have a build argument (`ARG`) used to set the relevant code language version (`NODE_VERSION` and `PYTHON_VERSION`).
+
+## CI
+
+When in CI, the version `ARG`s are passed by the `build-{application}.yaml` workflow, which is derived from `.tool-versions`.
+
+## Local
+
+For local building of containers, there are options:
+
+- To your `docker build` command, add `--build-arg {ARG}={VERSION}`, e.g. `--build-arg NODE_VERSION=24.16.0`.
+- When using the Nx `container` target, you need to add a `INPUT_BUILD_ARGS` env value, with `NODE_VERSION` and `application_path` subvalues. The two values _must_ be seperated by a newline (_not_ the `\n` escape character). See the [nx-container docs for details](https://nx-tools.vercel.app/docs/nx-container/faq#inline-execution)
+  ```shell
+  INPUT_BUILD_ARGS="application_path=dashboard
+  NODE_VERSION=24.16.0" nx run dashboard:container
+  ```


### PR DESCRIPTION
Addresses #4526. Makes use of [Docker Hardened Images](https://www.docker.com/products/hardened-images/) for image bases. 

## Changes 🚧

- Replace source images in backend pods with [dhi/python image](https://hub.docker.com/hardened-images/catalog/dhi/python/guides)
- Replace source images in frontend pods with [dhi/node image](https://hub.docker.com/hardened-images/catalog/dhi/node/guides)
- Refactored Dockerfiles to accommodate changes needed for DHI to run
- Add step to CI to extract Python's version from `/bc_obps/.tool-versions` to pass as an ARG to the backend Dockerfile

## To test 🔬

- Prior to merging, these images can be swapped out as replacements in local deployments and remotely in OpenShift by using this PR's commit hash after being built. 

## Notes 📝

We're using the `-dev` images from DHI for Node and Python so that we can still use shell scripting. These images are still more secured than our existing images. A future pass could remove any shell usage and switch to the non`-dev` DHI for the runner layers.