### PR TITLE
temp: 4558 add reporting field display titles

### DIFF
--- a/bc_obps/reporting/schema/report_final_review.py
+++ b/bc_obps/reporting/schema/report_final_review.py
@@ -23,6 +23,7 @@ from reporting.models import (
     SourceType,
     ReportNewEntrantEmission,
     ReportNewEntrantProduction,
+    ReportingField,
 )
 from reporting.schema.compliance_data import ComplianceDataSchemaOut
 from reporting.schema.emission_category import EmissionSummarySchemaOut
@@ -105,6 +106,47 @@ class ReportEmissionAllocationSchema(ModelSchema):
         fields = ['allocation_methodology', 'allocation_other_methodology_description']
 
 
+def get_reporting_field_display_titles() -> Dict[str, str]:
+    field_titles: Dict[str, str] = {}
+
+    for reporting_field in ReportingField.objects.only(
+        "slug",
+        "field_display_title",
+        "field_name",
+    ):
+        display_title = reporting_field.field_display_title or reporting_field.field_name
+
+        # Main reporting field
+        field_titles[reporting_field.slug] = display_title
+
+        # Generated "...FieldUnits" companion field
+        field_titles[f"{reporting_field.slug}FieldUnits"] = f"{display_title} Units"
+
+    return field_titles
+
+
+def add_methodology_display_titles(
+    value: Any,
+    field_titles: Dict[str, str],
+) -> Any:
+    if isinstance(value, dict):
+        updated = {key: add_methodology_display_titles(child_value, field_titles) for key, child_value in value.items()}
+
+        # Detect methodology blocks
+        if "methodology" in updated and isinstance(updated["methodology"], str):
+            display_titles = {key: field_titles[key] for key in updated.keys() if key in field_titles}
+
+            if display_titles:
+                updated["_field_display_titles"] = display_titles
+
+        return updated
+
+    if isinstance(value, list):
+        return [add_methodology_display_titles(item, field_titles) for item in value]
+
+    return value
+
+
 class ReportRawActivityDataSchema(ModelSchema):
     activity: str
     source_types: dict
@@ -116,6 +158,10 @@ class ReportRawActivityDataSchema(ModelSchema):
     @staticmethod
     def resolve_source_types(obj: ReportRawActivityData) -> dict:
         json_data = obj.json_data
+
+        field_titles = get_reporting_field_display_titles()
+
+        json_data = add_methodology_display_titles(json_data, field_titles)
 
         source_type_section = json_data.get("sourceTypes", {})
         source_type_section_keys = set(source_type_section.keys())
@@ -244,6 +290,10 @@ class FacilityReportSchema(ModelSchema):
     def resolve_activity_data(obj: FacilityReport) -> Dict[str, ReportRawActivityData]:
         activities = obj.reportrawactivitydata_records.all()
         return {activity.activity.name: activity for activity in activities}
+
+    @staticmethod
+    def resolve_field_display_titles(obj: FacilityReport) -> Dict[str, str]:
+        return get_reporting_field_display_titles()
 
     @staticmethod
     def resolve_report_products(obj: FacilityReport) -> Dict[str, ReportProduct]:

--- a/bc_obps/reporting/service/review_changes_service/report_review_changes_service.py
+++ b/bc_obps/reporting/service/review_changes_service/report_review_changes_service.py
@@ -2,7 +2,49 @@ from typing import Any, Dict, List
 from deepdiff import DeepDiff
 from deepdiff.helper import NotPresent
 
+from reporting.models import ReportingField
+
 from .diff_helpers import _DIFF_KWARGS, _CHANGE_TYPE_MAP, detect_renames, diff_sections, fix_facility_uuid_in_path
