### PR TITLE
chore: move deprecated enumNames from schema to uiSchema (rjsf6 pattern)

### DIFF
--- a/bciers/apps/registration/app/components/transfers/TransferForm.tsx
+++ b/bciers/apps/registration/app/components/transfers/TransferForm.tsx
@@ -8,10 +8,7 @@ import { useRouter } from "next/navigation";
 import { IChangeEvent } from "@rjsf/core";
 import { TransferFormData } from "@/registration/app/components/transfers/types";
 import { OperatorRow } from "@/administration/app/components/operators/types";
-import {
-  createTransferSchema,
-  transferUISchema,
-} from "@/registration/app/data/jsonSchema/transfer/transfer";
+import { createTransferSchemas } from "@/registration/app/data/jsonSchema/transfer/transfer";
 import fetchFacilitiesPageData from "@/administration/app/components/facilities/fetchFacilitiesPageData";
 import { FacilityRow } from "@/administration/app/components/facilities/types";
 import TaskList from "@bciers/components/form/components/TaskList";
@@ -30,12 +27,13 @@ export default function TransferForm({
   formData,
   operators,
 }: Readonly<TransferFormProps>) {
+  const { transferSchema, transferUISchema } = createTransferSchemas(operators);
   const router = useRouter();
 
   const [formState, setFormState] = useState(formData);
   const [key, resetKey] = useKey();
   const [error, setError] = useState(undefined);
-  const [schema, setSchema] = useState(createTransferSchema(operators));
+  const [schema, setSchema] = useState(transferSchema);
   const [uiSchema, setUiSchema] = useState(transferUISchema);
   const [fromOperatorOperations, setFromOperatorOperations] = useState(
     [] as any,
@@ -143,7 +141,13 @@ export default function TransferForm({
 
     setFromOperatorOperations(fromRes.rows);
     setToOperatorOperations(toRes.rows);
-    setSchema(createTransferSchema(operators, fromRes.rows, toRes.rows));
+    const updatedSchemaObjects = createTransferSchemas(
+      operators,
+      fromRes.rows,
+      toRes.rows,
+    );
+    setSchema(updatedSchemaObjects.transferSchema);
+    setUiSchema(updatedSchemaObjects.transferUISchema);
 
     // reset dependent selections
     setFormState({
@@ -190,15 +194,14 @@ export default function TransferForm({
       (operation: OperationRow) =>
         operation.operation__id !== transferFormData?.from_operation,
     );
-
-    setSchema(
-      createTransferSchema(
-        operators,
-        fromOperatorOperations,
-        filteredToOperatorOperations,
-        facilitiesRes.rows,
-      ),
+    const updatedSchemaObjects = createTransferSchemas(
+      operators,
+      fromOperatorOperations,
+      filteredToOperatorOperations,
+      facilitiesRes.rows,
     );
+    setSchema(updatedSchemaObjects.transferSchema);
+    setUiSchema(updatedSchemaObjects.transferUISchema);
 
     setFormState({
       ...transferFormData,

--- a/bciers/apps/registration/app/data/jsonSchema/transfer/transfer.ts
+++ b/bciers/apps/registration/app/data/jsonSchema/transfer/transfer.ts
@@ -5,7 +5,7 @@ import { FacilityRow } from "@/administration/app/components/facilities/types";
 import { OperationRow } from "@/administration/app/components/operations/types";
 import { OperatorRow } from "@/administration/app/components/operators/types";
 
-export const createTransferSchema = (
+export const createTransferSchemas = (
   operatorOptions: OperatorRow[],
   operationOptions: OperationRow[] = [], // fromOperationOptions and operationOptions are the same
   toOperationOptions: OperationRow[] = [],
@@ -130,6 +130,54 @@ export const createTransferSchema = (
     },
   };
 
+  const transferUISchema: UiSchema = {
+    "ui:FieldTemplate": SectionFieldTemplate,
+    "ui:options": {
+      label: false,
+    },
+    transfer_header: {
+      "ui:FieldTemplate": FieldTemplate,
+      "ui:classNames": "form-heading mb-8",
+    },
+    transfer_preface: {
+      "ui:classNames": "text-bc-bg-blue text-md",
+    },
+    from_operator: {
+      "ui:widget": "ComboBox",
+      "ui:placeholder": "Select the current operator",
+    },
+    to_operator: {
+      "ui:widget": "ComboBox",
+      "ui:placeholder": "Select the new operator",
+    },
+    transfer_entity: {
+      "ui:widget": "RadioWidget",
+      "ui:classNames": "md:gap-20",
+      "ui:options": {
+        inline: true,
+      },
+    },
+    operation: {
+      "ui:widget": "ComboBox",
+      "ui:placeholder": "Select the operation",
+    },
+    effective_date: {
+      "ui:widget": "DateWidget",
+    },
+    from_operation: {
+      "ui:widget": "ComboBox",
+      "ui:placeholder": "Select the operation",
+    },
+    facilities: {
+      "ui:widget": "MultiSelectWidgetWithTooltip",
+      "ui:placeholder": "Select facilities",
+    },
+    to_operation: {
+      "ui:widget": "ComboBox",
+      "ui:placeholder": "Select the operation",
+    },
+  };
+
   const transferSchemaCopy = JSON.parse(JSON.stringify(transferSchema));
 
   if (operationOptions.length > 0) {
@@ -160,8 +208,8 @@ export const createTransferSchema = (
     // Add the facility options to the facilities field
     transferSchemaCopy.dependencies.transfer_entity.allOf[1].then.properties.facilities.items.enum =
       facilityOptions.map((facility) => facility.facility__id);
-    transferSchemaCopy.dependencies.transfer_entity.allOf[1].then.properties.facilities.items.enumNames =
-      facilityOptions.map((facility: FacilityRow) => {
+    transferUISchema.facilities["ui:enumNames"] = facilityOptions.map(
+      (facility: FacilityRow) => {
         const {
           facility__name: facilityName,
           facility__latitude_of_largest_emissions: facilityLatitude,
@@ -170,56 +218,12 @@ export const createTransferSchema = (
         return facilityLatitude && facilityLongitude
           ? `${facilityName} - (${facilityLatitude}, ${facilityLongitude})`
           : facilityName;
-      });
+      },
+    );
   }
 
-  return transferSchemaCopy;
-};
-
-export const transferUISchema: UiSchema = {
-  "ui:FieldTemplate": SectionFieldTemplate,
-  "ui:options": {
-    label: false,
-  },
-  transfer_header: {
-    "ui:FieldTemplate": FieldTemplate,
-    "ui:classNames": "form-heading mb-8",
-  },
-  transfer_preface: {
-    "ui:classNames": "text-bc-bg-blue text-md",
-  },
-  from_operator: {
-    "ui:widget": "ComboBox",
-    "ui:placeholder": "Select the current operator",
-  },
-  to_operator: {
-    "ui:widget": "ComboBox",
-    "ui:placeholder": "Select the new operator",
-  },
-  transfer_entity: {
-    "ui:widget": "RadioWidget",
-    "ui:classNames": "md:gap-20",
-    "ui:options": {
-      inline: true,
-    },
-  },
-  operation: {
-    "ui:widget": "ComboBox",
-    "ui:placeholder": "Select the operation",
-  },
-  effective_date: {
-    "ui:widget": "DateWidget",
-  },
-  from_operation: {
-    "ui:widget": "ComboBox",
-    "ui:placeholder": "Select the operation",
-  },
-  facilities: {
-    "ui:widget": "MultiSelectWidgetWithTooltip",
-    "ui:placeholder": "Select facilities",
-  },
-  to_operation: {
-    "ui:widget": "ComboBox",
-    "ui:placeholder": "Select the operation",
-  },
+  return {
+    transferSchema: transferSchemaCopy,
+    transferUISchema: transferUISchema,
+  };
 };


### PR DESCRIPTION
This rjsf schema was missed when handling the deprecated "enumNames" property in the rjsf upgrade PR. Facilities in the transfers menu dropdown were showing as UUIDs rather than by their names.

Fixed:
<img width="1260" height="1300" alt="image" src="https://github.com/user-attachments/assets/2c538bf4-d02a-4299-8f0e-8c01130ce95c" />
