### PR TITLE
4479 - Add regulated product presence validator

### DIFF
--- a/bc_obps/reporting/service/report_validation/report_validation_error.py
+++ b/bc_obps/reporting/service/report_validation/report_validation_error.py
@@ -28,6 +28,7 @@ class ReportValidationErrorKey(StrEnum):
     REPORT_DATA_OUT_OF_BOUNDS_BY_REPORTING_FIELD = "report_data_out_of_bounds_by_reporting_field"
     ERROR_REQUIRED_FIELDS = "error_required_fields"
     ACTIVITY_JSON_SCHEMA_VALIDATION_ERROR = "activity_json_schema_validation_error"
+    MISSING_REGULATED_PRODUCT = "missing_regulated_product"
 
 
 class ErrorContext(BaseModel):

--- a/bc_obps/reporting/service/report_validation/validators/__init__.py
+++ b/bc_obps/reporting/service/report_validation/validators/__init__.py
@@ -10,6 +10,7 @@ from . import (
     report_emission_allocation_validator,
     supplementary_report_attachments_confirmation,
     supplementary_report_version_change,
+    report_regulated_product_presence,
 )
 
 from .required_fields import (
@@ -37,6 +38,7 @@ __all__ = [
     "report_activity_json_validation",
     "report_emission_allocation_validator",
     "report_data_by_fuel_type_validator",
+    "report_regulated_product_presence",
     "required_fields_report_operation_information",
     "required_fields_report_person_responsible",
     "required_fields_report_activity_data",

--- a/bc_obps/reporting/service/report_validation/validators/report_regulated_product_presence.py
+++ b/bc_obps/reporting/service/report_validation/validators/report_regulated_product_presence.py
@@ -1,0 +1,46 @@
+from registration.models.operation import Operation
+from reporting.models.report_operation import ReportOperation
+from reporting.models.report_version import ReportVersion
+from reporting.service.report_validation.report_validation_error import (
+    ErrorContext,
+    ReportValidationError,
+    ReportValidationErrorKey,
+    Severity,
+)
+from reporting.service.report_validation.report_validation_tags import ValidationTags
+
+TAGS = [ValidationTags.REPORT_VALIDATION]
+
+REGULATED_OPERATION_PURPOSES = [
+    Operation.Purposes.OBPS_REGULATED_OPERATION,
+    Operation.Purposes.OPTED_IN_OPERATION,
+    Operation.Purposes.NEW_ENTRANT_OPERATION,
+]
+
+
+def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
+    errors: dict[str, ReportValidationError] = {}
+
+    try:
+        report_operation: ReportOperation = report_version.report_operation
+    except ReportOperation.DoesNotExist:
+        return errors
+
+    if report_operation.registration_purpose not in REGULATED_OPERATION_PURPOSES:
+        return errors
+
+    if report_operation.regulated_products.filter(is_regulated=True).exists():
+        return errors
+
+    errors["missing_regulated_product"] = ReportValidationError(
+        severity=Severity.WARNING,
+        message=(
+            "No regulated products selected on Review Operation Information. "
+            "Expected one or more regulated products to be selected. "
+            "If the correct products are selected, you may continue."
+        ),
+        key=ReportValidationErrorKey.MISSING_REGULATED_PRODUCT,
+        context=ErrorContext(report_version_id=report_version.id),
+    )
+
+    return errors

--- a/bc_obps/reporting/tests/service/report_validation/test_report_validation_service.py
+++ b/bc_obps/reporting/tests/service/report_validation/test_report_validation_service.py
@@ -46,6 +46,7 @@ class TestReportValidationService:
             "reporting.service.report_validation.validators.report_activity_json_validation",
             "reporting.service.report_validation.validators.report_emission_allocation_validator",
             "reporting.service.report_validation.validators.report_data_by_fuel_type_validator",
+            "reporting.service.report_validation.validators.report_regulated_product_presence",
             "reporting.service.report_validation.validators.required_fields.required_fields_report_operation_information",
             "reporting.service.report_validation.validators.required_fields.required_fields_report_person_responsible",
             "reporting.service.report_validation.validators.required_fields.required_fields_report_activity_data",

--- a/bc_obps/reporting/tests/service/report_validation/validators/test_report_regulated_product_presence.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/test_report_regulated_product_presence.py
@@ -1,0 +1,130 @@
+from model_bakery.baker import make_recipe
+import pytest
+from registration.models.operation import Operation
+from registration.models.regulated_product import RegulatedProduct
+from reporting.service.report_validation.report_validation_error import (
+    ErrorContext,
+    ReportValidationError,
+    ReportValidationErrorKey,
+    Severity,
+)
+from reporting.service.report_validation.validators import (
+    report_regulated_product_presence,
+)
+
+
+regulated_products_required_purposes = [
+    Operation.Purposes.OBPS_REGULATED_OPERATION,
+    Operation.Purposes.OPTED_IN_OPERATION,
+    Operation.Purposes.NEW_ENTRANT_OPERATION,
+]
+
+regulated_products_not_required_purposes = [
+    Operation.Purposes.ELECTRICITY_IMPORT_OPERATION,
+    Operation.Purposes.REPORTING_OPERATION,
+    Operation.Purposes.POTENTIAL_REPORTING_OPERATION,
+]
+
+
+@pytest.mark.django_db
+class TestOperationRegulatedProductsSelectedValidator:
+    def test_all_purposes_are_evaluated(self):
+        assert set(regulated_products_required_purposes).union(regulated_products_not_required_purposes) == set(
+            Operation.Purposes
+        )
+
+    @pytest.mark.parametrize(
+        "reg_purpose",
+        regulated_products_required_purposes,
+    )
+    def test_warning_if_no_regulated_products_selected(self, reg_purpose):
+        report_operation = make_recipe(
+            "reporting.tests.utils.report_operation",
+            registration_purpose=reg_purpose,
+        )
+        report_operation.regulated_products.clear()
+
+        result = report_regulated_product_presence.validate(report_operation.report_version)
+
+        assert result == {
+            "missing_regulated_product": ReportValidationError(
+                Severity.WARNING,
+                (
+                    "No regulated products selected on Review Operation Information. "
+                    "Expected one or more regulated products to be selected. "
+                    "If the correct products are selected, you may continue."
+                ),
+                key=ReportValidationErrorKey.MISSING_REGULATED_PRODUCT,
+                context=ErrorContext(report_version_id=report_operation.report_version.id),
+            )
+        }
+
+    @pytest.mark.parametrize(
+        "reg_purpose",
+        regulated_products_required_purposes,
+    )
+    def test_warning_if_only_unregulated_products_selected(self, reg_purpose):
+        report_operation = make_recipe(
+            "reporting.tests.utils.report_operation",
+            registration_purpose=reg_purpose,
+        )
+
+        unregulated_product = RegulatedProduct.objects.create(
+            name="Unregulated product",
+            unit="tonnes",
+            is_regulated=False,
+        )
+
+        report_operation.regulated_products.set([unregulated_product])
+
+        result = report_regulated_product_presence.validate(report_operation.report_version)
+
+        assert result == {
+            "missing_regulated_product": ReportValidationError(
+                Severity.WARNING,
+                (
+                    "No regulated products selected on Review Operation Information. "
+                    "Expected one or more regulated products to be selected. "
+                    "If the correct products are selected, you may continue."
+                ),
+                key=ReportValidationErrorKey.MISSING_REGULATED_PRODUCT,
+                context=ErrorContext(report_version_id=report_operation.report_version.id),
+            )
+        }
+
+    @pytest.mark.parametrize(
+        "reg_purpose",
+        regulated_products_required_purposes,
+    )
+    def test_succeeds_if_regulated_product_selected(self, reg_purpose):
+        report_operation = make_recipe(
+            "reporting.tests.utils.report_operation",
+            registration_purpose=reg_purpose,
+        )
+
+        regulated_product = RegulatedProduct.objects.create(
+            name="Regulated product",
+            unit="tonnes",
+            is_regulated=True,
+        )
+
+        report_operation.regulated_products.set([regulated_product])
+
+        result = report_regulated_product_presence.validate(report_operation.report_version)
+
+        assert not result
+
+    @pytest.mark.parametrize(
+        "reg_purpose",
+        regulated_products_not_required_purposes,
+    )
+    def test_succeeds_if_regulated_products_not_required(self, reg_purpose):
+        report_operation = make_recipe(
+            "reporting.tests.utils.report_operation",
+            registration_purpose=reg_purpose,
+        )
+        report_operation.regulated_products.clear()
+
+        result = report_regulated_product_presence.validate(report_operation.report_version)
+
+        assert not result

--- a/bc_obps/reporting/tests/service/test_report_emission_allocation_service.py
+++ b/bc_obps/reporting/tests/service/test_report_emission_allocation_service.py
@@ -412,7 +412,7 @@ class TestReportEmissionAllocationService(TestCase):
         assert not retrieved_emission_allocations_data.has_missing_products
 
     # Only regulated products are checked for missing products
-    def test_has_missing_products_missing_regulated_products(self):
+    def test_has_missing_products_missing_regulated_product(self):
 
         product = make_recipe("registration.tests.utils.regulated_product", is_regulated=True)
         self.test_infrastructure.report_version.report_operation.regulated_products.add(product)

--- a/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsibleForm.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsibleForm.tsx
@@ -193,7 +193,7 @@ const PersonResponsibleForm = ({
       // preserve the existing snapshot data
       if (!updatedContactResponse || "error" in updatedContactResponse) {
         setSnackbarMessage(
-          "This contact was deleted but the existing information entered has been saved,",
+          "This contact was deleted but the existing information entered has been saved.",
         );
 
         return;

--- a/bciers/apps/reporting/src/app/components/shared/validation/config.ts
+++ b/bciers/apps/reporting/src/app/components/shared/validation/config.ts
@@ -231,6 +231,16 @@ If the value is accurate, you may save & continue.`;
         : undefined,
   }),
 
+  missing_regulated_product: createValidationUIConfig({
+    label: "Review Operation Information",
+    priority: 2,
+    renderMode: "inline_link",
+    getHref: (ctx) =>
+      ctx?.report_version_id
+        ? reportRoutes.reviewOperationInformation(ctx.report_version_id)
+        : undefined,
+  }),
+
   generic_error: createValidationUIConfig({
     renderMode: "message_only",
     getMessage: (error) =>

--- a/bciers/apps/reporting/src/app/components/shared/validation/types.ts
+++ b/bciers/apps/reporting/src/app/components/shared/validation/types.ts
@@ -16,6 +16,7 @@ export type ReportValidationMessageKey =
   | "missing_supplementary_report_existing_attachment_confirmation"
   | "missing_supplementary_report_attachments_confirmation"
   | "missing_supplementary_report_version_change"
+  | "missing_regulated_product"
   | "generic_error";
 
 // Additional metadata returned from backend used for dynamic content

--- a/bciers/apps/reporting/src/tests/components/shared/validation/config.test.ts
+++ b/bciers/apps/reporting/src/tests/components/shared/validation/config.test.ts
@@ -19,11 +19,12 @@ describe("validationUIConfig", () => {
     "missing_supplementary_report_existing_attachment_confirmation",
     "missing_supplementary_report_attachments_confirmation",
     "missing_supplementary_report_version_change",
+    "missing_regulated_product",
     "generic_error",
   ];
 
   it("has the expected number of configs", () => {
-    expect(Object.keys(validationUIConfig)).toHaveLength(14);
+    expect(Object.keys(validationUIConfig)).toHaveLength(15);
   });
 
   it("has a config for every validation key", () => {


### PR DESCRIPTION
Ticket: [4479](https://github.com/bcgov/cas-registration/issues/4479)


### 🚀 Impact
- Added validator for Regulated Operations should report at least 1 regulated product 

---

### 🔬 Local Testing:  

#### Start Test Environment
1. Start the API server:  
   ```sh
   cd bc_obps
   make prepare_backend
   ```  
2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

---

#### Test: 

1. Log in using `bc-cas-dev`
2. Navigate to reporting
3. Start a Regulated Operation report (ex: registration purpose is OBPS Regulated Operation, New Entrant or Opted-in Operation) 
4. Navigate to `report-validation`
**Expected Results:**
- No warning displays for missing regulated product
5. Navigate to `review-operation-information`
6. In field `Regulated products`, select **only** `non-regulated` product(s) (ex: Oil and gas non-processing, non-compression)
7. Navigate to `report-validation`
**Expected Results:**
- Warning displays for missing regulated product

<img width="1093" height="174" alt="image" src="https://github.com/user-attachments/assets/53bef5cb-99bf-4f42-a748-9416bbbfa480" />

8. Navigate to `sign-off`
9. Complete form and click 'Submit`
**Expected Results:**
- No warning displays for missing regulated product

10. Start a NON regulated operation report (ex: registration purpose is Reporting Operation, Potential Reporting Operation, Electricity Import Operation
11. Navigate to `report-validation`
**Expected Results:**
- No warning displays for missing regulated product
