### PR TITLE
4479 - Add warning in Validation page when there are no regulated products

### DIFF
--- a/bc_obps/reporting/service/report_validation/report_validation_error.py
+++ b/bc_obps/reporting/service/report_validation/report_validation_error.py
@@ -29,6 +29,7 @@ class ReportValidationErrorKey(StrEnum):
     ACTIVITY_DATA_COVERAGE = "activity_data_coverage"
     ERROR_REQUIRED_FIELDS = "error_required_fields"
     ACTIVITY_JSON_SCHEMA_VALIDATION_ERROR = "activity_json_schema_validation_error"
+    MISSING_REGULATED_PRODUCT = "missing_regulated_product"
 
 
 class ErrorContext(BaseModel):

--- a/bc_obps/reporting/service/report_validation/validators/__init__.py
+++ b/bc_obps/reporting/service/report_validation/validators/__init__.py
@@ -11,6 +11,7 @@ from . import (
     report_emission_allocation_validator,
     supplementary_report_attachments_confirmation,
     supplementary_report_version_change,
+    report_regulated_product_presence,
 )
 
 from .required_fields import (
@@ -50,4 +51,5 @@ __all__ = [
     "required_fields_report_additional_data",
     "required_fields_report_new_entrant_information",
     "required_fields_report_electricity_import_data",
+    "report_regulated_product_presence",
 ]

--- a/bc_obps/reporting/service/report_validation/validators/report_regulated_product_presence.py
+++ b/bc_obps/reporting/service/report_validation/validators/report_regulated_product_presence.py
@@ -1,0 +1,42 @@
+from registration.models.operation import Operation
+from reporting.models.report_operation import ReportOperation
+from reporting.models.report_version import ReportVersion
+from reporting.service.report_validation.report_validation_error import (
+    ErrorContext,
+    ReportValidationError,
+    ReportValidationErrorKey,
+    Severity,
+)
+from reporting.service.report_validation.report_validation_tags import ValidationTags
+
+TAGS = [ValidationTags.REPORT_VALIDATION]
+
+REGULATED_OPERATION_PURPOSES = [
+    Operation.Purposes.OBPS_REGULATED_OPERATION,
+    Operation.Purposes.OPTED_IN_OPERATION,
+    Operation.Purposes.NEW_ENTRANT_OPERATION,
+]
+
+
+def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
+    report_operation: ReportOperation = report_version.report_operation
+
+    errors = {}
+
+    is_regulated_operation = report_operation.registration_purpose in REGULATED_OPERATION_PURPOSES
+
+    has_regulated_product = report_operation.regulated_products.filter(is_regulated=True).exists()
+
+    if is_regulated_operation and not has_regulated_product:
+        errors["missing_regulated_products"] = ReportValidationError(
+            severity=Severity.WARNING,
+            message=(
+                "No regulated products selected on Review Operation Information. "
+                "Expected one or more regulated products to be selected. "
+                "If the correct products are selected, you may continue."
+            ),
+            key=ReportValidationErrorKey.MISSING_REGULATED_PRODUCT,
+            context=ErrorContext(report_version_id=report_version.id),
+        )
+
+    return errors

--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_operation_information.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_operation_information.py
@@ -28,7 +28,6 @@ class RequiredFieldsReportOperationInformationValidator(BaseRequiredFieldsValida
         {"field": "operation_name", "label": "Operation name", "field_type": "scalar"},
         {"field": "operator_legal_name", "label": "Operator legal name", "field_type": "scalar"},
         {"field": "activities", "label": "Activities", "field_type": "m2m"},
-        {"field": "regulated_products", "label": "Regulated products", "field_type": "m2m"},
     ]
 
     @classmethod
@@ -37,9 +36,7 @@ class RequiredFieldsReportOperationInformationValidator(BaseRequiredFieldsValida
         flow: ReportingFlow | None = None,
     ) -> list[RequiredFieldConfig]:
         if flow == ReportingFlow.EIO:
-            return [
-                field for field in cls.REQUIRED_FIELDS if field["field"] not in {"activities", "regulated_products"}
-            ]
+            return [field for field in cls.REQUIRED_FIELDS if field["field"] not in {"activities"}]
 
         return cls.REQUIRED_FIELDS
 

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_operation_information.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_operation_information.py
@@ -55,7 +55,6 @@ class TestRequiredFieldsReportOperationInformationValidator:
             "Operation name",
             "Operator legal name",
             "Activities",
-            "Regulated products",
             "Operation representative name",
         ]
 

