### PR TITLE
4754: Aluminum/Alumina Production activity bug fix

### DIFF
--- a/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
+++ b/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 TAGS = [ValidationTags.REPORT_VALIDATION, ValidationTags.ON_SUBMIT]
 
 
-def enable_jsonschema_draft_2020_validation(schema: Any, validateUnevaluatedProperties: bool = True) -> None:
+def enable_jsonschema_draft_2020_validation(schema: Any, validate_unevaluated_properties: bool = True) -> None:
     """
     RJSF uses draft-07 and doesn't support the `unevaluatedProperties` keyword.
     This method replaces the `dependencies` keyword with `dependentSchemas` and adds
@@ -29,14 +29,14 @@ def enable_jsonschema_draft_2020_validation(schema: Any, validateUnevaluatedProp
 
     if isinstance(schema, list):
         for item in schema:
-            enable_jsonschema_draft_2020_validation(item, validateUnevaluatedProperties)
+            enable_jsonschema_draft_2020_validation(item, validate_unevaluated_properties)
 
     if isinstance(schema, dict):
         for key in schema:
-            enable_jsonschema_draft_2020_validation(schema[key], validateUnevaluatedProperties)
+            enable_jsonschema_draft_2020_validation(schema[key], validate_unevaluated_properties)
         # Schemas with complex schema dependencies recommended to not set this due to validation failure
         # https://rjsf-team.github.io/react-jsonschema-form/docs/advanced-customization/internals/#json-schema-supporting-status
-        if validateUnevaluatedProperties:
+        if validate_unevaluated_properties:
             if "properties" in schema and schema.get("type") == "object":
                 schema["unevaluatedProperties"] = False
 

--- a/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
+++ b/bc_obps/reporting/service/report_validation/validators/report_activity_json_validation.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import Any
 import jsonschema
+from registration.models.activity import Activity
 from reporting.models.report_version import ReportVersion
 from reporting.models.source_type import SourceType
 from reporting.service.report_validation.report_validation_error import (
@@ -18,7 +19,7 @@ logger = logging.getLogger(__name__)
 TAGS = [ValidationTags.REPORT_VALIDATION, ValidationTags.ON_SUBMIT]
 
 
-def enable_jsonschema_draft_2020_validation(schema: Any) -> None:
+def enable_jsonschema_draft_2020_validation(schema: Any, validateUnevaluatedProperties: bool = True) -> None:
     """
     RJSF uses draft-07 and doesn't support the `unevaluatedProperties` keyword.
     This method replaces the `dependencies` keyword with `dependentSchemas` and adds
@@ -28,14 +29,16 @@ def enable_jsonschema_draft_2020_validation(schema: Any) -> None:
 
     if isinstance(schema, list):
         for item in schema:
-            enable_jsonschema_draft_2020_validation(item)
+            enable_jsonschema_draft_2020_validation(item, validateUnevaluatedProperties)
 
     if isinstance(schema, dict):
         for key in schema:
-            enable_jsonschema_draft_2020_validation(schema[key])
-
-        if "properties" in schema and schema.get("type") == "object":
-            schema["unevaluatedProperties"] = False
+            enable_jsonschema_draft_2020_validation(schema[key], validateUnevaluatedProperties)
+        # Schemas with complex schema dependencies recommended to not set this due to validation failure
+        # https://rjsf-team.github.io/react-jsonschema-form/docs/advanced-customization/internals/#json-schema-supporting-status
+        if validateUnevaluatedProperties:
+            if "properties" in schema and schema.get("type") == "object":
+                schema["unevaluatedProperties"] = False
 
         if "dependencies" in schema:
             schema["dependentSchemas"] = schema.pop("dependencies")
@@ -52,6 +55,7 @@ def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
             source_type_ids = list(
                 SourceType.objects.filter(json_key__in=source_type_json_keys).values_list("id", flat=True)
             )
+            alumina_activity = Activity.objects.get(slug='aluminum_production')
 
             activity_schema = json.loads(
                 FormBuilderService.build_form_schema(
@@ -61,8 +65,9 @@ def validate(report_version: ReportVersion) -> dict[str, ReportValidationError]:
                     str(facility_report.facility_id),
                 )
             )["schema"]
-
-            enable_jsonschema_draft_2020_validation(activity_schema)
+            enable_jsonschema_draft_2020_validation(
+                activity_schema, report_raw_activity.activity_id != alumina_activity.id
+            )
 
             validator = jsonschema.Draft202012Validator(activity_schema)
 

