### PR TITLE
4542 - undo pr 4616 and filter false positives

### DIFF
--- a/bc_obps/reporting/api/report_review_changes.py
+++ b/bc_obps/reporting/api/report_review_changes.py
@@ -10,16 +10,6 @@ from .permissions import approved_industry_user_report_version_composite_auth
 from service.report_version_service import ReportVersionService
 from reporting.service.review_changes_service.report_review_changes_service import ReportReviewChangesService
 
-EXCLUDE_REPORT_PRODUCT_ID = {
-    "facility_reports": {
-        "__all__": {
-            "report_emission_allocation": {
-                "report_product_emission_allocations": {"__all__": {"products": {"__all__": {"report_product_id"}}}},
-            }
-        }
-    }
-}
-
 
 @router.get(
     "/report-version/{version_id}/diff-data",
@@ -48,8 +38,8 @@ def get_report_version_diff_data(request: HttpRequest, version_id: int) -> tuple
     previous_version = ReportVersionService.fetch_full_report_version(
         previous_version_id, prefetch_full_facility_report=True
     )
-    current_data = ReviewChangesVersionSchema.from_orm(current_version).dict(exclude=EXCLUDE_REPORT_PRODUCT_ID)
-    previous_data = ReviewChangesVersionSchema.from_orm(previous_version).dict(exclude=EXCLUDE_REPORT_PRODUCT_ID)
+    current_data = ReviewChangesVersionSchema.from_orm(current_version).dict()
+    previous_data = ReviewChangesVersionSchema.from_orm(previous_version).dict()
 
     changed = ReportReviewChangesService.get_report_version_diff_changes(previous_data, current_data)
 

--- a/bc_obps/reporting/schema/report_product_emission_allocation.py
+++ b/bc_obps/reporting/schema/report_product_emission_allocation.py
@@ -34,7 +34,6 @@ class ReportProductEmissionAllocationsSchemaIn(Schema):
 
 class ReportProductEmissionAllocationSchemaOut(Schema):
     report_product_id: int
-    product_id: int
     product_name: str
     allocated_quantity: float
 

--- a/bc_obps/reporting/service/report_emission_allocation_service.py
+++ b/bc_obps/reporting/service/report_emission_allocation_service.py
@@ -24,7 +24,6 @@ class ReportProductEmissionAllocationData:
     """
 
     report_product_id: int
-    product_id: int
     product_name: str
     allocated_quantity: Decimal | int
 
@@ -116,7 +115,6 @@ class ReportEmissionAllocationService:
                 ).first()
                 product = ReportProductEmissionAllocationData(
                     report_product_id=rp.pk,
-                    product_id=rp.product_id,
                     product_name=rp.product.name,
                     allocated_quantity=product_emission.allocated_quantity if product_emission else 0,
                 )
@@ -277,7 +275,6 @@ class ReportEmissionAllocationService:
             report_product_emission_allocation_totals.append(
                 ReportProductEmissionAllocationData(
                     report_product_id=rp.pk,
-                    product_id=rp.product_id,
                     product_name=rp.product.name,
                     allocated_quantity=allocated_quantity if allocated_quantity else 0,
                 )

--- a/bc_obps/reporting/service/review_changes_service/report_review_changes_service.py
+++ b/bc_obps/reporting/service/review_changes_service/report_review_changes_service.py
@@ -8,7 +8,6 @@ from .diff_helpers import _DIFF_KWARGS, _CHANGE_TYPE_MAP, detect_renames, diff_s
 
 
 NOISY_DIFF_KEYS = {
-    "report_product_id",
     "report_version",
     "is_supplementary_report",
     "is_latest_submitted",

--- a/bc_obps/reporting/service/review_changes_service/report_review_changes_service.py
+++ b/bc_obps/reporting/service/review_changes_service/report_review_changes_service.py
@@ -46,9 +46,31 @@ def _get_field_display_title(field_path: str, field_display_titles: Dict[str, st
     return field_display_titles.get(field_name)
 
 
+def _normalize_products(products: List[Any]) -> List[tuple[Any, Any]] | None:
+    """
+    Extracts core business identifiers (product name and allocated quantity) from a list
+    of raw product records and returns a predictably sorted, comparable structure.
+
+    Returns:
+        - A sorted list of (product_name, allocated_quantity) tuples.
+        - None if any individual product item is not a dictionary structure.
+    """
+    normalized_products = []
+    for product in products:
+        if not isinstance(product, dict):
+            return None
+        normalized_products.append(
+            (
+                product.get("product_name"),
+                product.get("allocated_quantity"),
+            )
+        )
+    return sorted(normalized_products, key=lambda x: str(x[0]))
+
+
 def _is_false_positive_product_change(change: Dict[str, Any]) -> bool:
     """
-    Determine if a chsnge item is a false positive that should be ignored.
+    Determine if a change item is a false positive that should be ignored.
     """
     old_value = change.get("old_value")
     new_value = change.get("new_value")
@@ -63,14 +85,15 @@ def _is_false_positive_product_change(change: Dict[str, Any]) -> bool:
         return False
 
     # Check for matching product names and quantities
-    for i in range(len(new_products)):
-        if (new_products[i].get('product_name') != old_products[i].get('product_name')) or (
-            new_products[i].get("allocated_quantity") != old_products[i].get('allocated_quantity')
-        ):
-            return False
+    old_normalized = _normalize_products(old_products)
+    new_normalized = _normalize_products(new_products)
 
-    # if all checks pass, it's a false positive (supp report created report_product_id with no change)
-    return True
+    if old_normalized is None or new_normalized is None:
+        return False
+
+    # if all checks pass and products are the same,
+    # it's a false positive (supp report created report_product_id with no change)
+    return old_normalized == new_normalized
 
 
 def _last_item_report_product_id(change: Dict[str, Any]) -> bool:

--- a/bc_obps/reporting/service/review_changes_service/report_review_changes_service.py
+++ b/bc_obps/reporting/service/review_changes_service/report_review_changes_service.py
@@ -46,6 +46,41 @@ def _get_field_display_title(field_path: str, field_display_titles: Dict[str, st
     return field_display_titles.get(field_name)
 
 
+def _is_false_positive_product_change(change: Dict[str, Any]) -> bool:
+    """
+    Determine if a chsnge item is a false positive that should be ignored.
+    """
+    old_value = change.get("old_value")
+    new_value = change.get("new_value")
+    if not isinstance(old_value, dict) or not isinstance(new_value, dict):
+        return False
+
+    old_products = old_value.get('products', [])
+    new_products = new_value.get('products', [])
+
+    # Check for equal amount of products
+    if len(old_products) != len(new_products):
+        return False
+
+    # Check for matching product names and quantities
+    for i in range(len(new_products)):
+        if (new_products[i].get('product_name') != old_products[i].get('product_name')) or (
+            new_products[i].get("allocated_quantity") != old_products[i].get('allocated_quantity')
+        ):
+            return False
+
+    # if all checks pass, it's a false positive (supp report created report_product_id with no change)
+    return True
+
+
+def _last_item_report_product_id(change: Dict[str, Any]) -> bool:
+    """
+    Edge case to check if last item is report_product_id, which would show empty diff category
+    """
+    field = change.get("field", "")
+    return isinstance(field, str) and field.endswith("['report_product_id']")
+
+
 class ReportReviewChangesService:
     @classmethod
     def get_report_version_diff_changes(cls, previous: dict, current: dict) -> List[Dict[str, Any]]:
@@ -65,7 +100,15 @@ class ReportReviewChangesService:
         prev_facs: Dict[str, dict] = previous.get('facility_reports') or {}
         curr_facs: Dict[str, dict] = current.get('facility_reports') or {}
         changes.extend(detect_renames(prev_facs, curr_facs))
-        changes.extend(diff_sections(prev_facs, curr_facs, "root['facility_reports']"))
+        changes.extend(
+            change
+            for change in diff_sections(prev_facs, curr_facs, "root['facility_reports']")
+            if not _is_false_positive_product_change(change)
+        )
+
+        # edge case if only item is report_product_id after filtering false positives
+        if len(changes) == 1 and _last_item_report_product_id(changes[0]):
+            changes = []
 
         for change in changes:
             change["field_display_title"] = _get_field_display_title(change["field"], field_display_titles)

--- a/bc_obps/reporting/tests/api/test_report_emission_allocation_api.py
+++ b/bc_obps/reporting/tests/api/test_report_emission_allocation_api.py
@@ -36,7 +36,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -44,7 +43,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -62,7 +60,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -70,7 +67,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -88,7 +84,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -96,7 +91,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -114,7 +108,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -122,7 +115,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -140,7 +132,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 100000.0000,
                                     }
@@ -148,7 +139,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 400000.0000,
                                     }
@@ -166,7 +156,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -174,7 +163,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -192,7 +180,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -200,7 +187,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -218,7 +204,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -226,7 +211,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -244,7 +228,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -252,7 +235,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -270,7 +252,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -278,7 +259,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -296,7 +276,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -304,7 +283,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -322,7 +300,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 1,
-                                        'product_id': 2,
                                         'product_name': 'Cement equivalent',
                                         'allocated_quantity': 0,
                                     }
@@ -330,7 +307,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                                 ReportProductEmissionAllocationData(
                                     **{
                                         'report_product_id': 2,
-                                        'product_id': 6,
                                         'product_name': 'Gypsum wallboard',
                                         'allocated_quantity': 0,
                                     }
@@ -344,7 +320,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                     ReportProductEmissionAllocationData(
                         **{
                             'report_product_id': 1,
-                            'product_id': 2,
                             'product_name': 'Cement equivalent',
                             'allocated_quantity': 100000.0000,
                         }
@@ -352,7 +327,6 @@ class TestReportEmissionAllocationApi(CommonTestSetup):
                     ReportProductEmissionAllocationData(
                         **{
                             'report_product_id': 2,
-                            'product_id': 6,
                             'product_name': 'Gypsum wallboard',
                             'allocated_quantity': 400000.0000,
                         }

--- a/bc_obps/reporting/tests/service/review_changes_service/test_review_changes_service.py
+++ b/bc_obps/reporting/tests/service/review_changes_service/test_review_changes_service.py
@@ -1,0 +1,187 @@
+import pytest
+from reporting.service.review_changes_service.report_review_changes_service import (
+    ReportReviewChangesService,
+    _is_false_positive_product_change,
+    _normalize_products,
+    _get_field_display_title,
+)
+
+pytestmark = pytest.mark.django_db
+
+BASE_PATH = "reporting.service.review_changes_service.report_review_changes_service"
+
+
+@pytest.fixture
+def mock_detect_renames(mocker):
+    return mocker.patch(
+        f"{BASE_PATH}.detect_renames",
+        return_value=[],
+    )
+
+
+@pytest.fixture
+def mock_diff_sections(mocker):
+    return mocker.patch(
+        f"{BASE_PATH}.diff_sections",
+        return_value=[],
+    )
+
+
+@pytest.fixture
+def mock_fix_facility_uuid_in_path(mocker):
+    return mocker.patch(
+        f"{BASE_PATH}.fix_facility_uuid_in_path",
+        side_effect=lambda path, _: path,
+    )
+
+
+@pytest.fixture
+def mock_get_reporting_field_titles(mocker):
+    return mocker.patch(
+        f"{BASE_PATH}._get_reporting_field_display_titles",
+        return_value={"total_emissions": "Total Emissions Field"},
+    )
+
+
+class TestGetFieldDisplayTitle:
+    def test_parses_nested_bracket_notation_correctly(self):
+        titles = {"target_field": "Target Display Name"}
+        path = "root['facility_reports']['uuid-123']['target_field']"
+        assert _get_field_display_title(path, titles) == "Target Display Name"
+
+    def test_handles_trailing_array_indices_safely(self):
+        titles = {"target_field": "Target Display Name"}
+        path = "root['facility_reports'][0]"
+        assert _get_field_display_title(path, titles) is None
+
+
+class TestNormalizeProducts:
+    def test_normalizes_products_by_name_and_allocated_quantity(self):
+        products = [
+            {"product_name": "Product B", "allocated_quantity": 50, "report_product_id": 2},
+            {"product_name": "Product A", "allocated_quantity": 100, "report_product_id": 1},
+        ]
+        result = _normalize_products(products)
+        assert result == [("Product A", 100), ("Product B", 50)]
+
+    def test_returns_none_for_malformed_product(self):
+        products = [{"product_name": "Product A", "allocated_quantity": 100}, "invalid-product"]
+        assert _normalize_products(products) is None
+
+
+class TestIsFalsePositiveProductChange:
+    def test_returns_true_when_product_allocations_are_equivalent(self):
+        change = {
+            "old_value": {
+                "products": [{"product_name": "Product A", "allocated_quantity": 100, "report_product_id": 1}]
+            },
+            "new_value": {
+                "products": [{"product_name": "Product A", "allocated_quantity": 100, "report_product_id": 2}]
+            },
+        }
+        assert _is_false_positive_product_change(change) is True
+
+    def test_returns_true_when_products_are_same_but_order_changed(self):
+        change = {
+            "old_value": {
+                "products": [
+                    {"product_name": "Product A", "allocated_quantity": 100, "report_product_id": 1},
+                    {"product_name": "Product B", "allocated_quantity": 50, "report_product_id": 2},
+                ]
+            },
+            "new_value": {
+                "products": [
+                    {"product_name": "Product B", "allocated_quantity": 50, "report_product_id": 22},
+                    {"product_name": "Product A", "allocated_quantity": 100, "report_product_id": 11},
+                ]
+            },
+        }
+        assert _is_false_positive_product_change(change) is True
+
+    def test_returns_false_when_allocated_quantity_changed(self):
+        change = {
+            "old_value": {"products": [{"product_name": "Product A", "allocated_quantity": 100}]},
+            "new_value": {"products": [{"product_name": "Product A", "allocated_quantity": 200}]},
+        }
+
+        assert _is_false_positive_product_change(change) is False
+
+    def test_returns_false_when_product_name_changed(self):
+        change = {
+            "old_value": {"products": [{"product_name": "Product A", "allocated_quantity": 100}]},
+            "new_value": {"products": [{"product_name": "Product B", "allocated_quantity": 100}]},
+        }
+
+        assert _is_false_positive_product_change(change) is False
+
+    def test_returns_false_when_old_or_new_value_is_not_dict(self):
+        change = {
+            "old_value": "bad-value",
+            "new_value": {"products": []},
+        }
+
+        assert _is_false_positive_product_change(change) is False
+
+
+class TestReportReviewChangesService:
+    def test_get_report_version_diff_changes_success(
+        self,
+        mock_get_reporting_field_titles,
+        mock_detect_renames,
+        mock_diff_sections,
+        mock_fix_facility_uuid_in_path,
+    ):
+
+        prev = {"total_emissions": 500, "status": "draft"}
+        curr = {"total_emissions": 750, "status": "submitted"}
+
+        results = ReportReviewChangesService.get_report_version_diff_changes(prev, curr)
+
+        # "status" is noisy, so it should be skipped; only total_emissions remains
+        assert len(results) == 1
+        assert results == [
+            {
+                "field": "root['total_emissions']",
+                "field_display_title": "Total Emissions Field",
+                "old_value": 500,
+                "new_value": 750,
+                "change_type": "modified",
+            }
+        ]
+        assert results[0]["old_value"] == 500
+        assert results[0]["new_value"] == 750
+        assert results[0]["field_display_title"] == "Total Emissions Field"
+
+    def test_get_report_version_diff_changes_ignores_report_product_id_only_change(
+        self,
+        mock_get_reporting_field_titles,
+        mock_detect_renames,
+        mock_diff_sections,
+        mock_fix_facility_uuid_in_path,
+    ):
+        prev = {
+            "report_compliance_summary": {
+                "products": [
+                    {
+                        "name": "Product A",
+                        "allocated_quantity": 100,
+                        "report_product_id": 1,
+                    }
+                ]
+            }
+        }
+        curr = {
+            "report_compliance_summary": {
+                "products": [
+                    {
+                        "name": "Product A",
+                        "allocated_quantity": 100,
+                        "report_product_id": 2,
+                    }
+                ]
+            }
+        }
+
+        results = ReportReviewChangesService.get_report_version_diff_changes(prev, curr)
+
+        assert results == []

--- a/bciers/apps/reporting/src/app/components/changeReview/templates/EmissionAllocationChangeView.tsx
+++ b/bciers/apps/reporting/src/app/components/changeReview/templates/EmissionAllocationChangeView.tsx
@@ -340,6 +340,30 @@ export const EmissionAllocationChangeView: React.FC<
     return result;
   }
 
+  // Helper to determine if change is a false positive due to supplementary report report_product_id
+  function isFalsePositive(change: DisplayChangeItem): boolean {
+    // Check for equal value
+    if (change.oldValue !== change.newValue) return false;
+
+    // Check for equal amount of products
+    const oldProducts = (change as any).old_value?.products || [];
+    const newProducts = (change as any).new_value?.products || [];
+    if (oldProducts.length !== newProducts.length) return false;
+
+    // Check for matching product names and quantities
+    for (let i = 0; i < newProducts.length; i++) {
+      if (
+        newProducts[i]?.product_name !== oldProducts[i]?.product_name ||
+        newProducts[i]?.allocated_quantity !==
+          oldProducts[i]?.allocated_quantity
+      )
+        return false;
+    }
+
+    // If all checks passed, it's a false positive
+    return true;
+  }
+
   const generalFields = data
     .filter(
       (change) =>
@@ -359,7 +383,14 @@ export const EmissionAllocationChangeView: React.FC<
     .filter(isRelevantTotalChange)
     .flatMap(mapTotalChange);
 
-  const categorizedChanges = processChanges();
+  const categorizedChanges = processChanges()
+    .map((categorizedChange) => ({
+      ...categorizedChange,
+      changes: categorizedChange?.changes.filter(
+        (change) => !isFalsePositive(change),
+      ),
+    }))
+    .filter((categorizedChange) => categorizedChange.changes.length > 0);
 
   // Render section for a category
   const CategorySection = ({ category }: { category: ProcessedChange }) => (

--- a/bciers/apps/reporting/src/app/components/changeReview/templates/EmissionAllocationChangeView.tsx
+++ b/bciers/apps/reporting/src/app/components/changeReview/templates/EmissionAllocationChangeView.tsx
@@ -340,30 +340,6 @@ export const EmissionAllocationChangeView: React.FC<
     return result;
   }
 
-  // Helper to determine if change is a false positive due to supplementary report report_product_id
-  function isFalsePositive(change: DisplayChangeItem): boolean {
-    // Check for equal value
-    if (change.oldValue !== change.newValue) return false;
-
-    // Check for equal amount of products
-    const oldProducts = (change as any).old_value?.products || [];
-    const newProducts = (change as any).new_value?.products || [];
-    if (oldProducts.length !== newProducts.length) return false;
-
-    // Check for matching product names and quantities
-    for (let i = 0; i < newProducts.length; i++) {
-      if (
-        newProducts[i]?.product_name !== oldProducts[i]?.product_name ||
-        newProducts[i]?.allocated_quantity !==
-          oldProducts[i]?.allocated_quantity
-      )
-        return false;
-    }
-
-    // If all checks passed, it's a false positive
-    return true;
-  }
-
   const generalFields = data
     .filter(
       (change) =>
@@ -383,14 +359,7 @@ export const EmissionAllocationChangeView: React.FC<
     .filter(isRelevantTotalChange)
     .flatMap(mapTotalChange);
 
-  const categorizedChanges = processChanges()
-    .map((categorizedChange) => ({
-      ...categorizedChange,
-      changes: categorizedChange?.changes.filter(
-        (change) => !isFalsePositive(change),
-      ),
-    }))
-    .filter((categorizedChange) => categorizedChange.changes.length > 0);
+  const categorizedChanges = processChanges();
 
   // Render section for a category
   const CategorySection = ({ category }: { category: ProcessedChange }) => (


### PR DESCRIPTION
resolves: [4542](https://github.com/bcgov/cas-registration/issues/4542)
undoes: [4616](https://github.com/bcgov/cas-registration/pull/4616)

changes:

- undo 4616
- removed `report_product_id` from noisy diff keys
- new solution to filter false positive changes based on matching the report product name