### PR TITLE
chore(deps): bump tar from 7.5.11 to 7.5.16 to resolve node-tar CVE

### DIFF
--- a/bciers/package.json
+++ b/bciers/package.json
@@ -150,7 +150,7 @@
   "packageManager": "yarn@4.13.0",
   "resolutions": {
     "qs": "^6.14.2",
-    "tar": "^7.5.11",
+    "tar": "^7.5.16",
     "koa": "^3.1.2",
     "ajv@8.16.0": "8.18.0",
     "minimatch@npm:^3.0.4": "3.1.5",

--- a/bciers/yarn.lock
+++ b/bciers/yarn.lock
@@ -16578,16 +16578,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.11":
-  version: 7.5.15
-  resolution: "tar@npm:7.5.15"
+"tar@npm:^7.5.16":
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/8f039edb1d12fdd7df6c6f9877d125afe9f3da3f5f9317df326fdd090d48793d6998cede1506a1471f3e3a250db270a89dace28005eb5e99c5a9132d704ac956
+  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves: https://github.com/bcgov/cas-registration/security/dependabot/378