--- a/bc_obps/reporting/tests/service/report_validation/validators/test_report_regulated_product_presence.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/test_report_regulated_product_presence.py
@@ -1,0 +1,130 @@
+from model_bakery.baker import make_recipe
+import pytest
+from registration.models.operation import Operation
+from registration.models.regulated_product import RegulatedProduct
+from reporting.service.report_validation.report_validation_error import (
+    ErrorContext,
+    ReportValidationError,
+    ReportValidationErrorKey,
+    Severity,
+)
+from reporting.service.report_validation.validators import (
+    report_regulated_product_presence,
+)
+
+
+regulated_products_required_purposes = [
+    Operation.Purposes.OBPS_REGULATED_OPERATION,
+    Operation.Purposes.OPTED_IN_OPERATION,
+    Operation.Purposes.NEW_ENTRANT_OPERATION,
+]
+
+regulated_products_not_required_purposes = [
+    Operation.Purposes.ELECTRICITY_IMPORT_OPERATION,
+    Operation.Purposes.REPORTING_OPERATION,
+    Operation.Purposes.POTENTIAL_REPORTING_OPERATION,
+]
+
+
+@pytest.mark.django_db
+class TestOperationRegulatedProductsSelectedValidator:
+    def test_all_purposes_are_evaluated(self):
+        assert set(regulated_products_required_purposes).union(regulated_products_not_required_purposes) == set(
+            Operation.Purposes
+        )
+
+    @pytest.mark.parametrize(
+        "reg_purpose",
+        regulated_products_required_purposes,
+    )
+    def test_warning_if_no_regulated_products_selected(self, reg_purpose):
+        report_operation = make_recipe(
+            "reporting.tests.utils.report_operation",
+            registration_purpose=reg_purpose,
+        )
+        report_operation.regulated_products.clear()
+
+        result = report_regulated_product_presence.validate(report_operation.report_version)
+
+        assert result == {
+            "missing_regulated_products": ReportValidationError(
+                Severity.WARNING,
+                (
+                    "No regulated products selected on Review Operation Information. "
+                    "Expected one or more regulated products to be selected. "
+                    "If the correct products are selected, you may continue."
+                ),
+                key=ReportValidationErrorKey.MISSING_REGULATED_PRODUCT,
+                context=ErrorContext(report_version_id=report_operation.report_version.id),
+            )
+        }
+
+    @pytest.mark.parametrize(
+        "reg_purpose",
+        regulated_products_required_purposes,
+    )
+    def test_warning_if_only_unregulated_products_selected(self, reg_purpose):
+        report_operation = make_recipe(
+            "reporting.tests.utils.report_operation",
+            registration_purpose=reg_purpose,
+        )
+
+        unregulated_product = RegulatedProduct.objects.create(
+            name="Unregulated product",
+            unit="tonnes",
+            is_regulated=False,
+        )
+
+        report_operation.regulated_products.set([unregulated_product])
+
+        result = report_regulated_product_presence.validate(report_operation.report_version)
+
+        assert result == {
+            "missing_regulated_products": ReportValidationError(
+                Severity.WARNING,
+                (
+                    "No regulated products selected on Review Operation Information. "
+                    "Expected one or more regulated products to be selected. "
+                    "If the correct products are selected, you may continue."
+                ),
+                key=ReportValidationErrorKey.MISSING_REGULATED_PRODUCT,
+                context=ErrorContext(report_version_id=report_operation.report_version.id),
+            )
+        }
+
+    @pytest.mark.parametrize(
+        "reg_purpose",
+        regulated_products_required_purposes,
+    )
+    def test_succeeds_if_regulated_product_selected(self, reg_purpose):
+        report_operation = make_recipe(
+            "reporting.tests.utils.report_operation",
+            registration_purpose=reg_purpose,
+        )
+
+        regulated_product = RegulatedProduct.objects.create(
+            name="Regulated product",
+            unit="tonnes",
+            is_regulated=True,
+        )
+
+        report_operation.regulated_products.set([regulated_product])
+
+        result = report_regulated_product_presence.validate(report_operation.report_version)
+
+        assert not result
+
+    @pytest.mark.parametrize(
+        "reg_purpose",
+        regulated_products_not_required_purposes,
+    )
+    def test_succeeds_if_regulated_products_not_required(self, reg_purpose):
+        report_operation = make_recipe(
+            "reporting.tests.utils.report_operation",
+            registration_purpose=reg_purpose,
+        )
+        report_operation.regulated_products.clear()
+
+        result = report_regulated_product_presence.validate(report_operation.report_version)
+
+        assert not result

