### PR TITLE
Temp/e2e/4460 e2e view submitted report

### DIFF
--- a/bc_obps/reporting/fixtures/mock/report.json
+++ b/bc_obps/reporting/fixtures/mock/report.json
@@ -26,7 +26,7 @@
       "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488f",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2026-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2024
+      "reporting_year_id": 2025
     }
   },
   {
@@ -46,7 +46,7 @@
       "operation_id": "3f47b2e1-9a4c-4d3f-8b21-7e9a0c5d2f6b",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2026-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2024
+      "reporting_year_id": 2025
     }
   },
   {

--- a/bc_obps/reporting/fixtures/mock/report.json
+++ b/bc_obps/reporting/fixtures/mock/report.json
@@ -26,7 +26,7 @@
       "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488f",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2026-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2025
+      "reporting_year_id": 2024
     }
   },
   {
@@ -46,7 +46,7 @@
       "operation_id": "3f47b2e1-9a4c-4d3f-8b21-7e9a0c5d2f6b",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2026-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2025
+      "reporting_year_id": 2024
     }
   },
   {

--- a/bc_obps/reporting/management/commands/load_reporting_fixtures.py
+++ b/bc_obps/reporting/management/commands/load_reporting_fixtures.py
@@ -1,14 +1,12 @@
 import json
-from datetime import date, datetime, timezone
-from decimal import Decimal
+from datetime import date
 from uuid import UUID
-from compliance.models.compliance_period import CompliancePeriod
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
 from reporting.management.commands.utils import submit_report_from_fixture
+from reporting.management.commands.utils.reporting_year import ensure_temporal_objects_exist
 from reporting.models.report import Report
 from reporting.models.report_version import ReportVersion
-from reporting.models.reporting_year import ReportingYear
 from service.report_service import ReportService
 from service.report_version_service import ReportVersionService
 
@@ -63,41 +61,14 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS(f"Loading additional report fixture: {fixture}"))
             call_command('loaddata', fixture)
 
-        self.submit_reports()
-
     def load_reports(self, workflow):
         reports_fixture = f'{self.fixture_base_dir}/report.json'
         with open(reports_fixture) as f:
             reports = json.load(f)
-            current_reporting_year = date.today().year - 1
-            reports_to_create = []
-
-            for report in reports:
-                reports_to_create.append(report)
-                # Create a duplicate report in the current reporting year for each 2023 report fixture, to ensure we have data for the current year when running the e2e tests
-                if str(report['fields']['reporting_year_id']) == '2023':
-
-                    duplicated_report = {
-                        **report,
-                        'fields': {
-                            **report['fields'],
-                            'reporting_year_id': current_reporting_year,
-                        },
-                    }
-                    reports_to_create.append(duplicated_report)
-
-            reporting_year_ids = {int(report['fields']['reporting_year_id']) for report in reports_to_create}
-            for reporting_year_id in reporting_year_ids:
-                self.ensure_temporal_objects_exist(reporting_year_id)
+            reports_to_create = self.get_reports_to_create(reports)
 
             report_version_ids = []
             for report in reports_to_create:
