### PR TITLE
feat: operation-level activities appear at top of list on Review Faci…

### DIFF
--- a/bc_obps/reporting/schema/facility_report.py
+++ b/bc_obps/reporting/schema/facility_report.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from ninja import Field, FilterSchema, ModelSchema
 from pydantic import alias_generators
 from reporting.models import FacilityReport
+from reporting.schema.report_operation import ActivitySchema
 
 
 class FacilityReportOut(ModelSchema):
@@ -21,6 +22,8 @@ class FacilityReportOut(ModelSchema):
 
     operation_id: Optional[UUID] = None
     is_sync_allowed: bool = True
+    report_operation_activities: List[ActivitySchema] = []
+    other_activities: List[ActivitySchema] = []
 
 
 class FacilityReportIn(ModelSchema):

--- a/bc_obps/reporting/schema/facility_report.py
+++ b/bc_obps/reporting/schema/facility_report.py
@@ -22,7 +22,7 @@ class FacilityReportOut(ModelSchema):
 
     operation_id: Optional[UUID] = None
     is_sync_allowed: bool = True
-    report_operation_activities: List[ActivitySchema] = []
+    facility_activities: List[ActivitySchema] = []
     other_activities: List[ActivitySchema] = []
 
 

--- a/bc_obps/service/facility_report_service.py
+++ b/bc_obps/service/facility_report_service.py
@@ -1,6 +1,7 @@
 from uuid import UUID
+from dataclasses import dataclass
 from django.db import transaction
-from typing import Any, List, Optional, cast
+from typing import Any, Dict, List, Optional, cast
 from ninja import Query
 from registration.models import Activity, Facility
 from reporting.models import ReportActivity, ReportProductEmissionAllocation, ReportProduct
@@ -8,10 +9,21 @@ from reporting.models.facility_report import FacilityReport
 from reporting.models.report_operation import ReportOperation
 from reporting.models.report_raw_activity_data import ReportRawActivityData
 from reporting.schema.facility_report import FacilityReportListInSchema, FacilityReportFilterSchema
-from django.db.models import QuerySet
-from django.db.models import F
+from django.db.models import QuerySet, F
 from reporting.service.sync_validation_service import SyncValidationService
 from service.activity_service import ActivityService
+
+
+@dataclass
+class FacilityReportData:
+    facility_name: str
+    facility_type: str
+    facility_activities: List[Dict[str, Any]]
+    other_activities: List[Dict[str, Any]]
+    report_version_id: int
+    is_completed: bool
+    regulated_products: Optional[List[int]]
+    facility_bcghgid: Optional[str] = None
 
 
 class SaveFacilityReportData:
@@ -32,6 +44,30 @@ class SaveFacilityReportData:
 
 class FacilityReportService:
     @classmethod
