### PR TITLE
Fix/reporting only validator ignore regulated products

### DIFF
--- a/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_operation_information.py
+++ b/bc_obps/reporting/service/report_validation/validators/required_fields/required_fields_report_operation_information.py
@@ -40,6 +40,8 @@ class RequiredFieldsReportOperationInformationValidator(BaseRequiredFieldsValida
             return [
                 field for field in cls.REQUIRED_FIELDS if field["field"] not in {"activities", "regulated_products"}
             ]
+        elif flow in {ReportingFlow.REPORTING_ONLY_SFO, ReportingFlow.REPORTING_ONLY_LFO}:
+            return [field for field in cls.REQUIRED_FIELDS if field["field"] != "regulated_products"]
 
         return cls.REQUIRED_FIELDS
 

--- a/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_operation_information.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/required_fields/test_required_fields_report_operation_information.py
@@ -95,3 +95,25 @@ class TestRequiredFieldsReportOperationInformationValidator:
             result = validate(self.report_version)
 
         assert result == {}
+
+    def test_validate_passes_when_reporting_only_operation_has_no_products(self):
+        report_operation = baker.make_recipe(
+            "reporting.tests.utils.report_operation",
+            report_version=self.report_version,
+        )
+
+        activity = baker.make_recipe("reporting.tests.utils.activity")
+
+        report_operation.activities.add(activity)
+
+        baker.make_recipe(
+            "reporting.tests.utils.report_operation_representative",
+            report_version=self.report_version,
+            selected_for_report=True,
+        )
+
+        with patch(RESOLVE_FLOW_PATH, return_value=ReportingFlow.REPORTING_ONLY_SFO):
+            result = validate(self.report_version)
+
+        assert len(report_operation.regulated_products.all()) == 0
+        assert result == {}


### PR DESCRIPTION
The required_fields validator `reporting/service/report_validation/validators/required_fields/required_fields_report_operation_information.py` was incorrectly firing when a reporting-only operation had no regulated products. This PR makes.a small edit to the validator to ignore the m2m regulated_products field as a requirement & adds a test for the logic for the reporting-only flow passing without regulated_products.

To test this:

- Create a report for a reporting-only operation
- Go to the validation page
- There should be no validation error


#### Before fix:
<img width="1386" height="214" alt="image" src="https://github.com/user-attachments/assets/41cbab86-586f-46e7-817d-da3f6d2cd3d1" />

#### After fix:
<img width="1770" height="378" alt="image" src="https://github.com/user-attachments/assets/e76670a2-f8b4-4dbf-8f26-a554cd992fe7" />
