### PR TITLE
4693 Handle EC record for supplementary reports where previous credited emissions are between 0 and 1

### DIFF
--- a/bc_obps/compliance/service/supplementary_version_service/new_earned_credits_handler.py
+++ b/bc_obps/compliance/service/supplementary_version_service/new_earned_credits_handler.py
@@ -3,7 +3,7 @@ from django.db import transaction
 from compliance.models import ComplianceEarnedCredit, ComplianceReport, ComplianceReportVersion
 from compliance.service.earned_credits_service import ComplianceEarnedCreditsService
 from reporting.models import ReportComplianceSummary
-from compliance.service.supplementary_version_service.constants import ONE_DECIMAL, ZERO_DECIMAL
+from compliance.service.supplementary_version_service.constants import ONE_DECIMAL
 from compliance.service.supplementary_version_service.helpers import (
     get_previous_compliance_version_by_report_and_summary,
 )
@@ -22,7 +22,8 @@ class NewEarnedCreditsHandler:
         ).first()
         if previous_earned_credit_record:
             return False
-        return previous_summary.credited_emissions == ZERO_DECIMAL and new_summary.credited_emissions >= ONE_DECIMAL
+        # Credits below ONE_DECIMAL are never issued, so both 0 and 0 < x < 1 mean "no previous earned credits"
+        return previous_summary.credited_emissions < ONE_DECIMAL and new_summary.credited_emissions >= ONE_DECIMAL
 
     @staticmethod
     @transaction.atomic()

--- a/bc_obps/compliance/tests/service/supplementary_version_service/test_new_earned_credits_handler.py
+++ b/bc_obps/compliance/tests/service/supplementary_version_service/test_new_earned_credits_handler.py
@@ -166,6 +166,88 @@ class TestNewEarnedCreditsHandler(BaseSupplementaryVersionServiceTest):
         # Assert
         assert result is False
 
+    def test_can_handle_previous_below_one_credited_emissions(self):
+        # 0 < previous.credited_emissions < 1 fell through all handlers.
+        with pgtrigger.ignore('reporting.ReportComplianceSummary:immutable_report_version'):
+            self.previous_summary = baker.make_recipe(
+                'reporting.tests.utils.report_compliance_summary',
+                excess_emissions=0,
+                credited_emissions=Decimal('0.5'),
+                report_version=self.report_version_1,
+            )
+        self.new_summary = baker.make_recipe(
+            'reporting.tests.utils.report_compliance_summary',
+            excess_emissions=0,
+            credited_emissions=Decimal('100'),
+            report_version=self.report_version_2,
+        )
+        self.compliance_report = baker.make_recipe(
+            'compliance.tests.utils.compliance_report', report=self.report, compliance_period_id=1
+        )
+        self.previous_compliance_report_version = baker.make_recipe(
+            'compliance.tests.utils.compliance_report_version',
+            report_compliance_summary=self.previous_summary,
+        )
+
+        result = NewEarnedCreditsHandler.can_handle(self.new_summary, self.previous_summary)
+
+        assert result is True
+
+    def test_service_routes_to_new_earned_credits_handler_when_previous_below_one(
+        self,
+        mock_increased_handler,
+        mock_decreased_handler,
+        mock_no_change_handler,
+        mock_increased_credit_handler,
+        mock_decreased_credit_handler,
+        mock_new_earned_credits_handler,
+        mock_superceded_can_handle,
+    ):
+        # service must route to NewEarnedCreditsHandler
+        # when previous had 0 < credited_emissions < 1 (no earned credit record ever issued).
+        mock_superceded_can_handle.return_value = False
+        with pgtrigger.ignore('reporting.ReportComplianceSummary:immutable_report_version'):
+            self.previous_summary = baker.make_recipe(
+                'reporting.tests.utils.report_compliance_summary',
+                excess_emissions=0,
+                credited_emissions=Decimal('0.5'),
+                report_version=self.report_version_1,
+            )
+        self.new_summary = baker.make_recipe(
+            'reporting.tests.utils.report_compliance_summary',
+            excess_emissions=0,
+            credited_emissions=Decimal('100'),
+            report_version=self.report_version_2,
+        )
+        self.compliance_report = baker.make_recipe(
+            'compliance.tests.utils.compliance_report', report=self.report, compliance_period_id=1
+        )
+        self.previous_compliance_report_version = baker.make_recipe(
+            'compliance.tests.utils.compliance_report_version',
+            compliance_report=self.compliance_report,
+            report_compliance_summary=self.previous_summary,
+            is_supplementary=False,
+        )
+        mock_result = MagicMock(spec=ComplianceReportVersion)
+        mock_new_earned_credits_handler.return_value = mock_result
+
+        result = SupplementaryVersionService().handle_supplementary_version(
+            self.compliance_report, self.report_version_2, 2
+        )
+
+        mock_new_earned_credits_handler.assert_called_once_with(
+            compliance_report=self.compliance_report,
+            new_summary=self.new_summary,
+            previous_summary=self.previous_summary,
+            version_count=2,
+        )
+        assert result == mock_result
+        mock_increased_handler.assert_not_called()
+        mock_decreased_handler.assert_not_called()
+        mock_no_change_handler.assert_not_called()
+        mock_increased_credit_handler.assert_not_called()
+        mock_decreased_credit_handler.assert_not_called()
+
     def test_can_handle_returns_false_when_new_has_no_credited_emissions(self):
         # Arrange
         with pgtrigger.ignore('reporting.ReportComplianceSummary:immutable_report_version'):


### PR DESCRIPTION
[ISSUE 4693](https://github.com/bcgov/cas-registration/issues/4693)

## Summary

- **Bug:** When a previous report had `0 < credited_emissions < 1`, submitting a supplementary report that crosses the `>= 1` threshold raised a "no handler found" exception. `IncreasedCreditHandler` requires `previous.credited_emissions >= 1`, and `NewEarnedCreditsHandler` required `previous.credited_emissions == 0` — leaving the sub-one range unhandled.
- **Fix:** Relaxed `NewEarnedCreditsHandler.can_handle()` from `== ZERO_DECIMAL` to `< ONE_DECIMAL`. Credits below the 1 threshold are never issued, so both `0` and `0 < x < 1` represent the same state: no prior `ComplianceEarnedCredit` record exists. The fix correctly routes these cases to `NewEarnedCreditsHandler`.