### PR TITLE
Fix incorrect error message on production data page for SFOs without regulated products

### DIFF
--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -11,7 +11,7 @@ import {
   TitleOnlyFieldTemplate,
 } from "@bciers/components/form/fields";
 import { createFormContext } from "../shared/formContextHelpers";
-import NoRegulatedProductsAlertContent from "@reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate";
+import NoRegulatedProductsAlertFieldTemplate from "@reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate";
 
 interface Props {
   report_version_id: number;
@@ -80,7 +80,7 @@ const ProductionDataForm: React.FC<Props> = ({
     "ui:FieldTemplate": FieldTemplate,
     "ui:classNames": "form-heading-label",
     no_regulated_products_alert: {
-      "ui:FieldTemplate": NoRegulatedProductsAlertContent,
+      "ui:FieldTemplate": NoRegulatedProductsAlertFieldTemplate,
     },
   };
 

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -11,6 +11,7 @@ import {
   TitleOnlyFieldTemplate,
 } from "@bciers/components/form/fields";
 import { createFormContext } from "../shared/formContextHelpers";
+import NoRegulatedProductsAlertContent from "@reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate";
 
 interface Props {
   report_version_id: number;
@@ -64,29 +65,73 @@ const ProductionDataForm: React.FC<Props> = ({
     },
   };
 
+  const noRegulatedProductSFOSchema: RJSFSchema = {
+    type: "object",
+    title: "Production Data",
+    properties: {
+      no_regulated_products_alert: {
+        type: "object",
+        readOnly: true,
+      },
+    },
+  };
+
+  const noRegulatedProductSFOUiSchema: UiSchema = {
+    "ui:FieldTemplate": FieldTemplate,
+    "ui:classNames": "form-heading-label",
+    no_regulated_products_alert: {
+      "ui:FieldTemplate": NoRegulatedProductsAlertContent,
+    },
+  };
+
   const [formData, setFormData] = useState<any>(initialFormData);
   const [errors, setErrors] = useState<string[]>();
 
-  // Short circuit to allow LFO facilities to continue past this form without a regulated product to select
-  if (
-    ["Small Aggregate", "Medium Facility", "Large Facility"].includes(
-      facilityType,
-    ) &&
-    allowedProducts.length < 1
-  ) {
-    return (
-      <MultiStepFormWithTaskList
-        taskListElements={navigationInformation.taskList}
-        schema={noRegulatedProductSchema}
-        uiSchema={noRegulatedProductUiSchema}
-        formData={formData}
-        backUrl={navigationInformation.backUrl}
-        continueUrl={navigationInformation.continueUrl}
-        steps={navigationInformation.headerSteps}
-        initialStep={navigationInformation.headerStepIndex}
-        saveButtonDisabled={true}
-      />
-    );
+  // No regulated product short circuits
+  if (allowedProducts.length < 1) {
+    // Short circuit to allow LFO facilities to continue past this form without a regulated product to select
+    if (
+      ["Small Aggregate", "Medium Facility", "Large Facility"].includes(
+        facilityType,
+      )
+    ) {
+      return (
+        <MultiStepFormWithTaskList
+          taskListElements={navigationInformation.taskList}
+          schema={noRegulatedProductSchema}
+          uiSchema={noRegulatedProductUiSchema}
+          formData={formData}
+          backUrl={navigationInformation.backUrl}
+          continueUrl={navigationInformation.continueUrl}
+          steps={navigationInformation.headerSteps}
+          initialStep={navigationInformation.headerStepIndex}
+          saveButtonDisabled={true}
+        />
+      );
+    } else {
+      // Short circuit to show error message for SFO facilities that have no regulated products
+      return (
+        <MultiStepFormWithTaskList
+          taskListElements={navigationInformation.taskList}
+          schema={noRegulatedProductSFOSchema}
+          uiSchema={noRegulatedProductSFOUiSchema}
+          formData={formData}
+          backUrl={navigationInformation.backUrl}
+          continueUrl={navigationInformation.continueUrl}
+          steps={navigationInformation.headerSteps}
+          initialStep={navigationInformation.headerStepIndex}
+          errors={["A product must be selected."]}
+          saveButtonDisabled={true}
+          submitButtonDisabled={true}
+          formContext={{
+            no_regulated_products_alert: {
+              report_version_id,
+              facility_id,
+            },
+          }}
+        />
+      );
+    }
   }
 
   const onChange = (newFormData: {

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -126,7 +126,6 @@ const ProductionDataForm: React.FC<Props> = ({
           formContext={{
             no_regulated_products_alert: {
               report_version_id,
-              facility_id,
             },
           }}
         />

--- a/bciers/apps/reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate.tsx
@@ -11,7 +11,7 @@ const LinkToActivitiesPage: React.FC<Props> = ({ report_version_id }) => (
   </Link>
 );
 
-const NoRegulatedProductsAlertContent: React.FC<Props> = (props) => {
+const NoRegulatedProductsAlertFieldTemplate: React.FC<Props> = (props) => {
   return (
     <div>
       No regulated products selected on <LinkToActivitiesPage {...props} />.
@@ -21,6 +21,6 @@ const NoRegulatedProductsAlertContent: React.FC<Props> = (props) => {
 };
 
 export default AlertFieldTemplateFactory(
-  NoRegulatedProductsAlertContent,
+  NoRegulatedProductsAlertFieldTemplate,
   "ALERT",
 );

--- a/bciers/apps/reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate.tsx
@@ -1,0 +1,32 @@
+import AlertFieldTemplateFactory from "@bciers/components/form/fields/AlertFieldTemplateFactory";
+import Link from "next/link";
+
+interface Props {
+  report_version_id: number;
+  facility_id: string;
+}
+
+const LinkToActivitiesPage: React.FC<Props> = ({
+  report_version_id,
+  facility_id,
+}) => (
+  <Link
+    href={`/reports/${report_version_id}/facilities/${facility_id}/activities`}
+  >
+    Review Operation Information
+  </Link>
+);
+
+const NoRegulatedProductsAlertContent: React.FC<Props> = (props) => {
+  return (
+    <div>
+      No regulated products selected on <LinkToActivitiesPage {...props} />.
+      Expected one or more regulated products to be selected.
+    </div>
+  );
+};
+
+export default AlertFieldTemplateFactory(
+  NoRegulatedProductsAlertContent,
+  "ALERT",
+);

--- a/bciers/apps/reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate.tsx
@@ -3,16 +3,10 @@ import Link from "next/link";
 
 interface Props {
   report_version_id: number;
-  facility_id: string;
 }
 
-const LinkToActivitiesPage: React.FC<Props> = ({
-  report_version_id,
-  facility_id,
-}) => (
-  <Link
-    href={`/reports/${report_version_id}/facilities/${facility_id}/activities`}
-  >
+const LinkToActivitiesPage: React.FC<Props> = ({ report_version_id }) => (
+  <Link href={`/reports/${report_version_id}/review-operation-information`}>
     Review Operation Information
   </Link>
 );

--- a/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
@@ -81,10 +81,10 @@ describe("The ProductionDataForm component", () => {
     const calledProps = mockMultiStepFormWithTaskList.mock.calls[0][0];
     expect(
       mockMultiStepFormWithTaskList.mock.calls[0][0].schema.properties
-        .product_selection_title.title == "No Regulated Products to select",
-    );
-    expect(calledProps.continueUrl == "Continue");
-    expect(calledProps.saveButtonDisabled == true);
+        .product_selection_title.title,
+    ).toBe("No Regulated Products to select");
+    expect(calledProps.continueUrl).toBe("continue");
+    expect(calledProps.saveButtonDisabled).toBe(true);
   });
 
   it("Blocks an SFO facility and shows an error banner + message when no regulated products are available to be selected", async () => {
@@ -108,24 +108,23 @@ describe("The ProductionDataForm component", () => {
     );
 
     const calledProps = mockMultiStepFormWithTaskList.mock.calls[0][0];
-    // Alert
-    expect(
-      mockMultiStepFormWithTaskList.mock.calls[0][0].schema.properties
-        .no_regulated_products_alert.title == "No Regulated Products to select",
-    );
-    // buttons
-    expect(calledProps.continueUrl == "Continue");
-    expect(calledProps.saveButtonDisabled == true);
-    expect(calledProps.submitButtonDisabled == true);
-    // error banner (mocking so only check if properties are there)
-    expect(
-      calledProps.schema.properties.no_regulated_products_alert.type ==
-        "object",
-    );
-    expect(
-      calledProps.schema.properties.no_regulated_products_alert.readOnly ==
-        true,
-    );
+
+    expect(mockMultiStepFormWithTaskList).toHaveBeenCalledOnce();
+    // error message + disabled buttons
+    expect(calledProps.errors).toEqual(["A product must be selected."]);
+    expect(calledProps.saveButtonDisabled).toBe(true);
+    expect(calledProps.submitButtonDisabled).toBe(true);
+    // error banner
+    expect(calledProps.schema.properties.no_regulated_products_alert).toEqual({
+      type: "object",
+      readOnly: true,
+    });
+    // formContext used by AlertFieldTemplateFactory
+    expect(calledProps.formContext).toEqual({
+      no_regulated_products_alert: {
+        report_version_id: 1000,
+      },
+    });
   });
 
   it("on change, adds an item to the form data when a checkbox is checked", async () => {

--- a/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
@@ -87,6 +87,47 @@ describe("The ProductionDataForm component", () => {
     expect(calledProps.saveButtonDisabled == true);
   });
 
+  it("Blocks an SFO facility and shows an error banner + message when no regulated products are available to be selected", async () => {
+    const mockPush = vi.fn();
+    mockRouter.mockReturnValue({ push: mockPush });
+
+    render(
+      <ProductionDataForm
+        allowedProducts={[]}
+        initialData={[]}
+        facility_id="abcd"
+        report_version_id={1000}
+        schema={{ testSchema: true }}
+        navigationInformation={dummyNavigationInformation}
+        facilityType={"Single Facility"}
+        isPulpAndPaper={false}
+        overlappingIndustrialProcessEmissions={0}
+        reportingYear={2024}
+        isOptedOut={false}
+      />,
+    );
+
+    const calledProps = mockMultiStepFormWithTaskList.mock.calls[0][0];
+    // Alert
+    expect(
+      mockMultiStepFormWithTaskList.mock.calls[0][0].schema.properties
+        .no_regulated_products_alert.title == "No Regulated Products to select",
+    );
+    // buttons
+    expect(calledProps.continueUrl == "Continue");
+    expect(calledProps.saveButtonDisabled == true);
+    expect(calledProps.submitButtonDisabled == true);
+    // error banner (mocking so only check if properties are there)
+    expect(
+      calledProps.schema.properties.no_regulated_products_alert.type ==
+        "object",
+    );
+    expect(
+      calledProps.schema.properties.no_regulated_products_alert.readOnly ==
+        true,
+    );
+  });
+
   it("on change, adds an item to the form data when a checkbox is checked", async () => {
     render(
       <ProductionDataForm

--- a/bciers/apps/reporting/src/tests/components/products/ProductionDataPage.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/products/ProductionDataPage.test.tsx
@@ -120,9 +120,10 @@ describe("The Production Data component", () => {
         reporting_year: 2020,
       },
       payload: {
-        allowed_products: [],
+        allowed_products: [{ product_id: 123, name: "testProduct" }],
         report_products: [
           {
+            product_id: 123,
             product_name: "testProduct",
             unit: "tonnes of tests",
           },
@@ -132,7 +133,7 @@ describe("The Production Data component", () => {
     });
 
     render(await ProductionDataPage(props));
-    expect(screen.getByText("testProduct")).toBeVisible();
+    expect(screen.getAllByText("testProduct")[0]).toBeVisible();
     expect(
       screen.queryByLabelText("Production data for Apr 1 - Dec 31, 2024*"),
     ).not.toBeInTheDocument();
@@ -170,7 +171,7 @@ describe("The Production Data component", () => {
         reporting_year: 2024,
       },
       payload: {
-        allowed_products: [],
+        allowed_products: [{ product_id: 123, name: "testProduct" }],
         report_products: [
           {
             product_name: "testProduct",
@@ -199,7 +200,7 @@ describe("The Production Data component", () => {
         is_operation_opted_out: true,
       },
       payload: {
-        allowed_products: [],
+        allowed_products: [{ id: 123, name: "testProduct" }],
         report_products: [
           {
             product_name: "testProduct",

--- a/bciers/apps/reporting/src/tests/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate.test.tsx
+++ b/bciers/apps/reporting/src/tests/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate.test.tsx
@@ -1,4 +1,4 @@
-import NoRegulatedProductsAlertContent from "@reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate";
+import NoRegulatedProductsAlertFieldTemplate from "@reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate";
 import Form from "@rjsf/core";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import { render, screen } from "@testing-library/react";
@@ -15,7 +15,7 @@ const schema: RJSFSchema = {
 
 const uiSchema: UiSchema = {
   no_regulated_products_alert: {
-    "ui:FieldTemplate": NoRegulatedProductsAlertContent,
+    "ui:FieldTemplate": NoRegulatedProductsAlertFieldTemplate,
   },
 };
 

--- a/bciers/apps/reporting/src/tests/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate.test.tsx
+++ b/bciers/apps/reporting/src/tests/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate.test.tsx
@@ -1,0 +1,46 @@
+import NoRegulatedProductsAlertContent from "@reporting/src/data/jsonSchema/facility/NoRegulatedProductsAlertFieldTemplate";
+import Form from "@rjsf/core";
+import { RJSFSchema, UiSchema } from "@rjsf/utils";
+import { render, screen } from "@testing-library/react";
+
+const schema: RJSFSchema = {
+  type: "object",
+  properties: {
+    no_regulated_products_alert: {
+      type: "object",
+      readOnly: true,
+    },
+  },
+};
+
+const uiSchema: UiSchema = {
+  no_regulated_products_alert: {
+    "ui:FieldTemplate": NoRegulatedProductsAlertContent,
+  },
+};
+
+describe("The No Regulated Products Alert", () => {
+  it("renders links to the activities information page", () => {
+    render(
+      <Form
+        schema={schema}
+        uiSchema={uiSchema}
+        validator={{} as any}
+        formData={{}}
+        formContext={{
+          no_regulated_products_alert: {
+            report_version_id: 123,
+          },
+        }}
+      />,
+    );
+
+    const links = screen.getAllByRole("link", {
+      name: "Review Operation Information",
+    });
+
+    for (const link of links) {
+      expect(link.href).toMatch("/reports/123/review-operation-information");
+    }
+  });
+});


### PR DESCRIPTION
will resolve [4655](https://github.com/bcgov/cas-registration/issues/4655)

- added shortcut with proper error message when sfo has unregulated products
- added error banner template with a link to `review-operation-information` page
- updated tests related