### PR TITLE
Rename facility report download file name

### DIFF
--- a/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReview.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReview.tsx
@@ -1,21 +1,12 @@
-"use client";
-
-import FacilityReportSection from "@reporting/src/app/components/shared/FacilityReportSection";
-import { useEffect, useState } from "react";
-import { ReportData } from "@reporting/src/app/components/finalReview/reportTypes";
-import { useRouter } from "next/navigation";
-import Loading from "@bciers/components/loading/SkeletonGrid";
-import { Box, Button } from "@mui/material";
-import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/ReportingTaskList";
-import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
 import { getFacilityFinalReviewData } from "@reporting/src/app/utils/getFacilityFinalReviewData";
 import { ReportingOrigin } from "@reporting/src/app/components/taskList/types";
-import { ReportDownloadPdfButton } from "./templates/ReportDownloadPdfButton";
+import FacilityReportFinalReviewContent from "./FacilityReportFinalReviewContent";
 
 export interface OriginSearchParams {
   origin?: ReportingOrigin;
 }
-export default function FacilityReportFinalReview({
+
+export default async function FacilityReportFinalReview({
   version_id,
   facility_id,
   searchParams,
@@ -25,64 +16,9 @@ export default function FacilityReportFinalReview({
   searchParams?: OriginSearchParams;
 }) {
   const origin = searchParams?.origin;
-  const router = useRouter();
-  const [data, setData] = useState<ReportData | null>(null);
-  const [loading, setLoading] = useState(true);
-
   const backUrl = `/reporting/reports/${version_id}/${origin}#facility-grid`;
 
-  const taskListElements: TaskListElement[] = [
-    {
-      type: "Link",
-      text: "Back to previous page",
-      link: `${backUrl}`,
-      title: "Back to previous page",
-    },
-  ];
+  const data = await getFacilityFinalReviewData(version_id, facility_id);
 
-  useEffect(() => {
-    async function fetchData() {
-      if (!facility_id) {
-        setLoading(false);
-        setData(null);
-        return;
-      }
-      const finalReviewData = await getFacilityFinalReviewData(
-        version_id,
-        facility_id,
-      );
-      setData(finalReviewData);
-      setLoading(false);
-    }
-    fetchData();
-  }, [version_id, facility_id]);
-
-  if (loading || !data) return <Loading />;
-
-  return (
-    <div className="w-full flex">
-      <div className="hidden md:block print:hidden">
-        <ReportingTaskList elements={taskListElements} />
-      </div>
-      <div className="w-full">
-        <ReportDownloadPdfButton />
-        <FacilityReportSection facilityData={data} />
-        <Box
-          display="flex"
-          justifyContent="flex-start"
-          mt={3}
-          className="print:hidden"
-        >
-          <Button
-            variant="outlined"
-            onClick={() => {
-              router.push(backUrl);
-            }}
-          >
-            Back
-          </Button>
-        </Box>
-      </div>
-    </div>
-  );
+  return <FacilityReportFinalReviewContent data={data} backUrl={backUrl} />;
 }

--- a/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReview.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReview.tsx
@@ -10,11 +10,11 @@ export default async function FacilityReportFinalReview({
   version_id,
   facility_id,
   searchParams,
-}: {
+}: Readonly<{
   version_id: number;
   facility_id: string;
   searchParams?: OriginSearchParams;
-}) {
+}>) {
   const origin = searchParams?.origin;
   const backUrl = `/reporting/reports/${version_id}/${origin}#facility-grid`;
 

--- a/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReviewContent.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReviewContent.tsx
@@ -32,12 +32,12 @@ export default function FacilityReportFinalReviewContent({
       document.title = originalTitle;
     };
 
-    window.addEventListener("beforeprint", handleBeforePrint);
-    window.addEventListener("afterprint", handleAfterPrint);
+    globalThis.addEventListener("beforeprint", handleBeforePrint);
+    globalThis.addEventListener("afterprint", handleAfterPrint);
 
     return () => {
-      window.removeEventListener("beforeprint", handleBeforePrint);
-      window.removeEventListener("afterprint", handleAfterPrint);
+      globalThis.removeEventListener("beforeprint", handleBeforePrint);
+      globalThis.removeEventListener("afterprint", handleAfterPrint);
     };
   }, [data.facility_name]);
 

--- a/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReviewContent.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReviewContent.tsx
@@ -17,16 +17,27 @@ interface Props {
 export default function FacilityReportFinalReviewContent({
   data,
   backUrl,
-}: Props) {
+}: Readonly<Props>) {
   const router = useRouter();
 
   // Controls the PDF filename for both the Save as PDF button and Cmd/Ctrl+P.
   useEffect(() => {
-    if (!data.facility_name) return;
     const originalTitle = document.title;
-    document.title = `CAS OBPS_Reporting_${data.facility_name}`;
-    return () => {
+
+    const handleBeforePrint = () => {
+      document.title = `CAS OBPS_Reporting_${data.facility_name}`;
+    };
+
+    const handleAfterPrint = () => {
       document.title = originalTitle;
+    };
+
+    window.addEventListener("beforeprint", handleBeforePrint);
+    window.addEventListener("afterprint", handleAfterPrint);
+
+    return () => {
+      window.removeEventListener("beforeprint", handleBeforePrint);
+      window.removeEventListener("afterprint", handleAfterPrint);
     };
   }, [data.facility_name]);
 

--- a/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReviewContent.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReviewContent.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import FacilityReportSection from "@reporting/src/app/components/shared/FacilityReportSection";
+import { FacilityReport } from "@reporting/src/app/components/finalReview/reportTypes";
+import { Box, Button } from "@mui/material";
+import ReportingTaskList from "@bciers/components/navigation/reportingTaskList/ReportingTaskList";
+import { TaskListElement } from "@bciers/components/navigation/reportingTaskList/types";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { ReportDownloadPdfButton } from "./templates/ReportDownloadPdfButton";
+
+interface Props {
+  data: FacilityReport;
+  backUrl: string;
+}
+
+export default function FacilityReportFinalReviewContent({
+  data,
+  backUrl,
+}: Props) {
+  const router = useRouter();
+
+  // Controls the PDF filename for both the Save as PDF button and Cmd/Ctrl+P.
+  useEffect(() => {
+    if (!data.facility_name) return;
+    const originalTitle = document.title;
+    document.title = `CAS OBPS_Reporting_${data.facility_name}`;
+    return () => {
+      document.title = originalTitle;
+    };
+  }, [data.facility_name]);
+
+  const taskListElements: TaskListElement[] = [
+    {
+      type: "Link",
+      text: "Back to previous page",
+      link: backUrl,
+      title: "Back to previous page",
+    },
+  ];
+
+  return (
+    <div className="w-full flex">
+      <div className="hidden md:block print:hidden">
+        <ReportingTaskList elements={taskListElements} />
+      </div>
+      <div className="w-full">
+        <ReportDownloadPdfButton />
+        <FacilityReportSection facilityData={data} />
+        <Box
+          display="flex"
+          justifyContent="flex-start"
+          mt={3}
+          className="print:hidden"
+        >
+          <Button
+            variant="outlined"
+            onClick={() => {
+              router.push(backUrl);
+            }}
+          >
+            Back
+          </Button>
+        </Box>
+      </div>
+    </div>
+  );
+}

--- a/bciers/apps/reporting/src/tests/components/finalReview/FacilityReportFinalReview.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/finalReview/FacilityReportFinalReview.test.tsx
@@ -1,7 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/react";
 import { getFacilityFinalReviewData } from "@reporting/src/app/utils/getFacilityFinalReviewData";
-import { useRouter, usePathname } from "next/navigation";
 import FacilityReportFinalReview, {
   OriginSearchParams,
 } from "@reporting/src/app/components/finalReview/FacilityReportFinalReview";
@@ -10,108 +8,66 @@ vi.mock("@reporting/src/app/utils/getFacilityFinalReviewData", () => ({
   getFacilityFinalReviewData: vi.fn(),
 }));
 
-const mockRouterPush = vi.fn();
-vi.mock("next/navigation", async () => {
-  const actual: any = await vi.importActual("next/navigation");
-  return {
-    ...actual,
-    useRouter: vi.fn(),
-    usePathname: vi.fn(),
-  };
-});
-
 vi.mock(
-  "@bciers/components/navigation/reportingTaskList/ReportingTaskList",
+  "@reporting/src/app/components/finalReview/FacilityReportFinalReviewContent",
   () => ({
-    default: ({ elements }: any) => (
-      <div data-testid="reporting-task-list">
-        {elements.map((el: any) => el.text).join(", ")}
+    default: ({ data, backUrl }: any) => (
+      <div data-testid="facility-report-content">
+        <span data-testid="facility-name">{data.facility_name}</span>
+        <a data-testid="back-url" href={backUrl}>
+          Back
+        </a>
       </div>
     ),
   }),
 );
 
-vi.mock("@reporting/src/app/components/shared/FacilityReportSection", () => ({
-  __esModule: true,
-  default: ({ facilityData }: any) => (
-    <div data-testid="facility-report-section">
-      Facility Section: {facilityData.facility_name || "No Name"}
-    </div>
-  ),
-}));
-
-vi.mock("@bciers/components/loading/SkeletonGrid", () => ({
-  __esModule: true,
-  default: () => <div data-testid="loading">Loading...</div>,
-}));
-
 describe("FacilityReportFinalReview", () => {
-  const pathname = "/reporting/reports/123/final-review";
-
   beforeEach(() => {
     vi.clearAllMocks();
-    (useRouter as any).mockReturnValue({ push: mockRouterPush });
-    (usePathname as any).mockReturnValue(pathname);
   });
 
-  it("renders loading when data is being fetched", async () => {
-    (getFacilityFinalReviewData as any).mockImplementation(
-      () => new Promise(() => {}), // never resolves
-    );
-
-    render(<FacilityReportFinalReview version_id={1} facility_id={"123"} />);
-
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
-    expect(getFacilityFinalReviewData).toHaveBeenCalledWith(1, "123");
-  });
-
-  it("renders facility section and task list when data is loaded", async () => {
-    (getFacilityFinalReviewData as any).mockResolvedValue({
-      facility_name: "Test Facility",
-    });
-
-    render(<FacilityReportFinalReview version_id={123} facility_id={"123"} />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("facility-report-section")).toHaveTextContent(
-        "Test Facility",
-      );
-      expect(screen.getByTestId("reporting-task-list")).toHaveTextContent(
-        "Back to previous page",
-      );
-    });
-  });
-
-  it("does not fetch when facility_id is missing", async () => {
-    render(<FacilityReportFinalReview version_id={42} facility_id={""} />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("loading")).toBeInTheDocument();
-    });
-    expect(getFacilityFinalReviewData).not.toHaveBeenCalled();
-  });
-
-  it("navigates back when Back button is clicked", async () => {
+  it("fetches data and passes it to the content component", async () => {
     (getFacilityFinalReviewData as any).mockResolvedValue({
       facility_name: "Test Facility",
     });
 
     render(
-      <FacilityReportFinalReview
-        version_id={99}
-        facility_id={"123"}
-        searchParams={{ origin: "final-review" } as OriginSearchParams}
-      />,
+      await FacilityReportFinalReview({ version_id: 123, facility_id: "abc" }),
     );
 
-    // Wait for Back button to appear
-    const backButton = await screen.findByRole("button", { name: /back/i });
+    expect(getFacilityFinalReviewData).toHaveBeenCalledWith(123, "abc");
+    expect(screen.getByTestId("facility-name")).toHaveTextContent(
+      "Test Facility",
+    );
+  });
 
-    // Click the Back button
-    await userEvent.click(backButton);
+  it("constructs the correct backUrl from version_id and origin", async () => {
+    (getFacilityFinalReviewData as any).mockResolvedValue({
+      facility_name: "Test Facility",
+    });
 
-    // Check the URL passed to router.push
-    const expectedBackUrl = "/reporting/reports/99/final-review#facility-grid";
-    expect(mockRouterPush).toHaveBeenCalledWith(expectedBackUrl);
+    render(
+      await FacilityReportFinalReview({
+        version_id: 99,
+        facility_id: "abc",
+        searchParams: { origin: "final-review" } as OriginSearchParams,
+      }),
+    );
+
+    expect(screen.getByTestId("back-url")).toHaveAttribute(
+      "href",
+      "/reporting/reports/99/final-review#facility-grid",
+    );
+  });
+
+  it("throws when data fetching fails", async () => {
+    (getFacilityFinalReviewData as any).mockRejectedValue(
+      new Error("Failed to fetch"),
+    );
+
+    await expect(
+      FacilityReportFinalReview({ version_id: 1, facility_id: "abc" }),
+    ).rejects.toThrow("Failed to fetch");
   });
 });

--- a/bciers/apps/reporting/src/tests/components/finalReview/FacilityReportFinalReviewContent.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/finalReview/FacilityReportFinalReviewContent.test.tsx
@@ -1,0 +1,90 @@
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import FacilityReportFinalReviewContent from "@reporting/src/app/components/finalReview/FacilityReportFinalReviewContent";
+
+const mockRouterPush = vi.fn();
+vi.mock("next/navigation", async () => {
+  const actual: any = await vi.importActual("next/navigation");
+  return { ...actual, useRouter: vi.fn(() => ({ push: mockRouterPush })) };
+});
+
+vi.mock("@reporting/src/app/components/shared/FacilityReportSection", () => ({
+  __esModule: true,
+  default: ({ facilityData }: any) => <div>{facilityData.facility_name}</div>,
+}));
+
+const backUrl = "/reporting/reports/1/final-review#facility-grid";
+
+describe("FacilityReportFinalReviewContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a back navigation link pointing to the correct URL", () => {
+    render(
+      <FacilityReportFinalReviewContent
+        data={{ facility_name: "Test Facility" } as any}
+        backUrl={backUrl}
+      />,
+    );
+
+    const backLink = screen.getByRole("link", {
+      name: /back to previous page/i,
+    });
+    expect(backLink).toBeVisible();
+    expect(backLink).toHaveAttribute("href", backUrl);
+  });
+
+  it("renders the facility name", () => {
+    render(
+      <FacilityReportFinalReviewContent
+        data={{ facility_name: "Test Facility" } as any}
+        backUrl={backUrl}
+      />,
+    );
+
+    expect(screen.getByText("Test Facility")).toBeVisible();
+  });
+
+  it("sets document.title to the facility name on mount and restores it on unmount", () => {
+    const originalTitle = document.title;
+
+    const { unmount } = render(
+      <FacilityReportFinalReviewContent
+        data={{ facility_name: "Test Facility" } as any}
+        backUrl={backUrl}
+      />,
+    );
+
+    expect(document.title).toBe("CAS OBPS_Reporting_Test Facility");
+
+    unmount();
+
+    expect(document.title).toBe(originalTitle);
+  });
+
+  it("does not change document.title when facility_name is absent", () => {
+    const originalTitle = document.title;
+
+    render(
+      <FacilityReportFinalReviewContent data={{} as any} backUrl={backUrl} />,
+    );
+
+    expect(document.title).toBe(originalTitle);
+  });
+
+  it("navigates back when Back button is clicked", async () => {
+    render(
+      <FacilityReportFinalReviewContent
+        data={{ facility_name: "Test Facility" } as any}
+        backUrl={backUrl}
+      />,
+    );
+
+    await act(async () => {
+      screen.getByRole("button", { name: /back/i }).click();
+    });
+
+    expect(mockRouterPush).toHaveBeenCalledWith(backUrl);
+  });
+});

--- a/bciers/apps/reporting/src/tests/components/finalReview/FacilityReportFinalReviewContent.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/finalReview/FacilityReportFinalReviewContent.test.tsx
@@ -46,30 +46,22 @@ describe("FacilityReportFinalReviewContent", () => {
     expect(screen.getByText("Test Facility")).toBeVisible();
   });
 
-  it("sets document.title to the facility name on mount and restores it on unmount", () => {
+  it("sets document.title during print and restores it after print", () => {
     const originalTitle = document.title;
 
-    const { unmount } = render(
+    render(
       <FacilityReportFinalReviewContent
         data={{ facility_name: "Test Facility" } as any}
         backUrl={backUrl}
       />,
     );
 
+    expect(document.title).toBe(originalTitle);
+
+    globalThis.dispatchEvent(new Event("beforeprint"));
     expect(document.title).toBe("CAS OBPS_Reporting_Test Facility");
 
-    unmount();
-
-    expect(document.title).toBe(originalTitle);
-  });
-
-  it("does not change document.title when facility_name is absent", () => {
-    const originalTitle = document.title;
-
-    render(
-      <FacilityReportFinalReviewContent data={{} as any} backUrl={backUrl} />,
-    );
-
+    globalThis.dispatchEvent(new Event("afterprint"));
     expect(document.title).toBe(originalTitle);
   });
 


### PR DESCRIPTION
[ISSUE 4587](https://github.com/bcgov/cas-registration/issues/4587)


### Approach: setting `document.title` on mount

The browser derives the PDF filename from `document.title` when printing. The cleanest approach is to set the page title to the correct filename while the user is on the facility report page.

`FacilityReportFinalReviewContent` now uses a `useEffect` to set `document.title` on mount and restore the original title on unmount. This ensures the correct filename is used for both the print button and `Cmd/Ctrl + P`, without adding any special handling inside `DownloadPdfButton`.

As a result, `DownloadPdfButton` remains a simple `window.print()` call with no awareness of filenames.

### Refactor: server/client component split

`FacilityReportFinalReview` was a client component that fetched data via `useEffect` + `useState`, showing a loading skeleton while waiting. It has been split into:

- **`FacilityReportFinalReview`** (server component) — `async` function that awaits the data fetch directly. Loading is handled by the `Suspense` boundary already provided by `defaultPageFactory`.
- **`FacilityReportFinalReviewContent`** (client component) — receives `data` and `backUrl` as props and owns all interactivity: the task list, PDF button, `document.title` effect, and back navigation.