### PR TITLE
Fix required fields for LNG and NG activities

### DIFF
--- a/bc_obps/reporting/json_schemas/2024/lng_activities/10_centrifugal_compressor_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/10_centrifugal_compressor_venting.json
@@ -41,9 +41,9 @@
                   "readOnly": true,
                   "description": "Computed upon saving"
                 }
-              }
-            },
-            "required": ["gasType", "emission"]
+              },
+              "required": ["gasType", "emission"]
+            }
           }
         }
       }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/11_reciprocating_compressor_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/11_reciprocating_compressor_venting.json
@@ -41,9 +41,9 @@
                   "readOnly": true,
                   "description": "Computed upon saving"
                 }
-              }
-            },
-            "required": ["gasType", "emission"]
+              },
+              "required": ["gasType", "emission"]
+            }
           }
         }
       }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/12_equipment_leaks_detected_using_leak_detection.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/12_equipment_leaks_detected_using_leak_detection.json
@@ -41,9 +41,9 @@
                   "readOnly": true,
                   "description": "Computed upon saving"
                 }
-              }
-            },
-            "required": ["gasType", "emission"]
+              },
+              "required": ["gasType", "emission"]
+            }
           }
         }
       }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/13_population_count_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/13_population_count_sources.json
@@ -41,9 +41,9 @@
                   "readOnly": true,
                   "description": "Computed upon saving"
                 }
-              }
-            },
-            "required": ["gasType", "emission"]
+              },
+              "required": ["gasType", "emission"]
+            }
           }
         }
       }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/18_other_venting_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/18_other_venting_sources.json
@@ -46,9 +46,9 @@
                   "readOnly": true,
                   "description": "Computed upon saving"
                 }
-              }
-            },
-            "required": ["gasType", "emission"]
+              },
+              "required": ["gasType", "emission"]
+            }
           }
         }
       }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/19_other_fugitive_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/19_other_fugitive_sources.json
@@ -46,9 +46,9 @@
                   "readOnly": true,
                   "description": "Computed upon saving"
                 }
-              }
-            },
-            "required": ["gasType", "emission"]
+              },
+              "required": ["gasType", "emission"]
+            }
           }
         }
       }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/6_dehydrator_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/6_dehydrator_venting.json
@@ -44,9 +44,9 @@
                   "readOnly": true,
                   "description": "Computed upon saving"
                 }
-              }
-            },
-            "required": ["gasType", "emission"]
+              },
+              "required": ["gasType", "emission"]
+            }
           }
         }
       }

--- a/bc_obps/reporting/json_schemas/2024/ng_non_compression/10_other_venting_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_non_compression/10_other_venting_sources.json
@@ -50,9 +50,9 @@
                   "readOnly": true,
                   "description": "Computed upon saving"
                 }
-              }
-            },
-            "required": ["gasType", "emission"]
+              },
+              "required": ["gasType", "emission"]
+            }
           }
         }
       }


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-registration/issues/4753

The gasType, emissions, and methodology fields were already defined as `required` in the schemas - there was just a nesting issue on where the required fields were defined.

### Testing

Start a report with `LNG activities` and `Natural gas transmission (other than compression and processing)` activities selected. Progress to the activity forms and select the source types individually from the table below and click `Save` with no data entered.
 - EXPECT TO SEE: `This form can't be saved yet. Please fix the errors above.` with 'Gas Type' and 'Emissions' showing as required fields. You can select a gas type so the methodology field shows and confirm that it is also a required field.
  - EXPECT TO NOT SEE: `An internal server error has occurred`
 
 | Activity | Source Type | Fields |
| - | - | - |
| LNG | Dehydrator venting | Gas, Methodology |
| LNG | Centrifugal compressor venting | Gas, Methodology |
| LNG | Reciprocating compressor venting | Gas, Methodology |
| LNG | Equipment leaks detected using leak detection and leaker emission factor methods | Gas, Methodology |
| LNG | Population count sources | Gas, Methodology |
| LNG | Other venting sources | Gas, Methodology |
| LNG | Other fugitive sources | Gas, Methodology |
| Natural gas transmission (other than compression and processing) | Other venting sources | Gas, Methodology |