### PR TITLE
4782 Apply 3-Year Unit Listing Limit to Offsets Only

### DIFF
--- a/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
@@ -303,22 +303,35 @@ class BCCarbonRegistryAPIClient:
         filter_model.stateCode = {
             "columnFilters": [ColumnFilter(filterType="Text", type=filter_type, filter=state_filter)]
         }
-        filter_model.vintage = {
+
+        # BCO (offsets): filter by vintage. BCE (earned credits): fetch all vintages.
+        bco_filter = FilterModel(**filter_model.model_dump(exclude_none=True))
+        bco_filter.unitType = {"columnFilters": [ColumnFilter(filterType="Text", type="equals", filter="BCO")]}
+        bco_filter.vintage = {
             "columnFilters": [ColumnFilter(filterType="Number", type="greaterThanOrEqual", filter=vintage_year - 3)]
         }
 
-        payload = SearchFilterWrapper(
-            searchFilter=SearchFilter(
-                pagination=Pagination(start=start, limit=limit),
-                filterModel=filter_model,
+        bce_filter = FilterModel(**filter_model.model_dump(exclude_none=True))
+        bce_filter.unitType = {"columnFilters": [ColumnFilter(filterType="Text", type="equals", filter="BCE")]}
+
+        def _fetch(f: FilterModel) -> Dict:
+            return self._make_request(
+                "POST",
+                self.UNIT_SEARCH_ENDPOINT,
+                data=SearchFilterWrapper(
+                    searchFilter=SearchFilter(pagination=Pagination(start=start, limit=limit), filterModel=f)
+                ),
+                response_model=UnitDetailsResponse,
             )
-        )
-        return self._make_request(
-            "POST",
-            self.UNIT_SEARCH_ENDPOINT,
-            data=payload,
-            response_model=UnitDetailsResponse,
-        )
+
+        bco_result = _fetch(bco_filter)
+        bce_result = _fetch(bce_filter)
+
+        merged = bco_result.copy()
+        merged["entities"] = bco_result.get("entities", []) + bce_result.get("entities", [])
+        merged["totalEntities"] = bco_result.get("totalEntities", 0) + bce_result.get("totalEntities", 0)
+        merged["numberOfElements"] = bco_result.get("numberOfElements", 0) + bce_result.get("numberOfElements", 0)
+        return merged
 
     def get_project_details(self, project_id: Union[str, int]) -> Dict:
         if isinstance(project_id, str) and not project_id.isdigit():

--- a/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
@@ -305,14 +305,16 @@ class BCCarbonRegistryAPIClient:
         }
 
         # BCO (offsets): filter by vintage. BCE (earned credits): fetch all vintages.
-        bco_filter = FilterModel(**filter_model.model_dump(exclude_none=True))
-        bco_filter.unitType = {"columnFilters": [ColumnFilter(filterType="Text", type="equals", filter="BCO")]}
-        bco_filter.vintage = {
+        offset_filter = FilterModel(**filter_model.model_dump(exclude_none=True))
+        offset_filter.unitType = {"columnFilters": [ColumnFilter(filterType="Text", type="equals", filter="BCO")]}
+        offset_filter.vintage = {
             "columnFilters": [ColumnFilter(filterType="Number", type="greaterThanOrEqual", filter=vintage_year - 3)]
         }
 
-        bce_filter = FilterModel(**filter_model.model_dump(exclude_none=True))
-        bce_filter.unitType = {"columnFilters": [ColumnFilter(filterType="Text", type="equals", filter="BCE")]}
+        earned_credit_filter = FilterModel(**filter_model.model_dump(exclude_none=True))
+        earned_credit_filter.unitType = {
+            "columnFilters": [ColumnFilter(filterType="Text", type="equals", filter="BCE")]
+        }
 
         def _fetch(f: FilterModel) -> Dict:
             return self._make_request(
@@ -324,13 +326,15 @@ class BCCarbonRegistryAPIClient:
                 response_model=UnitDetailsResponse,
             )
 
-        bco_result = _fetch(bco_filter)
-        bce_result = _fetch(bce_filter)
+        offset_result = _fetch(offset_filter)
+        earned_credit_result = _fetch(earned_credit_filter)
 
-        merged = bco_result.copy()
-        merged["entities"] = bco_result.get("entities", []) + bce_result.get("entities", [])
-        merged["totalEntities"] = bco_result.get("totalEntities", 0) + bce_result.get("totalEntities", 0)
-        merged["numberOfElements"] = bco_result.get("numberOfElements", 0) + bce_result.get("numberOfElements", 0)
+        merged = offset_result.copy()
+        merged["entities"] = offset_result.get("entities", []) + earned_credit_result.get("entities", [])
+        merged["totalEntities"] = offset_result.get("totalEntities", 0) + earned_credit_result.get("totalEntities", 0)
+        merged["numberOfElements"] = offset_result.get("numberOfElements", 0) + earned_credit_result.get(
+            "numberOfElements", 0
+        )
         return merged
 
     def get_project_details(self, project_id: Union[str, int]) -> Dict:

--- a/bc_obps/compliance/service/bc_carbon_registry/schema.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/schema.py
@@ -40,6 +40,7 @@ class FilterModel(BaseModel):
     accountTypeCode: CommonFilterType = None
     stateCode: CommonFilterType = None
     vintage: CommonFilterType = None
+    unitType: CommonFilterType = None
     complianceYear: CommonFilterType = None
     boroId: CommonFilterType = None
 

--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
@@ -548,7 +548,21 @@ class TestBCCarbonRegistryAPIClient:
     def test_list_all_units_holding_account_success(self, authenticated_client):
         # Arrange
         client, mock_request = authenticated_client
-        mock_response = Mock(
+        base_entity = {
+            "id": MOCK_FIFTEEN_DIGIT_STRING,
+            "entityId": MOCK_FIFTEEN_DIGIT_INT,
+            "standardId": MOCK_FIFTEEN_DIGIT_INT,
+            "standardName": "Test Standard",
+            "accountId": MOCK_FIFTEEN_DIGIT_INT,
+            "accountName": "Test Account",
+            "projectId": MOCK_FIFTEEN_DIGIT_INT,
+            "holdingQuantity": 2.0,
+            "serialNo": "BC-BCO-IN-104000000037027-01032025-30032025-16414-16752-SPG",
+            "unitMeasurementName": "tCO2e",
+            "unitType": "BCO",
+            "className": "BCO",
+        }
+        bco_response = Mock(
             status_code=200,
             json=lambda: {
                 "totalEntities": 1,
@@ -556,30 +570,28 @@ class TestBCCarbonRegistryAPIClient:
                 "numberOfElements": 1,
                 "first": True,
                 "last": True,
-                "entities": [
-                    {
-                        "id": MOCK_FIFTEEN_DIGIT_STRING,
-                        "entityId": MOCK_FIFTEEN_DIGIT_INT,
-                        "standardId": MOCK_FIFTEEN_DIGIT_INT,
-                        "standardName": "Test Standard",
-                        "accountId": MOCK_FIFTEEN_DIGIT_INT,
-                        "accountName": "Test Account",
-                        "projectId": MOCK_FIFTEEN_DIGIT_INT,
-                        "holdingQuantity": 2.0,
-                        "serialNo": "BC-BCE-IN-104000000037027-01032025-30032025-16414-16752-SPG",
-                        "unitMeasurementName": "tCO2e",
-                        "unitType": "BCO",
-                        "className": "BCO",
-                    }
-                ],
+                "entities": [{**base_entity, "unitType": "BCO", "className": "BCO"}],
             },
         )
-        mock_request.return_value = mock_response
+        bce_response = Mock(
+            status_code=200,
+            json=lambda: {
+                "totalEntities": 1,
+                "totalPages": 1,
+                "numberOfElements": 1,
+                "first": True,
+                "last": True,
+                "entities": [{**base_entity, "unitType": "BCE", "className": "BCE"}],
+            },
+        )
+        mock_request.side_effect = [bco_response, bce_response]
         # Act
         result = client.list_all_units(account_id="123", vintage_year=2022, limit=10, start=0)
         # Assert
-        assert result["totalEntities"] == 1
-        assert len(result["entities"]) == 1
+        assert result["totalEntities"] == 2
+        assert result["numberOfElements"] == 2
+        assert len(result["entities"]) == 2
+        assert mock_request.call_count == 2
         assert sorted(list(result["entities"][0].keys())) == sorted(
             [
                 "id",
@@ -596,64 +608,96 @@ class TestBCCarbonRegistryAPIClient:
                 "className",
             ]
         )
-        mock_request.assert_called_once()
-        # Verify the payload uses accountId, accountTypeCode REGULATED_OPERATION, and stateCode ACTIVE
-        call_kwargs = mock_request.call_args
-        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
-        filter_model = payload["searchFilter"]["filterModel"]
-        assert "accountId" in filter_model
-        assert "subAccountId" not in filter_model
-        assert filter_model["accountTypeCode"]["columnFilters"][0]["filter"] == "REGULATED_OPERATION"
-        assert filter_model["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE"
-        assert filter_model["stateCode"]["columnFilters"][0]["type"] == "equals"
+        # Verify BCO request: unitType=BCO, vintage>=2019 (2022-3), accountId, REGULATED_OPERATION, ACTIVE
+        bco_payload = mock_request.call_args_list[0].kwargs.get("json") or mock_request.call_args_list[0][1].get("json")
+        bco_filter = bco_payload["searchFilter"]["filterModel"]
+        assert "accountId" in bco_filter
+        assert "subAccountId" not in bco_filter
+        assert bco_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "REGULATED_OPERATION"
+        assert bco_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE"
+        assert bco_filter["stateCode"]["columnFilters"][0]["type"] == "equals"
+        assert bco_filter["unitType"]["columnFilters"][0]["filter"] == "BCO"
+        assert bco_filter["vintage"]["columnFilters"][0]["filter"] == 2019
+        assert bco_filter["vintage"]["columnFilters"][0]["type"] == "greaterThanOrEqual"
+        # Verify BCE request: unitType=BCE, no vintage filter, same account/state filters
+        bce_payload = mock_request.call_args_list[1].kwargs.get("json") or mock_request.call_args_list[1][1].get("json")
+        bce_filter = bce_payload["searchFilter"]["filterModel"]
+        assert "accountId" in bce_filter
+        assert "subAccountId" not in bce_filter
+        assert bce_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "REGULATED_OPERATION"
+        assert bce_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE"
+        assert bce_filter["unitType"]["columnFilters"][0]["filter"] == "BCE"
+        assert "vintage" not in bce_filter
 
     def test_list_all_units_sub_account_success(self, authenticated_client):
         # Arrange
         client, mock_request = authenticated_client
-        mock_response = Mock(
+        base_entity = {
+            "id": MOCK_FIFTEEN_DIGIT_STRING,
+            "entityId": MOCK_FIFTEEN_DIGIT_INT,
+            "standardId": MOCK_FIFTEEN_DIGIT_INT,
+            "standardName": "Test Standard",
+            "accountId": MOCK_FIFTEEN_DIGIT_INT,
+            "accountName": "Test Sub Account",
+            "projectId": MOCK_FIFTEEN_DIGIT_INT,
+            "holdingQuantity": 3.0,
+            "serialNo": "BC-BCE-IN-104000000037027-01032025-30032025-16414-16752-SPG",
+            "unitMeasurementName": "tCO2e",
+            "unitType": "BCO",
+            "className": "BCO",
+        }
+        bco_response = Mock(
             status_code=200,
             json=lambda: {
-                "totalEntities": 2,
+                "totalEntities": 1,
                 "totalPages": 1,
-                "numberOfElements": 2,
+                "numberOfElements": 1,
                 "first": True,
                 "last": True,
-                "entities": [
-                    {
-                        "id": MOCK_FIFTEEN_DIGIT_STRING,
-                        "entityId": MOCK_FIFTEEN_DIGIT_INT,
-                        "standardId": MOCK_FIFTEEN_DIGIT_INT,
-                        "standardName": "Test Standard",
-                        "accountId": MOCK_FIFTEEN_DIGIT_INT,
-                        "accountName": "Test Sub Account",
-                        "projectId": MOCK_FIFTEEN_DIGIT_INT,
-                        "holdingQuantity": 3.0,
-                        "serialNo": "BC-BCE-IN-104000000037027-01032025-30032025-16414-16752-SPG",
-                        "unitMeasurementName": "tCO2e",
-                        "unitType": "BCO",
-                        "className": "BCO",
-                    }
-                ],
+                "entities": [{**base_entity, "unitType": "BCO", "className": "BCO"}],
             },
         )
-        mock_request.return_value = mock_response
+        bce_response = Mock(
+            status_code=200,
+            json=lambda: {
+                "totalEntities": 1,
+                "totalPages": 1,
+                "numberOfElements": 1,
+                "first": True,
+                "last": True,
+                "entities": [{**base_entity, "unitType": "BCE", "className": "BCE"}],
+            },
+        )
+        mock_request.side_effect = [bco_response, bce_response]
         # Act
         result = client.list_all_units(
             account_id="456", vintage_year=2022, limit=10, start=0, account_type="sub_account"
         )
         # Assert
         assert result["totalEntities"] == 2
-        assert len(result["entities"]) == 1
-        mock_request.assert_called_once()
-        # Verify the payload uses subAccountId, accountTypeCode COMPLIANCE_SUB_ACCOUNT, and stateCode ACTIVE,RETIRED
-        call_kwargs = mock_request.call_args
-        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
-        filter_model = payload["searchFilter"]["filterModel"]
-        assert "subAccountId" in filter_model
-        assert "accountId" not in filter_model
-        assert filter_model["accountTypeCode"]["columnFilters"][0]["filter"] == "COMPLIANCE_SUB_ACCOUNT"
-        assert filter_model["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE,RETIRED"
-        assert filter_model["stateCode"]["columnFilters"][0]["type"] == "in"
+        assert result["numberOfElements"] == 2
+        assert len(result["entities"]) == 2
+        assert mock_request.call_count == 2
+        # Verify BCO request: subAccountId, COMPLIANCE_SUB_ACCOUNT, ACTIVE,RETIRED, vintage filter, unitType=BCO
+        bco_payload = mock_request.call_args_list[0].kwargs.get("json") or mock_request.call_args_list[0][1].get("json")
+        bco_filter = bco_payload["searchFilter"]["filterModel"]
+        assert "subAccountId" in bco_filter
+        assert "accountId" not in bco_filter
+        assert bco_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "COMPLIANCE_SUB_ACCOUNT"
+        assert bco_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE,RETIRED"
+        assert bco_filter["stateCode"]["columnFilters"][0]["type"] == "in"
+        assert bco_filter["unitType"]["columnFilters"][0]["filter"] == "BCO"
+        assert "vintage" in bco_filter
+        # Verify BCE request: subAccountId, COMPLIANCE_SUB_ACCOUNT, ACTIVE,RETIRED, no vintage filter, unitType=BCE
+        bce_payload = mock_request.call_args_list[1].kwargs.get("json") or mock_request.call_args_list[1][1].get("json")
+        bce_filter = bce_payload["searchFilter"]["filterModel"]
+        assert "subAccountId" in bce_filter
+        assert "accountId" not in bce_filter
+        assert bce_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "COMPLIANCE_SUB_ACCOUNT"
+        assert bce_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE,RETIRED"
+        assert bce_filter["stateCode"]["columnFilters"][0]["type"] == "in"
+        assert bce_filter["unitType"]["columnFilters"][0]["filter"] == "BCE"
+        assert "vintage" not in bce_filter
 
     def test_list_all_units_invalid_params(self, setup, caplog):
         # Arrange
@@ -667,7 +711,7 @@ class TestBCCarbonRegistryAPIClient:
     def test_list_all_units_no_units_in_vintage(self, authenticated_client):
         # Arrange
         client, mock_request = authenticated_client
-        mock_response = Mock(
+        empty_response = Mock(
             status_code=200,
             json=lambda: {
                 "totalEntities": 0,
@@ -678,15 +722,17 @@ class TestBCCarbonRegistryAPIClient:
                 "entities": [],
             },
         )
-        mock_request.return_value = mock_response
+        # Both BCO and BCE requests return empty results
+        mock_request.side_effect = [empty_response, empty_response]
 
         # Act
         result = client.list_all_units(account_id="123", vintage_year=2022, limit=10, start=0)
 
         # Assert
         assert result["totalEntities"] == 0
+        assert result["numberOfElements"] == 0
         assert len(result["entities"]) == 0
-        mock_request.assert_called_once()
+        assert mock_request.call_count == 2
 
     def test_get_project_details_success(self, authenticated_client):
         # Arrange

--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
@@ -562,7 +562,7 @@ class TestBCCarbonRegistryAPIClient:
             "unitType": "BCO",
             "className": "BCO",
         }
-        bco_response = Mock(
+        offset_response = Mock(
             status_code=200,
             json=lambda: {
                 "totalEntities": 1,
@@ -573,7 +573,7 @@ class TestBCCarbonRegistryAPIClient:
                 "entities": [{**base_entity, "unitType": "BCO", "className": "BCO"}],
             },
         )
-        bce_response = Mock(
+        earned_credit_response = Mock(
             status_code=200,
             json=lambda: {
                 "totalEntities": 1,
@@ -584,7 +584,7 @@ class TestBCCarbonRegistryAPIClient:
                 "entities": [{**base_entity, "unitType": "BCE", "className": "BCE"}],
             },
         )
-        mock_request.side_effect = [bco_response, bce_response]
+        mock_request.side_effect = [offset_response, earned_credit_response]
         # Act
         result = client.list_all_units(account_id="123", vintage_year=2022, limit=10, start=0)
         # Assert
@@ -609,25 +609,29 @@ class TestBCCarbonRegistryAPIClient:
             ]
         )
         # Verify BCO request: unitType=BCO, vintage>=2019 (2022-3), accountId, REGULATED_OPERATION, ACTIVE
-        bco_payload = mock_request.call_args_list[0].kwargs.get("json") or mock_request.call_args_list[0][1].get("json")
-        bco_filter = bco_payload["searchFilter"]["filterModel"]
-        assert "accountId" in bco_filter
-        assert "subAccountId" not in bco_filter
-        assert bco_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "REGULATED_OPERATION"
-        assert bco_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE"
-        assert bco_filter["stateCode"]["columnFilters"][0]["type"] == "equals"
-        assert bco_filter["unitType"]["columnFilters"][0]["filter"] == "BCO"
-        assert bco_filter["vintage"]["columnFilters"][0]["filter"] == 2019
-        assert bco_filter["vintage"]["columnFilters"][0]["type"] == "greaterThanOrEqual"
+        offset_payload = mock_request.call_args_list[0].kwargs.get("json") or mock_request.call_args_list[0][1].get(
+            "json"
+        )
+        offset_filter = offset_payload["searchFilter"]["filterModel"]
+        assert "accountId" in offset_filter
+        assert "subAccountId" not in offset_filter
+        assert offset_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "REGULATED_OPERATION"
+        assert offset_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE"
+        assert offset_filter["stateCode"]["columnFilters"][0]["type"] == "equals"
+        assert offset_filter["unitType"]["columnFilters"][0]["filter"] == "BCO"
+        assert offset_filter["vintage"]["columnFilters"][0]["filter"] == 2019
+        assert offset_filter["vintage"]["columnFilters"][0]["type"] == "greaterThanOrEqual"
         # Verify BCE request: unitType=BCE, no vintage filter, same account/state filters
-        bce_payload = mock_request.call_args_list[1].kwargs.get("json") or mock_request.call_args_list[1][1].get("json")
-        bce_filter = bce_payload["searchFilter"]["filterModel"]
-        assert "accountId" in bce_filter
-        assert "subAccountId" not in bce_filter
-        assert bce_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "REGULATED_OPERATION"
-        assert bce_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE"
-        assert bce_filter["unitType"]["columnFilters"][0]["filter"] == "BCE"
-        assert "vintage" not in bce_filter
+        earned_credit_payload = mock_request.call_args_list[1].kwargs.get("json") or mock_request.call_args_list[1][
+            1
+        ].get("json")
+        earned_credit_filter = earned_credit_payload["searchFilter"]["filterModel"]
+        assert "accountId" in earned_credit_filter
+        assert "subAccountId" not in earned_credit_filter
+        assert earned_credit_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "REGULATED_OPERATION"
+        assert earned_credit_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE"
+        assert earned_credit_filter["unitType"]["columnFilters"][0]["filter"] == "BCE"
+        assert "vintage" not in earned_credit_filter
 
     def test_list_all_units_sub_account_success(self, authenticated_client):
         # Arrange
@@ -646,7 +650,7 @@ class TestBCCarbonRegistryAPIClient:
             "unitType": "BCO",
             "className": "BCO",
         }
-        bco_response = Mock(
+        offset_response = Mock(
             status_code=200,
             json=lambda: {
                 "totalEntities": 1,
@@ -657,7 +661,7 @@ class TestBCCarbonRegistryAPIClient:
                 "entities": [{**base_entity, "unitType": "BCO", "className": "BCO"}],
             },
         )
-        bce_response = Mock(
+        earned_credit_response = Mock(
             status_code=200,
             json=lambda: {
                 "totalEntities": 1,
@@ -668,7 +672,7 @@ class TestBCCarbonRegistryAPIClient:
                 "entities": [{**base_entity, "unitType": "BCE", "className": "BCE"}],
             },
         )
-        mock_request.side_effect = [bco_response, bce_response]
+        mock_request.side_effect = [offset_response, earned_credit_response]
         # Act
         result = client.list_all_units(
             account_id="456", vintage_year=2022, limit=10, start=0, account_type="sub_account"
@@ -679,25 +683,29 @@ class TestBCCarbonRegistryAPIClient:
         assert len(result["entities"]) == 2
         assert mock_request.call_count == 2
         # Verify BCO request: subAccountId, COMPLIANCE_SUB_ACCOUNT, ACTIVE,RETIRED, vintage filter, unitType=BCO
-        bco_payload = mock_request.call_args_list[0].kwargs.get("json") or mock_request.call_args_list[0][1].get("json")
-        bco_filter = bco_payload["searchFilter"]["filterModel"]
-        assert "subAccountId" in bco_filter
-        assert "accountId" not in bco_filter
-        assert bco_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "COMPLIANCE_SUB_ACCOUNT"
-        assert bco_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE,RETIRED"
-        assert bco_filter["stateCode"]["columnFilters"][0]["type"] == "in"
-        assert bco_filter["unitType"]["columnFilters"][0]["filter"] == "BCO"
-        assert "vintage" in bco_filter
+        offset_payload = mock_request.call_args_list[0].kwargs.get("json") or mock_request.call_args_list[0][1].get(
+            "json"
+        )
+        offset_filter = offset_payload["searchFilter"]["filterModel"]
+        assert "subAccountId" in offset_filter
+        assert "accountId" not in offset_filter
+        assert offset_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "COMPLIANCE_SUB_ACCOUNT"
+        assert offset_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE,RETIRED"
+        assert offset_filter["stateCode"]["columnFilters"][0]["type"] == "in"
+        assert offset_filter["unitType"]["columnFilters"][0]["filter"] == "BCO"
+        assert "vintage" in offset_filter
         # Verify BCE request: subAccountId, COMPLIANCE_SUB_ACCOUNT, ACTIVE,RETIRED, no vintage filter, unitType=BCE
-        bce_payload = mock_request.call_args_list[1].kwargs.get("json") or mock_request.call_args_list[1][1].get("json")
-        bce_filter = bce_payload["searchFilter"]["filterModel"]
-        assert "subAccountId" in bce_filter
-        assert "accountId" not in bce_filter
-        assert bce_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "COMPLIANCE_SUB_ACCOUNT"
-        assert bce_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE,RETIRED"
-        assert bce_filter["stateCode"]["columnFilters"][0]["type"] == "in"
-        assert bce_filter["unitType"]["columnFilters"][0]["filter"] == "BCE"
-        assert "vintage" not in bce_filter
+        earned_credit_payload = mock_request.call_args_list[1].kwargs.get("json") or mock_request.call_args_list[1][
+            1
+        ].get("json")
+        earned_credit_filter = earned_credit_payload["searchFilter"]["filterModel"]
+        assert "subAccountId" in earned_credit_filter
+        assert "accountId" not in earned_credit_filter
+        assert earned_credit_filter["accountTypeCode"]["columnFilters"][0]["filter"] == "COMPLIANCE_SUB_ACCOUNT"
+        assert earned_credit_filter["stateCode"]["columnFilters"][0]["filter"] == "ACTIVE,RETIRED"
+        assert earned_credit_filter["stateCode"]["columnFilters"][0]["type"] == "in"
+        assert earned_credit_filter["unitType"]["columnFilters"][0]["filter"] == "BCE"
+        assert "vintage" not in earned_credit_filter
 
     def test_list_all_units_invalid_params(self, setup, caplog):
         # Arrange


### PR DESCRIPTION
[ISSUE 4782](https://github.com/bcgov/cas-registration/issues/4782)

## 🧪 Testing:  

---
⚠️ IMPORTANT: 

- Ensure invoices are created in eLicensing by using Django Admin to set the invoice generation date to a past date, or by running the SQL query below in the database:

```
UPDATE erc.compliance_period
SET invoice_generation_date = (CURRENT_DATE - INTERVAL '1 day')
WHERE reporting_year_id = 2025;
```
---

####  Submit an obligation report
1. Log in using `bc-cas-dev`
2. For report `Compliance SFO - Obligation not met`, navigate to http://localhost:3000/reporting/reports/3/sign-off
3. Complete the form
4. Click Submit
5. Navigate to the Compliance Summaries data grid
6. Click the Manage Obligation link for the relevant entry
7. Click the Apply Compliance Units button
8. Use Chesca's BCCR account ID to view available units (103200000029267)
9. Confirm the new compliance units have a vintage year older than three years