+    def _build_facility_report_data(cls, facility_report: FacilityReport, report_version_id: int) -> FacilityReportData:
+        report_operation = ReportOperation.objects.filter(report_version_id=report_version_id).first()
+
+        all_activities = ActivityService.get_all_activities()
+        operation_activity_ids = (
+            set(report_operation.activities.values_list('id', flat=True)) if report_operation else set()
+        )
+        operation_activities = [activity for activity in all_activities if activity['id'] in operation_activity_ids]
+        other_activities = [activity for activity in all_activities if activity['id'] not in operation_activity_ids]
+
+        return FacilityReportData(
+            facility_name=facility_report.facility_name,
+            facility_type=facility_report.facility_type,
+            facility_activities=operation_activities,
+            other_activities=other_activities,
+            report_version_id=report_version_id,
+            is_completed=facility_report.is_completed,
+            regulated_products=list(
+                ReportProduct.objects.filter(facility_report_id=facility_report.id).values_list('product_id', flat=True)
+            ),
+            facility_bcghgid=facility_report.facility_bcghgid,
+        )
+
+    @classmethod
     def get_facility_report_by_version_and_id(cls, report_version_id: int, facility_id: UUID) -> FacilityReport:
         facility_report = FacilityReport.objects.annotate(operation_id=F('report_version__report__operation_id')).get(
             report_version_id=report_version_id, facility_id=facility_id
@@ -39,20 +75,11 @@ class FacilityReportService:
 
         facility_report.is_sync_allowed = SyncValidationService.is_facility_sync_allowed(report_version_id, facility_id)  # type: ignore[attr-defined]
 
-        # Partition all activities into those selected on the related ReportOperation
-        # and the remaining ("other") activities, so the facility review UI can render
-        # them as two separate checklists.
-        report_operation = ReportOperation.objects.filter(report_version_id=report_version_id).first()
-        operation_activity_ids = (
-            set(report_operation.activities.values_list('id', flat=True)) if report_operation else set()
-        )
-        all_activities = ActivityService.get_all_activities()
-        facility_report.facility_activities = [  # type: ignore[attr-defined]
-            a for a in all_activities if a['id'] in operation_activity_ids
-        ]
-        facility_report.other_activities = [  # type: ignore[attr-defined]
-            a for a in all_activities if a['id'] not in operation_activity_ids
-        ]
+        facility_report_data = cls._build_facility_report_data(facility_report, report_version_id)
+
+        for field_name in ('facility_activities', 'other_activities'):
+            setattr(facility_report, field_name, getattr(facility_report_data, field_name))
+
         return facility_report
 
     @classmethod
@@ -73,9 +100,7 @@ class FacilityReportService:
         """
         Add activities to a facility report without removing or duplicating existing ones.
         """
-        facility_report.activities.add(
-            *Activity.objects.exclude(id__in=facility_report.activities.all()).filter(id__in=activities)
-        )
+        facility_report.activities.add(*Activity.objects.filter(id__in=activities))
 
     @classmethod
     def set_activities_for_facility_report(cls, facility_report: FacilityReport, activities: List[int]) -> None:

--- a/bc_obps/service/facility_report_service.py
+++ b/bc_obps/service/facility_report_service.py
@@ -48,7 +48,7 @@ class FacilityReportService:
         all_activities = list(
             Activity.objects.all().order_by('weight', 'name').values('id', 'name', 'applicable_to', 'regulated_name')
         )
-        facility_report.report_operation_activities = [  # type: ignore[attr-defined]
+        facility_report.facility_activities = [  # type: ignore[attr-defined]
             a for a in all_activities if a['id'] in operation_activity_ids
         ]
         facility_report.other_activities = [  # type: ignore[attr-defined]

--- a/bc_obps/service/facility_report_service.py
+++ b/bc_obps/service/facility_report_service.py
@@ -11,6 +11,7 @@ from reporting.schema.facility_report import FacilityReportListInSchema, Facilit
 from django.db.models import QuerySet
 from django.db.models import F
 from reporting.service.sync_validation_service import SyncValidationService
+from service.activity_service import ActivityService
 
 
 class SaveFacilityReportData:
@@ -43,11 +44,9 @@ class FacilityReportService:
         # them as two separate checklists.
         report_operation = ReportOperation.objects.filter(report_version_id=report_version_id).first()
         operation_activity_ids = (
-            list(report_operation.activities.values_list('id', flat=True)) if report_operation else []
+            set(report_operation.activities.values_list('id', flat=True)) if report_operation else set()
         )
-        all_activities = list(
-            Activity.objects.all().order_by('weight', 'name').values('id', 'name', 'applicable_to', 'regulated_name')
-        )
+        all_activities = ActivityService.get_all_activities()
         facility_report.facility_activities = [  # type: ignore[attr-defined]
             a for a in all_activities if a['id'] in operation_activity_ids
         ]

--- a/bc_obps/service/facility_report_service.py
+++ b/bc_obps/service/facility_report_service.py
@@ -5,6 +5,7 @@ from ninja import Query
 from registration.models import Activity, Facility
 from reporting.models import ReportActivity, ReportProductEmissionAllocation, ReportProduct
 from reporting.models.facility_report import FacilityReport
+from reporting.models.report_operation import ReportOperation
 from reporting.models.report_raw_activity_data import ReportRawActivityData
 from reporting.schema.facility_report import FacilityReportListInSchema, FacilityReportFilterSchema
 from django.db.models import QuerySet
@@ -36,6 +37,23 @@ class FacilityReportService:
         )
 
         facility_report.is_sync_allowed = SyncValidationService.is_facility_sync_allowed(report_version_id, facility_id)  # type: ignore[attr-defined]
+
+        # Partition all activities into those selected on the related ReportOperation
+        # and the remaining ("other") activities, so the facility review UI can render
+        # them as two separate checklists.
+        report_operation = ReportOperation.objects.filter(report_version_id=report_version_id).first()
+        operation_activity_ids = (
+            list(report_operation.activities.values_list('id', flat=True)) if report_operation else []
+        )
+        all_activities = list(
+            Activity.objects.all().order_by('weight', 'name').values('id', 'name', 'applicable_to', 'regulated_name')
+        )
+        facility_report.report_operation_activities = [  # type: ignore[attr-defined]
+            a for a in all_activities if a['id'] in operation_activity_ids
+        ]
+        facility_report.other_activities = [  # type: ignore[attr-defined]
+            a for a in all_activities if a['id'] not in operation_activity_ids
+        ]
         return facility_report
 
     @classmethod

--- a/bc_obps/service/report_service.py
+++ b/bc_obps/service/report_service.py
@@ -110,6 +110,11 @@ class ReportService:
         report_operation.operation_bcghgid = data.operation_bcghgid
         report_operation.bc_obps_regulated_operation_id = data.bc_obps_regulated_operation_id
 
+        # Capture previous operation activities so we can compute which activities
+        # are newly added by this save and propagate only those to existing facility
+        # reports as defaults (preserving any user-made facility-level selections).
+        previous_operation_activity_ids = set(report_operation.activities.values_list('id', flat=True))
+
         # Fetch and set ManyToMany fields
         activities = Activity.objects.filter(id__in=data.activities)
         report_operation.activities.set(activities)
@@ -117,16 +122,32 @@ class ReportService:
         report_operation.regulated_products.set(regulated_products)
         report_operation.save()
 
+        newly_added_operation_activity_ids = list(set(data.activities) - previous_operation_activity_ids)
+
         if report_operation.operation_type == 'Linear Facilities Operation':
             facility_reports: QuerySet[FacilityReport] = FacilityReport.objects.filter(
                 report_version__id=report_version_id
             )
             for f in facility_reports:
-                # For LFOs, only set activities if the facility doesn't have any yet (initial setup)
-                # This prevents overwriting user-selected activities at the facility level
-                if not f.activities.exists():
+                if f.is_completed:
+                    # Once a facility report is marked complete, do not propagate
+                    # operation-level activity changes to it. The user must reopen
+                    # the facility report to make further changes.
+                    pass
+                elif not f.activities.exists():
+                    # Initial setup: seed all operation activities as facility defaults.
                     FacilityReportService.add_activities_to_facility_report(
                         facility_report=f, activities=data.activities
+                    )
+                elif newly_added_operation_activity_ids:
+                    # In-progress facility: only add the newly-selected operation
+                    # activities so they appear pre-selected in the operation list on
+                    # the facility page. Activities removed from the operation are NOT
+                    # removed from the facility report; they will appear in the "other
+                    # activities" list with their current selection state preserved,
+                    # so the user can keep or uncheck them.
+                    FacilityReportService.add_activities_to_facility_report(
+                        facility_report=f, activities=newly_added_operation_activity_ids
                     )
                 # Always update regulated products
                 FacilityReportService.prune_report_product_data_for_facility_report(

--- a/bc_obps/service/report_service.py
+++ b/bc_obps/service/report_service.py
@@ -110,11 +110,6 @@ class ReportService:
         report_operation.operation_bcghgid = data.operation_bcghgid
         report_operation.bc_obps_regulated_operation_id = data.bc_obps_regulated_operation_id
 
-        # Capture previous operation activities so we can compute which activities
-        # are newly added by this save and propagate only those to existing facility
-        # reports as defaults (preserving any user-made facility-level selections).
-        previous_operation_activity_ids = set(report_operation.activities.values_list('id', flat=True))
-
         # Fetch and set ManyToMany fields
         activities = Activity.objects.filter(id__in=data.activities)
         report_operation.activities.set(activities)
@@ -122,33 +117,15 @@ class ReportService:
         report_operation.regulated_products.set(regulated_products)
         report_operation.save()
 
-        newly_added_operation_activity_ids = list(set(data.activities) - previous_operation_activity_ids)
-
         if report_operation.operation_type == 'Linear Facilities Operation':
             facility_reports: QuerySet[FacilityReport] = FacilityReport.objects.filter(
                 report_version__id=report_version_id
             )
-            for f in facility_reports:
-                if f.is_completed:
-                    # Once a facility report is marked complete, do not propagate
-                    # operation-level activity changes to it. The user must reopen
-                    # the facility report to make further changes.
-                    pass
-                elif not f.activities.exists():
-                    # Initial setup: seed all operation activities as facility defaults.
-                    FacilityReportService.add_activities_to_facility_report(
-                        facility_report=f, activities=data.activities
-                    )
-                elif newly_added_operation_activity_ids:
-                    # In-progress facility: only add the newly-selected operation
-                    # activities so they appear pre-selected in the operation list on
-                    # the facility page. Activities removed from the operation are NOT
-                    # removed from the facility report; they will appear in the "other
-                    # activities" list with their current selection state preserved,
-                    # so the user can keep or uncheck them.
-                    FacilityReportService.add_activities_to_facility_report(
-                        facility_report=f, activities=newly_added_operation_activity_ids
-                    )
+            # For facility reports that haven't yet been marked Completed,
+            # add all operation-level activities as defaults (without removing any existing facility-level selections the user may have made)
+            uncompleted_reports = (f for f in facility_reports if not f.is_completed)
+            for f in uncompleted_reports:
+                FacilityReportService.add_activities_to_facility_report(facility_report=f, activities=data.activities)
                 # Always update regulated products
                 FacilityReportService.prune_report_product_data_for_facility_report(
                     facility_report=f, regulated_products=data.regulated_products

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.core.exceptions import ObjectDoesNotExist
+from registration.models.activity import Activity
 from reporting.models.report_emission_allocation import ReportEmissionAllocation
 from reporting.models.report_raw_activity_data import ReportRawActivityData
 from reporting.tests.utils.bakers import activity_baker
@@ -40,7 +41,6 @@ class TestFacilityReportService(TestCase):
         facility_report = baker.make_recipe('reporting.tests.utils.facility_report')
         a1 = activity_baker()
         a2 = activity_baker()
-        a3 = activity_baker()
         report_operation = baker.make_recipe(
             'reporting.tests.utils.report_operation',
             report_version=facility_report.report_version,
@@ -56,7 +56,7 @@ class TestFacilityReportService(TestCase):
         other_activity_ids = {a['id'] for a in result.other_activities}
 
         assert facility_activity_ids == {a1.id, a2.id}
-        assert other_activity_ids == {a3.id}
+        assert other_activity_ids == {a.id for a in Activity.objects.exclude(id__in=[a1.id, a2.id])}
 
     def test_get_activities_throws_if_facility_report_does_not_exist(self):
         with self.assertRaises(ObjectDoesNotExist) as exception_context:

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -52,11 +52,11 @@ class TestFacilityReportService(TestCase):
             facility_id=facility_report.facility_id,
         )
 
-        operation_activity_ids = {a['id'] for a in result.report_operation_activities}
+        facility_activity_ids = {a['id'] for a in result.facility_activities}
         other_activity_ids = {a['id'] for a in result.other_activities}
-        assert {a1.id, a2.id}.issubset(operation_activity_ids)
+        assert {a1.id, a2.id}.issubset(facility_activity_ids)
         assert a3.id in other_activity_ids
-        assert operation_activity_ids.isdisjoint(other_activity_ids)
+        assert facility_activity_ids.isdisjoint(other_activity_ids)
 
     def test_get_activities_throws_if_facility_report_does_not_exist(self):
         with self.assertRaises(ObjectDoesNotExist) as exception_context:

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -54,9 +54,9 @@ class TestFacilityReportService(TestCase):
 
         facility_activity_ids = {a['id'] for a in result.facility_activities}
         other_activity_ids = {a['id'] for a in result.other_activities}
-        assert {a1.id, a2.id}.issubset(facility_activity_ids)
-        assert a3.id in other_activity_ids
-        assert facility_activity_ids.isdisjoint(other_activity_ids)
+
+        assert facility_activity_ids == {a1.id, a2.id}
+        assert other_activity_ids == {a3.id}
 
     def test_get_activities_throws_if_facility_report_does_not_exist(self):
         with self.assertRaises(ObjectDoesNotExist) as exception_context:

--- a/bc_obps/service/tests/test_facility_report_service.py
+++ b/bc_obps/service/tests/test_facility_report_service.py
@@ -33,6 +33,31 @@ class TestFacilityReportService(TestCase):
             report_version_id=facility_report.report_version_id, facility_id=facility_report.facility_id
         )
 
+    @staticmethod
+    def test_returns_facility_report_with_split_activity_lists():
+        """The facility report response splits activities into those selected on the
+        related ReportOperation and the remaining "other" activities."""
+        facility_report = baker.make_recipe('reporting.tests.utils.facility_report')
+        a1 = activity_baker()
+        a2 = activity_baker()
+        a3 = activity_baker()
+        report_operation = baker.make_recipe(
+            'reporting.tests.utils.report_operation',
+            report_version=facility_report.report_version,
+        )
+        report_operation.activities.add(a1, a2)
+
+        result = FacilityReportService.get_facility_report_by_version_and_id(
+            report_version_id=facility_report.report_version_id,
+            facility_id=facility_report.facility_id,
+        )
+
+        operation_activity_ids = {a['id'] for a in result.report_operation_activities}
+        other_activity_ids = {a['id'] for a in result.other_activities}
+        assert {a1.id, a2.id}.issubset(operation_activity_ids)
+        assert a3.id in other_activity_ids
+        assert operation_activity_ids.isdisjoint(other_activity_ids)
+
     def test_get_activities_throws_if_facility_report_does_not_exist(self):
         with self.assertRaises(ObjectDoesNotExist) as exception_context:
             FacilityReportService.get_activity_ids_for_facility(

--- a/bc_obps/service/tests/test_report_service.py
+++ b/bc_obps/service/tests/test_report_service.py
@@ -398,11 +398,14 @@ class TestReportService(TestCase):
         assert not ReportProduct.objects.filter(id=report_product_2.id).exists()
         assert not ReportProduct.objects.filter(id=report_product_3.id).exists()
 
-    def test_lfo_does_not_update_facility_activities_if_facility_already_has_activities(self):
+    def test_lfo_adds_newly_selected_operation_activities_to_existing_facility(self):
         """
-        Test that for LFOs, when a facility already has activities,
-        updating operation-level activities does NOT modify the facility's activities.
-        This prevents overwriting user-selected activities at the facility level.
+        For LFOs, when a facility already has activities and the user adds new
+        activities at the operation level, those newly-selected operation activities
+        are added to the facility report (so they appear pre-selected in the
+        operation list on the Review Facility Information page). Activities removed
+        from the operation are NOT removed from the facility, so any user-made
+        facility-level selections are preserved.
         """
         operator = baker.make_recipe('registration.tests.utils.operator')
         operation = operation_baker(type=Operation.Types.LFO, operator_id=operator.id)
@@ -425,6 +428,7 @@ class TestReportService(TestCase):
             operation_type="Linear Facilities Operation",
             operation_bcghgid="Updated BC GHID",
             bc_obps_regulated_operation_id="Updated Regulated Operation ID",
+            # Operation activities change: keep 1, drop 2 & 3, add 18 & 14
             activities=[1, 18, 14],
             regulated_products=[1],
             operation_representative_name=[1, 2],
@@ -436,13 +440,15 @@ class TestReportService(TestCase):
 
         facility_report.refresh_from_db()
 
-        # Activities should NOT be updated since facility already had activities
-        assert facility_report.activities.count() == 3
+        # Newly-selected operation activities (18, 14) are added.
+        # Existing facility activities (1, 2, 3) are preserved -- including 2 & 3
+        # which were deselected at the operation level (user choice is not lost).
         self.assertQuerySetEqual(
             facility_report.activities.all(),
-            Activity.objects.filter(id__in=[1, 2, 3]),
+            Activity.objects.filter(id__in=[1, 2, 3, 18, 14]),
             ordered=False,
         )
+        # Existing report activity rows for kept activities are preserved.
         self.assertQuerySetEqual(
             facility_report.reportactivity_records.all(),
             [report_activity],
@@ -487,5 +493,48 @@ class TestReportService(TestCase):
         self.assertQuerySetEqual(
             facility_report.activities.all(),
             Activity.objects.filter(id__in=[18, 14]),
+            ordered=False,
+        )
+
+    def test_lfo_does_not_update_activities_for_completed_facility_report(self):
+        """
+        Once a facility report is marked as completed, changes to operation-level
+        activities must NOT propagate to that facility's activities.
+        """
+        operator = baker.make_recipe('registration.tests.utils.operator')
+        operation = operation_baker(type=Operation.Types.LFO, operator_id=operator.id)
+        report = baker.make_recipe('reporting.tests.utils.report', operation=operation)
+        report_version = baker.make_recipe('reporting.tests.utils.report_version', report=report)
+        report_operation = baker.make_recipe('reporting.tests.utils.report_operation', report_version=report_version)
+        report_operation.activities.set([1, 2, 3])
+        facility_report = baker.make_recipe(
+            'reporting.tests.utils.facility_report',
+            report_version=report_version,
+            is_completed=True,
+        )
+        facility_report.activities.set([1, 2, 3])
+
+        data = ReportOperationIn(
+            operator_legal_name="Updated Legal Name",
+            operator_trade_name="Updated Trade Name",
+            operation_name="Updated Operation Name",
+            operation_type="Linear Facilities Operation",
+            operation_bcghgid="Updated BC GHID",
+            bc_obps_regulated_operation_id="Updated Regulated Operation ID",
+            activities=[1, 18, 14],
+            regulated_products=[1],
+            operation_representative_name=[1, 2],
+            operation_report_type="New Report Type",
+            registration_purpose="OBPS Regulated Operation",
+        )
+
+        ReportService.save_report_operation(report_version.id, data)
+
+        facility_report.refresh_from_db()
+
+        # The completed facility's activities are unchanged.
+        self.assertQuerySetEqual(
+            facility_report.activities.all(),
+            Activity.objects.filter(id__in=[1, 2, 3]),
             ordered=False,
         )

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
@@ -72,9 +72,9 @@ export const FacilityReview: React.FC<Props> = ({
     );
     const updatedFormData = {
       ...formData,
-      activities: selectedActivityNames
-        .map((activityName: string) => activityNameToIdMap.get(activityName))
-        .filter((id): id is number => id !== undefined),
+      activities: selectedActivityNames.map((activityName: string) =>
+        activityNameToIdMap.get(activityName),
+      ),
     };
 
     const response = await actionHandler(endpoint, method, pathToRevalidate, {

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
@@ -18,7 +18,8 @@ interface Props {
   version_id: number;
   operationId: string;
   facility_id: string;
-  activitiesData: ActivityData[];
+  reportOperationActivities: ActivityData[];
+  otherActivities: ActivityData[];
   navigationInformation: NavigationInformation;
   formsData: FacilityReviewFormData;
   schema: RJSFSchema;
@@ -30,7 +31,8 @@ export interface FacilityReviewFormData {
   facility_name: string;
   facility_type: string;
   facility_bcghgid: string | null;
-  activities: string[];
+  report_operation_activities: string[];
+  other_activities: string[];
   facility: string;
 }
 
@@ -38,7 +40,8 @@ export const FacilityReview: React.FC<Props> = ({
   version_id,
   operationId,
   facility_id,
-  activitiesData,
+  reportOperationActivities,
+  otherActivities,
   navigationInformation,
   formsData,
   schema,
@@ -52,30 +55,26 @@ export const FacilityReview: React.FC<Props> = ({
     const method = "POST";
     const endpoint = `reporting/report-version/${version_id}/facility-report/${facility_id}`;
     const pathToRevalidate = `reporting/reports/${version_id}/facilities/${facility_id}/review-facility-information`;
-
-    if (formData.activities.length === 0) {
+    const selectedActivityNames = [
+      ...(formData.report_operation_activities ?? []),
+      ...(formData.other_activities ?? []),
+    ];
+    if (selectedActivityNames.length === 0) {
       setErrors([
-        createGenericReportValidationError(
-          "You must select at least one activity.",
-        ),
-      ]);
+        createGenericReportValidationError("You must select at least one activity."),]);
       return false;
     }
 
-    const activityNameToIdMap = new Map(
-      activitiesData.map((activity: ActivityData) => [
-        activity.name,
-        activity.id,
-      ]),
+    const activityNameToIdMap = new Map<string, number>(
+      [...reportOperationActivities, ...otherActivities].map(
+        (activity: ActivityData) => [activity.name, activity.id],
+      ),
     );
     const updatedFormData = {
       ...formData,
-      activities: formData.activities
-        .map((activityName: string) => {
-          return activityNameToIdMap.get(activityName);
-        })
-        .filter((id: number | undefined) => id !== undefined) // Filter out undefined IDs
-        .map(Number), // Ensure all IDs are numbers
+      activities: selectedActivityNames
+        .map((activityName: string) => activityNameToIdMap.get(activityName))
+        .filter((id): id is number => id !== undefined),
     };
 
     const response = await actionHandler(endpoint, method, pathToRevalidate, {

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
@@ -18,7 +18,7 @@ interface Props {
   version_id: number;
   operationId: string;
   facility_id: string;
-  reportOperationActivities: ActivityData[];
+  facilityActivities: ActivityData[];
   otherActivities: ActivityData[];
   navigationInformation: NavigationInformation;
   formsData: FacilityReviewFormData;
@@ -31,7 +31,7 @@ export interface FacilityReviewFormData {
   facility_name: string;
   facility_type: string;
   facility_bcghgid: string | null;
-  report_operation_activities: string[];
+  facility_activities: string[];
   other_activities: string[];
   facility: string;
 }
@@ -40,7 +40,7 @@ export const FacilityReview: React.FC<Props> = ({
   version_id,
   operationId,
   facility_id,
-  reportOperationActivities,
+  facilityActivities,
   otherActivities,
   navigationInformation,
   formsData,
@@ -56,7 +56,7 @@ export const FacilityReview: React.FC<Props> = ({
     const endpoint = `reporting/report-version/${version_id}/facility-report/${facility_id}`;
     const pathToRevalidate = `reporting/reports/${version_id}/facilities/${facility_id}/review-facility-information`;
     const selectedActivityNames = [
-      ...(formData.report_operation_activities ?? []),
+      ...(formData.facility_activities ?? []),
       ...(formData.other_activities ?? []),
     ];
     if (selectedActivityNames.length === 0) {
@@ -66,7 +66,7 @@ export const FacilityReview: React.FC<Props> = ({
     }
 
     const activityNameToIdMap = new Map<string, number>(
-      [...reportOperationActivities, ...otherActivities].map(
+      [...facilityActivities, ...otherActivities].map(
         (activity: ActivityData) => [activity.name, activity.id],
       ),
     );

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewForm.tsx
@@ -61,7 +61,10 @@ export const FacilityReview: React.FC<Props> = ({
     ];
     if (selectedActivityNames.length === 0) {
       setErrors([
-        createGenericReportValidationError("You must select at least one activity."),]);
+        createGenericReportValidationError(
+          "You must select at least one activity.",
+        ),
+      ]);
       return false;
     }
 

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewPage.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewPage.tsx
@@ -13,12 +13,11 @@ export default async function FacilityReviewPage({
   const orderedActivities = await getOrderedActivities(version_id, facility_id);
 
   const facilityData = await getFacilityReportDetails(version_id, facility_id);
-  const reportOperationActivities =
-    facilityData.report_operation_activities ?? [];
+  const facilityActivities = facilityData.facility_activities ?? [];
   const otherActivities = facilityData.other_activities ?? [];
 
   const savedActivityIds: number[] = facilityData.activities ?? [];
-  const selectedReportOperationActivityNames = reportOperationActivities
+  const selectedFacilityActivityNames = facilityActivities
     .filter((a: { id: number }) => savedActivityIds.includes(a.id))
     .map((a: { name: string }) => a.name);
   const selectedOtherActivityNames = otherActivities
@@ -38,12 +37,12 @@ export default async function FacilityReviewPage({
 
   const formData = {
     ...facilityData,
-    report_operation_activities: selectedReportOperationActivityNames,
+    facility_activities: selectedFacilityActivityNames,
     other_activities: selectedOtherActivityNames,
   };
   const isSyncAllowed = facilityData.is_sync_allowed ?? true;
   const reviewSchema = buildFacilitySchema(
-    reportOperationActivities,
+    facilityActivities,
     otherActivities,
     isSyncAllowed,
   );
@@ -51,7 +50,7 @@ export default async function FacilityReviewPage({
     <FacilityReviewForm
       version_id={version_id}
       facility_id={facility_id}
-      reportOperationActivities={reportOperationActivities}
+      facilityActivities={facilityActivities}
       otherActivities={otherActivities}
       navigationInformation={navInfo}
       formsData={formData}

--- a/bciers/apps/reporting/src/app/components/facility/FacilityReviewPage.tsx
+++ b/bciers/apps/reporting/src/app/components/facility/FacilityReviewPage.tsx
@@ -2,7 +2,6 @@ import FacilityReviewForm from "./FacilityReviewForm";
 import { HasFacilityId } from "@reporting/src/app/utils/defaultPageFactoryTypes";
 import { getOrderedActivities } from "@reporting/src/app/utils/getOrderedActivities";
 import { getFacilityReportDetails } from "@reporting/src/app/utils/getFacilityReportDetails";
-import { getAllActivities } from "@reporting/src/app/utils/getAllActivities";
 import { buildFacilitySchema } from "@reporting/src/data/jsonSchema/facilities";
 import { getNavigationInformation } from "../taskList/navigationInformation";
 import { HeaderStep, ReportingPage } from "../taskList/types";
@@ -14,10 +13,17 @@ export default async function FacilityReviewPage({
   const orderedActivities = await getOrderedActivities(version_id, facility_id);
 
   const facilityData = await getFacilityReportDetails(version_id, facility_id);
-  const activitiesData = await getAllActivities();
-  const selectedActivities = activitiesData.filter((item: { id: number }) =>
-    facilityData.activities.includes(item.id),
-  );
+  const reportOperationActivities =
+    facilityData.report_operation_activities ?? [];
+  const otherActivities = facilityData.other_activities ?? [];
+
+  const savedActivityIds: number[] = facilityData.activities ?? [];
+  const selectedReportOperationActivityNames = reportOperationActivities
+    .filter((a: { id: number }) => savedActivityIds.includes(a.id))
+    .map((a: { name: string }) => a.name);
+  const selectedOtherActivityNames = otherActivities
+    .filter((a: { id: number }) => savedActivityIds.includes(a.id))
+    .map((a: { name: string }) => a.name);
 
   const navInfo = await getNavigationInformation(
     HeaderStep.ReportInformation,
@@ -32,17 +38,21 @@ export default async function FacilityReviewPage({
 
   const formData = {
     ...facilityData,
-    activities: selectedActivities.map(
-      (activity: { name: string }) => activity.name,
-    ),
+    report_operation_activities: selectedReportOperationActivityNames,
+    other_activities: selectedOtherActivityNames,
   };
   const isSyncAllowed = facilityData.is_sync_allowed ?? true;
-  const reviewSchema = buildFacilitySchema(activitiesData, isSyncAllowed);
+  const reviewSchema = buildFacilitySchema(
+    reportOperationActivities,
+    otherActivities,
+    isSyncAllowed,
+  );
   return (
     <FacilityReviewForm
       version_id={version_id}
       facility_id={facility_id}
-      activitiesData={activitiesData}
+      reportOperationActivities={reportOperationActivities}
+      otherActivities={otherActivities}
       navigationInformation={navInfo}
       formsData={formData}
       schema={reviewSchema}

--- a/bciers/apps/reporting/src/data/jsonSchema/facilities.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/facilities.ts
@@ -12,7 +12,8 @@ export interface ActivityData {
 }
 
 export const buildFacilitySchema = (
-  activities: ActivityData[],
+  reportOperationActivities: ActivityData[],
+  otherActivities: ActivityData[],
   isSyncAllowed: boolean = true,
 ) =>
   ({
@@ -36,13 +37,29 @@ export const buildFacilitySchema = (
         title: "Activities",
         type: "string",
       },
-
-      activities: {
+      activity_selection_description: {
+        title:
+          "Select ONLY the activities that apply to this facility. Deselect any activities that are not applicable to this facility.",
+        type: "string",
+      },
+      report_operation_activities: {
         type: "array",
-        title: "Activities",
         items: {
           type: "string",
-          enum: activities.map((activitiy) => activitiy.name),
+          enum: reportOperationActivities.map((activity) => activity.name),
+        },
+        uniqueItems: true,
+      },
+      other_activities_title: {
+        title: "Other activities",
+        type: "string",
+      },
+      other_activities: {
+        type: "array",
+        title: "Other activities",
+        items: {
+          type: "string",
+          enum: otherActivities.map((activity) => activity.name),
         },
         uniqueItems: true,
       },
@@ -85,7 +102,22 @@ export const buildFacilityReviewUiSchema = (
     "ui:FieldTemplate": TitleOnlyFieldTemplate,
     "ui:classNames": "mt-2 mb-5 emission-array-header",
   },
-  activities: {
+  activity_selection_description: {
+    "ui:FieldTemplate": TitleOnlyFieldTemplate,
+  },
+  report_operation_activities: {
+    "ui:FieldTemplate": FieldTemplate,
+    "ui:widget": CheckboxGroupWidget,
+    "ui:options": {
+      label: false,
+      columns: 1,
+    },
+  },
+  other_activities_title: {
+    "ui:FieldTemplate": TitleOnlyFieldTemplate,
+    "ui:classNames": "mt-4 mb-2 emission-array-header",
+  },
+  other_activities: {
     "ui:FieldTemplate": FieldTemplate,
     "ui:widget": CheckboxGroupWidget,
     "ui:options": {

--- a/bciers/apps/reporting/src/data/jsonSchema/facilities.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/facilities.ts
@@ -12,7 +12,7 @@ export interface ActivityData {
 }
 
 export const buildFacilitySchema = (
-  reportOperationActivities: ActivityData[],
+  facilityActivities: ActivityData[],
   otherActivities: ActivityData[],
   isSyncAllowed: boolean = true,
 ) =>
@@ -42,11 +42,11 @@ export const buildFacilitySchema = (
           "Select ONLY the activities that apply to this facility. Deselect any activities that are not applicable to this facility.",
         type: "string",
       },
-      report_operation_activities: {
+      facility_activities: {
         type: "array",
         items: {
           type: "string",
-          enum: reportOperationActivities.map((activity) => activity.name),
+          enum: facilityActivities.map((activity) => activity.name),
         },
         uniqueItems: true,
       },
@@ -105,7 +105,7 @@ export const buildFacilityReviewUiSchema = (
   activity_selection_description: {
     "ui:FieldTemplate": TitleOnlyFieldTemplate,
   },
-  report_operation_activities: {
+  facility_activities: {
     "ui:FieldTemplate": FieldTemplate,
     "ui:widget": CheckboxGroupWidget,
     "ui:options": {

--- a/bciers/apps/reporting/src/data/jsonSchema/facilities.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/facilities.ts
@@ -50,10 +50,6 @@ export const buildFacilitySchema = (
         },
         uniqueItems: true,
       },
-      other_activities_title: {
-        title: "Other activities",
-        type: "string",
-      },
       other_activities: {
         type: "array",
         title: "Other activities",
@@ -112,10 +108,6 @@ export const buildFacilityReviewUiSchema = (
       label: false,
       columns: 1,
     },
-  },
-  other_activities_title: {
-    "ui:FieldTemplate": TitleOnlyFieldTemplate,
-    "ui:classNames": "mt-4 mb-2 emission-array-header",
   },
   other_activities: {
     "ui:FieldTemplate": FieldTemplate,

--- a/bciers/apps/reporting/src/tests/components/facility/FacilityReviewForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/facility/FacilityReviewForm.test.tsx
@@ -43,6 +43,11 @@ const mockActivitiesData: {
   id: number;
   applicable_to: string;
 }[] = [{ name: "Activity 1", id: 1, applicable_to: "abc" }];
+const mockOtherActivities: {
+  name: string;
+  id: number;
+  applicable_to: string;
+}[] = [{ name: "Activity 2", id: 2, applicable_to: "abc" }];
 const mockSchema = { testSchema: true };
 
 const mockFormData: FacilityReviewFormData = {
@@ -50,7 +55,8 @@ const mockFormData: FacilityReviewFormData = {
   facility_name: "Test Facility",
   facility_type: "Test Type",
   facility_bcghgid: null,
-  activities: ["Activity 1"],
+  report_operation_activities: ["Activity 1"],
+  other_activities: [],
   facility: "abcd",
 };
 
@@ -60,7 +66,8 @@ const renderFacilityReview = (
   <FacilityReview
     version_id={1000}
     facility_id="abcd"
-    activitiesData={mockActivitiesData}
+    reportOperationActivities={mockActivitiesData}
+    otherActivities={mockOtherActivities}
     navigationInformation={dummyNavigationInformation}
     formsData={formData}
     schema={mockSchema}
@@ -73,7 +80,8 @@ const mockFormDataWithoutActivities: FacilityReviewFormData = {
   facility_name: "Test Facility",
   facility_type: "Test Type",
   facility_bcghgid: null,
-  activities: [],
+  report_operation_activities: [],
+  other_activities: [],
   facility: "abcd",
 };
 const renderFacilityReviewWithoutActivities = (
@@ -82,7 +90,8 @@ const renderFacilityReviewWithoutActivities = (
   <FacilityReview
     version_id={1000}
     facility_id="abcd"
-    activitiesData={mockActivitiesData}
+    reportOperationActivities={mockActivitiesData}
+    otherActivities={mockOtherActivities}
     navigationInformation={dummyNavigationInformation}
     formsData={formData}
     schema={mockSchema}
@@ -108,7 +117,7 @@ describe("The FacilityReview component", () => {
       "POST",
       "reporting/reports/1000/facilities/abcd/review-facility-information",
       {
-        body: '{"operation_id":"1234","facility_name":"Test Facility","facility_type":"Test Type","facility_bcghgid":null,"activities":[1],"facility":"abcd"}',
+        body: '{"operation_id":"1234","facility_name":"Test Facility","facility_type":"Test Type","facility_bcghgid":null,"report_operation_activities":["Activity 1"],"other_activities":[],"facility":"abcd","activities":[1]}',
       },
     );
   });
@@ -126,7 +135,8 @@ describe("The FacilityReview component", () => {
           facility_name: "Test Facility",
           facility_type: "Test Type",
           facility_bcghgid: null,
-          activities: ["Activity 1"],
+          report_operation_activities: ["Activity 1"],
+          other_activities: ["Activity 2"],
           facility: "abcd",
         },
       }),
@@ -140,7 +150,8 @@ describe("The FacilityReview component", () => {
       facility_name: "Test Facility",
       facility_type: "Test Type",
       facility_bcghgid: null,
-      activities: ["Activity 1"],
+      report_operation_activities: ["Activity 1"],
+      other_activities: ["Activity 2"],
       facility: "abcd",
     });
   });
@@ -177,7 +188,8 @@ describe("The FacilityReview component", () => {
       <FacilityReview
         version_id={1000}
         facility_id="abcd"
-        activitiesData={mockActivitiesData}
+        reportOperationActivities={mockActivitiesData}
+        otherActivities={mockOtherActivities}
         navigationInformation={dummyNavigationInformation}
         formsData={mockFormData}
         schema={mockSchema}
@@ -201,7 +213,8 @@ describe("The FacilityReview component", () => {
       <FacilityReview
         version_id={1000}
         facility_id="abcd"
-        activitiesData={mockActivitiesData}
+        reportOperationActivities={mockActivitiesData}
+        otherActivities={mockOtherActivities}
         navigationInformation={dummyNavigationInformation}
         formsData={mockFormData}
         schema={mockSchema}
@@ -219,7 +232,11 @@ describe("The FacilityReview component", () => {
   });
 
   it("schema includes info_note and sync_button when isSyncAllowed is true", () => {
-    const schemaWithSync = buildFacilitySchema(mockActivitiesData, true);
+    const schemaWithSync = buildFacilitySchema(
+      mockActivitiesData,
+      mockOtherActivities,
+      true,
+    );
 
     // Verify info_note and sync_button are in the schema properties
     expect(schemaWithSync.properties?.info_note).toBeDefined();
@@ -227,7 +244,11 @@ describe("The FacilityReview component", () => {
   });
 
   it("schema excludes info_note and sync_button when isSyncAllowed is false", () => {
-    const schemaWithoutSync = buildFacilitySchema(mockActivitiesData, false);
+    const schemaWithoutSync = buildFacilitySchema(
+      mockActivitiesData,
+      mockOtherActivities,
+      false,
+    );
 
     // Verify info_note and sync_button are NOT in the schema properties
     expect(schemaWithoutSync.properties?.info_note).toBeUndefined();

--- a/bciers/apps/reporting/src/tests/components/facility/FacilityReviewForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/facility/FacilityReviewForm.test.tsx
@@ -188,7 +188,7 @@ describe("The FacilityReview component", () => {
       <FacilityReview
         version_id={1000}
         facility_id="abcd"
-        reportOperationActivities={mockActivitiesData}
+        facilityActivities={mockActivitiesData}
         otherActivities={mockOtherActivities}
         navigationInformation={dummyNavigationInformation}
         formsData={mockFormData}
@@ -213,7 +213,7 @@ describe("The FacilityReview component", () => {
       <FacilityReview
         version_id={1000}
         facility_id="abcd"
-        reportOperationActivities={mockActivitiesData}
+        facilityActivities={mockActivitiesData}
         otherActivities={mockOtherActivities}
         navigationInformation={dummyNavigationInformation}
         formsData={mockFormData}

--- a/bciers/apps/reporting/src/tests/components/facility/FacilityReviewForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/facility/FacilityReviewForm.test.tsx
@@ -55,7 +55,7 @@ const mockFormData: FacilityReviewFormData = {
   facility_name: "Test Facility",
   facility_type: "Test Type",
   facility_bcghgid: null,
-  report_operation_activities: ["Activity 1"],
+  facility_activities: ["Activity 1"],
   other_activities: [],
   facility: "abcd",
 };
@@ -66,7 +66,7 @@ const renderFacilityReview = (
   <FacilityReview
     version_id={1000}
     facility_id="abcd"
-    reportOperationActivities={mockActivitiesData}
+    facilityActivities={mockActivitiesData}
     otherActivities={mockOtherActivities}
     navigationInformation={dummyNavigationInformation}
     formsData={formData}
@@ -80,7 +80,7 @@ const mockFormDataWithoutActivities: FacilityReviewFormData = {
   facility_name: "Test Facility",
   facility_type: "Test Type",
   facility_bcghgid: null,
-  report_operation_activities: [],
+  facility_activities: [],
   other_activities: [],
   facility: "abcd",
 };
@@ -90,7 +90,7 @@ const renderFacilityReviewWithoutActivities = (
   <FacilityReview
     version_id={1000}
     facility_id="abcd"
-    reportOperationActivities={mockActivitiesData}
+    facilityActivities={mockActivitiesData}
     otherActivities={mockOtherActivities}
     navigationInformation={dummyNavigationInformation}
     formsData={formData}
@@ -117,7 +117,7 @@ describe("The FacilityReview component", () => {
       "POST",
       "reporting/reports/1000/facilities/abcd/review-facility-information",
       {
-        body: '{"operation_id":"1234","facility_name":"Test Facility","facility_type":"Test Type","facility_bcghgid":null,"report_operation_activities":["Activity 1"],"other_activities":[],"facility":"abcd","activities":[1]}',
+        body: '{"operation_id":"1234","facility_name":"Test Facility","facility_type":"Test Type","facility_bcghgid":null,"facility_activities":["Activity 1"],"other_activities":[],"facility":"abcd","activities":[1]}',
       },
     );
   });
@@ -135,7 +135,7 @@ describe("The FacilityReview component", () => {
           facility_name: "Test Facility",
           facility_type: "Test Type",
           facility_bcghgid: null,
-          report_operation_activities: ["Activity 1"],
+          facility_activities: ["Activity 1"],
           other_activities: ["Activity 2"],
           facility: "abcd",
         },
@@ -150,7 +150,7 @@ describe("The FacilityReview component", () => {
       facility_name: "Test Facility",
       facility_type: "Test Type",
       facility_bcghgid: null,
-      report_operation_activities: ["Activity 1"],
+      facility_activities: ["Activity 1"],
       other_activities: ["Activity 2"],
       facility: "abcd",
     });


### PR DESCRIPTION
ISSUE #4546 

### Manual Testing I Performed

Brine LFO

- started new 2025 report
- Regulated
- starting activities: Ammonia production, GSC excluding line tracing (at SFO)
- 2 facilities at start: Facility 36, 3000

Facility 3000:
- by default, GSC excluding line tracing & Ammonia production selected and at top of list
- also selected Fuel combustion by mobile
- filled out and saved Fuel combustion activity form
- left facility report as Incomplete

Went back to Review Operation Info page, added new activity Electricity transmission

Facility 3000:
- now has activities GSC excl. line tracing, Ammonia production, Electricity transmission selected and at top of list. Fuel combustion by mobile is selected but is in second list (not at top)

Facility 36:
- has GSC exc. line tracing, Ammonia production, and Electricity transmission selected and at top of list (by default)
- deselected Ammonia production and saved
- refreshed the page, Ammonia production still deselected but still appears near top of list (Electricity transmission, selected, is listed after Ammonia)
- marked facility report as Complete

Went back to Review Operation Info, removed GSC excl line tracing, added new activity Lead production

Facility 36 (was already marked Completed) - top of activities list:
[ ] Ammonia production
[x] Electricity transmission
[ ] Lead production
[x] GSC excl. line tracing

Facility 3000 (not yet marked Completed) - top of activities list:
[x] Ammonia production
[x] Electricity transmission 
[x] Lead production
[x] GSC excl. line tracing
[ ] 3 other GSCs
[x] Fuel combustion by mobile