### PR TITLE
chore: fix log index for check-document-file-status 

### DIFF
--- a/helm/cas-bciers/templates/backend/check-file-status-deployment.yaml
+++ b/helm/cas-bciers/templates/backend/check-file-status-deployment.yaml
@@ -43,7 +43,7 @@ spec:
               readOnly: true
         {{- include "cas-logging-sidecar.containers" (dict
             "containerToSidecar" "check-document-file-status"
-            "logName" "cas-bciers-dev-logs"
+            "logName" (index .Values "cas-logging-sidecar" "logName")
             "host" (index .Values "cas-logging-sidecar" "host")
             "appName" "check-document-file-status") | nindent 8 }}
       volumes:


### PR DESCRIPTION
All logs from all environments (dev/test/prod) were being indexed as "dev", making it impossible to filter only the prod logs when looking at this job in kibana.