-                already_exists_in_db = Report.objects.filter(
-                    operation_id=report['fields']['operation_id'],
-                    reporting_year_id=current_reporting_year,
-                ).exists()
-                if already_exists_in_db:
-                    continue
                 report_version_id = ReportService.create_report(
                     operation_id=report['fields']['operation_id'],
                     reporting_year=report['fields']['reporting_year_id'],
@@ -110,6 +81,45 @@ class Command(BaseCommand):
                 ro.operator_legal_name = _strip_admin_suffix(ro.operator_legal_name)
                 ro.operation_name = _strip_admin_suffix(ro.operation_name)
                 ro.save()
+            self.submit_reports()
+
+    def get_reports_to_create(self, reports):
+        current_reporting_year = date.today().year - 1
+        reports_to_create = []
+        queued_operation_year_pairs = set()
+
+        for report in reports:
+            operation_id = report['fields']['operation_id']
+            reporting_year_id = int(report['fields']['reporting_year_id'])
+            operation_year_pair = (operation_id, reporting_year_id)
+
+            # track which operation/reporting year pairs we've already queued to avoid duplicates
+            if operation_year_pair not in queued_operation_year_pairs:
+                reports_to_create.append(report)
+                queued_operation_year_pairs.add(operation_year_pair)
+
+            # Create a duplicate report in the current reporting year for each 2023 report fixture.
+            # skip if there is already queued a report for this operation and reporting year to avoid creating duplicates
+            if str(report['fields']['reporting_year_id']) == '2023':
+                duplicate_operation_year_pair = (operation_id, current_reporting_year)
+                if duplicate_operation_year_pair in queued_operation_year_pairs:
+                    continue
+
+                duplicated_report = {
+                    **report,
+                    'fields': {
+                        **report['fields'],
+                        'reporting_year_id': current_reporting_year,
+                    },
+                }
+                reports_to_create.append(duplicated_report)
+                queued_operation_year_pairs.add(duplicate_operation_year_pair)
+
+        reporting_year_ids = {int(report['fields']['reporting_year_id']) for report in reports_to_create}
+        for reporting_year_id in reporting_year_ids:
+            ensure_temporal_objects_exist(reporting_year_id)
+
+        return reports_to_create
 
     def submit_reports(self):
         operation_ids_to_submit = [
@@ -129,39 +139,3 @@ class Command(BaseCommand):
         # create supplementary report
         for report in Report.objects.filter(operation_id=operation_ids_to_submit[0]):
             ReportVersionService.create_report_version(report)
-
-    def ensure_reporting_year_exists(self, reporting_year_id: int):
-        _, created = ReportingYear.objects.get_or_create(
-            reporting_year=reporting_year_id,
-            defaults={
-                'reporting_window_start': datetime(reporting_year_id + 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
-                'reporting_window_end': datetime(
-                    reporting_year_id + 1, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc
-                ),
-                'report_due_date': datetime(reporting_year_id + 1, 5, 31, 23, 59, 59, 999000, tzinfo=timezone.utc),
-                'report_open_date': datetime(reporting_year_id + 1, 3, 1, 0, 0, 0, tzinfo=timezone.utc),
-                'description': f'Auto-created reporting year for fixture load: {reporting_year_id}',
-            },
-        )
-
-        if created:
-            self.stdout.write(self.style.WARNING(f"Created missing reporting year: {reporting_year_id}"))
-
-    def ensure_compliance_period_exists(self, reporting_year_id: int):
-        _, created = CompliancePeriod.objects.get_or_create(
-            reporting_year_id=reporting_year_id,
-            defaults={
-                'start_date': date(reporting_year_id, 1, 1),
-                'end_date': date(reporting_year_id, 12, 31),
-                'compliance_deadline': date(reporting_year_id + 1, 11, 30),
-                'invoice_generation_date': date(reporting_year_id + 1, 11, 1),
-                'max_credit_usage_percentage': Decimal('0.50'),
-            },
-        )
-
-        if created:
-            self.stdout.write(self.style.WARNING(f"Created missing compliance period: {reporting_year_id}"))
-
-    def ensure_temporal_objects_exist(self, reporting_year_id: int):
-        self.ensure_reporting_year_exists(reporting_year_id)
-        self.ensure_compliance_period_exists(reporting_year_id)

--- a/bc_obps/reporting/management/commands/load_reporting_fixtures.py
+++ b/bc_obps/reporting/management/commands/load_reporting_fixtures.py
@@ -1,10 +1,14 @@
 import json
+from datetime import date, datetime, timezone
+from decimal import Decimal
 from uuid import UUID
+from compliance.models.compliance_period import CompliancePeriod
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
 from reporting.management.commands.utils import submit_report_from_fixture
 from reporting.models.report import Report
 from reporting.models.report_version import ReportVersion
+from reporting.models.reporting_year import ReportingYear
 from service.report_service import ReportService
 from service.report_version_service import ReportVersionService
 
@@ -59,12 +63,33 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS(f"Loading additional report fixture: {fixture}"))
             call_command('loaddata', fixture)
 
+        self.submit_reports()
+
     def load_reports(self, workflow):
         reports_fixture = f'{self.fixture_base_dir}/report.json'
         with open(reports_fixture) as f:
             reports = json.load(f)
-            report_version_ids = []
+            current_year_minus_one = date.today().year - 1
+            reports_to_create = []
+
             for report in reports:
+                reports_to_create.append(report)
+                if str(report['fields']['reporting_year_id']) == '2023':
+                    duplicated_report = {
+                        **report,
+                        'fields': {
+                            **report['fields'],
+                            'reporting_year_id': current_year_minus_one,
+                        },
+                    }
+                    reports_to_create.append(duplicated_report)
+
+            reporting_year_ids = {int(report['fields']['reporting_year_id']) for report in reports_to_create}
+            for reporting_year_id in reporting_year_ids:
+                self.ensure_reporting_year_exists(reporting_year_id)
+
+            report_version_ids = []
+            for report in reports_to_create:
                 report_version_id = ReportService.create_report(
                     operation_id=report['fields']['operation_id'],
                     reporting_year=report['fields']['reporting_year_id'],
@@ -78,22 +103,55 @@ class Command(BaseCommand):
                 ro.operation_name = _strip_admin_suffix(ro.operation_name)
                 ro.save()
 
-            # submit reports
-            operation_ids_to_submit = [
-                UUID('002d5a9e-32a6-4191-938c-2c02bfec592d'),  # Banana LFO
-                UUID('b65a3fbc-c81a-49c0-a43a-67bd3a0b488e'),  # Bangles
-            ]
+    def ensure_reporting_year_exists(self, reporting_year_id: int):
+        _, created = ReportingYear.objects.get_or_create(
+            reporting_year=reporting_year_id,
+            defaults={
+                'reporting_window_start': datetime(reporting_year_id + 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                'reporting_window_end': datetime(
+                    reporting_year_id + 1, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc
+                ),
+                'report_due_date': datetime(reporting_year_id + 1, 5, 31, 23, 59, 59, 999000, tzinfo=timezone.utc),
+                'report_open_date': datetime(reporting_year_id + 1, 3, 1, 0, 0, 0, tzinfo=timezone.utc),
+                'description': f'Auto-created reporting year for fixture load: {reporting_year_id}',
+            },
+        )
 
-            for operation_id in operation_ids_to_submit:
-                # set up required data for submission
-                # multiple report versions to submit if there are multiple years
-                report_versions = ReportVersion.objects.filter(
-                    report__operation_id=operation_id,
-                )
+        if created:
+            self.stdout.write(self.style.WARNING(f"Created missing reporting year: {reporting_year_id}"))
 
-                for report_version in report_versions:
+        self.ensure_compliance_period_exists(reporting_year_id)
 
-                    submit_report_from_fixture(report_version, UUID('ba2ba62a-1218-42e0-942a-ab9e92ce8822'))
-            # create supplementary report
-            for report in Report.objects.filter(operation_id=operation_ids_to_submit[0]):
-                ReportVersionService.create_report_version(report)
+    def ensure_compliance_period_exists(self, reporting_year_id: int):
+        _, created = CompliancePeriod.objects.get_or_create(
+            reporting_year_id=reporting_year_id,
+            defaults={
+                'start_date': date(reporting_year_id, 1, 1),
+                'end_date': date(reporting_year_id, 12, 31),
+                'compliance_deadline': date(reporting_year_id + 1, 11, 30),
+                'invoice_generation_date': date(reporting_year_id + 1, 11, 1),
+                'max_credit_usage_percentage': Decimal('0.50'),
+            },
+        )
+
+        if created:
+            self.stdout.write(self.style.WARNING(f"Created missing compliance period: {reporting_year_id}"))
+
+    def submit_reports(self):
+        operation_ids_to_submit = [
+            UUID('002d5a9e-32a6-4191-938c-2c02bfec592d'),  # Banana LFO
+            UUID('b65a3fbc-c81a-49c0-a43a-67bd3a0b488e'),  # Bangles
+        ]
+
+        for operation_id in operation_ids_to_submit:
+            # multiple report versions to submit if there are multiple years
+            report_versions = ReportVersion.objects.filter(
+                report__operation_id=operation_id,
+            )
+
+            for report_version in report_versions:
+                submit_report_from_fixture(report_version, UUID('ba2ba62a-1218-42e0-942a-ab9e92ce8822'))
+
+        # create supplementary report
+        for report in Report.objects.filter(operation_id=operation_ids_to_submit[0]):
+            ReportVersionService.create_report_version(report)

--- a/bc_obps/reporting/management/commands/load_reporting_fixtures.py
+++ b/bc_obps/reporting/management/commands/load_reporting_fixtures.py
@@ -117,6 +117,25 @@ class Command(BaseCommand):
                 ro.operation_name = _strip_admin_suffix(ro.operation_name)
                 ro.save()
 
+    def submit_reports(self):
+        operation_ids_to_submit = [
+            UUID('002d5a9e-32a6-4191-938c-2c02bfec592d'),  # Banana LFO
+            UUID('b65a3fbc-c81a-49c0-a43a-67bd3a0b488e'),  # Bangles
+        ]
+
+        for operation_id in operation_ids_to_submit:
+            # multiple report versions to submit if there are multiple years
+            report_versions = ReportVersion.objects.filter(
+                report__operation_id=operation_id,
+            )
+
+            for report_version in report_versions:
+                submit_report_from_fixture(report_version, UUID('ba2ba62a-1218-42e0-942a-ab9e92ce8822'))
+
+        # create supplementary report
+        for report in Report.objects.filter(operation_id=operation_ids_to_submit[0]):
+            ReportVersionService.create_report_version(report)
+
     def ensure_reporting_year_exists(self, reporting_year_id: int):
         _, created = ReportingYear.objects.get_or_create(
             reporting_year=reporting_year_id,
@@ -152,22 +171,3 @@ class Command(BaseCommand):
     def ensure_temporal_objects_exist(self, reporting_year_id: int):
         self.ensure_reporting_year_exists(reporting_year_id)
         self.ensure_compliance_period_exists(reporting_year_id)
-
-    def submit_reports(self):
-        operation_ids_to_submit = [
-            UUID('002d5a9e-32a6-4191-938c-2c02bfec592d'),  # Banana LFO
-            UUID('b65a3fbc-c81a-49c0-a43a-67bd3a0b488e'),  # Bangles
-        ]
-
-        for operation_id in operation_ids_to_submit:
-            # multiple report versions to submit if there are multiple years
-            report_versions = ReportVersion.objects.filter(
-                report__operation_id=operation_id,
-            )
-
-            for report_version in report_versions:
-                submit_report_from_fixture(report_version, UUID('ba2ba62a-1218-42e0-942a-ab9e92ce8822'))
-
-        # create supplementary report
-        for report in Report.objects.filter(operation_id=operation_ids_to_submit[0]):
-            ReportVersionService.create_report_version(report)

--- a/bc_obps/reporting/management/commands/load_reporting_fixtures.py
+++ b/bc_obps/reporting/management/commands/load_reporting_fixtures.py
@@ -74,14 +74,8 @@ class Command(BaseCommand):
 
             for report in reports:
                 reports_to_create.append(report)
-                # Create a duplicate report in the current reporting year for each 2024 report
+                # Create a duplicate report in the current reporting year for each 2023 report fixture, to ensure we have data for the current year when running the e2e tests
                 if str(report['fields']['reporting_year_id']) == '2023':
-                    duplicate_exists_in_db = Report.objects.filter(
-                        operation_id=report['fields']['operation_id'],
-                        reporting_year_id=current_reporting_year,
-                    ).exists()
-                    if duplicate_exists_in_db:
-                        continue
 
                     duplicated_report = {
                         **report,
@@ -98,11 +92,11 @@ class Command(BaseCommand):
 
             report_version_ids = []
             for report in reports_to_create:
-                duplicate_exists_in_db = Report.objects.filter(
+                already_exists_in_db = Report.objects.filter(
                     operation_id=report['fields']['operation_id'],
                     reporting_year_id=current_reporting_year,
                 ).exists()
-                if duplicate_exists_in_db:
+                if already_exists_in_db:
                     continue
                 report_version_id = ReportService.create_report(
                     operation_id=report['fields']['operation_id'],

--- a/bc_obps/reporting/management/commands/load_reporting_fixtures.py
+++ b/bc_obps/reporting/management/commands/load_reporting_fixtures.py
@@ -69,27 +69,41 @@ class Command(BaseCommand):
         reports_fixture = f'{self.fixture_base_dir}/report.json'
         with open(reports_fixture) as f:
             reports = json.load(f)
-            current_year_minus_one = date.today().year - 1
+            current_reporting_year = date.today().year - 1
             reports_to_create = []
 
             for report in reports:
                 reports_to_create.append(report)
+                # Create a duplicate report in the current reporting year for each 2024 report
                 if str(report['fields']['reporting_year_id']) == '2023':
+                    duplicate_exists_in_db = Report.objects.filter(
+                        operation_id=report['fields']['operation_id'],
+                        reporting_year_id=current_reporting_year,
+                    ).exists()
+                    if duplicate_exists_in_db:
+                        continue
+
                     duplicated_report = {
                         **report,
                         'fields': {
                             **report['fields'],
-                            'reporting_year_id': current_year_minus_one,
+                            'reporting_year_id': current_reporting_year,
                         },
                     }
                     reports_to_create.append(duplicated_report)
 
             reporting_year_ids = {int(report['fields']['reporting_year_id']) for report in reports_to_create}
             for reporting_year_id in reporting_year_ids:
-                self.ensure_reporting_year_exists(reporting_year_id)
+                self.ensure_temporal_objects_exist(reporting_year_id)
 
             report_version_ids = []
             for report in reports_to_create:
+                duplicate_exists_in_db = Report.objects.filter(
+                    operation_id=report['fields']['operation_id'],
+                    reporting_year_id=current_reporting_year,
+                ).exists()
+                if duplicate_exists_in_db:
+                    continue
                 report_version_id = ReportService.create_report(
                     operation_id=report['fields']['operation_id'],
                     reporting_year=report['fields']['reporting_year_id'],
@@ -120,8 +134,6 @@ class Command(BaseCommand):
         if created:
             self.stdout.write(self.style.WARNING(f"Created missing reporting year: {reporting_year_id}"))
 
-        self.ensure_compliance_period_exists(reporting_year_id)
-
     def ensure_compliance_period_exists(self, reporting_year_id: int):
         _, created = CompliancePeriod.objects.get_or_create(
             reporting_year_id=reporting_year_id,
@@ -136,6 +148,10 @@ class Command(BaseCommand):
 
         if created:
             self.stdout.write(self.style.WARNING(f"Created missing compliance period: {reporting_year_id}"))
+
+    def ensure_temporal_objects_exist(self, reporting_year_id: int):
+        self.ensure_reporting_year_exists(reporting_year_id)
+        self.ensure_compliance_period_exists(reporting_year_id)
 
     def submit_reports(self):
         operation_ids_to_submit = [

--- a/bc_obps/reporting/management/commands/utils/reporting_year.py
+++ b/bc_obps/reporting/management/commands/utils/reporting_year.py
@@ -1,0 +1,42 @@
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from compliance.models.compliance_period import CompliancePeriod
+from reporting.models.reporting_year import ReportingYear
+
+
+def ensure_reporting_year_exists(reporting_year_id: int):
+    _, created = ReportingYear.objects.get_or_create(
+        reporting_year=reporting_year_id,
+        defaults={
+            'reporting_window_start': datetime(reporting_year_id + 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            'reporting_window_end': datetime(reporting_year_id + 1, 12, 31, 23, 59, 59, 999000, tzinfo=timezone.utc),
+            'report_due_date': datetime(reporting_year_id + 1, 5, 31, 23, 59, 59, 999000, tzinfo=timezone.utc),
+            'report_open_date': datetime(reporting_year_id + 1, 3, 1, 0, 0, 0, tzinfo=timezone.utc),
+            'description': f'Auto-created reporting year for fixture load: {reporting_year_id}',
+        },
+    )
+
+    if created:
+        print(f"Created missing reporting year: {reporting_year_id}")
+
+
+def ensure_compliance_period_exists(reporting_year_id: int):
+    _, created = CompliancePeriod.objects.get_or_create(
+        reporting_year_id=reporting_year_id,
+        defaults={
+            'start_date': date(reporting_year_id, 1, 1),
+            'end_date': date(reporting_year_id, 12, 31),
+            'compliance_deadline': date(reporting_year_id + 1, 11, 30),
+            'invoice_generation_date': date(reporting_year_id + 1, 11, 1),
+            'max_credit_usage_percentage': Decimal('0.50'),
+        },
+    )
+
+    if created:
+        print(f"Created missing compliance period: {reporting_year_id}")
+
+
+def ensure_temporal_objects_exist(reporting_year_id: int):
+    ensure_reporting_year_exists(reporting_year_id)
+    ensure_compliance_period_exists(reporting_year_id)

--- a/bciers/apps/reporting-e2e/poms/annual-report.ts
+++ b/bciers/apps/reporting-e2e/poms/annual-report.ts
@@ -1,0 +1,26 @@
+import { ReportRoutes } from "@/reporting-e2e/utils/enums";
+import { REPORTING_REPORTS_BASE_PATH } from "@/reporting-e2e/utils/constants";
+import { SubmittedPOM } from "@/reporting-e2e/poms/submitted";
+
+export class AnnualReportPOM extends SubmittedPOM {
+  override readonly urlRegex: RegExp;
+
+  private static readonly ANNUAL_REPORT_FIELDS = [
+    "Review Operation Information",
+    "Person Responsible for Submitting Report",
+    "Report Information",
+    "Back To All Reports",
+  ] as const;
+
+  constructor(page: SubmittedPOM["page"]) {
+    super(page);
+    this.urlRegex = new RegExp(
+      String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/${ReportRoutes.ANNUAL_REPORT}`,
+      "i",
+    );
+  }
+
+  protected override getReportFields(): readonly string[] {
+    return AnnualReportPOM.ANNUAL_REPORT_FIELDS;
+  }
+}

--- a/bciers/apps/reporting-e2e/poms/current-reports.ts
+++ b/bciers/apps/reporting-e2e/poms/current-reports.ts
@@ -182,6 +182,7 @@ export class CurrentReportsPOM {
     await expect(row).toBeVisible();
     await this.clickViewReportDetails(row, isExternalUser);
   }
+
   /**
    * Clicks the "View Details" button for a specific report version in the report history page, based on the version number.
    */
@@ -196,23 +197,6 @@ export class CurrentReportsPOM {
       .first();
     await expect(row).toBeVisible();
     await this.clickViewReportDetails(row);
-  }
-
-  /**
-   * Clicks the "View Details" button for a specific facility report
-   * in the facility grid on the Submitted report view.
-   */
-  async viewDetailsFromFacilityGrid(
-    facilityName: string,
-    facilityId: string,
-    isExternalUser: boolean = true,
-  ): Promise<void> {
-    const row = this.page
-      .getByRole("row")
-      .filter({ hasText: facilityName })
-      .first();
-    await expect(row).toBeVisible();
-    await this.clickViewFacilityReportDetails(row, facilityId, isExternalUser);
   }
 
   /***
@@ -266,68 +250,6 @@ export class CurrentReportsPOM {
       ],
       true,
     );
-  }
-
-  async verifySubmittedReportView(
-    operationName: string,
-    isLFO: boolean = false,
-    isExternalUser: boolean = true,
-  ): Promise<void> {
-    const fields = [
-      operationName,
-      "Review Operation Information",
-      "Person Responsible for Submitting Report",
-      "Report Information",
-      "Back To All Reports",
-    ];
-    const lfoSpecificFields = [
-      "Operation Emission Summary",
-      "Compliance Summary",
-    ];
-    const sfoSpecificFields = [
-      "Non-Attributable Emissions",
-      "Emissions Summary (in tCO2e)",
-    ];
-    const externalUserOnlyFields = ["Attachments"];
-    await assertFieldVisibility(
-      this.page,
-      fields
-        .concat(isLFO ? lfoSpecificFields : sfoSpecificFields)
-        .concat(isExternalUser ? externalUserOnlyFields : []),
-      true,
-    );
-
-    await this.verifySaveAsPDF();
-  }
-
-  async verifyFacilitySubmittedReportView(facilityName: string): Promise<void> {
-    await assertFieldVisibility(
-      this.page,
-      [
-        facilityName,
-        "Report Information",
-        "Non-Attributable Emissions",
-        "Emissions Summary",
-        "Allocation of Emissions",
-      ],
-      true,
-    );
-
-    await this.verifySaveAsPDF();
-  }
-
-  async verifySaveAsPDF(): Promise<void> {
-    const saveAsPDFButton = this.page.getByRole("button", {
-      name: /Save as PDF/i,
-    });
-    await expect(saveAsPDFButton).toBeVisible();
-    await expect(saveAsPDFButton).toBeEnabled();
-
-    await this.page.evaluate(
-      "(() => {window.waitForPrintDialog = new Promise(f => window.print = f);})()",
-    );
-    await saveAsPDFButton.click();
-    await this.page.waitForFunction("window.waitForPrintDialog");
   }
 
   async verifyReportStatus(
@@ -416,33 +338,6 @@ export class CurrentReportsPOM {
     }).toPass({ timeout: 1000 });
 
     await viewReportDetailsButton.click();
-    await expect(this.page).toHaveURL(routeRegex, { timeout: 15_000 });
-  }
-
-  private async clickViewFacilityReportDetails(
-    row: Locator,
-    facilityId: string,
-    isExternalUser: boolean = true,
-  ): Promise<void> {
-    const viewFacilityReportDetailsButton = row.getByRole("button", {
-      name: new RegExp(ACTION_BUTTON_TEXT.VIEW_DETAILS, "i"),
-    });
-    await expect(viewFacilityReportDetailsButton).toBeVisible();
-    await expect(viewFacilityReportDetailsButton).toBeEnabled();
-    const viewReportRoute = isExternalUser
-      ? ReportRoutes.SUBMITTED_REPORT
-      : ReportRoutes.ANNUAL_REPORT;
-    const viewFacilityReportRoute = facilityId ? `facility/${facilityId}` : "";
-    const routeRegex = new RegExp(
-      String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/${viewReportRoute}/${viewFacilityReportRoute}`,
-      "i",
-    );
-
-    await expect(async () => {
-      await viewFacilityReportDetailsButton.click({ trial: true });
-    }).toPass({ timeout: 1000 });
-    await this.page.waitForTimeout(1000); // TODO: figure out why this won't work without the wait
-    await viewFacilityReportDetailsButton.click();
     await expect(this.page).toHaveURL(routeRegex, { timeout: 15_000 });
   }
 

--- a/bciers/apps/reporting-e2e/poms/current-reports.ts
+++ b/bciers/apps/reporting-e2e/poms/current-reports.ts
@@ -189,18 +189,35 @@ export class CurrentReportsPOM {
     await expect(row).toBeVisible();
     this.clickViewReportDetails(row, isExternalUser);
   }
-
+  /**
+   * Clicks the "View Details" button for a specific report version in the report history page, based on the version number.
+   */
   async viewDetailsFromReportHistory(
-    versionName: string = "Version 1",
+    version: string | number = "1",
   ): Promise<void> {
     await waitForGridReady(this.page);
-
+    const versionName = `Version ${version}`;
     const row = this.page
       .getByRole("row")
       .filter({ hasText: versionName })
       .first();
     await expect(row).toBeVisible();
     this.clickViewReportDetails(row);
+  }
+
+  /**
+   * Clicks the "View Details" button for a specific facility report
+   * in the facility grid on the Submitted report view.
+   */
+  async viewDetailsFromFacilityGrid(
+    facilityName: string,
+    facilityId: string,
+  ): Promise<void> {
+    const row = this.page
+      .getByRole("row")
+      .filter({ hasText: facilityName })
+      .first();
+    this.clickViewFacilityReportDetails(row, facilityId);
   }
 
   /***
@@ -288,13 +305,12 @@ export class CurrentReportsPOM {
     await this.verifySaveAsPDF();
   }
 
-  async verifyFacilityAnnualReportView(facilityName: string): Promise<void> {
+  async verifyFacilitySubmittedReportView(facilityName: string): Promise<void> {
     await assertFieldVisibility(
       this.page,
       [
         facilityName,
         "Report Information",
-        "Facility Information",
         "Non-Attributable Emissions",
         "Emissions Summary",
         "Allocation of Emissions",
@@ -303,27 +319,6 @@ export class CurrentReportsPOM {
     );
 
     await this.verifySaveAsPDF();
-  }
-
-  async viewDetailsFromFacilityGrid(
-    facilityName: string,
-    facilityId: string,
-  ): Promise<void> {
-    const row = this.page
-      .getByRole("row")
-      .filter({ hasText: facilityName })
-      .first();
-    this.clickViewReportDetails(row);
-    await expect(this.page).toHaveURL(
-      new RegExp(
-        String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/annual-report/facility/${facilityId}`,
-        "i",
-      ),
-      { timeout: 30_000 },
-    );
-    await expect(this.page).toHaveURL(
-      this.getProductionDataUrl("*", facilityId),
-    );
   }
 
   async verifySaveAsPDF(): Promise<void> {
@@ -418,6 +413,26 @@ export class CurrentReportsPOM {
     await expect(this.page).toHaveURL(
       new RegExp(
         String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/${viewReportRoute}$`,
+        "i",
+      ),
+      { timeout: 30_000 },
+    );
+  }
+
+  private async clickViewFacilityReportDetails(
+    row: Locator,
+    facilityId: string,
+  ): Promise<void> {
+    const viewFacilityReportDetailsButton = row.getByTestId(
+      `view-details-${facilityId}`,
+    );
+    await expect(viewFacilityReportDetailsButton).toBeVisible();
+    await expect(viewFacilityReportDetailsButton).toBeEnabled();
+    await viewFacilityReportDetailsButton.click({ delay: 1000 });
+
+    await expect(this.page).toHaveURL(
+      new RegExp(
+        String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/annual-report/facility/${facilityId}`,
         "i",
       ),
       { timeout: 30_000 },

--- a/bciers/apps/reporting-e2e/poms/current-reports.ts
+++ b/bciers/apps/reporting-e2e/poms/current-reports.ts
@@ -121,7 +121,7 @@ export class CurrentReportsPOM {
   }
 
   // -----------------
-  // navigation
+  // report grid actions
   // -----------------
 
   /**
@@ -169,16 +169,15 @@ export class CurrentReportsPOM {
 
   /**
    * Finds the operation row in the reports grid and clicks "View Details"
-   * to view a submitted report.
+   * or "View Report" to view a submitted report.
    *
-   * Waits for navigation to the submitted report details page and returns
-   * the report version ID extracted from the URL.
+   * Waits for navigation to the submitted report details page.
    */
-  async viewDetailsForReport(
+  async viewDetailsFromReportGrid(
     operationName: string,
     isExternalUser: boolean = true,
     reportingYear?: string,
-  ): Promise<number> {
+  ): Promise<void> {
     await waitForGridReady(this.page);
 
     const row = this.page
@@ -188,32 +187,20 @@ export class CurrentReportsPOM {
       .first();
 
     await expect(row).toBeVisible();
-    // External users see "View Details" button, internal users see "View Report" button
-    const viewReportDetailsButton = row.getByRole("button", {
-      name: new RegExp(
-        isExternalUser
-          ? ACTION_BUTTON_TEXT.VIEW_DETAILS
-          : ACTION_BUTTON_TEXT.VIEW_REPORT + "$",
-        "i",
-      ),
-    });
-    await expect(viewReportDetailsButton).toBeVisible();
-    await expect(viewReportDetailsButton).toBeEnabled();
+    this.clickViewReportDetails(row, isExternalUser);
+  }
 
-    await viewReportDetailsButton.click({ delay: 1000 });
-    await viewReportDetailsButton.click();
-    const viewReportRoute = isExternalUser
-      ? ReportRoutes.SUBMITTED_REPORT
-      : ReportRoutes.ANNUAL_REPORT;
-    await expect(this.page).toHaveURL(
-      new RegExp(
-        String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/${viewReportRoute}$`,
-        "i",
-      ),
-      { timeout: 30_000 },
-    );
+  async viewDetailsFromReportHistory(
+    versionName: string = "Version 1",
+  ): Promise<void> {
+    await waitForGridReady(this.page);
 
-    return this.extractReportVersionIdFromUrl(this.page, viewReportRoute);
+    const row = this.page
+      .getByRole("row")
+      .filter({ hasText: versionName })
+      .first();
+    await expect(row).toBeVisible();
+    this.clickViewReportDetails(row);
   }
 
   /***
@@ -256,26 +243,6 @@ export class CurrentReportsPOM {
     ]);
   }
 
-  // Navigate to the production data route for this report id and facility id
-  async gotoProductionData(reportId: string | number, facilityId: string) {
-    await this.page.goto(this.getProductionDataUrl(reportId, facilityId));
-  }
-
-  // Navigate to the review changes page
-  async gotoReviewChanges(reportId: string | number): Promise<void> {
-    await this.page.goto(this.getReviewChangesUrl(reportId));
-  }
-
-  // Navigate to the attachments page
-  async gotoAtachments(reportId: string | number): Promise<void> {
-    await this.page.goto(this.getAttachmentsUrl(reportId));
-  }
-
-  // Navigate to the sign-off route for this report id
-  async gotoSignOff(reportId: string | number) {
-    await this.page.goto(this.getSignOffUrl(reportId));
-  }
-
   async verifySubmissionPage(): Promise<void> {
     await assertFieldVisibility(
       this.page,
@@ -289,18 +256,74 @@ export class CurrentReportsPOM {
     );
   }
 
-  async verifySubmittedReportView(operationName: string): Promise<void> {
+  async verifySubmittedReportView(
+    operationName: string,
+    isLFO: boolean = false,
+    isExternalUser: boolean = true,
+  ): Promise<void> {
+    const fields = [
+      operationName,
+      "Review Operation Information",
+      "Person Responsible for Submitting Report",
+      "Report Information",
+      "Back To All Reports",
+    ];
+    const lfoSpecificFields = [
+      "Operation Emission Summary",
+      "Compliance Summary",
+    ];
+    const sfoSpecificFields = [
+      "Non-Attributable Emissions",
+      "Emissions Summary (in tCO2e)",
+    ];
+    const externalUserOnlyFields = ["Attachments"];
     await assertFieldVisibility(
       this.page,
-      [operationName, "Review Operation Information", "Back To All Reports"],
+      fields
+        .concat(isLFO ? lfoSpecificFields : sfoSpecificFields)
+        .concat(isExternalUser ? externalUserOnlyFields : []),
       true,
     );
 
-    await expect(
-      this.page.getByRole("button", {
-        name: /Save as PDF/i,
-      }),
-    ).toBeVisible();
+    await this.verifySaveAsPDF();
+  }
+
+  async verifyFacilityAnnualReportView(facilityName: string): Promise<void> {
+    await assertFieldVisibility(
+      this.page,
+      [
+        facilityName,
+        "Report Information",
+        "Facility Information",
+        "Non-Attributable Emissions",
+        "Emissions Summary",
+        "Allocation of Emissions",
+      ],
+      true,
+    );
+
+    await this.verifySaveAsPDF();
+  }
+
+  async viewDetailsFromFacilityGrid(
+    facilityName: string,
+    facilityId: string,
+  ): Promise<void> {
+    const row = this.page
+      .getByRole("row")
+      .filter({ hasText: facilityName })
+      .first();
+    this.clickViewReportDetails(row);
+    await expect(this.page).toHaveURL(
+      new RegExp(
+        String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/annual-report/facility/${facilityId}`,
+        "i",
+      ),
+      { timeout: 30_000 },
+    );
+    await expect(this.page).toHaveURL(
+      this.getProductionDataUrl("*", facilityId),
+    );
   }
 
   async verifySaveAsPDF(): Promise<void> {
@@ -334,6 +357,30 @@ export class CurrentReportsPOM {
   }
 
   // -----------------
+  // navigation
+  // -----------------
+
+  // Navigate to the production data route for this report id and facility id
+  async gotoProductionData(reportId: string | number, facilityId: string) {
+    await this.page.goto(this.getProductionDataUrl(reportId, facilityId));
+  }
+
+  // Navigate to the review changes page
+  async gotoReviewChanges(reportId: string | number): Promise<void> {
+    await this.page.goto(this.getReviewChangesUrl(reportId));
+  }
+
+  // Navigate to the attachments page
+  async gotoAttachments(reportId: string | number): Promise<void> {
+    await this.page.goto(this.getAttachmentsUrl(reportId));
+  }
+
+  // Navigate to the sign-off route for this report id
+  async gotoSignOff(reportId: string | number) {
+    await this.page.goto(this.getSignOffUrl(reportId));
+  }
+
+  // -----------------
   // helpers
   // -----------------
   private async clickSaveAndContinue(
@@ -346,6 +393,35 @@ export class CurrentReportsPOM {
       inForm: opts?.inForm,
       waitForUrl,
     });
+  }
+
+  private async clickViewReportDetails(
+    row: Locator,
+    isExternalUser: boolean = true,
+  ): Promise<void> {
+    const viewReportDetailsButton = row.getByRole("button", {
+      name: new RegExp(
+        isExternalUser
+          ? ACTION_BUTTON_TEXT.VIEW_DETAILS
+          : ACTION_BUTTON_TEXT.VIEW_REPORT + "$",
+        "i",
+      ),
+    });
+    await expect(viewReportDetailsButton).toBeVisible();
+    await expect(viewReportDetailsButton).toBeEnabled();
+    await viewReportDetailsButton.click({ delay: 1000 });
+    await viewReportDetailsButton.click();
+
+    const viewReportRoute = isExternalUser
+      ? ReportRoutes.SUBMITTED_REPORT
+      : ReportRoutes.ANNUAL_REPORT;
+    await expect(this.page).toHaveURL(
+      new RegExp(
+        String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/${viewReportRoute}$`,
+        "i",
+      ),
+      { timeout: 30_000 },
+    );
   }
 
   private extractReportVersionIdFromUrl(
@@ -734,7 +810,7 @@ export class CurrentReportsPOM {
       new RegExp(`${this.getReportValidationUrl(reportId)}\\/?$`, "i"),
     );
 
-    await this.gotoAtachments(reportId);
+    await this.gotoAttachments(reportId);
     await this.fillAttachments();
     await this.clickSaveAndContinue(new RegExp(this.getSignOffUrl(reportId)));
 

--- a/bciers/apps/reporting-e2e/poms/current-reports.ts
+++ b/bciers/apps/reporting-e2e/poms/current-reports.ts
@@ -4,6 +4,7 @@ import {
   AttachmentCheckboxLabel,
   FacilityIDs,
   OPERATION_NAMES,
+  REPORT_STATUS,
   ReportIDs,
   ReportRoutes,
   SignOffCheckboxLabel,
@@ -187,7 +188,7 @@ export class CurrentReportsPOM {
       .first();
 
     await expect(row).toBeVisible();
-    this.clickViewReportDetails(row, isExternalUser);
+    await this.clickViewReportDetails(row, isExternalUser);
   }
   /**
    * Clicks the "View Details" button for a specific report version in the report history page, based on the version number.
@@ -202,7 +203,7 @@ export class CurrentReportsPOM {
       .filter({ hasText: versionName })
       .first();
     await expect(row).toBeVisible();
-    this.clickViewReportDetails(row);
+    await this.clickViewReportDetails(row);
   }
 
   /**
@@ -212,12 +213,14 @@ export class CurrentReportsPOM {
   async viewDetailsFromFacilityGrid(
     facilityName: string,
     facilityId: string,
+    isExternalUser: boolean = true,
   ): Promise<void> {
     const row = this.page
       .getByRole("row")
       .filter({ hasText: facilityName })
       .first();
-    this.clickViewFacilityReportDetails(row, facilityId);
+    await expect(row).toBeVisible();
+    await this.clickViewFacilityReportDetails(row, facilityId, isExternalUser);
   }
 
   /***
@@ -337,7 +340,7 @@ export class CurrentReportsPOM {
 
   async verifyReportStatus(
     operationName: string,
-    expectedStatus: string,
+    expectedStatus: REPORT_STATUS,
   ): Promise<void> {
     await waitForGridReady(this.page);
     const row = this.page
@@ -346,9 +349,11 @@ export class CurrentReportsPOM {
       .first();
     await expect(row).toBeVisible();
     await expect(row.getByText(expectedStatus)).toBeVisible();
-    await expect(
-      row.getByRole("button", { name: ACTION_BUTTON_TEXT.VIEW_DETAILS }),
-    ).toBeVisible();
+    if (expectedStatus === REPORT_STATUS.SUBMITTED) {
+      await expect(
+        row.getByRole("button", { name: ACTION_BUTTON_TEXT.VIEW_DETAILS }),
+      ).toBeVisible();
+    }
   }
 
   // -----------------
@@ -397,46 +402,56 @@ export class CurrentReportsPOM {
     const viewReportDetailsButton = row.getByRole("button", {
       name: new RegExp(
         isExternalUser
-          ? ACTION_BUTTON_TEXT.VIEW_DETAILS
+          ? ACTION_BUTTON_TEXT.VIEW_DETAILS + "$"
           : ACTION_BUTTON_TEXT.VIEW_REPORT + "$",
         "i",
       ),
     });
     await expect(viewReportDetailsButton).toBeVisible();
     await expect(viewReportDetailsButton).toBeEnabled();
-    await viewReportDetailsButton.click({ delay: 1000 });
-    await viewReportDetailsButton.click();
 
     const viewReportRoute = isExternalUser
       ? ReportRoutes.SUBMITTED_REPORT
       : ReportRoutes.ANNUAL_REPORT;
-    await expect(this.page).toHaveURL(
-      new RegExp(
-        String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/${viewReportRoute}$`,
-        "i",
-      ),
-      { timeout: 30_000 },
+
+    const routeRegex = new RegExp(
+      String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/${viewReportRoute}`,
+      "i",
     );
+
+    await expect(async () => {
+      await viewReportDetailsButton.click({ trial: true });
+    }).toPass({ timeout: 1000 });
+
+    await viewReportDetailsButton.click();
+    await expect(this.page).toHaveURL(routeRegex, { timeout: 15_000 });
   }
 
   private async clickViewFacilityReportDetails(
     row: Locator,
     facilityId: string,
+    isExternalUser: boolean = true,
   ): Promise<void> {
-    const viewFacilityReportDetailsButton = row.getByTestId(
-      `view-details-${facilityId}`,
-    );
+    const viewFacilityReportDetailsButton = row.getByRole("button", {
+      name: new RegExp(ACTION_BUTTON_TEXT.VIEW_DETAILS, "i"),
+    });
     await expect(viewFacilityReportDetailsButton).toBeVisible();
     await expect(viewFacilityReportDetailsButton).toBeEnabled();
-    await viewFacilityReportDetailsButton.click({ delay: 1000 });
-
-    await expect(this.page).toHaveURL(
-      new RegExp(
-        String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/annual-report/facility/${facilityId}`,
-        "i",
-      ),
-      { timeout: 30_000 },
+    const viewReportRoute = isExternalUser
+      ? ReportRoutes.SUBMITTED_REPORT
+      : ReportRoutes.ANNUAL_REPORT;
+    const viewFacilityReportRoute = facilityId ? `facility/${facilityId}` : "";
+    const routeRegex = new RegExp(
+      String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/${viewReportRoute}/${viewFacilityReportRoute}`,
+      "i",
     );
+
+    await expect(async () => {
+      await viewFacilityReportDetailsButton.click({ trial: true });
+    }).toPass({ timeout: 1000 });
+    await this.page.waitForTimeout(1000); // TODO: figure out why this won't work without the wait
+    await viewFacilityReportDetailsButton.click();
+    await expect(this.page).toHaveURL(routeRegex, { timeout: 15_000 });
   }
 
   private extractReportVersionIdFromUrl(
@@ -468,16 +483,25 @@ export class CurrentReportsPOM {
     const operationSearchField = this.page
       .getByRole("columnheader", { name: "Operation search field" })
       .getByPlaceholder("Search");
-    operationSearchField.fill(operationName);
+    await operationSearchField.fill(operationName);
 
     await expect(operationSearchField).toHaveValue(operationName);
 
-    const row = await this.page
+    await this.page.waitForURL(
+      (u) =>
+        u.searchParams.get("operation_name") === operationName &&
+        /\/current-reports\/?$/i.test(u.pathname),
+      { timeout: 10_000 },
+    );
+
+    await waitForGridReady(this.page);
+
+    const row = this.page
       .getByRole("row")
       .filter({ hasText: operationName })
-      .all();
+      .first();
 
-    expect(row.length).toBeGreaterThanOrEqual(1);
+    await expect(row).toBeVisible({ timeout: 30_000 });
   }
 
   /**

--- a/bciers/apps/reporting-e2e/poms/current-reports.ts
+++ b/bciers/apps/reporting-e2e/poms/current-reports.ts
@@ -41,6 +41,9 @@ export class CurrentReportsPOM {
   readonly url: string =
     process.env.E2E_BASEURL + AppRoutes.GRID_REPORTING_CURRENT_REPORTS;
 
+  readonly pastReportsUrl: string =
+    process.env.E2E_BASEURL + AppRoutes.GRID_REPORTING_PAST_REPORTS;
+
   readonly saveAndContinueButton: Locator;
 
   readonly submitButton: Locator;
@@ -57,6 +60,11 @@ export class CurrentReportsPOM {
 
   async route() {
     await this.page.goto(this.url);
+    await waitForGridReady(this.page, { timeout: 30_000 });
+  }
+
+  async routeToPastReports() {
+    await this.page.goto(this.pastReportsUrl);
     await waitForGridReady(this.page, { timeout: 30_000 });
   }
 
@@ -159,6 +167,95 @@ export class CurrentReportsPOM {
     );
   }
 
+  /**
+   * Finds the operation row in the reports grid and clicks "View Details"
+   * to view a submitted report.
+   *
+   * Waits for navigation to the submitted report details page and returns
+   * the report version ID extracted from the URL.
+   */
+  async viewDetailsForReport(
+    operationName: string,
+    isExternalUser: boolean = true,
+    reportingYear?: string,
+  ): Promise<number> {
+    await waitForGridReady(this.page);
+
+    const row = this.page
+      .getByRole("row")
+      .filter({ hasText: operationName })
+      .filter({ hasText: reportingYear ?? "" }) // if reportingYear is provided, filter by it as well
+      .first();
+
+    await expect(row).toBeVisible();
+    // External users see "View Details" button, internal users see "View Report" button
+    const viewReportDetailsButton = row.getByRole("button", {
+      name: new RegExp(
+        isExternalUser
+          ? ACTION_BUTTON_TEXT.VIEW_DETAILS
+          : ACTION_BUTTON_TEXT.VIEW_REPORT + "$",
+        "i",
+      ),
+    });
+    await expect(viewReportDetailsButton).toBeVisible();
+    await expect(viewReportDetailsButton).toBeEnabled();
+
+    await viewReportDetailsButton.click({ delay: 1000 });
+    await viewReportDetailsButton.click();
+    const viewReportRoute = isExternalUser
+      ? ReportRoutes.SUBMITTED_REPORT
+      : ReportRoutes.ANNUAL_REPORT;
+    await expect(this.page).toHaveURL(
+      new RegExp(
+        String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/${viewReportRoute}$`,
+        "i",
+      ),
+      { timeout: 30_000 },
+    );
+
+    return this.extractReportVersionIdFromUrl(this.page, viewReportRoute);
+  }
+
+  /***
+   * Finds the operation row in the reports grid, clicks the "Report history" action,
+   * and waits for navigation to the report history page.
+   */
+  async reportHistoryForOperation(
+    operationName: string,
+    reportingYear?: string,
+  ): Promise<void> {
+    await waitForGridReady(this.page);
+    const row = this.page
+      .getByRole("row")
+      .filter({ hasText: operationName })
+      .filter({ hasText: reportingYear ?? "" }) // if reportingYear is provided, filter by it as well
+      .first();
+
+    await expect(row).toBeVisible();
+
+    const moreActionsButton = row.locator("#basic-button");
+    await expect(moreActionsButton).toBeVisible();
+
+    await moreActionsButton.click();
+    const reportHistoryButton = this.page.getByRole("menuitem", {
+      name: new RegExp(ACTION_BUTTON_TEXT.REPORT_HISTORY, "i"),
+    });
+    await expect(reportHistoryButton).toBeVisible();
+    await expect(reportHistoryButton).toBeEnabled();
+
+    await Promise.all([
+      this.page.waitForURL(
+        (u) =>
+          new RegExp(
+            String.raw`${AppRoutes.REPORT_HISTORY_GRID}/\d+$`,
+            "i",
+          ).test(u.toString()),
+        { waitUntil: "domcontentloaded" },
+      ),
+      reportHistoryButton.click(),
+    ]);
+  }
+
   // Navigate to the production data route for this report id and facility id
   async gotoProductionData(reportId: string | number, facilityId: string) {
     await this.page.goto(this.getProductionDataUrl(reportId, facilityId));
@@ -190,6 +287,34 @@ export class CurrentReportsPOM {
       ],
       true,
     );
+  }
+
+  async verifySubmittedReportView(operationName: string): Promise<void> {
+    await assertFieldVisibility(
+      this.page,
+      [operationName, "Review Operation Information", "Back To All Reports"],
+      true,
+    );
+
+    await expect(
+      this.page.getByRole("button", {
+        name: /Save as PDF/i,
+      }),
+    ).toBeVisible();
+  }
+
+  async verifySaveAsPDF(): Promise<void> {
+    const saveAsPDFButton = this.page.getByRole("button", {
+      name: /Save as PDF/i,
+    });
+    await expect(saveAsPDFButton).toBeVisible();
+    await expect(saveAsPDFButton).toBeEnabled();
+
+    await this.page.evaluate(
+      "(() => {window.waitForPrintDialog = new Promise(f => window.print = f);})()",
+    );
+    await saveAsPDFButton.click();
+    await this.page.waitForFunction("window.waitForPrintDialog");
   }
 
   async verifyReportStatus(

--- a/bciers/apps/reporting-e2e/poms/current-reports.ts
+++ b/bciers/apps/reporting-e2e/poms/current-reports.ts
@@ -42,9 +42,6 @@ export class CurrentReportsPOM {
   readonly url: string =
     process.env.E2E_BASEURL + AppRoutes.GRID_REPORTING_CURRENT_REPORTS;
 
-  readonly pastReportsUrl: string =
-    process.env.E2E_BASEURL + AppRoutes.GRID_REPORTING_PAST_REPORTS;
-
   readonly saveAndContinueButton: Locator;
 
   readonly submitButton: Locator;
@@ -61,11 +58,6 @@ export class CurrentReportsPOM {
 
   async route() {
     await this.page.goto(this.url);
-    await waitForGridReady(this.page, { timeout: 30_000 });
-  }
-
-  async routeToPastReports() {
-    await this.page.goto(this.pastReportsUrl);
     await waitForGridReady(this.page, { timeout: 30_000 });
   }
 

--- a/bciers/apps/reporting-e2e/poms/submitted.ts
+++ b/bciers/apps/reporting-e2e/poms/submitted.ts
@@ -5,7 +5,7 @@ import {
   ACTION_BUTTON_TEXT,
   REPORTING_REPORTS_BASE_PATH,
 } from "@/reporting-e2e/utils/constants";
-import { assertFieldVisibility } from "@bciers/e2e/utils/helpers";
+import { assertFieldVisibility, clickButton } from "@bciers/e2e/utils/helpers";
 
 export class SubmittedPOM {
   readonly page: Page;
@@ -88,26 +88,16 @@ export class SubmittedPOM {
       .getByRole("row")
       .filter({ hasText: facilityName })
       .first();
-    //const row = await getGridRowByText(this.page, facilityName);
+
     await expect(row).toBeVisible();
-    const viewFacilityReportDetailsButton = row.getByRole("button", {
-      name: new RegExp(ACTION_BUTTON_TEXT.VIEW_DETAILS, "i"),
-    });
-    await expect(viewFacilityReportDetailsButton).toBeVisible();
-    await expect(viewFacilityReportDetailsButton).toBeEnabled();
 
     const viewFacilityReportRoute = `${this.urlRegex.source}/facility/${facilityId}`;
+
     const routeRegex = new RegExp(String.raw`${viewFacilityReportRoute}`, "i");
 
-    await expect(async () => {
-      await viewFacilityReportDetailsButton.click({ trial: true });
-    }).toPass({ timeout: 1000 });
-    await this.page.waitForTimeout(1000); // TODO: figure out why this won't work without the wait
-    await Promise.all([
-      this.page.waitForURL((u) => routeRegex.test(u.toString()), {
-        waitUntil: "domcontentloaded",
-      }),
-      viewFacilityReportDetailsButton.click(),
-    ]);
+    await clickButton(this.page, ACTION_BUTTON_TEXT.VIEW_DETAILS, {
+      root: row,
+      waitForUrl: routeRegex,
+    });
   }
 }

--- a/bciers/apps/reporting-e2e/poms/submitted.ts
+++ b/bciers/apps/reporting-e2e/poms/submitted.ts
@@ -1,0 +1,117 @@
+import { Page, expect } from "@playwright/test";
+import { ReportRoutes } from "../utils/enums";
+import { verifySaveAsPDF } from "@/reporting-e2e/utils/helpers";
+import {
+  ACTION_BUTTON_TEXT,
+  REPORTING_REPORTS_BASE_PATH,
+} from "@/reporting-e2e/utils/constants";
+import { assertFieldVisibility } from "@bciers/e2e/utils/helpers";
+
+export class SubmittedPOM {
+  readonly page: Page;
+  readonly urlRegex: RegExp;
+
+  static readonly SUBMITTED_REPORT_FIELDS = [
+    "Review Operation Information",
+    "Person Responsible for Submitting Report",
+    "Report Information",
+    "Attachments",
+    "Back To All Reports",
+  ] as const;
+
+  static readonly LFO_SUBMITTED_REPORT_FIELDS = [
+    "Operation Emission Summary",
+    "Compliance Summary",
+  ] as const;
+
+  static readonly SFO_SUBMITTED_REPORT_FIELDS = [
+    "Non-Attributable Emissions",
+    "Emissions Summary (in tCO2e)",
+  ] as const;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.urlRegex = new RegExp(
+      String.raw`${REPORTING_REPORTS_BASE_PATH}/\d+/${ReportRoutes.SUBMITTED_REPORT}`,
+      "i",
+    );
+  }
+
+  protected getReportFields(): readonly string[] {
+    return SubmittedPOM.SUBMITTED_REPORT_FIELDS;
+  }
+
+  async verifySubmittedReportView(
+    operationName: string,
+    isLFO: boolean = false,
+  ): Promise<void> {
+    const fields = [operationName, ...this.getReportFields()];
+
+    await assertFieldVisibility(
+      this.page,
+      fields.concat(
+        isLFO
+          ? SubmittedPOM.LFO_SUBMITTED_REPORT_FIELDS
+          : SubmittedPOM.SFO_SUBMITTED_REPORT_FIELDS,
+      ),
+      true,
+    );
+
+    await verifySaveAsPDF(this.page);
+  }
+
+  async verifyFacilitySubmittedReportView(facilityName: string): Promise<void> {
+    await assertFieldVisibility(
+      this.page,
+      [
+        facilityName,
+        "Report Information",
+        "Non-Attributable Emissions",
+        "Emissions Summary",
+        "Allocation of Emissions",
+      ],
+      true,
+    );
+
+    await verifySaveAsPDF(this.page);
+  }
+
+  /**
+   * Clicks the "View Details" button for a specific facility report
+   * in the facility grid on the Submitted report view.
+   */
+  async viewDetailsFromFacilityGrid(
+    facilityName: string,
+    facilityId: string,
+  ): Promise<void> {
+    const row = this.page
+      .getByRole("row")
+      .filter({ hasText: facilityName })
+      .first();
+    //const row = await getGridRowByText(this.page, facilityName);
+    await expect(row).toBeVisible();
+    const viewFacilityReportDetailsButton = row.getByRole("button", {
+      name: new RegExp(ACTION_BUTTON_TEXT.VIEW_DETAILS, "i"),
+    });
+    await expect(viewFacilityReportDetailsButton).toBeVisible();
+    await expect(viewFacilityReportDetailsButton).toBeEnabled();
+
+    const viewFacilityReportRoute = `${this.urlRegex.source}/facility/${facilityId}`;
+    const routeRegex = new RegExp(String.raw`${viewFacilityReportRoute}`, "i");
+
+    await expect(async () => {
+      await viewFacilityReportDetailsButton.click({ trial: true });
+    }).toPass({ timeout: 1000 });
+    await this.page.waitForTimeout(1000); // TODO: figure out why this won't work without the wait
+    await viewFacilityReportDetailsButton.click();
+    await expect(this.page).toHaveURL(routeRegex, { timeout: 15_000 });
+    // await Promise.all([
+    //   this.page.waitForURL(
+    //     (u) =>
+    //       routeRegex.test(u.toString()),
+    //     { waitUntil: "domcontentloaded" },
+    //   ),
+    //   viewFacilityReportDetailsButton.click(),
+    // ]);
+  }
+}

--- a/bciers/apps/reporting-e2e/poms/submitted.ts
+++ b/bciers/apps/reporting-e2e/poms/submitted.ts
@@ -103,15 +103,11 @@ export class SubmittedPOM {
       await viewFacilityReportDetailsButton.click({ trial: true });
     }).toPass({ timeout: 1000 });
     await this.page.waitForTimeout(1000); // TODO: figure out why this won't work without the wait
-    await viewFacilityReportDetailsButton.click();
-    await expect(this.page).toHaveURL(routeRegex, { timeout: 15_000 });
-    // await Promise.all([
-    //   this.page.waitForURL(
-    //     (u) =>
-    //       routeRegex.test(u.toString()),
-    //     { waitUntil: "domcontentloaded" },
-    //   ),
-    //   viewFacilityReportDetailsButton.click(),
-    // ]);
+    await Promise.all([
+      this.page.waitForURL((u) => routeRegex.test(u.toString()), {
+        waitUntil: "domcontentloaded",
+      }),
+      viewFacilityReportDetailsButton.click(),
+    ]);
   }
 }

--- a/bciers/apps/reporting-e2e/tests/workflows/LFO/submit-report.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/LFO/submit-report.spec.ts
@@ -3,6 +3,7 @@ import { UserRole } from "@bciers/e2e/utils/enums";
 import {
   FacilityIDs,
   OPERATION_NAMES,
+  REPORT_STATUS,
   ReportRoutes,
 } from "@/reporting-e2e/utils/enums";
 import { CurrentReportsPOM } from "@/reporting-e2e/poms/current-reports";
@@ -256,7 +257,10 @@ test.describe("LFO: create and submit a new report for the current reporting yea
 
     // ── 23. Return to the grid and verify the report status ──
     await page.getByRole("link", { name: "Return to report table" }).click();
-    await grid.verifyReportStatus(OPERATION_NAMES.BEES_LFO, "Submitted");
+    await grid.verifyReportStatus(
+      OPERATION_NAMES.BEES_LFO,
+      REPORT_STATUS.SUBMITTED,
+    );
     await takeStabilizedScreenshot(happoScreenshot, page, {
       component: "LFO Report - Current Reports Grid",
       variant: "submitted",

--- a/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
@@ -38,6 +38,7 @@ test.describe("LFO: view a submitted report for the current reporting year", () 
     await grid.viewDetailsFromFacilityGrid(
       "Facility 1",
       FacilityIDs.BANANA_LFO_1,
+      isExternalUser,
     );
     await grid.verifyFacilitySubmittedReportView("Facility 1");
     await takeStabilizedScreenshot(happoScreenshot, page, {
@@ -81,6 +82,7 @@ test.describe("LFO: view a submitted report for the current reporting year", () 
           await grid.viewDetailsFromFacilityGrid(
             "Facility 1",
             FacilityIDs.BANANA_LFO_1,
+            isExternalUser,
           );
           await grid.verifyFacilitySubmittedReportView("Facility 1");
           await takeStabilizedScreenshot(happoScreenshot, page, {

--- a/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
@@ -18,17 +18,16 @@ test.describe("LFO: view a submitted report for the current reporting year", () 
     const grid = new CurrentReportsPOM(page);
     await grid.route();
 
-    await grid.searchByOperationName(OPERATION_NAMES.BANGLES_SFO);
+    await grid.searchByOperationName(OPERATION_NAMES.BANANA_LFO);
 
     // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
-    await grid.viewDetailsForReport(OPERATION_NAMES.BANGLES_SFO, true);
+    await grid.reportHistoryForOperation(OPERATION_NAMES.BANANA_LFO);
+    await grid.viewDetailsFromReportHistory();
+    await grid.verifySubmittedReportView(OPERATION_NAMES.BANANA_LFO, true);
 
-    await grid.verifySubmittedReportView(OPERATION_NAMES.BANGLES_SFO);
-    // - 3. Click the "Save as PDF" button and verify the 'Print' dialog opens
-    await grid.verifySaveAsPDF();
     await takeStabilizedScreenshot(happoScreenshot, page, {
       component: "LFO Report - Submitted",
-      variant: "Industry user views submitted report",
+      variant: "external",
     });
   });
 });
@@ -43,17 +42,20 @@ internalTest.describe(
         const grid = new CurrentReportsPOM(page);
         await grid.route();
 
-        await grid.searchByOperationName(OPERATION_NAMES.BANGLES_SFO);
+        await grid.searchByOperationName(OPERATION_NAMES.BANANA_LFO);
 
         // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
-        await grid.viewDetailsForReport(OPERATION_NAMES.BANGLES_SFO, false);
+        await grid.viewDetailsFromReportGrid(OPERATION_NAMES.BANANA_LFO, false);
 
-        await grid.verifySubmittedReportView(OPERATION_NAMES.BANGLES_SFO);
-        // - 3. Click the "Save as PDF" button and verify the 'Print' dialog opens
-        await grid.verifySaveAsPDF();
+        await grid.verifySubmittedReportView(
+          OPERATION_NAMES.BANANA_LFO,
+          true,
+          false,
+        );
+
         await takeStabilizedScreenshot(happoScreenshot, page, {
           component: "LFO Report - Submitted",
-          variant: "CAS analyst views submitted report",
+          variant: "internal",
         });
       },
     );

--- a/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
@@ -14,6 +14,8 @@ test.describe("LFO: view a submitted report for the current reporting year", () 
     page,
     happoScreenshot,
   }) => {
+    const isExternalUser = true;
+    const isLFO = true;
     // ── 1. Navigate to the past reports grid ──
     const grid = new CurrentReportsPOM(page);
     await grid.route();
@@ -23,7 +25,11 @@ test.describe("LFO: view a submitted report for the current reporting year", () 
     // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
     await grid.reportHistoryForOperation(OPERATION_NAMES.BANANA_LFO);
     await grid.viewDetailsFromReportHistory();
-    await grid.verifySubmittedReportView(OPERATION_NAMES.BANANA_LFO, true);
+    await grid.verifySubmittedReportView(
+      OPERATION_NAMES.BANANA_LFO,
+      isLFO,
+      isExternalUser,
+    );
 
     await takeStabilizedScreenshot(happoScreenshot, page, {
       component: "LFO Report - Submitted",
@@ -38,6 +44,8 @@ internalTest.describe(
     internalTest(
       "CAS analyst views a submitted LFO report",
       async ({ page, happoScreenshot }) => {
+        const isExternalUser = false;
+        const isLFO = true;
         // ── 1. Navigate to the past reports grid ──
         const grid = new CurrentReportsPOM(page);
         await grid.route();
@@ -45,12 +53,15 @@ internalTest.describe(
         await grid.searchByOperationName(OPERATION_NAMES.BANANA_LFO);
 
         // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
-        await grid.viewDetailsFromReportGrid(OPERATION_NAMES.BANANA_LFO, false);
+        await grid.viewDetailsFromReportGrid(
+          OPERATION_NAMES.BANANA_LFO,
+          isExternalUser,
+        );
 
         await grid.verifySubmittedReportView(
           OPERATION_NAMES.BANANA_LFO,
-          true,
-          false,
+          isLFO,
+          isExternalUser,
         );
 
         await takeStabilizedScreenshot(happoScreenshot, page, {

--- a/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
@@ -3,6 +3,8 @@ import { UserRole } from "@bciers/e2e/utils/enums";
 import { FacilityIDs, OPERATION_NAMES } from "@/reporting-e2e/utils/enums";
 import { CurrentReportsPOM } from "@/reporting-e2e/poms/current-reports";
 import { takeStabilizedScreenshot } from "@bciers/e2e/utils/helpers";
+import { SubmittedPOM } from "@/reporting-e2e/poms/submitted";
+import { AnnualReportPOM } from "@/reporting-e2e/poms/annual-report";
 
 const test = setupBeforeAllTest(UserRole.INDUSTRY_USER_ADMIN);
 const internalTest = setupBeforeAllTest(UserRole.CAS_ANALYST);
@@ -14,7 +16,6 @@ test.describe("LFO: view a submitted report for the current reporting year", () 
     page,
     happoScreenshot,
   }) => {
-    const isExternalUser = true;
     const isLFO = true;
     // ── 1. Navigate to the past reports grid ──
     const grid = new CurrentReportsPOM(page);
@@ -25,22 +26,22 @@ test.describe("LFO: view a submitted report for the current reporting year", () 
     // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
     await grid.reportHistoryForOperation(OPERATION_NAMES.BANANA_LFO);
     await grid.viewDetailsFromReportHistory();
-    await grid.verifySubmittedReportView(
+
+    const submittedReport = new SubmittedPOM(page);
+    await submittedReport.verifySubmittedReportView(
       OPERATION_NAMES.BANANA_LFO,
       isLFO,
-      isExternalUser,
     );
 
     await takeStabilizedScreenshot(happoScreenshot, page, {
       component: "LFO Report - Submitted",
       variant: "external",
     });
-    await grid.viewDetailsFromFacilityGrid(
+    await submittedReport.viewDetailsFromFacilityGrid(
       "Facility 1",
       FacilityIDs.BANANA_LFO_1,
-      isExternalUser,
     );
-    await grid.verifyFacilitySubmittedReportView("Facility 1");
+    await submittedReport.verifyFacilitySubmittedReportView("Facility 1");
     await takeStabilizedScreenshot(happoScreenshot, page, {
       component: "LFO Facility Report - Submitted",
       variant: "external",
@@ -67,10 +68,11 @@ test.describe("LFO: view a submitted report for the current reporting year", () 
             isExternalUser,
           );
 
-          await grid.verifySubmittedReportView(
+          const submittedReport = new AnnualReportPOM(page);
+
+          await submittedReport.verifySubmittedReportView(
             OPERATION_NAMES.BANANA_LFO,
             isLFO,
-            isExternalUser,
           );
 
           await takeStabilizedScreenshot(happoScreenshot, page, {
@@ -79,12 +81,11 @@ test.describe("LFO: view a submitted report for the current reporting year", () 
           });
 
           // -- 3. Click "View Details" for the facility report — navigates to the facility 'Submitted' report view ──
-          await grid.viewDetailsFromFacilityGrid(
+          await submittedReport.viewDetailsFromFacilityGrid(
             "Facility 1",
             FacilityIDs.BANANA_LFO_1,
-            isExternalUser,
           );
-          await grid.verifyFacilitySubmittedReportView("Facility 1");
+          await submittedReport.verifyFacilitySubmittedReportView("Facility 1");
           await takeStabilizedScreenshot(happoScreenshot, page, {
             component: "LFO Facility Report - Submitted",
             variant: "internal",

--- a/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
@@ -1,6 +1,6 @@
 import { setupBeforeAllTest } from "@bciers/e2e/setupBeforeAll";
 import { UserRole } from "@bciers/e2e/utils/enums";
-import { OPERATION_NAMES } from "@/reporting-e2e/utils/enums";
+import { FacilityIDs, OPERATION_NAMES } from "@/reporting-e2e/utils/enums";
 import { CurrentReportsPOM } from "@/reporting-e2e/poms/current-reports";
 import { takeStabilizedScreenshot } from "@bciers/e2e/utils/helpers";
 
@@ -35,40 +35,60 @@ test.describe("LFO: view a submitted report for the current reporting year", () 
       component: "LFO Report - Submitted",
       variant: "external",
     });
-  });
-});
-
-internalTest.describe(
-  "LFO: view a submitted report for the current reporting year",
-  () => {
-    internalTest(
-      "CAS analyst views a submitted LFO report",
-      async ({ page, happoScreenshot }) => {
-        const isExternalUser = false;
-        const isLFO = true;
-        // ── 1. Navigate to the past reports grid ──
-        const grid = new CurrentReportsPOM(page);
-        await grid.route();
-
-        await grid.searchByOperationName(OPERATION_NAMES.BANANA_LFO);
-
-        // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
-        await grid.viewDetailsFromReportGrid(
-          OPERATION_NAMES.BANANA_LFO,
-          isExternalUser,
-        );
-
-        await grid.verifySubmittedReportView(
-          OPERATION_NAMES.BANANA_LFO,
-          isLFO,
-          isExternalUser,
-        );
-
-        await takeStabilizedScreenshot(happoScreenshot, page, {
-          component: "LFO Report - Submitted",
-          variant: "internal",
-        });
-      },
+    await grid.viewDetailsFromFacilityGrid(
+      "Facility 1",
+      FacilityIDs.BANANA_LFO_1,
     );
-  },
-);
+    await grid.verifyFacilitySubmittedReportView("Facility 1");
+    await takeStabilizedScreenshot(happoScreenshot, page, {
+      component: "LFO Facility Report - Submitted",
+      variant: "external",
+    });
+  });
+
+  internalTest.describe(
+    "LFO: view a submitted report for the current reporting year",
+    () => {
+      internalTest(
+        "CAS analyst views a submitted LFO report",
+        async ({ page, happoScreenshot }) => {
+          const isExternalUser = false;
+          const isLFO = true;
+          // ── 1. Navigate to the past reports grid ──
+          const grid = new CurrentReportsPOM(page);
+          await grid.route();
+
+          await grid.searchByOperationName(OPERATION_NAMES.BANANA_LFO);
+
+          // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
+          await grid.viewDetailsFromReportGrid(
+            OPERATION_NAMES.BANANA_LFO,
+            isExternalUser,
+          );
+
+          await grid.verifySubmittedReportView(
+            OPERATION_NAMES.BANANA_LFO,
+            isLFO,
+            isExternalUser,
+          );
+
+          await takeStabilizedScreenshot(happoScreenshot, page, {
+            component: "LFO Report - Submitted",
+            variant: "internal",
+          });
+
+          // -- 3. Click "View Details" for the facility report — navigates to the facility 'Submitted' report view ──
+          await grid.viewDetailsFromFacilityGrid(
+            "Facility 1",
+            FacilityIDs.BANANA_LFO_1,
+          );
+          await grid.verifyFacilitySubmittedReportView("Facility 1");
+          await takeStabilizedScreenshot(happoScreenshot, page, {
+            component: "LFO Facility Report - Submitted",
+            variant: "internal",
+          });
+        },
+      );
+    },
+  );
+});

--- a/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/LFO/view-report.spec.ts
@@ -1,0 +1,61 @@
+import { setupBeforeAllTest } from "@bciers/e2e/setupBeforeAll";
+import { UserRole } from "@bciers/e2e/utils/enums";
+import { OPERATION_NAMES } from "@/reporting-e2e/utils/enums";
+import { CurrentReportsPOM } from "@/reporting-e2e/poms/current-reports";
+import { takeStabilizedScreenshot } from "@bciers/e2e/utils/helpers";
+
+const test = setupBeforeAllTest(UserRole.INDUSTRY_USER_ADMIN);
+const internalTest = setupBeforeAllTest(UserRole.CAS_ANALYST);
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("LFO: view a submitted report for the current reporting year", () => {
+  test("Industry user views a submitted LFO report", async ({
+    page,
+    happoScreenshot,
+  }) => {
+    // ── 1. Navigate to the past reports grid ──
+    const grid = new CurrentReportsPOM(page);
+    await grid.route();
+
+    await grid.searchByOperationName(OPERATION_NAMES.BANGLES_SFO);
+
+    // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
+    await grid.viewDetailsForReport(OPERATION_NAMES.BANGLES_SFO, true);
+
+    await grid.verifySubmittedReportView(OPERATION_NAMES.BANGLES_SFO);
+    // - 3. Click the "Save as PDF" button and verify the 'Print' dialog opens
+    await grid.verifySaveAsPDF();
+    await takeStabilizedScreenshot(happoScreenshot, page, {
+      component: "LFO Report - Submitted",
+      variant: "Industry user views submitted report",
+    });
+  });
+});
+
+internalTest.describe(
+  "LFO: view a submitted report for the current reporting year",
+  () => {
+    internalTest(
+      "CAS analyst views a submitted LFO report",
+      async ({ page, happoScreenshot }) => {
+        // ── 1. Navigate to the past reports grid ──
+        const grid = new CurrentReportsPOM(page);
+        await grid.route();
+
+        await grid.searchByOperationName(OPERATION_NAMES.BANGLES_SFO);
+
+        // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
+        await grid.viewDetailsForReport(OPERATION_NAMES.BANGLES_SFO, false);
+
+        await grid.verifySubmittedReportView(OPERATION_NAMES.BANGLES_SFO);
+        // - 3. Click the "Save as PDF" button and verify the 'Print' dialog opens
+        await grid.verifySaveAsPDF();
+        await takeStabilizedScreenshot(happoScreenshot, page, {
+          component: "LFO Report - Submitted",
+          variant: "CAS analyst views submitted report",
+        });
+      },
+    );
+  },
+);

--- a/bciers/apps/reporting-e2e/tests/workflows/SFO/submit-report.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/SFO/submit-report.spec.ts
@@ -3,6 +3,7 @@ import { UserRole } from "@bciers/e2e/utils/enums";
 import {
   FacilityIDs,
   OPERATION_NAMES,
+  REPORT_STATUS,
   ReportRoutes,
 } from "@/reporting-e2e/utils/enums";
 import { CurrentReportsPOM } from "@/reporting-e2e/poms/current-reports";
@@ -203,7 +204,10 @@ test.describe("SFO: create and submit a new report for the current reporting yea
 
     // ── 18. Return to the grid and verify the report status ──
     await page.getByRole("link", { name: "Return to report table" }).click();
-    await grid.verifyReportStatus(OPERATION_NAMES.BUGLE_SFO, "Submitted");
+    await grid.verifyReportStatus(
+      OPERATION_NAMES.BUGLE_SFO,
+      REPORT_STATUS.SUBMITTED,
+    );
     await takeStabilizedScreenshot(happoScreenshot, page, {
       component: "SFO Report - Current Reports Grid",
       variant: "submitted",

--- a/bciers/apps/reporting-e2e/tests/workflows/SFO/view-report.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/SFO/view-report.spec.ts
@@ -1,0 +1,65 @@
+import { setupBeforeAllTest } from "@bciers/e2e/setupBeforeAll";
+import { UserRole } from "@bciers/e2e/utils/enums";
+import { OPERATION_NAMES } from "@/reporting-e2e/utils/enums";
+import { CurrentReportsPOM } from "@/reporting-e2e/poms/current-reports";
+import { takeStabilizedScreenshot } from "@bciers/e2e/utils/helpers";
+
+const test = setupBeforeAllTest(UserRole.INDUSTRY_USER_ADMIN);
+const internalTest = setupBeforeAllTest(UserRole.CAS_ANALYST);
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("SFO: view a submitted report for the current reporting year", () => {
+  test("Industry user views a submitted SFO report", async ({
+    page,
+    happoScreenshot,
+  }) => {
+    // ── 1. Navigate to the past reports grid ──
+    const grid = new CurrentReportsPOM(page);
+    await grid.route();
+
+    await grid.searchByOperationName(OPERATION_NAMES.BANGLES_SFO);
+
+    // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
+    await grid.viewDetailsFromReportGrid(OPERATION_NAMES.BANGLES_SFO, true);
+
+    await grid.verifySubmittedReportView(OPERATION_NAMES.BANGLES_SFO);
+
+    await takeStabilizedScreenshot(happoScreenshot, page, {
+      component: "SFO Report - Submitted",
+      variant: "external",
+    });
+  });
+});
+
+internalTest.describe(
+  "SFO: view a submitted report for the current reporting year",
+  () => {
+    internalTest(
+      "CAS analyst views a submitted SFO report",
+      async ({ page, happoScreenshot }) => {
+        // ── 1. Navigate to the past reports grid ──
+        const grid = new CurrentReportsPOM(page);
+        await grid.route();
+
+        await grid.searchByOperationName(OPERATION_NAMES.BANGLES_SFO);
+
+        // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
+        await grid.viewDetailsFromReportGrid(
+          OPERATION_NAMES.BANGLES_SFO,
+          false,
+        );
+
+        await grid.verifySubmittedReportView(
+          OPERATION_NAMES.BANGLES_SFO,
+          false,
+          false,
+        );
+        await takeStabilizedScreenshot(happoScreenshot, page, {
+          component: "SFO Report - Submitted",
+          variant: "internal",
+        });
+      },
+    );
+  },
+);

--- a/bciers/apps/reporting-e2e/tests/workflows/SFO/view-report.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/SFO/view-report.spec.ts
@@ -14,6 +14,8 @@ test.describe("SFO: view a submitted report for the current reporting year", () 
     page,
     happoScreenshot,
   }) => {
+    const isExternalUser = true;
+    const isLFO = false;
     // ── 1. Navigate to the past reports grid ──
     const grid = new CurrentReportsPOM(page);
     await grid.route();
@@ -21,9 +23,16 @@ test.describe("SFO: view a submitted report for the current reporting year", () 
     await grid.searchByOperationName(OPERATION_NAMES.BANGLES_SFO);
 
     // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
-    await grid.viewDetailsFromReportGrid(OPERATION_NAMES.BANGLES_SFO, true);
+    await grid.viewDetailsFromReportGrid(
+      OPERATION_NAMES.BANGLES_SFO,
+      isExternalUser,
+    );
 
-    await grid.verifySubmittedReportView(OPERATION_NAMES.BANGLES_SFO);
+    await grid.verifySubmittedReportView(
+      OPERATION_NAMES.BANGLES_SFO,
+      isLFO,
+      isExternalUser,
+    );
 
     await takeStabilizedScreenshot(happoScreenshot, page, {
       component: "SFO Report - Submitted",
@@ -38,6 +47,8 @@ internalTest.describe(
     internalTest(
       "CAS analyst views a submitted SFO report",
       async ({ page, happoScreenshot }) => {
+        const isExternalUser = false;
+        const isLFO = false;
         // ── 1. Navigate to the past reports grid ──
         const grid = new CurrentReportsPOM(page);
         await grid.route();
@@ -47,13 +58,13 @@ internalTest.describe(
         // ── 2. Click "View Details" for the report — navigates to the 'Submitted' report view ──
         await grid.viewDetailsFromReportGrid(
           OPERATION_NAMES.BANGLES_SFO,
-          false,
+          isExternalUser,
         );
 
         await grid.verifySubmittedReportView(
           OPERATION_NAMES.BANGLES_SFO,
-          false,
-          false,
+          isLFO,
+          isExternalUser,
         );
         await takeStabilizedScreenshot(happoScreenshot, page, {
           component: "SFO Report - Submitted",

--- a/bciers/apps/reporting-e2e/tests/workflows/SFO/view-report.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/SFO/view-report.spec.ts
@@ -3,6 +3,8 @@ import { UserRole } from "@bciers/e2e/utils/enums";
 import { OPERATION_NAMES } from "@/reporting-e2e/utils/enums";
 import { CurrentReportsPOM } from "@/reporting-e2e/poms/current-reports";
 import { takeStabilizedScreenshot } from "@bciers/e2e/utils/helpers";
+import { SubmittedPOM } from "@/reporting-e2e/poms/submitted";
+import { AnnualReportPOM } from "@/reporting-e2e/poms/annual-report";
 
 const test = setupBeforeAllTest(UserRole.INDUSTRY_USER_ADMIN);
 const internalTest = setupBeforeAllTest(UserRole.CAS_ANALYST);
@@ -27,11 +29,11 @@ test.describe("SFO: view a submitted report for the current reporting year", () 
       OPERATION_NAMES.BANGLES_SFO,
       isExternalUser,
     );
+    const submittedReport = new SubmittedPOM(page);
 
-    await grid.verifySubmittedReportView(
+    await submittedReport.verifySubmittedReportView(
       OPERATION_NAMES.BANGLES_SFO,
       isLFO,
-      isExternalUser,
     );
 
     await takeStabilizedScreenshot(happoScreenshot, page, {
@@ -60,11 +62,11 @@ internalTest.describe(
           OPERATION_NAMES.BANGLES_SFO,
           isExternalUser,
         );
+        const submittedReport = new AnnualReportPOM(page);
 
-        await grid.verifySubmittedReportView(
+        await submittedReport.verifySubmittedReportView(
           OPERATION_NAMES.BANGLES_SFO,
           isLFO,
-          isExternalUser,
         );
         await takeStabilizedScreenshot(happoScreenshot, page, {
           component: "SFO Report - Submitted",

--- a/bciers/apps/reporting-e2e/utils/constants.ts
+++ b/bciers/apps/reporting-e2e/utils/constants.ts
@@ -45,4 +45,6 @@ export const ACTION_BUTTON_TEXT = {
   START: "Start",
   CONTINUE: "Continue",
   VIEW_DETAILS: "View Details",
+  VIEW_REPORT: "View Report",
+  REPORT_HISTORY: "Report history",
 } as const;

--- a/bciers/apps/reporting-e2e/utils/enums.ts
+++ b/bciers/apps/reporting-e2e/utils/enums.ts
@@ -1,6 +1,8 @@
 // App routes
 export enum AppRoutes {
   GRID_REPORTING_CURRENT_REPORTS = "reporting/reports",
+  GRID_REPORTING_PAST_REPORTS = "reporting/reports/previous-years",
+  REPORT_HISTORY_GRID = "reporting/reports/report-history",
 }
 
 // Report record ids
@@ -42,6 +44,8 @@ export enum ReportRoutes {
   FINAL_REVIEW = "final-review",
   VERIFICATION = "verification",
   ATTACHMENTS = "attachments",
+  SUBMITTED_REPORT = "submitted",
+  ANNUAL_REPORT = "annual-report",
 }
 
 // Attachment checkboxes
@@ -79,6 +83,8 @@ export const OPERATION_NAMES = {
   OBLIGATION_NOT_MET: "Compliance SFO - Obligation not met",
   EARNED_CREDITS: "Compliance SFO - Earned credits",
   NO_OBLIGATION: "Compliance SFO - No obligation",
+  BANANA_LFO: "Banana LFO - Registered - name from admin",
+  BANGLES_SFO: "Bangles SFO - Registered - has Multiple Operators",
   BUGLE_SFO: "Bugle SFO - Registered",
   BEES_LFO: "Bees LFO - Registered - name from admin",
 } as const;
@@ -88,3 +94,10 @@ export const REPORT_ID_TO_OPERATION_NAME: Record<ReportIDs, string> = {
   [ReportIDs.EARNED_CREDITS]: OPERATION_NAMES.EARNED_CREDITS,
   [ReportIDs.NO_OBLIGATION]: OPERATION_NAMES.NO_OBLIGATION,
 };
+
+export enum REPORT_STATUS {
+  DRAFT = "Draft",
+  SUBMITTED = "Submitted",
+  DRAFT_SUPPLEMENTARY = "Draft Supplementary Report",
+  NOT_STARTED = "Not Started",
+}

--- a/bciers/apps/reporting-e2e/utils/enums.ts
+++ b/bciers/apps/reporting-e2e/utils/enums.ts
@@ -19,6 +19,7 @@ export enum FacilityIDs {
   NO_OBLIGATION = "2",
   BUGLE_SFO = "f486f2fb-62ed-438d-bb3e-0819b51e3aff",
   BEES_LFO = "d477f3d9-2917-4f36-b5ae-166d47dc8172",
+  BANANA_LFO_1 = "f486f2fb-62ed-438d-bb3e-0819b51e3aeb",
 }
 
 // Report workflow routes
@@ -83,7 +84,7 @@ export const OPERATION_NAMES = {
   OBLIGATION_NOT_MET: "Compliance SFO - Obligation not met",
   EARNED_CREDITS: "Compliance SFO - Earned credits",
   NO_OBLIGATION: "Compliance SFO - No obligation",
-  BANANA_LFO: "Banana LFO - Registered - name from admin",
+  BANANA_LFO: "Banana LFO - Registered",
   BANGLES_SFO: "Bangles SFO - Registered - has Multiple Operators",
   BUGLE_SFO: "Bugle SFO - Registered",
   BEES_LFO: "Bees LFO - Registered - name from admin",

--- a/bciers/apps/reporting-e2e/utils/helpers.ts
+++ b/bciers/apps/reporting-e2e/utils/helpers.ts
@@ -10,3 +10,17 @@ export async function verifyFormTitle(
     ),
   ).toHaveText(title);
 }
+
+export async function verifySaveAsPDF(page: Page): Promise<void> {
+  const saveAsPDFButton = page.getByRole("button", {
+    name: /Save as PDF/i,
+  });
+  await expect(saveAsPDFButton).toBeVisible();
+  await expect(saveAsPDFButton).toBeEnabled();
+
+  await page.evaluate(
+    "(() => {window.waitForPrintDialog = new Promise(f => window.print = f);})()",
+  );
+  await saveAsPDFButton.click();
+  await page.waitForFunction("window.waitForPrintDialog");
+}

--- a/bciers/libs/e2e/src/utils/helpers.ts
+++ b/bciers/libs/e2e/src/utils/helpers.ts
@@ -614,7 +614,7 @@ export async function assertFieldVisibility(
   visible: boolean,
 ) {
   for (const field of fields) {
-    await expect(page.getByText(field)).toBeVisible({
+    await expect(page.getByText(field).first()).toBeVisible({
       visible: visible,
     });
   }

--- a/bciers/libs/e2e/src/utils/helpers.ts
+++ b/bciers/libs/e2e/src/utils/helpers.ts
@@ -41,32 +41,43 @@ export async function analyzeAccessibility(
 
 /**
  * Clicks a button by accessible name and optionally waits for navigation.
+ *
+ * Supports scoping the button lookup to a specific root Locator
+ * (useful for grids, tables, dialogs, and repeated button names).
+ *
+ * Uses Playwright web-first assertions to ensure the button is
+ * visible and enabled before clicking.
+ *
+ * For SPA/client-side navigation (e.g. Next.js router.push),
+ * optionally waits for a matching URL after the click.
+ *
  * @param page - Playwright Page instance
  * @param buttonText - Button accessible name or RegExp
+ * @param opts.root - Optional Locator to scope the button search
  * @param opts.inForm - Scope the button search to a <form> (default: false)
- * @param opts.waitForUrl - RegExp to wait for after clicking (optional)
+ * @param opts.waitForUrl - RegExp URL to wait for after clicking (optional)
  */
 export async function clickButton(
   page: Page,
   buttonText: string | RegExp,
   opts?: {
-    inForm?: boolean; // default false
+    root?: Locator;
+    inForm?: boolean;
     waitForUrl?: RegExp;
   },
 ): Promise<void> {
-  const { inForm = false, waitForUrl } = opts ?? {};
+  const { root, inForm = false, waitForUrl } = opts ?? {};
 
   const name =
     buttonText instanceof RegExp ? buttonText : new RegExp(buttonText, "i");
 
-  const root = inForm ? page.locator("form") : page;
-  const button = root.getByRole("button", { name });
+  const searchRoot = root ?? (inForm ? page.locator("form") : page);
+  const button = searchRoot.getByRole("button", { name });
 
   await expect(button).toBeVisible({ timeout: 30_000 });
   await expect(button).toBeEnabled({ timeout: 30_000 });
 
   if (waitForUrl) {
-    // Use a lighter wait for SPA navigation
     await Promise.all([
       page.waitForURL((u) => waitForUrl.test(u.toString()), {
         timeout: 30_000,

--- a/docs/frontend/testing/playwright.md
+++ b/docs/frontend/testing/playwright.md
@@ -375,139 +375,7 @@ yarn compliance:e2e
 
 ### Run with Playwright UI mode
 
-```bash
-cd bciers
-yarn reg:e2e:ui
-```
-
-```bash
-cd bciers
-yarn report:e2e:ui
-```
-
 UI mode is best for writing and debugging tests interactively.
-
-### Run E2E like CI locally
-
-Use `CI=true` to more closely match the CI environment. This is useful when a test passes in UI mode but fails in CI.
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 CI=true yarn report:e2e
-```
-
-Run a specific Reporting test like CI:
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium
-```
-
-Run headed while still using CI-like settings:
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed
-```
-
-## Running Tests With Trace
-
-Traces are the best way to debug CI-style failures because they show:
-
-- each Playwright action
-- screenshots before and after actions
-- DOM snapshots
-- console logs
-- network requests
-- locator resolution
-- actionability checks
-
-### Run a specific test with trace
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed --trace on
-```
-
-### Run a specific test with trace only on failure
-
-This is usually the best default when debugging a flaky test:
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed --trace retain-on-failure
-```
-
-### Run trace on first retry
-
-Useful when the test usually passes but fails occasionally:
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --trace on-first-retry
-```
-
-### Find trace files
-
-Trace files may be written under the app-specific e2e output folder, not always root `dist`.
-
-```bash
-cd bciers
-find . -type f -name "trace.zip"
-```
-
-For Reporting specifically:
-
-```bash
-cd bciers
-find apps/reporting-e2e -type f -name "trace.zip"
-```
-
-Example Reporting trace path:
-
-```txt
-apps/reporting-e2e/dist/.playwright/test-output/workflows-LFO-submit-repor-d8122-nd-submits-a-new-LFO-report-chromium/trace.zip
-```
-
-### Open a trace
-
-```bash
-cd bciers
-yarn playwright show-trace apps/reporting-e2e/dist/.playwright/test-output/workflows-LFO-submit-repor-d8122-nd-submits-a-new-LFO-report-chromium/trace.zip
-```
-
-Open a retry trace:
-
-```bash
-cd bciers
-yarn playwright show-trace apps/reporting-e2e/dist/.playwright/test-output/workflows-LFO-submit-repor-d8122-nd-submits-a-new-LFO-report-chromium-retry1/trace.zip
-```
-
-### Common trace troubleshooting checklist
-
-When reviewing a trace, check:
-
-1. Did the click happen?
-2. Was the target element visible and enabled?
-3. Was the element covered by a snackbar, loading overlay, sticky header, or modal?
-4. Did the expected request fire?
-5. Did the request return a success status?
-6. Did the URL change to what the test expected?
-7. Did the UI render the expected next page?
-8. Did the test wait for a URL when no navigation actually happened?
-9. Did HMR or React re-render remove the element during the action?
-10. Did the test timeout because an earlier wait never resolved?
-
-For failures like:
-
-```txt
-Error: page.waitForURL: Test ended.
-waiting for navigation until "domcontentloaded"
-```
-
-Check whether the click actually triggers navigation. If it only saves data or updates state, remove the `waitForURL` and assert a visible UI state instead.
-
-## UI Mode (Local Development)
 
 When running Playwright in UI mode:
 
@@ -544,7 +412,78 @@ HMR logs such as these are expected in UI mode and do not indicate test failure:
 [Fast Refresh] rebuilding
 ```
 
+### Run E2E like CI locally
+
+Use `CI=true` to more closely match the CI environment. This is useful when a test passes in UI mode but fails in CI.
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e
+```
+
+Run a specific Reporting test like CI:
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium
+```
+
+Run headed while still using CI-like settings:
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed
+```
+
 ## Debugging Playwright
+
+### Common trace troubleshooting checklist
+1. Did the click happen?
+2. Was the target element visible and enabled?
+3. Was the element covered by a snackbar, loading overlay, sticky header, or modal?
+4. Did the expected request fire?
+5. Did the request return a success status?
+6. Did the URL change to what the test expected?
+7. Did the UI render the expected next page?
+8. Did the test wait for a URL when no navigation actually happened?
+9. Did HMR or React re-render remove the element during the action?
+10. Did the test timeout because an earlier wait never resolved?
+
+
+## Running Tests With Trace
+
+Traces are the best way to debug CI-style failures because they show:
+
+- each Playwright action
+- screenshots before and after actions
+- DOM snapshots
+- console logs
+- network requests
+- locator resolution
+- actionability checks
+
+### Run a specific test with trace
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed --trace on
+```
+
+### Find trace files
+
+Trace files may be written under the app-specific e2e output folder, not always root `dist`.
+
+```bash
+cd bciers
+find . -type f -name "trace.zip"
+```
+
+### Open a trace
+
+```bash
+cd bciers
+yarn playwright show-trace apps/reporting-e2e/dist/.playwright/test-output/workflows-LFO-submit-repor-d8122-nd-submits-a-new-LFO-report-chromium/trace.zip
+```
 
 ### HTML report
 

--- a/docs/frontend/testing/playwright.md
+++ b/docs/frontend/testing/playwright.md
@@ -387,36 +387,6 @@ yarn report:e2e:ui
 
 UI mode is best for writing and debugging tests interactively.
 
-### Run a specific test file
-
-When passing Playwright arguments through an Nx/yarn target, put them after `--`.
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 yarn report:e2e -- tests/workflows/LFO/view-report.spec.ts --project=chromium --headed
-```
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed
-```
-
-For Compliance:
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 yarn compliance:e2e -- tests/workflows/manage-obligation/report-compliance-obligation.spec.ts --project=chromium --headed
-```
-
-### Run a specific test by title
-
-Use `-g` to match the test name.
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed -g "Industry user starts, fills, and submits a new LFO report"
-```
-
 ### Run E2E like CI locally
 
 Use `CI=true` to more closely match the CI environment. This is useful when a test passes in UI mode but fails in CI.
@@ -439,22 +409,6 @@ Run headed while still using CI-like settings:
 cd bciers
 BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed
 ```
-
-Run with one worker to reproduce serial CI behavior or reduce local noise:
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --workers=1
-```
-
-Run only Chromium:
-
-```bash
-cd bciers
-BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- --project=chromium
-```
-
-> Important: when using an Nx target like `yarn report:e2e`, Playwright args must come after `--`. Otherwise Nx may interpret `--project=chromium` as an Nx project.
 
 ## Running Tests With Trace
 

--- a/docs/frontend/testing/playwright.md
+++ b/docs/frontend/testing/playwright.md
@@ -2,159 +2,748 @@
 
 ## Introduction
 
-Playwright is a powerful end-to-end testing library for web applications. It provides a simple API to automate browser actions, allowing developers to create robust and maintainable tests.
+Playwright is our end-to-end testing framework for validating user workflows across the BCIERS applications. These tests should behave like a real user as much as possible: navigate through the UI, use accessible locators, wait for visible user-facing states, and avoid depending on implementation details.
+
+The goal of this guide is to help us write tests that are:
+
+- reliable in CI
+- easy to debug locally
+- readable during PR review
+- resistant to flakiness caused by timing, HMR, animations, network latency, or app re-renders
 
 ## Getting Started
 
-To get started with Playwright, you'll need to install it as a dependency in your project:
+Ensure you have the correct env variables set up in the `bciers/.env.local` file. You can copy the `.env.local.example` file and update the values accordingly.
+
+Install Playwright browsers the first time you run e2e tests locally:
 
 ```bash
-cd bc_obps && make run
-npm install @playwright/test
+cd bciers
+yarn playwright install
 ```
 
-Ensure you have the correct env variables set up in the `bciers/.env.local` file. You can copy the `.env.local.example` file and update the values accordingly.
+Run the backend and frontend apps before running the tests:
+
+```bash
+cd bc_obps
+make run
+```
+
+```bash
+cd bciers
+yarn dev-all
+```
+
+For Registration-only tests, you can run only the Registration app:
+
+```bash
+cd bciers
+yarn reg
+```
 
 ## Test organization in our monorepo
 
-The e2e tests are organized in separate projects in the `/bciers/apps` directory. Each project has its own `/bciers/apps/apppname-e2e` directory where the tests are located. To run the tests we need to have the `Dashboard` app running due to our auth implementation alongside whichever app we are testing. There are shared utilities in the `bciers/libs/e2e` directory that can be used across all e2e tests.
+The e2e tests are organized in separate projects in the `/bciers/apps` directory. Each project has its own e2e app directory, for example:
+
+```txt
+bciers/apps/registration-e2e
+bciers/apps/reporting-e2e
+bciers/apps/compliance-e2e
+```
+
+To run most BCIERS app tests, the Dashboard app must also be running because of our authentication implementation. Shared utilities live in:
+
+```txt
+bciers/libs/e2e
+```
+
+Use shared helpers and page object models when they improve consistency, but avoid over-abstracting simple test steps. A readable test failure is usually better than a very generic helper that hides what the test is doing.
 
 ## Writing Tests
 
 ### Basic Test Structure
 
-Playwright tests follow a simple structure. Each test case is a JavaScript or TypeScript function with Playwright APIs for interacting with the browser.
+```typescript
+import { expect, test } from "@playwright/test";
 
-```javascript
-const { test } = require("@playwright/test");
-test("Example Test", async ({ page }) => {
-  // Your test logic goes here
+test("example test", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible();
 });
 ```
 
 ### Locators
 
-#### Prefer User-Facing Attributes
+#### Prefer user-facing locators
 
-When selecting elements, prefer using user-facing attributes over XPath or CSS selectors. This ensures that the tests are tied to the actual user experience and are less prone to breakage when the underlying structure changes.
+Use locators that match what a user can perceive: roles, names, labels, placeholders, and text. These are more stable than CSS selectors because they are tied to the user experience instead of DOM structure.
 
-```javascript
-// Bad: Using XPath
-await page.click('//div[@class="my-button"]');
-// Good: Using User-Facing Attribute
-await page.click('[data-testid="my-button"]');
+```typescript
+// Good
+await page.getByRole("button", { name: /continue/i }).click();
+await page.getByLabel(/operation name/i).fill("Test Operation");
+await page.getByRole("heading", { name: /review report/i }).waitFor();
+
+// Acceptable when there is no accessible user-facing locator
+await page.getByTestId("report-status").click();
+
+// Avoid
+await page.locator(".MuiButton-root").click();
+await page.locator("//div[@class='my-button']").click();
 ```
+
+#### Use scoped locators for repeated UI
+
+When a page has repeated buttons, rows, or cards, first locate the parent, then locate the action inside that parent.
+
+```typescript
+const row = page.getByRole("row").filter({ hasText: "Facility 1" }).first();
+
+await expect(row).toBeVisible();
+
+await row.getByRole("button", { name: /view details/i }).click();
+```
+
+This prevents accidentally clicking the first matching button elsewhere on the page.
 
 #### Code Generation
 
-To find locators, leverage Playwright's code generation feature. Use the following command to record user actions and generate test code:
+To find locators, use Playwright codegen:
 
 ```bash
-cd bciers && npx playwright codegen http://localhost:3000
+cd bciers
+npx playwright codegen http://localhost:3000
+```
+
+Use generated locators as a starting point, then clean them up to prefer accessible roles and stable names.
+
+## Best Patterns to Prevent Flaky Tests
+
+### 1. Avoid hard waits
+
+Do not use `waitForTimeout()` as a stability fix. It makes tests slower and still fails when CI is slower than expected.
+
+```typescript
+// Avoid
+await page.waitForTimeout(3000);
+
+// Prefer a user-visible readiness assertion
+await expect(
+  page.getByRole("heading", { name: /final review/i }),
+).toBeVisible();
+```
+
+### 2. Wait for the result of an action, not just the action
+
+A click only proves that Playwright dispatched the click. It does not prove that the app finished saving, navigating, rendering, or loading data.
+
+```typescript
+await page.getByRole("button", { name: /continue/i }).click();
+
+await expect(
+  page.getByRole("heading", { name: /review facilities/i }),
+).toBeVisible();
+```
+
+### 3. Pair navigation waits with clicks
+
+When a click is expected to navigate, start the URL wait before the click. This avoids a race where the navigation happens before the test starts waiting.
+
+```typescript
+await Promise.all([
+  page.waitForURL(/\/reports\/\d+\/review-facility-information/, {
+    waitUntil: "domcontentloaded",
+  }),
+  page.getByRole("button", { name: /continue/i }).click(),
+]);
+```
+
+If the click does not always navigate, do not use `waitForURL`. Assert the actual expected UI state instead.
+
+```typescript
+await page.getByRole("button", { name: /save/i }).click();
+
+await expect(page.getByText(/saved successfully/i)).toBeVisible();
+```
+
+### 4. Prefer Playwright auto-waiting assertions
+
+Playwright assertions retry until the condition passes or the timeout is reached.
+
+```typescript
+await expect(page.getByTestId("status")).toHaveText("Submitted");
+await expect(page.getByRole("button", { name: /submit/i })).toBeEnabled();
+await expect(page.getByRole("progressbar")).toBeHidden();
+```
+
+Avoid manually checking state immediately after an action:
+
+```typescript
+// Avoid
+expect(await page.getByTestId("status").textContent()).toBe("Submitted");
+```
+
+### 5. Wait for page-ready signals
+
+Use a clear signal that the page is actually ready before interacting with it. Good readiness signals include:
+
+- heading is visible
+- expected tab is selected
+- grid has loaded at least one expected row
+- loading spinner is hidden
+- submit button is enabled
+- URL matches the expected route
+
+```typescript
+await expect(
+  page.getByRole("heading", { name: /current reports/i }),
+).toBeVisible();
+await expect(page.getByRole("progressbar")).toBeHidden();
+await expect(page.getByRole("button", { name: /start report/i })).toBeEnabled();
+```
+
+### 6. Avoid brittle URL-only assertions
+
+URL assertions are useful, but they should not be the only proof that the page is ready. A route can change before the page data has finished loading.
+
+```typescript
+await expect(page).toHaveURL(/\/reports\/\d+\/final-review/);
+await expect(
+  page.getByRole("heading", { name: /final review/i }),
+).toBeVisible();
+```
+
+### 7. Use `expect.toPass()` for retrying a whole interaction block
+
+Use `expect.toPass()` when the page may re-render during HMR, loading, or transient state changes. This is useful for interaction blocks where retrying just one assertion is not enough.
+
+```typescript
+await expect(async () => {
+  const row = page.getByRole("row").filter({ hasText: "Facility 1" }).first();
+
+  await expect(row).toBeVisible();
+  await expect(
+    row.getByRole("button", { name: /view details/i }),
+  ).toBeEnabled();
+
+  await row.getByRole("button", { name: /view details/i }).click();
+}).toPass();
+```
+
+Use this intentionally. Do not wrap the entire test in `toPass()`.
+
+### 8. Check buttons are visible and enabled before clicking
+
+This gives cleaner failure messages and avoids clicking during disabled/loading states.
+
+```typescript
+const button = page.getByRole("button", { name: /continue/i });
+
+await expect(button).toBeVisible();
+await expect(button).toBeEnabled();
+
+await button.click();
+```
+
+### 9. Avoid `force: true` unless there is a strong reason
+
+`force: true` bypasses Playwright actionability checks. It can hide real UX bugs where a user would not actually be able to click the element.
+
+```typescript
+// Avoid unless intentionally testing a hidden/covered control
+await button.click({ force: true });
+```
+
+### 10. Keep tests isolated
+
+Each test should set up or select its own data and should not depend on the outcome of a previous test. A test should pass when run:
+
+- alone
+- with the full suite
+- in a different order
+- on retry
+
+Avoid shared mutable state between tests unless it is reset by fixtures or database setup.
+
+### 11. Prefer deterministic test data
+
+Use predictable test data that will not collide with other tests or previous local runs.
+
+```typescript
+const operationName = `E2E Operation ${test.info().workerIndex}`;
+```
+
+When possible, use seeded fixtures or dedicated e2e setup helpers instead of relying on whatever data exists locally.
+
+### 12. Be careful with network waits
+
+Waiting for a network response can be useful, but do not make tests too tightly coupled to implementation details. Prefer UI assertions unless the test specifically needs to verify an API-driven side effect.
+
+```typescript
+const saveResponse = page.waitForResponse(
+  (response) =>
+    response.url().includes("/api/reporting") &&
+    response.request().method() === "POST" &&
+    response.ok(),
+);
+
+await page.getByRole("button", { name: /save/i }).click();
+await saveResponse;
+
+await expect(page.getByText(/saved successfully/i)).toBeVisible();
+```
+
+### 13. Stabilize screenshots before visual comparison
+
+For Happo screenshots, wait for the page or component to stabilize before taking a screenshot. Use the shared helpers where available:
+
+- `takeStabilizedScreenshot`
+- `stabilizeGrid`
+- `stabilizeAccordion`
+
+```typescript
+await stabilizeGrid(page);
+await takeStabilizedScreenshot(happoPlaywright, page, {
+  component: "Current Reports Grid",
+  variant: "industry_user",
+  targets: ["chrome"],
+});
+```
+
+### 14. Prefer helper methods with explicit expectations
+
+Page object methods should include the readiness and actionability checks needed for the action to be reliable.
+
+```typescript
+async clickContinue(): Promise<void> {
+  const button = this.page.getByRole("button", { name: /continue/i });
+
+  await expect(button).toBeVisible();
+  await expect(button).toBeEnabled();
+
+  await Promise.all([
+    this.page.waitForURL(/expected-next-route/, { waitUntil: "domcontentloaded" }),
+    button.click(),
+  ]);
+}
+```
+
+If the route is conditional, pass the expected URL into the helper or assert a stable UI state instead.
+
+## Running E2E Tests Locally
+
+### Prerequisites
+
+Start the backend:
+
+```bash
+cd bc_obps
+make run
+```
+
+Start the frontend apps:
+
+```bash
+cd bciers
+yarn dev-all
+```
+
+For Registration-only testing:
+
+```bash
+cd bciers
+yarn reg
+```
+
+### Run an app's e2e suite
+
+```bash
+cd bciers
+yarn reg:e2e
+```
+
+```bash
+cd bciers
+yarn report:e2e
+```
+
+```bash
+cd bciers
+yarn compliance:e2e
+```
+
+### Run with Playwright UI mode
+
+```bash
+cd bciers
+yarn reg:e2e:ui
+```
+
+```bash
+cd bciers
+yarn report:e2e:ui
+```
+
+UI mode is best for writing and debugging tests interactively.
+
+### Run a specific test file
+
+When passing Playwright arguments through an Nx/yarn target, put them after `--`.
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 yarn report:e2e -- tests/workflows/LFO/view-report.spec.ts --project=chromium --headed
+```
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed
+```
+
+For Compliance:
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 yarn compliance:e2e -- tests/workflows/manage-obligation/report-compliance-obligation.spec.ts --project=chromium --headed
+```
+
+### Run a specific test by title
+
+Use `-g` to match the test name.
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed -g "Industry user starts, fills, and submits a new LFO report"
+```
+
+### Run E2E like CI locally
+
+Use `CI=true` to more closely match the CI environment. This is useful when a test passes in UI mode but fails in CI.
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e
+```
+
+Run a specific Reporting test like CI:
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium
+```
+
+Run headed while still using CI-like settings:
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed
+```
+
+Run with one worker to reproduce serial CI behavior or reduce local noise:
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --workers=1
+```
+
+Run only Chromium:
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- --project=chromium
+```
+
+> Important: when using an Nx target like `yarn report:e2e`, Playwright args must come after `--`. Otherwise Nx may interpret `--project=chromium` as an Nx project.
+
+## Running Tests With Trace
+
+Traces are the best way to debug CI-style failures because they show:
+
+- each Playwright action
+- screenshots before and after actions
+- DOM snapshots
+- console logs
+- network requests
+- locator resolution
+- actionability checks
+
+### Run a specific test with trace
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed --trace on
+```
+
+### Run a specific test with trace only on failure
+
+This is usually the best default when debugging a flaky test:
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed --trace retain-on-failure
+```
+
+### Run trace on first retry
+
+Useful when the test usually passes but fails occasionally:
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --trace on-first-retry
+```
+
+### Find trace files
+
+Trace files may be written under the app-specific e2e output folder, not always root `dist`.
+
+```bash
+cd bciers
+find . -type f -name "trace.zip"
+```
+
+For Reporting specifically:
+
+```bash
+cd bciers
+find apps/reporting-e2e -type f -name "trace.zip"
+```
+
+Example Reporting trace path:
+
+```txt
+apps/reporting-e2e/dist/.playwright/test-output/workflows-LFO-submit-repor-d8122-nd-submits-a-new-LFO-report-chromium/trace.zip
+```
+
+### Open a trace
+
+```bash
+cd bciers
+yarn playwright show-trace apps/reporting-e2e/dist/.playwright/test-output/workflows-LFO-submit-repor-d8122-nd-submits-a-new-LFO-report-chromium/trace.zip
+```
+
+Open a retry trace:
+
+```bash
+cd bciers
+yarn playwright show-trace apps/reporting-e2e/dist/.playwright/test-output/workflows-LFO-submit-repor-d8122-nd-submits-a-new-LFO-report-chromium-retry1/trace.zip
+```
+
+### Common trace troubleshooting checklist
+
+When reviewing a trace, check:
+
+1. Did the click happen?
+2. Was the target element visible and enabled?
+3. Was the element covered by a snackbar, loading overlay, sticky header, or modal?
+4. Did the expected request fire?
+5. Did the request return a success status?
+6. Did the URL change to what the test expected?
+7. Did the UI render the expected next page?
+8. Did the test wait for a URL when no navigation actually happened?
+9. Did HMR or React re-render remove the element during the action?
+10. Did the test timeout because an earlier wait never resolved?
+
+For failures like:
+
+```txt
+Error: page.waitForURL: Test ended.
+waiting for navigation until "domcontentloaded"
+```
+
+Check whether the click actually triggers navigation. If it only saves data or updates state, remove the `waitForURL` and assert a visible UI state instead.
+
+## UI Mode (Local Development)
+
+When running Playwright in UI mode:
+
+```bash
+yarn <app>:e2e:ui
+```
+
+We allow HMR / Fast Refresh from Next.js during local development.
+
+### Why
+
+- faster iteration while writing or debugging tests
+- immediate feedback when editing tests or POMs
+- useful for interactive debugging
+
+### Trade-offs
+
+- HMR can trigger React re-mounts
+- elements may briefly disappear and reappear
+- transient DOM states can expose timing issues
+
+To mitigate this, tests should:
+
+- use Playwright assertions that auto-retry
+- wait for clear page-ready signals
+- prefer stable user-facing locators
+- retry small interaction blocks with `expect.toPass()` when appropriate
+- avoid disabling HMR unless explicitly validating production-like behavior
+
+HMR logs such as these are expected in UI mode and do not indicate test failure:
+
+```txt
+[HMR] connected
+[Fast Refresh] rebuilding
+```
+
+## Debugging Playwright
+
+### HTML report
+
+The HTML report shows test results by browser, duration, retries, failure details, screenshots, videos, and traces.
+
+Open the local report:
+
+```bash
+cd bciers
+yarn playwright show-report
+```
+
+For a specific app report path, search for reports:
+
+```bash
+cd bciers
+find . -type d -name "playwright-report"
+```
+
+Then open the relevant one:
+
+```bash
+yarn playwright show-report path/to/playwright-report
+```
+
+For debugging CI, download the HTML report artifact from GitHub Actions, extract it locally, and open it with:
+
+```bash
+cd bciers
+yarn playwright show-report playwright-report
+```
+
+### Debugging Playwright in CI
+
+If tests fail in CI and the job output is not enough, enable or uncomment the HTML report upload steps in the GitHub Actions e2e workflow files.
+
+These are located in:
+
+```txt
+bciers/.github/workflows/test-nx-project-e2e.yaml
 ```
 
 ## Generating Playwright Storage State for Authenticated Tests
 
-In order to run authenticated end-to-end (E2E) tests without going through the login flow each time, we use **Playwright storage state stringifyed JSON** to persist session cookies and tokens.
+In order to run authenticated e2e tests without going through the login flow each time, we use Playwright storage state stringified JSON to persist session cookies and tokens.
 
-### Step-by-Step: Create a Storage State File
+### Step-by-step: Create a Storage State File
 
-1. **Update auth.js config to set token.app_role as the storage state role**
+1. **Update auth config to set `token.app_role` as the storage state role**
 
-   In `bciers/apps/dashboard/auth/auth.config.ts`, force set the token's app_role for use with Playwright.
+   In `bciers/apps/dashboard/auth/auth.config.ts`, temporarily force the token's app role for use with Playwright:
 
-```
-    // 🔒 return encrypted nextauth JWT
-    token.app_role = "name_of_role";
-    return token;
-```
+   ```typescript
+   token.app_role = "name_of_role";
+   return token;
+   ```
 
-🔐 This ensures when the session from name_of_role.json is loaded, and the app treats a logged in user as a name_of_role.
+2. **Update auth config to set `maxAge` as far future expiry**
 
-2. **Update auth.js config to set maxAge as far future expiry**
+   In `bciers/apps/dashboard/auth/index.ts`, temporarily force the token expiration time:
 
-   In `bciers/apps/dashboard/auth/index.ts`, force set the token expiration time for use with Playwright.
-
-```
-
-    maxAge: 60 * 60 * 24 * 365 * 100, // 100 years
-```
+   ```typescript
+   maxAge: 60 * 60 * 24 * 365 * 100, // 100 years
+   ```
 
 3. **Start your local dev servers**
 
-   Run the following terminal commands:
-
-   ```sh
-   cd bc_obps &&  make run
+   ```bash
+   cd bc_obps
+   make run
    ```
 
-   ```sh
-   cd bciers && yarn dev-all
+   ```bash
+   cd bciers
+   yarn dev-all
    ```
 
-4. **Open Playwright Codegen and Login Manually**
-
-   Run the following terminal command:
+4. **Open Playwright codegen and login manually**
 
    ```bash
    cd bciers
    npx playwright codegen http://localhost:3000 --save-storage=name_of_role.json
    ```
 
-   - This will open a Chromium browser with developer tools.
-   - Interact with the site as a **name_of_role** user
-   - Complete the login flow manually.
+5. **Close the browser window**
 
-5. **Close the Browser Window**
+   Once fully logged in, close the Playwright browser window. The session will be saved to:
 
-   Once you're fully logged in and the app is loaded, close the Playwright browser window. The session (cookies, tokens) will be saved to a file named:
-
-   ```
+   ```txt
    name_of_role.json
    ```
 
-6. **Revert auth config update**
+6. **Revert the temporary auth config changes**
 
-   In `bciers/apps/dashboard/auth/auth.config.ts`, revert the logic update on the token app_role.
-   In `bciers/apps/dashboard/auth/index.ts`, revert the update on the maxAge.
+   Revert changes in:
 
-7. **Stringify and add to .env.local**
+   ```txt
+   bciers/apps/dashboard/auth/auth.config.ts
+   bciers/apps/dashboard/auth/index.ts
+   ```
 
-   Create an E2E_NAME_OF_ROLE_STORAGE_STATE key to with JSON string contents of name_of_role.json to .env.local
-   Ensure that all "expire" properties are set to -1.
+7. **Stringify and add to `.env.local`**
 
-8. **Add as a GitHub Secret**
+   Create an env key like:
 
-   In the GitHub repository, navigate to `Settings → Secrets and variables → Actions → New repository secret`.Add a new secret:
+   ```txt
+   E2E_NAME_OF_ROLE_STORAGE_STATE=
+   ```
 
-```
-  Name: E2E_NAME_OF_ROLE_STORAGE_STATE
+   Paste the stringified JSON contents of `name_of_role.json`.
 
-  Value: Paste the full stringified contents from .env.local
-```
+   Ensure all `expires` properties are set to `-1`.
 
-9. **Reference in GitHub Actions workflow**
+8. **Add as a GitHub secret**
 
-   In `in .github/workflows/test-nx-project-e2e.yaml`, add reference to `E2E_NAME_OF_ROLE_STORAGE_STATE: ${{ secrets.E2E_NAME_OF_ROLE_STORAGE_STATE}}`
+   In GitHub, go to:
 
-10. **Delete the name_of_role.json file**
+   ```txt
+   Settings → Secrets and variables → Actions → New repository secret
+   ```
 
-> 🛑 **Do not commit this file if it contains sensitive credentials or tokens**
+   Add:
 
----
+   ```txt
+   Name: E2E_NAME_OF_ROLE_STORAGE_STATE
+   Value: full stringified contents
+   ```
 
-### Visual Comparisons
+9. **Reference the secret in the GitHub Actions workflow**
 
-[Happo](https://happo.io/) is a cross browser screenshot testing library used to test for visual regressions. It is integrated with Playwright to capture screenshots of your application and compare them against a baseline to detect any visual changes and will upload the screenshots to the happo servers.
+   In `.github/workflows/test-nx-project-e2e.yaml`, add:
 
-To view and approve Happo diffs, open a pull request with your changes and let the e2e tests run. Once the tests are complete, the Happo report will appear in the list of CI jobs. If there are differences, you can approve or reject them. If you approve them, the new screenshots will be used as the baseline for future tests once merged.
+   ```yaml
+   E2E_NAME_OF_ROLE_STORAGE_STATE: ${{ secrets.E2E_NAME_OF_ROLE_STORAGE_STATE }}
+   ```
 
-Read more about Happo and how to review diffs here:
+10. **Delete the local storage state file**
+
+    Do not commit storage state files containing credentials, cookies, or tokens.
+
+## Visual Comparisons
+
+[Happo](https://happo.io/) is a cross-browser screenshot testing library used to test for visual regressions. It is integrated with Playwright to capture screenshots of the application and compare them against a baseline.
+
+To view and approve Happo diffs, open a pull request with your changes and let the e2e tests run. Once the tests are complete, the Happo report appears in the CI job list. If there are differences, approve or reject them in Happo.
+
+Read more:
+
 [Reviewing Happo Diffs](https://docs.happo.io/docs/reviewing-diffs)
 
-#### Basic setup to take Happo screenshots in your test file
+### Basic setup to take Happo screenshots
 
-```javascript
+```typescript
 import { test } from "@playwright/test";
 import happoPlaywright from "happo-playwright";
 
@@ -167,11 +756,11 @@ test.afterEach(async () => {
 });
 ```
 
-#### Taking a screenshot
+### Taking a screenshot
 
-Using html selector to take screenshot of entire page. Use something more specific if testing a component.
+Use a specific selector when testing a component. Use `html` only when intentionally testing the whole page.
 
-```javascript
+```typescript
 const selector = page.locator("html");
 
 await happoPlaywright.screenshot(page, selector, {
@@ -180,193 +769,92 @@ await happoPlaywright.screenshot(page, selector, {
 });
 ```
 
-If you experience flakiness, you can use the `takeStabilizedScreenshot` function instead. It contains an assertion to wait for the page to stabilize before taking the shot. See https://playwright.dev/docs/api/class-elementhandle#element-handle-wait-for-element-state for more information about the `stable` state.
+If screenshots are flaky, prefer `takeStabilizedScreenshot` and the shared stabilization helpers:
 
-Additionally, we have two helper functions to stabilize specific page elements, the grids (`stabilizeGrid`) and accordions (`stabilizeAccordion`).
-
-Additionally additionally, sometimes we were unable to get the screenshots to stabilize. In these cases, we only took the screenshots in the browsers that were stable. For example:
-
-```javascript
-// 📷 Cheese!
+```typescript
 await stabilizeAccordion(page, 4);
-await takeStabilizedScreenshot(happoPlaywright, operationsPage.page, {
+
+await takeStabilizedScreenshot(happoPlaywright, page, {
   component: "Operations Details Page cas_analyst",
   variant: "pending",
   targets: ["chrome"],
 });
 ```
 
-#### Using Happo on your local e2e tests
+### Using Happo locally
 
-To view diffs found while running your local e2e tests ask the dev team for access to the Happo dashboard. Add the Happo API key and secret to your .env file. The API key and secret can be found in the Happo dashboard under the Account section.
+Ask the dev team for access to the Happo dashboard. Add the Happo API key and secret to your `.env` file. After running e2e tests locally, screenshots can be viewed in the Happo dashboard as snap requests.
 
-After you run your e2e tests the screenshots can be viewed in the Happo dashboard as snap requests.
+## Accessibility testing with Playwright and Axe
 
-### Best Practices
+Accessibility is important. To test a page for accessibility issues, import the `analyzeAccessibility` helper and pass it the page object.
 
-#### Test Isolation
+```typescript
+import { analyzeAccessibility } from "@/e2e/utils/helpers";
 
-Ensure that each test is independent and does not rely on the state or outcome of other tests. This helps in maintaining a clean and predictable test suite.
-
-#### Use `expect` Assertions
-
-Use `expect` assertions to verify the expected behavior of the application. Playwright includes async matchers that will wait until the expected condition is met. Consider the following example:
-
-```javascript
-await expect(page.getByTestId("status")).toHaveText("Submitted");
-```
-
-Playwright will be re-testing the element with the test id of status until the fetched element has the "Submitted" text. It will re-fetch the element and check it over and over, until the condition is met or until the timeout is reached.
-
-### e2e Testing
-
-#### Prerequisites
-
-- To run playwright end-to-end tests for the first time, you may need to run `yarn playwright install ` to install the browsers
-  Ensure you have the configuration from file `bciers/bciers/.env.local.example` in `bciers/bciers/.env.local` with values reflecting instructions in file `bciers/bciers/.env.local.example`
-
-  1.0 Ensure the server is running:
-
-For BCIERS app tests the BCIERS apps and run the backend in two terminals:
-
-```bash
-cd bci && yarn dev-all
-cd bc_obps && make run
-```
-
-To run Registration e2e test, just run the `reg` app before running the tests:
-
-```bash
-cd bciers && yarn reg
-cd bc_obps && make run
-```
-
-2.0 Run the tests:
-
-Run tests from new terminal command:
-Run tests in the background using terminal command `yarn <app shortform>:e2e`. These commands are located in `package.json`:
-
-```bash
-cd bciers && yarn reg:e2e
-```
-
-Run tests with the Playwright GUI using terminal command:
-
-```bash
-cd bciers && yarn reg:e2e:ui
-```
-
-Run a single test using terminal command (example):
-
-```bash
-cd bciers && npx nx run compliance:e2e -- bciers/apps/compliance-e2e/tests/workflows/manage-obligation/report-compliance-obligation.spec.ts
-```
-
-### UI Mode (Local Development)
-
-When running Playwright in **UI mode**:
-
-```bash
-yarn <app>:e2e:ui
-```
-
-We **allow HMR (Hot Module Reload / Fast Refresh)** from Next.js 16.
-
-**Why:**
-
-- Faster iteration while writing or debugging tests
-- Immediate feedback when editing test files or POMs
-- Ideal for interactive debugging
-
-**Trade-offs:**
-
-- HMR can trigger React re-mounts and transient DOM states
-- Elements may briefly disappear/reappear
-- This can introduce timing-related flakiness
-
-To mitigate this, our tests follow these patterns:
-
-- Use `expect.toPass()` to retry entire interaction blocks
-- Wait for clear “page ready” signals (tabs, headings, grids)
-- Prefer stable, user-facing locators over structural selectors
-
-HMR logs such as:
-
-```
-[HMR] connected
-[Fast Refresh] rebuilding
-```
-
-are expected in UI mode and **do not indicate test failure**.
-
-Best Practice
-
-- **Use Playwright UI mode with HMR enabled** when developing and debugging tests.
-- If you encounter flaky behavior, prefer improving test stability (retry patterns, better readiness checks) rather than disabling HMR.
-- HMR should only be disabled when explicitly validating production-like behavior.
-
-### Debugging Playwright
-
-**HTML report**
-The HTML report shows you a report of all your tests that have been ran and on which browsers as well as how long they took. Tests can be filtered by passed tests, failed, flakey or skipped tests. You can also search for a particular test. Clicking on a test will open the detailed view where you can see more information on your tests such as the errors, the test steps and the trace.
-
-For debugging CI, you can download the HTML report artifact found in `GitHub\Actions\
-📊 e2e report artifact` and extract the files to `bciers/playwright-report`. To view the downloaded the HTML report artifact locally run terminal command:
-
-```bash
-cd bciers && yarn reg:e2e:report
-
-```
-
-#### Debugging Playwright in CI
-
-[Debugging CI Playwright documentation](https://playwright.dev/docs/ci-intro#downloading-the-html-report)
-
-If you are running into issues with your tests in CI, you can uncomment the Playwright html report upload steps in our GitHub Actions e2e workflow files. This will allow you to download the HTML report artifact from the CI job and view it locally if more context is needed than what is displayed in the failed job.
-
-These commented jobs are located in the `bciers/.github/workflows` directory in `test-nx-project-e2e.yaml`.
-
-#### Traces
-
-Traces are normally run in a Continuous Integration(CI) environment, because locally you can use UI Mode for developing and debugging tests. However, if you want to run traces locally without using UI Mode, you can force tracing to be on with --trace on.
-
-```bash
-npx playwright test --trace on
-```
-
-**Opening the trace**
-In the HTML report click on the trace icon next to the test name file name.
-
-### Accessibility testing with Playwright and Axe
-
-[Playwright accessiblity testing documentation](https://playwright.dev/docs/accessibility-testing)
-
-Accessibility is important. To test a page for accessibility issues import the `analyzeAccessibility` helper function in a playwright e2e test and pass it the page object:
-
-```javascript
-import { analyzeAccessibility, setupTestEnvironment } from "@/e2e/utils/helpers";
-
-...
-
-// ♿️ Analyze accessibility
 await analyzeAccessibility(page);
-
 ```
 
-If this step fails the library will provide details about why it failed and how to fix it.
+If this step fails, the accessibility library provides details about the issue and how to fix it.
 
 ## Testing Strategy
 
 ### Registration
 
-We have good vitest and pytest coverage (integration tests), so we've taken a minimalistic approach to e2e tests in Registration. We've also prioritized readability over abstraction, so there is some repetition in the tests, but this makes it easier to find failures (vs. trying to find the relevant value of a variable in a loop).
+Registration has strong Vitest and pytest coverage, so the Registration e2e suite intentionally stays minimal. The e2e tests focus on the highest-value user workflows.
 
-We load the db with our mock data before running tests.
+We prioritize readability over abstraction. Some repetition is acceptable when it makes failures easier to understand.
 
-We test:
+We load the database with mock data before running tests.
 
-- creating and registering a new SFO with a New Entrant purpose and a new operation rep
-- registering an existing LFO with Opt-In purpose and a new facility
-- accessibility on every form. Where the SFO/LFO form is the same, we analyze only in the SFO test
+Current Registration coverage includes:
 
-This covers 2/3 registration types (SFO/LFO), 2/6 purposes, and all of the form steps. We only fill in required fields, we only test as industry_user role, and we only test editable mode (not view).
+- creating and registering a new SFO with a New Entrant purpose and a new operation representative
+- registering an existing LFO with an Opt-In purpose and a new facility
+- accessibility checks on every form
+- SFO/LFO shared form accessibility covered once where the form is the same
+
+This covers:
+
+- 2 of 3 registration types: SFO and LFO
+- 2 of 6 purposes
+- all required form steps
+- `industry_user` role
+- editable mode only
+
+## Quick Reference Commands
+
+### Run Reporting e2e like CI
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e
+```
+
+### Run one Reporting test file headed with trace
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed --trace on
+```
+
+### Find Reporting traces
+
+```bash
+cd bciers
+find apps/reporting-e2e -type f -name "trace.zip"
+```
+
+### Open a Reporting trace
+
+```bash
+cd bciers
+yarn playwright show-trace apps/reporting-e2e/dist/.playwright/test-output/<trace-folder>/trace.zip
+```
+
+### Run one test by title
+
+```bash
+cd bciers
+BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium -g "Industry user starts, fills, and submits a new LFO report"
+```


### PR DESCRIPTION

### Run E2E like CI locally

Use `CI=true` to more closely match the CI environment. This is useful when a test passes in UI mode but fails in CI or vise versa:

```bash
cd bciers
BASE_URL=http://localhost:5000 CI=true yarn report:e2e
```

Run a specific Reporting test like CI:

```bash
cd bciers
BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium
```

Run headed while still using CI-like settings:

```bash
cd bciers
BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed
```

## Running Tests With Trace

Traces are the best way to debug CI-style failures because they show:

- each Playwright action
- screenshots before and after actions
- DOM snapshots
- console logs
- network requests
- locator resolution
- actionability checks

### Run a specific test with trace

```bash
cd bciers
BASE_URL=http://localhost:5000 CI=true yarn report:e2e -- tests/workflows/LFO/submit-report.spec.ts --project=chromium --headed --trace on
```

### Find trace files

Trace files may be written under the app-specific e2e output folder, not always root `dist`.

```bash
cd bciers
find . -type f -name "trace.zip"
```

### Open a trace

```bash
cd bciers
yarn playwright show-trace apps/reporting-e2e/dist/.playwright/test-output/workflows-LFO-submit-repor-d8122-nd-submits-a-new-LFO-report-chromium/trace.zip
```