+
+
+NOISY_DIFF_KEYS = {
+    "report_product_id",
+    "report_version",
+    "is_supplementary_report",
+    "is_latest_submitted",
+    "status",
+}
+
+
+def _remove_noisy_diff_keys(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _remove_noisy_diff_keys(child_value)
+            for key, child_value in value.items()
+            if key not in NOISY_DIFF_KEYS
+        }
+
+    if isinstance(value, list):
+        return [_remove_noisy_diff_keys(item) for item in value]
+
+    return value
+
+
+def _get_reporting_field_display_titles() -> Dict[str, str]:
+    return {
+        reporting_field.slug: reporting_field.field_display_title or reporting_field.field_name
+        for reporting_field in ReportingField.objects.only(
+            "slug",
+            "field_display_title",
+            "field_name",
+        )
+    }
+
+
+def _get_field_display_title(field_path: str, field_display_titles: Dict[str, str]) -> str | None:
+    field_name = field_path.split("['")[-1].removesuffix("']")
+
+    return field_display_titles.get(field_name)
 
 
 class ReportReviewChangesService:
@@ -10,9 +52,14 @@ class ReportReviewChangesService:
     def get_report_version_diff_changes(cls, previous: dict, current: dict) -> List[Dict[str, Any]]:
         """
         Compare two serialized report versions and return a list of human-readable field changes.
-        Each entry has: field, old_value, new_value, change_type (added / removed / modified).
+        Each entry has: field, field_display_title, old_value, new_value, change_type.
         """
         previous, current = previous or {}, current or {}
+
+        previous = _remove_noisy_diff_keys(previous)
+        current = _remove_noisy_diff_keys(current)
+
+        field_display_titles = _get_reporting_field_display_titles()
         changes: List[Dict[str, Any]] = []
 
         # Facility reports
@@ -20,6 +67,9 @@ class ReportReviewChangesService:
         curr_facs: Dict[str, dict] = current.get('facility_reports') or {}
         changes.extend(detect_renames(prev_facs, curr_facs))
         changes.extend(diff_sections(prev_facs, curr_facs, "root['facility_reports']"))
+
+        for change in changes:
+            change["field_display_title"] = _get_field_display_title(change["field"], field_display_titles)
 
         # Compliance products
         prod_root = "root['report_compliance_summary']['products']"
@@ -29,14 +79,20 @@ class ReportReviewChangesService:
         curr_products = {
             p['name']: p for p in (current.get('report_compliance_summary') or {}).get('products', []) if p.get('name')
         }
-        changes.extend(diff_sections(prev_products, curr_products, prod_root))
 
