### PR TITLE
4688 Update raw activity report version when cloning for supplemental

### DIFF
--- a/bc_obps/reporting/service/report_supplementary_version_service/report_supplementary_cloning.py
+++ b/bc_obps/reporting/service/report_supplementary_version_service/report_supplementary_cloning.py
@@ -240,6 +240,9 @@ def clone_activity_raw_json_data(old_activity_to_clone: ReportActivity, new_faci
     cloned_raw_data = copy.deepcopy(old_raw_data)
     cloned_raw_data.pk = None  # Reset the primary key so a new record is created.
     cloned_raw_data.facility_report = new_facility_report  # Update the relationship to the new facility report.
+    cloned_raw_data.report_version = (  # Update the relationship to the new report version.
+        new_facility_report.report_version
+    )
     cloned_raw_data.save()
 
 

--- a/bc_obps/reporting/tests/service/test_report_supplementary_service/test_report_supplementary_cloning.py
+++ b/bc_obps/reporting/tests/service/test_report_supplementary_service/test_report_supplementary_cloning.py
@@ -135,6 +135,7 @@ class ReportSupplementaryCloningTests(TestCase):
         # Create a ReportRawActivityData for self.old_facility_activity
         self.old_facility_activity_raw_data = make_recipe(
             "reporting.tests.utils.report_raw_activity_data",
+            report_version=self.old_report_version,
             facility_report=self.old_facility_activity.facility_report,
             activity=self.old_facility_activity.activity,
             json_data=self.old_facility_activity.json_data,
@@ -476,7 +477,9 @@ class ReportSupplementaryCloningTests(TestCase):
             "The json_data of the cloned ReportActivity should match the original.",
         )
 
-        new_raw_data = ReportRawActivityData.objects.filter(facility_report=new_facility_report).all()
+        new_raw_data = ReportRawActivityData.objects.filter(
+            facility_report=new_facility_report, report_version=self.new_report_version
+        ).all()
         self.assertEqual(new_raw_data.count(), 1, "There should be one cloned ReportRawActivityData.")
         self.assertEqual(
             new_raw_data[0].json_data,


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-registration/issues/4688

When `report_version` was added to `report_raw_activity_data` in https://github.com/bcgov/cas-registration/issues/4512, handling for this field was not added to `report_supplementary_cloning`. This led to a bug where activity data could not be saved in a supplemental report. This PR fixes that.


### Testing
1. Submit a report with activity data
2. Start a supplementary report
3. Attempt to update activity data in supplementary report.
 - EXPECT: Update to succeed.