### PR TITLE
chore: add ignore trigger to migration

### DIFF
--- a/bc_obps/reporting/migrations/0189_reportoperation_naics_code.py
+++ b/bc_obps/reporting/migrations/0189_reportoperation_naics_code.py
@@ -5,12 +5,15 @@ from django.db import migrations, models
 
 
 def populate_naics_code(apps, schema_editor):
+    import common.lib.pgtrigger as pgtrigger
+
     ReportOperation = apps.get_model("reporting", "ReportOperation")
     for report_op in ReportOperation.objects.select_related("report_version__report__operation").all():
         operation = report_op.report_version.report.operation
         if operation.naics_code_id:
-            report_op.naics_code_id = operation.naics_code_id
-            report_op.save(update_fields=["naics_code_id"])
+            with pgtrigger.ignore('reporting.ReportOperation:immutable_report_version'):
+                report_op.naics_code_id = operation.naics_code_id
+                report_op.save(update_fields=["naics_code_id"])
 
 
 class Migration(migrations.Migration):

--- a/bc_obps/reporting/migrations/0189_reportoperation_naics_code.py
+++ b/bc_obps/reporting/migrations/0189_reportoperation_naics_code.py
@@ -10,7 +10,7 @@ def populate_naics_code(apps, schema_editor):
     ReportOperation = apps.get_model("reporting", "ReportOperation")
     for report_op in ReportOperation.objects.select_related("report_version__report__operation").all():
         operation = report_op.report_version.report.operation
-        if operation.naics_code_id:
+        if operation.naics_code_id and not report_op.naics_code_id:
             with pgtrigger.ignore('reporting.ReportOperation:immutable_report_version'):
                 report_op.naics_code_id = operation.naics_code_id
                 report_op.save(update_fields=["naics_code_id"])


### PR DESCRIPTION
Related PR: https://github.com/bcgov/cas-registration/pull/4659

A fix that adds pgtrigger.ignore when populating the NAICS code to avoid immutable report version errors