### PR TITLE
Update error key and context for activity json validator

### DIFF
--- a/bc_obps/reporting/service/report_validation/report_validation_error.py
+++ b/bc_obps/reporting/service/report_validation/report_validation_error.py
@@ -28,7 +28,7 @@ class ReportValidationErrorKey(StrEnum):
     REPORT_DATA_OUT_OF_BOUNDS_BY_FUEL_TYPE = "report_data_out_of_bounds_by_fuel_type"
     REPORT_DATA_OUT_OF_BOUNDS_BY_REPORTING_FIELD = "report_data_out_of_bounds_by_reporting_field"
     ERROR_REQUIRED_FIELDS = "error_required_fields"
-    ACTIVITY_JSON_SCHEMA_VALIDATION_ERROR = "activity_json_schema_validation_error"
+    REPORT_ACTIVITY_JSON_VALIDATION = "report_activity_json_validation"
     MISSING_REGULATED_PRODUCT = "missing_regulated_product"
 
 

--- a/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
+++ b/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
@@ -5,6 +5,7 @@ import jsonschema
 from reporting.models.report_version import ReportVersion
 from reporting.models.source_type import SourceType
 from reporting.service.report_validation.report_validation_error import (
+    ErrorContext,
     ReportValidationError,
     ReportValidationErrorKey,
     Severity,
@@ -72,7 +73,14 @@ def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
                     ReportValidationError(
                         severity=Severity.ERROR,
                         message=f"Validation error: {e.message} at: {' > '.join(str(elt) for elt in e.path)}",
-                        key=ReportValidationErrorKey.ACTIVITY_JSON_SCHEMA_VALIDATION_ERROR,
+                        key=ReportValidationErrorKey.REPORT_ACTIVITY_JSON_VALIDATION,
+                        context=ErrorContext(
+                            report_version_id=report_version.id,
+                            facility_id=facility_report.facility_id,
+                            facility_name=facility_report.facility.name,
+                            activity_id=report_raw_activity.activity_id,
+                            activity_name=report_raw_activity.activity.name,
+                        ),
                     )
                 )
 

--- a/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
+++ b/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
@@ -15,7 +15,7 @@ from reporting.service.report_validation.report_validation_tags import Validatio
 
 logger = logging.getLogger(__name__)
 
-TAGS = [ValidationTags.REPORT_VALIDATION]
+TAGS = [ValidationTags.REPORT_VALIDATION, ValidationTags.ON_SUBMIT]
 
 
 def enable_jsonschema_draft_2020_validation(schema: Any) -> None:

--- a/bciers/apps/reporting/src/app/components/shared/validation/config.ts
+++ b/bciers/apps/reporting/src/app/components/shared/validation/config.ts
@@ -94,11 +94,11 @@ export const validationUIConfig: Partial<
     formatMessage: ({ error }) => {
       const ctx = error.context;
 
-      return `Validation error detected for ${String(
+      return `JSON schema validation failure detected for ${String(
         ctx?.facility_name ?? "facility",
       )} ${String(
         ctx?.activity_name ?? "activity",
-      )}. Please review the activity data and correct any invalid or unexpected values.`;
+      )}. Please forward this error message to ghgregulator@gov.bc.ca to resolve this issue.`;
     },
   }),
 


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-registration/issues/4741

### Testing
1. Make invalid json_data. The included SQL script will update report_version 3 to have invalid data.
2. Navigate to [http://localhost:3000/reporting/reports/3/report-validation](http://localhost:3000/reporting/reports/3/report-validation)
   - EXPECT TO SEE: a formatted error that includes a hyperlink to the problem activity
   - DO NOT EXPECT TO SEE: a simple error key (```activity_json_schema_validation_error```) or generic error message

Update SQL: 
```sql
UPDATE erc.report_raw_activity_data
SET json_data='{"sourceTypes": {"gscWithProductionOfUsefulEnergy": {"methodology": [{"fuels": {"fuelType": {"fuelName": "Diesel", "fuelClassification": "Non-biomass"}, "emissions": [{"units": {"methodology": "Default EF"}, "gasType": "CO2", "emission": 11000}], "fuelDescription": "Diesel fuel", "annualFuelAmount": 12000}, "gscUnitName": "GSC Unit Name 1", "gscUnitType": "Kiln"}]}}, "gscWithProductionOfUsefulEnergy": true}'::jsonb
WHERE report_version_id=3;
```

navigate to [http://localhost:3000/reporting/reports/3/report-validation](http://localhost:3000/reporting/reports/3/report-validation)