### PR TITLE
Chore/4667 pdb anti affinity

### DIFF
--- a/helm/cas-bciers/templates/administration/deployment.yaml
+++ b/helm/cas-bciers/templates/administration/deployment.yaml
@@ -56,3 +56,21 @@ spec:
       restartPolicy: Always
       volumes:
              {{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
+      affinity:
+        {
+          podAntiAffinity: {
+            preferredDuringSchedulingIgnoredDuringExecution: [
+              {
+                podAffinityTerm: {
+                  labelSelector: {
+                    matchLabels: {
+                      app.kubernetes.io/instance: cas-bciers,
+                      component: administration-frontend
+                    }
+                  },
+                },
+                weight: 1
+              }
+            ]
+          }
+        }

--- a/helm/cas-bciers/templates/administration/pdb.yaml
+++ b/helm/cas-bciers/templates/administration/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-administration-frontend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: cas-bciers
+      component: administration-frontend

--- a/helm/cas-bciers/templates/backend/deployment.yaml
+++ b/helm/cas-bciers/templates/backend/deployment.yaml
@@ -96,3 +96,21 @@ spec:
             - key: credentials.json
               path: attachment-credentials.json
       restartPolicy: Always
+      affinity:
+        {
+          podAntiAffinity: {
+            preferredDuringSchedulingIgnoredDuringExecution: [
+              {
+                podAffinityTerm: {
+                  labelSelector: {
+                    matchLabels: {
+                      app.kubernetes.io/instance: cas-bciers,
+                      component: backend
+                    }
+                  },
+                },
+                weight: 1
+              }
+            ]
+          }
+        }

--- a/helm/cas-bciers/templates/backend/pdb.yaml
+++ b/helm/cas-bciers/templates/backend/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-backend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: cas-bciers
+      component: backend

--- a/helm/cas-bciers/templates/compliance/deployment.yaml
+++ b/helm/cas-bciers/templates/compliance/deployment.yaml
@@ -56,3 +56,21 @@ spec:
       restartPolicy: Always
       volumes:
              {{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
+      affinity:
+        {
+          podAntiAffinity: {
+            preferredDuringSchedulingIgnoredDuringExecution: [
+              {
+                podAffinityTerm: {
+                  labelSelector: {
+                    matchLabels: {
+                      app.kubernetes.io/instance: cas-bciers,
+                      component: compliance-frontend
+                    }
+                  },
+                },
+                weight: 1
+              }
+            ]
+          }
+        }

--- a/helm/cas-bciers/templates/compliance/pdb.yaml
+++ b/helm/cas-bciers/templates/compliance/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-compliance-frontend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: cas-bciers
+      component: compliance-frontend

--- a/helm/cas-bciers/templates/dashboard/deployment.yaml
+++ b/helm/cas-bciers/templates/dashboard/deployment.yaml
@@ -56,3 +56,21 @@ spec:
       restartPolicy: Always
       volumes:
               {{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
+      affinity:
+        {
+          podAntiAffinity: {
+            preferredDuringSchedulingIgnoredDuringExecution: [
+              {
+                podAffinityTerm: {
+                  labelSelector: {
+                    matchLabels: {
+                      app.kubernetes.io/instance: cas-bciers,
+                      component: dashboard-frontend
+                    }
+                  },
+                },
+                weight: 1
+              }
+            ]
+          }
+        }

--- a/helm/cas-bciers/templates/dashboard/pdb.yaml
+++ b/helm/cas-bciers/templates/dashboard/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-compliance-frontend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: cas-bciers
+      component: compliance-frontend

--- a/helm/cas-bciers/templates/registration/deployment.yaml
+++ b/helm/cas-bciers/templates/registration/deployment.yaml
@@ -56,3 +56,21 @@ spec:
       restartPolicy: Always
       volumes:
         {{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
+      affinity:
+        {
+          podAntiAffinity: {
+            preferredDuringSchedulingIgnoredDuringExecution: [
+              {
+                podAffinityTerm: {
+                  labelSelector: {
+                    matchLabels: {
+                      app.kubernetes.io/instance: cas-bciers,
+                      component: registration-frontend
+                    }
+                  },
+                },
+                weight: 1
+              }
+            ]
+          }
+        }

--- a/helm/cas-bciers/templates/registration/pdb.yaml
+++ b/helm/cas-bciers/templates/registration/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-registration-frontend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: cas-bciers
+      component: registration-frontend

--- a/helm/cas-bciers/templates/reporting/deployment.yaml
+++ b/helm/cas-bciers/templates/reporting/deployment.yaml
@@ -56,3 +56,21 @@ spec:
       restartPolicy: Always
       volumes:
         {{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
+      affinity:
+        {
+          podAntiAffinity: {
+            preferredDuringSchedulingIgnoredDuringExecution: [
+              {
+                podAffinityTerm: {
+                  labelSelector: {
+                    matchLabels: {
+                      app.kubernetes.io/instance: cas-bciers,
+                      component: reporting-frontend
+                    }
+                  },
+                },
+                weight: 1
+              }
+            ]
+          }
+        }

--- a/helm/cas-bciers/templates/reporting/pdb.yaml
+++ b/helm/cas-bciers/templates/reporting/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cas-bciers.fullname" . }}-reporting-frontend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: cas-bciers
+      component: reporting-frontend


### PR DESCRIPTION
Adds Pod Disruption Budgets and Node Anti-Affinity rules for bciers deployments for better reliability during cluster maintenance.