### PR TITLE
4755 allow analysts to revise READY_TO_APPROVE suggestions prior to director action

### DIFF
--- a/bc_obps/compliance/service/earned_credits_service.py
+++ b/bc_obps/compliance/service/earned_credits_service.py
@@ -124,11 +124,8 @@ class ComplianceEarnedCreditsService:
         Handles the update of earned credits by a CAS analyst
         """
 
-        # Prevent further updates once an analyst has provided a final suggestion
-        if earned_credit.analyst_suggestion in [
-            ComplianceEarnedCredit.AnalystSuggestion.READY_TO_APPROVE,
-            ComplianceEarnedCredit.AnalystSuggestion.REQUIRING_SUPPLEMENTARY_REPORT,
-        ]:
+        # Prevent further updates once the analyst has declined the request
+        if earned_credit.analyst_suggestion == ComplianceEarnedCredit.AnalystSuggestion.REQUIRING_SUPPLEMENTARY_REPORT:
             raise UserError("Updates are not allowed after the analyst has provided a final suggestion")
 
         analyst_allowed_statuses = [

--- a/bc_obps/compliance/tests/service/test_compliance_earned_credits_service.py
+++ b/bc_obps/compliance/tests/service/test_compliance_earned_credits_service.py
@@ -293,11 +293,6 @@ class TestComplianceEarnedCreditsService:
         "existing_suggestion, existing_status, new_suggestion",
         [
             (
-                ComplianceEarnedCredit.AnalystSuggestion.READY_TO_APPROVE,
-                ComplianceEarnedCredit.IssuanceStatus.ISSUANCE_REQUESTED,
-                ComplianceEarnedCredit.AnalystSuggestion.REQUIRING_CHANGE_OF_BCCR_HOLDING_ACCOUNT_ID,
-            ),
-            (
                 ComplianceEarnedCredit.AnalystSuggestion.REQUIRING_SUPPLEMENTARY_REPORT,
                 ComplianceEarnedCredit.IssuanceStatus.DECLINED,
                 ComplianceEarnedCredit.AnalystSuggestion.READY_TO_APPROVE,
@@ -327,6 +322,37 @@ class TestComplianceEarnedCreditsService:
             ComplianceEarnedCreditsService.update_earned_credit(
                 earned_credit.compliance_report_version_id, payload, self.cas_analyst
             )
+
+    @patch('compliance.service.earned_credits_service.retryable_send_notice_of_credits_requested_email')
+    def test_update_earned_credit_cas_analyst_can_revise_ready_to_approve_before_director_decides(
+        self, mock_send_email
+    ):
+        # Analyst previously submitted READY_TO_APPROVE but the director hasn't acted yet.
+        # The analyst should be able to return and change their suggestion.
+        earned_credit = self.earned_credit_base
+        earned_credit.issuance_status = ComplianceEarnedCredit.IssuanceStatus.ISSUANCE_REQUESTED
+        earned_credit.analyst_suggestion = ComplianceEarnedCredit.AnalystSuggestion.READY_TO_APPROVE
+        earned_credit.analyst_comment = "Looks good"
+        earned_credit.save()
+
+        payload = {
+            "analyst_suggestion": ComplianceEarnedCredit.AnalystSuggestion.REQUIRING_CHANGE_OF_BCCR_HOLDING_ACCOUNT_ID.value,
+            "analyst_comment": "Actually, please fix the account ID",
+        }
+
+        result = ComplianceEarnedCreditsService.update_earned_credit(
+            earned_credit.compliance_report_version_id, payload, self.cas_analyst
+        )
+
+        earned_credit.refresh_from_db()
+        assert (
+            earned_credit.analyst_suggestion
+            == ComplianceEarnedCredit.AnalystSuggestion.REQUIRING_CHANGE_OF_BCCR_HOLDING_ACCOUNT_ID
+        )
+        assert earned_credit.analyst_comment == "Actually, please fix the account ID"
+        assert earned_credit.issuance_status == ComplianceEarnedCredit.IssuanceStatus.CHANGES_REQUIRED
+        assert result == earned_credit
+        mock_send_email.execute.assert_not_called()
 
     @patch('compliance.service.earned_credits_service.retryable_send_notice_of_credits_requested_email')
     @patch.object(ComplianceEarnedCreditsService, 'create_bccr_project_for_earned_credit')

--- a/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/internal/review-credits-issuance-request/InternalReviewCreditsIssuanceRequestComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/internal/review-credits-issuance-request/InternalReviewCreditsIssuanceRequestComponent.tsx
@@ -43,10 +43,8 @@ const InternalReviewCreditsIssuanceRequestComponent = ({
   );
   const isFinalAnalystSuggestion =
     hasPriorAnalystSubmission &&
-    (initialFormData?.analyst_suggestion ===
-      AnalystSuggestion.READY_TO_APPROVE ||
-      initialFormData?.analyst_suggestion ===
-        AnalystSuggestion.REQUIRING_SUPPLEMENTARY_REPORT);
+    initialFormData?.analyst_suggestion ===
+      AnalystSuggestion.REQUIRING_SUPPLEMENTARY_REPORT;
 
   const handleFormChange = (
     e: IChangeEvent<RequestIssuanceComplianceSummaryData>,

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/request-issuance/internal/review-credits-issuance-request/InternalReviewCreditsIssuanceRequestComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/request-issuance/internal/review-credits-issuance-request/InternalReviewCreditsIssuanceRequestComponent.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import InternalReviewCreditsIssuanceRequestComponent from "@/compliance/src/app/components/compliance-summary/request-issuance/internal/review-credits-issuance-request/InternalReviewCreditsIssuanceRequestComponent";
-import { IssuanceStatus, AnalystSuggestion } from "@bciers/utils/src/enums";
+import { AnalystSuggestion, IssuanceStatus } from "@bciers/utils/src/enums";
 import { useSessionRole } from "@bciers/utils/src/sessionUtils";
 import { actionHandler } from "@bciers/actions";
 
@@ -286,10 +286,13 @@ describe("InternalReviewCreditsIssuanceRequestComponent", () => {
     expect(actionHandler).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps button enabled and navigates when prior submission has READY_TO_APPROVE", async () => {
+  it("keeps form editable and resubmits when analyst returns after prior READY_TO_APPROVE submission", async () => {
+    // Analyst previously submitted READY_TO_APPROVE but the director hasn't acted yet.
+    // Returning to this page should show an editable form and call the API on Continue.
     const formDataWithPriorSubmission = {
       ...mockFormData,
       analyst_suggestion: AnalystSuggestion.READY_TO_APPROVE,
+      issuance_status: IssuanceStatus.ISSUANCE_REQUESTED,
       analyst_submitted_date: "2023-01-01",
       analyst_submitted_by: "Test User",
     };
@@ -301,12 +304,28 @@ describe("InternalReviewCreditsIssuanceRequestComponent", () => {
       />,
     );
 
+    // Form must be editable
+    expect(
+      screen.getByRole("radio", { name: "Ready to approve" }),
+    ).not.toBeDisabled();
+    expect(screen.getByRole("textbox")).not.toBeDisabled();
+
     const continueButton = screen.getByRole("button", { name: "Continue" });
     expect(continueButton).not.toBeDisabled();
 
     fireEvent.click(continueButton);
     await waitFor(() => {
-      expect(actionHandler).not.toHaveBeenCalled();
+      expect(actionHandler).toHaveBeenCalledWith(
+        "compliance/compliance-report-versions/123/earned-credits",
+        "PUT",
+        "/compliance-administration/compliance-summaries/123/review-by-director",
+        {
+          body: JSON.stringify({
+            analyst_suggestion: AnalystSuggestion.READY_TO_APPROVE,
+            analyst_comment: "Test comment",
+          }),
+        },
+      );
       expect(mockPush).toHaveBeenCalledWith(
         `/compliance-administration/compliance-summaries/${mockComplianceReportVersionId}/review-by-director`,
       );
@@ -357,34 +376,6 @@ describe("InternalReviewCreditsIssuanceRequestComponent", () => {
 
     const continueButton = screen.getByRole("button", { name: "Continue" });
     expect(continueButton).not.toBeDisabled();
-  });
-
-  it("navigates without submitting when CAS analyst has prior final suggestion", async () => {
-    const formDataWithPriorSubmission = {
-      ...mockFormData,
-      analyst_suggestion: AnalystSuggestion.READY_TO_APPROVE,
-      analyst_submitted_date: "2023-01-01",
-      analyst_submitted_by: "Test User",
-    };
-
-    render(
-      <InternalReviewCreditsIssuanceRequestComponent
-        initialFormData={formDataWithPriorSubmission}
-        complianceReportVersionId={mockComplianceReportVersionId}
-      />,
-    );
-
-    const continueButton = screen.getByRole("button", { name: "Continue" });
-    expect(continueButton).not.toBeDisabled();
-
-    fireEvent.click(continueButton);
-
-    await waitFor(() => {
-      expect(actionHandler).not.toHaveBeenCalled();
-      expect(mockPush).toHaveBeenCalledWith(
-        `/compliance-administration/compliance-summaries/${mockComplianceReportVersionId}/review-by-director`,
-      );
-    });
   });
 
   it("keeps form editable when prior submission had non-final suggestion", () => {


### PR DESCRIPTION
[ISSUE 4755](https://github.com/bcgov/cas-registration/issues/4755)

## Testing Steps 🧪 

1. Log in as the **industry user** (bc-cas-dev)
2. Navigate to the **Compliance Summaries** page
3. Two existing records are available for requesting earned credits — choose either one and click the **Request Issuance of Credits** link
<img width="1585" height="512" alt="Screenshot 2026-06-05 at 9 04 55 AM" src="https://github.com/user-attachments/assets/9ded9f92-5fc6-4a8e-8f42-289cc73f8880" />

4. Click **Continue**
<img width="1576" height="880" alt="Screenshot 2026-06-05 at 9 05 13 AM" src="https://github.com/user-attachments/assets/0c836b1b-f7ea-4747-a65a-57d1e76745ad" />

5. Enter the BCCR Holding Account ID and click **Request Issuance of Earned Credits** (Use my Holding Account ID: 103200000029268)
<img width="1567" height="888" alt="Screenshot 2026-06-05 at 9 05 29 AM" src="https://github.com/user-attachments/assets/90dfd076-37ab-453c-a86c-53f8de0cca52" />
<img width="1563" height="620" alt="Screenshot 2026-06-05 at 9 05 51 AM" src="https://github.com/user-attachments/assets/45735362-6efd-4ea6-b860-18c713a25a83" />

6. Log out and log back in as a **CAS Analyst**
7. Navigate to the **Compliance Summaries** page
8. Click the **Review Credits Issuance Request** link for the record submitted by the industry user
<img width="1599" height="512" alt="Screenshot 2026-06-05 at 9 06 53 AM" src="https://github.com/user-attachments/assets/e173b22c-3fc2-4b98-ab6d-6821d7250ace" />

9. Click **Continue**
<img width="1562" height="875" alt="Screenshot 2026-06-05 at 9 07 03 AM" src="https://github.com/user-attachments/assets/846a2630-b1e6-41fd-b975-1a77e9a2c6b2" />

10. Select **Ready to Approve**, add a comment, and click **Continue**
<img width="1571" height="871" alt="Screenshot 2026-06-05 at 9 07 13 AM" src="https://github.com/user-attachments/assets/ed68f2be-3137-411c-949d-cc79e3156e32" />

11. From the **Review by Director** page, click the **Back** button
<img width="1571" height="880" alt="Screenshot 2026-06-05 at 9 07 34 AM" src="https://github.com/user-attachments/assets/5e4aa11d-6a10-4574-83f8-6f9fa3f92de9" />

12. Verify the form is still editable — the analyst should be able to select a different suggestion and update the comment