-        # All remaining top-level fields (registration_purpose included — DeepDiff handles it natively)
+        product_changes = diff_sections(prev_products, curr_products, prod_root)
+        for change in product_changes:
+            change["field_display_title"] = _get_field_display_title(change["field"], field_display_titles)
+
+        changes.extend(product_changes)
+
+        # All remaining top-level fields
         diff = DeepDiff(previous, current, exclude_regex_paths=[r".*?facility_reports.*"], **_DIFF_KWARGS)
         for diff_key, items in diff.items():
             changes = changes + [
                 {
                     "field": fix_facility_uuid_in_path(item.path(), current),
+                    "field_display_title": _get_field_display_title(item.path(), field_display_titles),
                     "old_value": None if isinstance(item.t1, NotPresent) else item.t1,
                     "new_value": None if isinstance(item.t2, NotPresent) else item.t2,
                     "change_type": _CHANGE_TYPE_MAP.get(diff_key, 'modified'),

--- a/bciers/apps/reporting/src/app/components/changeReview/constants/types.ts
+++ b/bciers/apps/reporting/src/app/components/changeReview/constants/types.ts
@@ -10,6 +10,7 @@ export type ChangeItemValue =
   | number;
 export interface ChangeItem {
   field: string;
+  field_display_title?: string;
   oldValue: ChangeItemValue;
   newValue: ChangeItemValue;
   change_type: ChangeType;

--- a/bciers/apps/reporting/src/app/components/changeReview/utils/activityRenderUtils.tsx
+++ b/bciers/apps/reporting/src/app/components/changeReview/utils/activityRenderUtils.tsx
@@ -12,6 +12,39 @@ import {
   verticalBorder,
 } from "@reporting/src/app/components/changeReview/constants/styles";
 
+type FieldDisplayTitles = Record<string, string>;
+
+const FIELD_DISPLAY_TITLES_KEY = "_field_display_titles";
+
+const getFieldLabel = (key: string, fieldDisplayTitles: FieldDisplayTitles) =>
+  fieldDisplayTitles[key] ?? formatKey(key);
+
+const getFieldDisplayTitles = (
+  obj: unknown,
+  inheritedFieldDisplayTitles: FieldDisplayTitles,
+): FieldDisplayTitles => {
+  if (!obj || typeof obj !== "object" || Array.isArray(obj)) {
+    return inheritedFieldDisplayTitles;
+  }
+
+  const localTitles = (obj as Record<string, unknown>)[
+    FIELD_DISPLAY_TITLES_KEY
+  ];
+
+  if (
+    !localTitles ||
+    typeof localTitles !== "object" ||
+    Array.isArray(localTitles)
+  ) {
+    return inheritedFieldDisplayTitles;
+  }
+
+  return {
+    ...inheritedFieldDisplayTitles,
+    ...(localTitles as FieldDisplayTitles),
+  };
+};
+
 export const getDeletedStyles = (isDeleted: boolean): React.CSSProperties =>
   isDeleted ? { textDecoration: "line-through", color: "#666" } : {};
 
@@ -40,8 +73,14 @@ export const renderField = (
   key: string,
   value: unknown,
   deletedStyles: React.CSSProperties,
+  fieldDisplayTitles: FieldDisplayTitles = {},
 ): React.ReactNode => {
-  const label = <strong style={deletedStyles}>{formatKey(key)}:</strong>;
+  const label = (
+    <strong style={deletedStyles}>
+      {getFieldLabel(key, fieldDisplayTitles)}:
+    </strong>
+  );
+
   const wrapper = (children: React.ReactNode) => (
     <div
       style={{
@@ -55,9 +94,11 @@ export const renderField = (
       {children}
     </div>
   );
+
   if (typeof value === "number") {
     return wrapper(renderNumberField(key, deletedStyles, value));
   }
+
   return wrapper(<span style={deletedStyles}>{String(value)}</span>);
 };
 
@@ -79,8 +120,14 @@ export const renderObject = (
   obj: unknown,
   labelPrefix = "",
   isDeleted = false,
+  inheritedFieldDisplayTitles: FieldDisplayTitles = {},
 ): React.ReactNode => {
   const deletedStyles = getDeletedStyles(isDeleted);
+
+  const fieldDisplayTitles = getFieldDisplayTitles(
+    obj,
+    inheritedFieldDisplayTitles,
+  );
 
   // ---- Array branch -------------------------------------------------------
   if (Array.isArray(obj)) {
@@ -91,6 +138,7 @@ export const renderObject = (
       // Special: sourceSubType units → reorder keys then delegate to renderObject
       if (lower === "units" && isObj && "sourceSubType" in item) {
         const unitObj = item as Record<string, unknown>;
+
         const orderedKeys = [
           "sourceSubType",
           ...Object.keys(unitObj).filter(
@@ -103,14 +151,22 @@ export const renderObject = (
             k.toLowerCase().includes("emissions"),
           ),
         ];
+
         const orderedItem = Object.fromEntries(
           orderedKeys.map((k) => [k, unitObj[k]]),
         );
+
         return (
           <div key={`${labelPrefix}-${index}`} style={{ marginBottom: 12 }}>
             {renderHeading(`Source sub-type ${index + 1}:`, deletedStyles)}
+
             <div style={{ marginLeft: 10 }}>
-              {renderObject(orderedItem, labelPrefix, isDeleted)}
+              {renderObject(
+                orderedItem,
+                labelPrefix,
+                isDeleted,
+                fieldDisplayTitles,
+              )}
             </div>
           </div>
         );
@@ -125,6 +181,7 @@ export const renderObject = (
             : "";
 
       const title = singularLabel ? `${singularLabel} ${index + 1}:` : "";
+
       const containerStyle = {
         marginLeft: 20,
         marginBottom: 8,
@@ -134,8 +191,9 @@ export const renderObject = (
       return (
         <div key={`${labelPrefix}-${index}`} style={containerStyle}>
           {title && renderHeading(title, deletedStyles)}
+
           <div style={{ marginLeft: 10 }}>
-            {renderObject(item, labelPrefix, isDeleted)}
+            {renderObject(item, labelPrefix, isDeleted, fieldDisplayTitles)}
           </div>
         </div>
       );
@@ -145,23 +203,36 @@ export const renderObject = (
   // ---- Object branch ------------------------------------------------------
   if (obj && typeof obj === "object") {
     return Object.entries(obj).map(([key, value], idx) => {
+      if (key === FIELD_DISPLAY_TITLES_KEY) return null;
+
       const isObjOrArr = typeof value === "object" && value !== null;
 
       // Special: methodology object
       if (key === "methodology" && isObjOrArr && !Array.isArray(value)) {
+        const methodologyFieldDisplayTitles = getFieldDisplayTitles(
+          value,
+          fieldDisplayTitles,
+        );
+
         const mObj = value as Record<string, unknown>;
+
         const methodName =
           typeof mObj.methodology === "string" ? mObj.methodology : undefined;
+
         const rest = sortMethodologyEntries(
-          Object.entries(mObj).filter(([k]) => k !== "methodology"),
+          Object.entries(mObj).filter(
+            ([k]) => k !== "methodology" && k !== FIELD_DISPLAY_TITLES_KEY,
+          ),
         );
 
         return (
           <div key={`${key}-${idx}`} style={{ marginBottom: 4 }}>
             <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
               <strong style={deletedStyles}>Methodology:</strong>
+
               {methodName && <span style={deletedStyles}>{methodName}</span>}
             </div>
+
             {rest.map(([pKey, pVal], pIdx) => {
               // Any object-valued key (months, quarters, or any future period type)
               // is rendered as a blue sub-header with its fields indented beneath it.
@@ -171,13 +242,23 @@ export const renderObject = (
                     key={`${pKey}-${pIdx}`}
                     style={{ marginLeft: 20, marginBottom: 8 }}
                   >
-                    {renderHeading(`${formatKey(pKey)}:`, deletedStyles)}
+                    {renderHeading(
+                      `${getFieldLabel(pKey, methodologyFieldDisplayTitles)}:`,
+                      deletedStyles,
+                    )}
+
                     <div style={{ marginLeft: 16 }}>
-                      {renderObject(pVal, pKey, isDeleted)}
+                      {renderObject(
+                        pVal,
+                        pKey,
+                        isDeleted,
+                        methodologyFieldDisplayTitles,
+                      )}
                     </div>
                   </div>
                 );
               }
+
               return (
                 <div
                   key={`${pKey}-${pIdx}`}
@@ -189,7 +270,10 @@ export const renderObject = (
                     gap: "4px",
                   }}
                 >
-                  <strong style={deletedStyles}>{formatKey(pKey)}:</strong>
+                  <strong style={deletedStyles}>
+                    {getFieldLabel(pKey, methodologyFieldDisplayTitles)}:
+                  </strong>
+
                   <span style={deletedStyles}>{String(pVal)}</span>
                 </div>
               );
@@ -202,7 +286,7 @@ export const renderObject = (
       if (key === "fuelType" && isObjOrArr && !Array.isArray(value)) {
         return (
           <React.Fragment key={`${key}-${idx}`}>
-            {renderObject(value, "", isDeleted)}
+            {renderObject(value, "", isDeleted, fieldDisplayTitles)}
           </React.Fragment>
         );
       }
@@ -210,6 +294,7 @@ export const renderObject = (
       // Default: suppress label for array-container keys (their contents already
       // get "N+1" headings) and for fuelType (rendered flat with no wrapper).
       const suppressLabel = Array.isArray(value) || key === "fuelType";
+
       return (
         <div
           key={`${key}-${idx}`}
@@ -217,15 +302,22 @@ export const renderObject = (
             marginBottom: 4,
             ...(isObjOrArr
               ? {}
-              : { display: "flex", alignItems: "center", gap: "4px" }),
+              : {
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "4px",
+                }),
           }}
         >
           {!suppressLabel && (
-            <strong style={deletedStyles}>{formatKey(key)}:</strong>
+            <strong style={deletedStyles}>
+              {getFieldLabel(key, fieldDisplayTitles)}:
+            </strong>
           )}
+
           {isObjOrArr ? (
             <span style={deletedStyles}>
-              {renderObject(value, key, isDeleted)}
+              {renderObject(value, key, isDeleted, fieldDisplayTitles)}
             </span>
           ) : typeof value === "number" ? (
             <NumberField.Root
@@ -236,7 +328,10 @@ export const renderObject = (
             >
               <NumberField.Group>
                 <NumberField.Input
-                  style={{ ...numberStyles, ...deletedStyles }}
+                  style={{
+                    ...numberStyles,
+                    ...deletedStyles,
+                  }}
                   name={key}
                 />
               </NumberField.Group>
@@ -260,10 +355,18 @@ export const renderObject = (
 export const renderFuels = (
   sourceTypeValue: Record<string, any>,
   deletedStyles: React.CSSProperties,
-) => (
-  <div style={dataCardStyle}>
-    {Object.entries(sourceTypeValue)
-      .filter(([key]) => ["fuel name", "fuel unit"].includes(key.toLowerCase()))
-      .map(([key, value]) => renderField(key, value, deletedStyles))}
-  </div>
-);
+) => {
+  const fieldDisplayTitles = getFieldDisplayTitles(sourceTypeValue, {});
+
+  return (
+    <div style={dataCardStyle}>
+      {Object.entries(sourceTypeValue)
+        .filter(([key]) =>
+          ["fuel name", "fuel unit"].includes(key.toLowerCase()),
+        )
+        .map(([key, value]) =>
+          renderField(key, value, deletedStyles, fieldDisplayTitles),
+        )}
+    </div>
+  );
+};

--- a/bciers/apps/reporting/src/app/components/changeReview/utils/activityViewHelpers.tsx
+++ b/bciers/apps/reporting/src/app/components/changeReview/utils/activityViewHelpers.tsx
@@ -306,6 +306,9 @@ export const renderDiffTree = (items: SegmentedChange[]): React.ReactNode => {
   >();
 
   for (const item of items) {
+    if (item.segs.includes("_field_display_titles")) {
+      continue;
+    }
     const [first, second, ...rest] = item.segs;
     if (first === undefined) continue;
 
@@ -365,7 +368,10 @@ export const renderDiffTree = (items: SegmentedChange[]): React.ReactNode => {
           return (
             <ChangeItemDisplay
               key={key}
-              item={{ ...change, displayLabel: label }}
+              item={{
+                ...change,
+                displayLabel: change.field_display_title ?? label,
+              }}
             />
           );
         }


### PR DESCRIPTION
resolves: [4558](https://github.com/bcgov/cas-registration/issues/4558)

### 🚀 Impact
* Added `ReportingField` display titles to activity data rendering in both `Review Changes` and `Final Review`

  * **Review Changes:** attached `field_display_title` directly to each diff item so the resolved display label travels with the exact changed field
  * **Final Review:** injected `_field_display_titles` metadata into methodology blocks for dynamic field label rendering
  * Preserved existing frontend key formatting as a fallback when no display title exists

* Refactored `report_review_changes_service.py` to reduce review-change noise by recursively removing system-managed fields before diffing (e.g. `report_product_id`, `report_version`, `status`, `is_latest_submitted`, `is_supplementary_report`)

  * Prevents false-positive “changes” caused by regenerated IDs/version metadata rather than actual user-edited report data:
          before: `changed: Array(24)`
          after: `changed: Array(7)`


### Screenshots:

<img width="1103" height="962" alt="image" src="https://github.com/user-attachments/assets/69468ec3-8216-4197-8226-fea91cfd79f8" />

<img width="1103" height="962" alt="image" src="https://github.com/user-attachments/assets/c94e700e-1ab3-49a8-9c6c-284affd76fad" />
