### PR TITLE
4642 - Update report attachments endpoint auth scope to include `cas_*` roles

### DIFF
--- a/bc_obps/common/tests/endpoints/auth/constants.py
+++ b/bc_obps/common/tests/endpoints/auth/constants.py
@@ -149,11 +149,6 @@ ENDPOINTS = {
         },
         {
             "method": "get",
-            "endpoint_name": "get_report_attachments",
-            "kwargs": {"version_id": MOCK_INT},
-        },
-        {
-            "method": "get",
             "endpoint_name": "get_emission_allocations",
             "kwargs": {"version_id": MOCK_INT, "facility_id": MOCK_UUID},
         },
@@ -548,11 +543,6 @@ ENDPOINTS = {
             "kwargs": {"version_id": MOCK_INT},
         },
         {
-            "method": "get",
-            "endpoint_name": "get_report_attachment_url",
-            "kwargs": {"version_id": MOCK_INT, "file_id": MOCK_INT},
-        },
-        {
             "method": "delete",
             "endpoint_name": "delete_report_version",
             "kwargs": {"version_id": MOCK_INT},
@@ -620,6 +610,16 @@ ENDPOINTS = {
             "method": "get",
             "endpoint_name": "generate_compliance_report_version_late_submission_penalty_invoice",
             "kwargs": {"compliance_report_version_id": MOCK_INT},
+        },
+        {
+            "method": "get",
+            "endpoint_name": "get_report_attachments",
+            "kwargs": {"version_id": MOCK_INT},
+        },
+        {
+            "method": "get",
+            "endpoint_name": "get_report_attachment_url",
+            "kwargs": {"version_id": MOCK_INT, "file_id": MOCK_INT},
         },
     ],
     "authorized_irc_user_and_industry_admin_user": [],

--- a/bc_obps/reporting/api/report_attachments.py
+++ b/bc_obps/reporting/api/report_attachments.py
@@ -67,7 +67,7 @@ def save_report_attachments(
     response={200: AttachmentsWithConfirmationOut, custom_codes_4xx: Message},
     tags=EMISSIONS_REPORT_TAGS,
     description="Returns both the attachments and (if any) the supplementary report confirmation.",
-    auth=approved_industry_user_report_version_composite_auth,
+    auth=approved_authorized_roles_report_version_composite_auth,
 )
 def get_report_attachments(
     request: HttpRequest,

--- a/bc_obps/reporting/tests/api/test_report_attachment_api.py
+++ b/bc_obps/reporting/tests/api/test_report_attachment_api.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import ANY, call, patch, MagicMock
 from django.core.files.base import ContentFile
 from model_bakery.baker import make_recipe
@@ -12,6 +13,7 @@ class TestReportAttachmentEndpoints(CommonTestSetup):
     def setup_method(self):
         self.report_version = make_recipe("reporting.tests.utils.report_version")
         self.endpoint_under_test = f"/api/reporting/report-version/{self.report_version.id}/attachments"
+        self.file_url_endpoint = f"{self.endpoint_under_test}/1234"
 
         super().setup_method()
         TestUtils.authorize_current_user_as_operator_user(self, operator=self.report_version.report.operator)
@@ -93,10 +95,12 @@ class TestReportAttachmentEndpoints(CommonTestSetup):
     @patch(
         "reporting.service.report_attachment_service.ReportAttachmentService.get_attachment_confirmation", autospec=True
     )
-    def test_get_attachments_returns_expected_schema(
+    @pytest.mark.parametrize("role", ["industry_user", "cas_admin"])
+    def test_get_attachments_returns_expected_schema_for_authorized_roles(
         self,
         mock_get_confirmation: MagicMock,
         mock_get_attachments: MagicMock,
+        role: str,
     ):
         # Arrange: fake attachment and confirmation
         fake_attachment = ReportAttachment(
@@ -114,12 +118,11 @@ class TestReportAttachmentEndpoints(CommonTestSetup):
             confirm_supplementary_required_attachments_uploaded=True,
         )
 
-        TestUtils.save_app_role(self, "industry_user")
-
         # Act
-        response = TestUtils.client.get(
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            role,
             self.endpoint_under_test,
-            HTTP_AUTHORIZATION=self.auth_header_dumps,
         )
 
         # Assert
@@ -137,8 +140,35 @@ class TestReportAttachmentEndpoints(CommonTestSetup):
                 "confirm_supplementary_required_attachments_uploaded": True,
             },
         }
+
         mock_get_attachments.assert_called_once_with(self.report_version.id)
         mock_get_confirmation.assert_called_once_with(self.report_version.id)
+
+    @patch(
+        "reporting.service.report_attachment_service.ReportAttachmentService.get_attachment",
+        autospec=True,
+    )
+    @pytest.mark.parametrize("role", ["industry_user", "cas_admin"])
+    def test_get_file_url(
+        self,
+        mock_get_attachment: MagicMock,
+        role: str,
+    ):
+        mock_attachment = MagicMock()
+        mock_attachment.get_file_url.return_value = "this is a very fake url"
+
+        mock_get_attachment.return_value = mock_attachment
+
+        response = TestUtils.mock_get_with_auth_role(
+            self,
+            role,
+            self.file_url_endpoint,
+        )
+
+        mock_get_attachment.assert_called_with(self.report_version.id, 1234)
+
+        assert response.status_code == 200
+        assert response.json() == "this is a very fake url"
 
     @patch(
         "reporting.service.report_attachment_service.ReportAttachmentService.save_attachment_confirmation",
@@ -171,25 +201,6 @@ class TestReportAttachmentEndpoints(CommonTestSetup):
         assert response.status_code == 500
         mock_set_attachment.assert_not_called()
         mock_get_attachments.assert_not_called()
-
-    @patch(
-        "reporting.service.report_attachment_service.ReportAttachmentService.get_attachment",
-        autospec=True,
-    )
-    def test_get_file_url(self, mock_get_attachment: MagicMock):
-        mock_attachment = MagicMock()
-        mock_attachment.get_file_url.return_value = "this is a very fake url"
-
-        mock_get_attachment.return_value = mock_attachment
-
-        response = TestUtils.mock_get_with_auth_role(
-            self,
-            "industry_user",
-            f"/api/reporting/report-version/{self.report_version.id}/attachments/1234",
-        )
-
-        mock_get_attachment.assert_called_with(self.report_version.id, 1234)
-        assert response.json() == "this is a very fake url"
 
     def test_validates_report_version_id(self):
         assert_report_version_ownership_is_validated("get_report_attachments")


### PR DESCRIPTION
resolves [4642](https://github.com/bcgov/cas-registration/issues/4642)