--- a/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsibleForm.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsibleForm.tsx
@@ -193,7 +193,7 @@ const PersonResponsibleForm = ({
       // preserve the existing snapshot data
       if (!updatedContactResponse || "error" in updatedContactResponse) {
         setSnackbarMessage(
-          "This contact was deleted but the existing information entered has been saved,",
+          "This contact was deleted but the existing information entered has been saved.",
         );
 
         return;

--- a/bciers/apps/reporting/src/app/components/shared/validation/config.ts
+++ b/bciers/apps/reporting/src/app/components/shared/validation/config.ts
@@ -253,6 +253,16 @@ If the value is accurate, you may save & continue.`;
         : undefined,
   }),
 
+  missing_regulated_product: createValidationUIConfig({
+    label: "Review Operation Information",
+    priority: 2,
+    renderMode: "inline_link",
+    getHref: (ctx) =>
+      ctx?.report_version_id
+        ? reportRoutes.reviewOperationInformation(ctx.report_version_id)
+        : undefined,
+  }),
+
   generic_error: createValidationUIConfig({
     renderMode: "message_only",
     getMessage: (error) =>

--- a/bciers/apps/reporting/src/app/components/shared/validation/types.ts
+++ b/bciers/apps/reporting/src/app/components/shared/validation/types.ts
@@ -17,6 +17,7 @@ export type ReportValidationMessageKey =
   | "missing_supplementary_report_existing_attachment_confirmation"
   | "missing_supplementary_report_attachments_confirmation"
   | "missing_supplementary_report_version_change"
+  | "missing_regulated_product"
   | "generic_error";
 
 // Additional metadata returned from backend used for dynamic content

--- a/bciers/apps/reporting/src/tests/components/shared/validation/config.test.ts
+++ b/bciers/apps/reporting/src/tests/components/shared/validation/config.test.ts
@@ -20,11 +20,12 @@ describe("validationUIConfig", () => {
     "missing_supplementary_report_existing_attachment_confirmation",
     "missing_supplementary_report_attachments_confirmation",
     "missing_supplementary_report_version_change",
+    "missing_regulated_product",
     "generic_error",
   ];
 
   it("has the expected number of configs", () => {
-    expect(Object.keys(validationUIConfig)).toHaveLength(15);
+    expect(Object.keys(validationUIConfig)).toHaveLength(16);
   });
 
   it("has a config for every validation key", () => {


### PR DESCRIPTION
Ticket: [4479](https://github.com/bcgov/cas-registration/issues/4479)


### 🚀 Impact
- Added validator for Regulated Operations should report at least 1 regulated product 

---

### 🔬 Local Testing:  

#### Start Test Environment
1. Start the API server:  
   ```sh
   cd bc_obps
   make prepare_backend
   ```  
2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

---

#### Test: 

1. Log in using `bc-cas-dev`
2. Navigate to reporting
3. Start a report
4. 
5. 
**Expected Results:**
- 


