### PR TITLE
Ensure 'title' is present in emissions uischemas

### DIFF
--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/coalStorageUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/coalStorageUiSchema.ts
@@ -28,6 +28,7 @@ const uiSchema = {
         "ui:FieldTemplate": FieldTemplate,
         "ui:options": {
           arrayAddLabel: "Add Emission",
+          title: "Emission",
           padding: "p-2",
           label: false,
         },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/common.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/common.ts
@@ -23,6 +23,7 @@ export const emissionsFieldsUiSchema = {
   "ui:FieldTemplate": FieldTemplate,
   "ui:options": {
     arrayAddLabel: "Add Emission",
+    title: "Emission",
     label: false,
     padding: "p-2",
   },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/hydrogenProduction.ts
@@ -34,6 +34,7 @@ const uiSchema = {
         "ui:FieldTemplate": FieldTemplate,
         "ui:options": {
           arrayAddLabel: "Add Emission",
+          title: "Emission",
           padding: "p-2",
           label: false,
         },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/industrialWastewaterProcessingUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/industrialWastewaterProcessingUiSchema.ts
@@ -41,6 +41,7 @@ const uiSchema = {
         "ui:FieldTemplate": FieldTemplate,
         "ui:options": {
           arrayAddLabel: "Add Emission",
+          title: "Emission",
           padding: "p-2",
           label: false,
         },
@@ -86,6 +87,7 @@ const uiSchema = {
         "ui:FieldTemplate": FieldTemplate,
         "ui:options": {
           arrayAddLabel: "Add Emission",
+          title: "Emission",
           padding: "p-2",
           label: false,
         },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/leadProductionUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/leadProductionUiSchema.ts
@@ -28,6 +28,7 @@ const uiSchema = {
         "ui:FieldTemplate": FieldTemplate,
         "ui:options": {
           arrayAddLabel: "Add Emission",
+          title: "Emission",
           padding: "p-2",
           label: false,
         },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/limeManufacturingUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/limeManufacturingUiSchema.ts
@@ -28,6 +28,7 @@ const uiSchema = {
         "ui:FieldTemplate": FieldTemplate,
         "ui:options": {
           arrayAddLabel: "Add Emission",
+          title: "Emission",
           padding: "p-2",
           label: false,
         },

--- a/bciers/apps/reporting/src/app/components/activities/uiSchemas/zincProductionUiSchema.ts
+++ b/bciers/apps/reporting/src/app/components/activities/uiSchemas/zincProductionUiSchema.ts
@@ -28,6 +28,7 @@ const uiSchema = {
         "ui:FieldTemplate": FieldTemplate,
         "ui:options": {
           arrayAddLabel: "Add Emission",
+          title: "Emission",
           padding: "p-2",
           label: false,
         },


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-registration/issues/4795

### Changes
Several Activity UISchemas, as well as the shared `emissionsFieldsUiSchema`, did not have the "title" defined for the emissions blocks. These have been updated.

I also explored utilizing the `emissionsFieldsUiSchema` more, as the emissions sections all tend to share most of the what is defined there. But I found that with the fact that most schemas do have _something_ different, the necessitated spreading and adding and overriding of values made the schemas less readable.