### PR TITLE
Make source sub-type required in activity schemas

### DIFF
--- a/bc_obps/reporting/json_schemas/2024/lng_activities/10_centrifugal_compressor_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/10_centrifugal_compressor_venting.json
@@ -45,7 +45,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/11_reciprocating_compressor_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/11_reciprocating_compressor_venting.json
@@ -45,7 +45,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/12_equipment_leaks_detected_using_leak_detection.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/12_equipment_leaks_detected_using_leak_detection.json
@@ -45,7 +45,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/13_population_count_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/13_population_count_sources.json
@@ -45,7 +45,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/18_other_venting_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/18_other_venting_sources.json
@@ -50,7 +50,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/19_other_fugitive_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/19_other_fugitive_sources.json
@@ -50,7 +50,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/5_acid_gas_removal_venting_or_incineration.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/5_acid_gas_removal_venting_or_incineration.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/6_dehydrator_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/6_dehydrator_venting.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/8_releases_from_tanks_used_for_storage.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/8_releases_from_tanks_used_for_storage.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/lng_activities/9_flare_stacks.json
+++ b/bc_obps/reporting/json_schemas/2024/lng_activities/9_flare_stacks.json
@@ -77,7 +77,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_non_compression/10_other_venting_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_non_compression/10_other_venting_sources.json
@@ -54,7 +54,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_non_compression/11_other_fugitive_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_non_compression/11_other_fugitive_sources.json
@@ -54,7 +54,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_non_compression/12_third_party_line_hits_with_release_of_gas.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_non_compression/12_third_party_line_hits_with_release_of_gas.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_non_compression/1_ng_pneumatic_high_bleed_device_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_non_compression/1_ng_pneumatic_high_bleed_device_venting.json
@@ -80,7 +80,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_non_compression/2_ng_pneumatic_pump_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_non_compression/2_ng_pneumatic_pump_venting.json
@@ -80,7 +80,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_non_compression/3_ng_pneumatic_low_bleed_device_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_non_compression/3_ng_pneumatic_low_bleed_device_venting.json
@@ -80,7 +80,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_non_compression/4_ng_pneumatic_intermittent_device_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_non_compression/4_ng_pneumatic_intermittent_device_venting.json
@@ -80,7 +80,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_non_compression/6_flare_stacks.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_non_compression/6_flare_stacks.json
@@ -82,7 +82,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_non_compression/7_equipment_leaks_detected_using_leak_detection.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_non_compression/7_equipment_leaks_detected_using_leak_detection.json
@@ -50,7 +50,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_non_compression/8_population_count_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_non_compression/8_population_count_sources.json
@@ -54,7 +54,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/10_population_count_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/10_population_count_sources.json
@@ -50,7 +50,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/12_other_venting_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/12_other_venting_sources.json
@@ -54,7 +54,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/13_other_fugitive_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/13_other_fugitive_sources.json
@@ -54,7 +54,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/14_third_party_line_hits_with_release_of_gas.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/14_third_party_line_hits_with_release_of_gas.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/1_ng_pneumatic_high_bleed_device_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/1_ng_pneumatic_high_bleed_device_venting.json
@@ -81,7 +81,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/2_ng_pneumatic_pump_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/2_ng_pneumatic_pump_venting.json
@@ -81,7 +81,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/3_ng_pneumatic_low_bleed_device_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/3_ng_pneumatic_low_bleed_device_venting.json
@@ -81,7 +81,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/4_ng_pneumatic_intermittent_device_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/4_ng_pneumatic_intermittent_device_venting.json
@@ -81,7 +81,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/6_flare_stacks.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/6_flare_stacks.json
@@ -81,7 +81,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/7_centrifugal_compressor_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/7_centrifugal_compressor_venting.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/8_reciprocating_compressor_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/8_reciprocating_compressor_venting.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/9_equipment_leaks_detected_using_leak_detection.json
+++ b/bc_obps/reporting/json_schemas/2024/ng_other_than_non_compression/9_equipment_leaks_detected_using_leak_detection.json
@@ -50,7 +50,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_non_compression/other_fugitive_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_non_compression/other_fugitive_sources.json
@@ -53,7 +53,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/acid_gas_removal_venting_or_incineration.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/acid_gas_removal_venting_or_incineration.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/blowdown_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/blowdown_venting.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/centrifugal_compressor_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/centrifugal_compressor_venting.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/dehydrator_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/dehydrator_venting.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/equipment_leaks_detected_using_leak_detection.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/equipment_leaks_detected_using_leak_detection.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/flaring_stacks.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/flaring_stacks.json
@@ -80,7 +80,8 @@
               "required": ["annualFuelAmount"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/other_fugitive_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/other_fugitive_sources.json
@@ -55,7 +55,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/other_venting_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/other_venting_sources.json
@@ -53,7 +53,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/population_count_sources.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/population_count_sources.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/reciprocating_compressor_venting.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/reciprocating_compressor_venting.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }

--- a/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/releases_from_tanks_used_for_storage.json
+++ b/bc_obps/reporting/json_schemas/2024/og_extraction_other_than_ncnp/releases_from_tanks_used_for_storage.json
@@ -48,7 +48,8 @@
               "required": ["gasType", "emission"]
             }
           }
-        }
+        },
+        "required": ["sourceSubType"]
       }
     }
   }


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-registration/issues/4799

### Changes
Made `souceSubType` a required field in all activity schemas where it shows up

Activities with Source Sub-Type field not named in ticket:
 - Oil & Gas extraction (other than compression and processing)
 - Liquefied Natural Gas activities