### PR TITLE
Chore/4705 package minimum age

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+npmMinimalAgeGate: 7d

--- a/bc_obps/.tool-versions
+++ b/bc_obps/.tool-versions
@@ -1,3 +1,3 @@
 python 3.12.11
-poetry 2.3.3
+poetry 2.4.1
 postgres 16.2

--- a/bc_obps/poetry.toml
+++ b/bc_obps/poetry.toml
@@ -1,0 +1,2 @@
+[solver]
+min-release-age = 7

--- a/bciers/.yarnrc.yml
+++ b/bciers/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+npmMinimalAgeGate: 7d

--- a/docs/backend/misc.md
+++ b/docs/backend/misc.md
@@ -44,3 +44,15 @@ def my_migration_function(apps, schema_editor):
 ```
 
 Reference: <https://codereview.doctor/features/django/best-practice/avoid-model-imports-in-migrations>
+
+## Poetry
+
+We use Poetry to manage our python packages.
+
+### New package delay
+
+Poetry is configured to disallow adding packages younger than 7 days old, in an effort to prevent supply chain attacks. If a critical pacakage release is required that is younger than seven days an exception rule must be added to allow that package. **This should be removed once the 7 days have elapsed**.
+
+In `/bc_obps/poetry.toml`, under the `[solver]` header, add `min-release-age-exclude = "{package_name}"`. This can also be done from the command line in the `/bc_obps` folder with `poetry config solver.min-release-age-exclude "package_name" --local`. You can then update the package to the critical version required.
+
+See the [Poetry documentation](https://python-poetry.org/docs/configuration#solvermin-release-age-exclude) for more info.

--- a/docs/frontend/developer-guide.md
+++ b/docs/frontend/developer-guide.md
@@ -230,3 +230,15 @@ module.exports = {
   prefix: 'tw-',   👈 Use your desired prefix
 }
 ```
+
+## Yarn
+
+We use Yarn to manage our npm packages.
+
+### New package delay
+
+Yarn is configured to disallow adding packages younger than 7 days old, in an effort to prevent supply chain attacks. If a critical pacakage release is required that is younger than seven days an exception rule must be added to allow that package. **This should be removed once the 7 days have elapsed**.
+
+In `.yarnrc.yaml` (either in the repository root or in `/bciers`), add `npmPreapprovedPackages: [{package_name}]`. You can then update the package to the critical version required.
+
+See the [Yarn documentation](https://yarnpkg.com/configuration/yarnrc#npmPreapprovedPackages) for more details.

--- a/renovate.json5
+++ b/renovate.json5
@@ -45,7 +45,7 @@
     schedule: ["every weekend"],
   },
 
-  // minimumReleaseAge: "3 days"
+   minimumReleaseAge: "7 days"
   // Waits N days before opening a PR for a newly released version.
   // Prevents chasing packages that publish a bad release and immediately patch it —
   // Renovate will simply wait and open a PR for the stable follow-up version instead.


### PR DESCRIPTION
Addresses #4705. Adds package age limits to the package managers we use, in order to reduce vulnerability to supply-chain attacks.

## Changes 🚧

- Added age gate configs to Poetry, Yarn and Renovate.
- Added documentation for targeted bypassing of age gates.

## To test 🔬

1. Poetry has been updated, run `asdf plugin update poetry` to match the version used, and then `asdf reshim`.
1. In the `/bciers` folder, run `yarn add -D @typescript/native-preview` (a package with daily releases). 
    1. Run `yarn why @typescript/native-preview`, and the package version should be older than 7 days (version format is `7.0.0-dev.2026MMDD`.
    1. Run `yarn add -D @typescript/native-preview@7.0.0-dev.2026MMDD`, where `MMDD` is a few days newer than above. Yarn should fail with an error of `No candidates found` in the resolution step for that package.
    1. Clean up the package with `yarn remove @typescript/native-preview`.

1. In the `/bc_obps` folder, run `poetry add tf-nightly --dry-run`. The first line should list the version added, in the format `Using version ^2.22.0.dev2026MMDD for tf-nightly`, check the version selected is older than 7 days. 
    1. Attempt to run `poetry add tf-nightly@2.22.0.dev2026MMDD`, where `MMDD` is a few days newer than above. Poetry should report `Could not find a matching version of package tf-nightly`.

## Notes 📝

Renovate will still create PRs for packages requiring updates, but will flag them as pending. See the [Renovate docs for more info](https://docs.renovatebot.com/key-concepts/minimum-release-age/).