--- a/bc_obps/reporting/tests/service/report_validation/validators/test_report_activity_json_validator.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/test_report_activity_json_validator.py
@@ -6,6 +6,7 @@ from registration.models.activity import Activity
 from reporting.models.reporting_year import ReportingYear
 from reporting.service.report_validation.report_validation_error import (
     ReportValidationError,
+    ReportValidationErrorKey,
     Severity,
 )
 from reporting.service.report_validation.validators.report_activity_json_validation import (
@@ -56,7 +57,6 @@ class TestReportActivityJsonValidator:
             and "dependencies" not in schema["properties"]["test_prop"]
         )
 
-    @pytest.mark.skip("Validator disabled until fixes with jsonschema draft2020 can be addressed. (reporting/#941)")
     @patch("service.form_builder_service.FormBuilderService.build_form_schema")
     def test_validate_with_extra_field(self, mock_build_form_schema):
         mock_build_form_schema.return_value = json.dumps(
@@ -102,7 +102,7 @@ class TestReportActivityJsonValidator:
 
         raw_activity_data = make_recipe(
             "reporting.tests.utils.report_raw_activity_data",
-            report_version=1,
+            report_version=raw_activity_data.facility_report.report_version,
             facility_report__facility__id="00000000-0000-0000-0000-000000000012",
             activity__slug="test-activity",
             json_data={
@@ -121,6 +121,7 @@ class TestReportActivityJsonValidator:
             "facility_00000000-0000-0000-0000-000000000012_test-activity": ReportValidationError(
                 Severity.ERROR,
                 "Validation error: Unevaluated properties are not allowed ('prop3' was unexpected) at: sourceTypes > testSourceType",
+                ReportValidationErrorKey.ACTIVITY_JSON_SCHEMA_VALIDATION_ERROR,
             )
         }
 
@@ -289,3 +290,42 @@ class TestReportActivityJsonValidator:
         errors = validate(raw_activity_data.facility_report.report_version)
 
         assert errors == {}
+
+    def test_validate_with_flag_exludes_unevaluated_properties(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "test_prop": {
+                    "type": "object",
+                    "properties": {
+                        "test_prop_1": {"type": "string"},
+                        "test_prop_2": {"type": "object", "properties": {"test_prop_3": {"type": "string"}}},
+                    },
+                    "dependencies": {
+                        "test_prop_1": {
+                            "properties": {
+                                "test_prop_2": {
+                                    "type": "object",
+                                    "properties": {"test_prop_3": {}},
+                                },
+                            }
+                        }
+                    },
+                },
+            },
+            "dependencies": {"name": {"minLength": 3}},
+        }
+
+        enable_jsonschema_draft_2020_validation(schema, False)
+
+        assert "unevaluatedProperties" not in schema
+        assert "unevaluatedProperties" not in schema["properties"]["test_prop"]
+        assert (
+            "unevaluatedProperties"
+            not in schema["properties"]["test_prop"]["properties"]["test_prop_2"]["properties"]["test_prop_3"]
+        )
+        assert (
+            "unevaluatedProperties"
+            not in schema["properties"]["test_prop"]["dependentSchemas"]["test_prop_1"]["properties"]["test_prop_2"]
+        )

--- a/bc_obps/reporting/tests/service/report_validation/validators/test_report_activity_json_validator.py
+++ b/bc_obps/reporting/tests/service/report_validation/validators/test_report_activity_json_validator.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 from model_bakery.baker import make_recipe
 import pytest
 from registration.models.activity import Activity
@@ -121,7 +121,8 @@ class TestReportActivityJsonValidator:
             "facility_00000000-0000-0000-0000-000000000012_test-activity": ReportValidationError(
                 Severity.ERROR,
                 "Validation error: Unevaluated properties are not allowed ('prop3' was unexpected) at: sourceTypes > testSourceType",
-                ReportValidationErrorKey.ACTIVITY_JSON_SCHEMA_VALIDATION_ERROR,
+                ReportValidationErrorKey.REPORT_ACTIVITY_JSON_VALIDATION,
+                context=ANY,
             )
         }
 


### PR DESCRIPTION
Resolves: 4754

- Dynamic schemas with allOf/anyOf/oneOf + if/then dependancies are not recommended to have unevaluatedProperties = False. https://rjsf-team.github.io/react-jsonschema-form/docs/advanced-customization/internals/#json-schema-supporting-status
- AllOf evaluates on each object branch individually, leading to errors as one branch does not contain the properties of the other. This PR makes sure the validator does not add unevaluatedProperties if the activity is aluminum_production
- also cleans up an extra test found in the same related test file