### PR TITLE
Less warnings in backend python tests

### DIFF
--- a/bc_obps/compliance/tests/api/test_permissions.py
+++ b/bc_obps/compliance/tests/api/test_permissions.py
@@ -65,21 +65,21 @@ class TestVersionOwnershipFromUrl:
             "registration.tests.utils.operation_designated_operator_timeline",
             operation=operation,
             operator=old_user_operator.operator,
-            start_date="2023-05-01",
-            end_date="2023-12-31",
+            start_date="2023-05-01T00:00:00Z",
+            end_date="2023-12-31T00:00:00Z",
         )
         make_recipe(
             "registration.tests.utils.operation_designated_operator_timeline",
             operation=operation,
             operator=new_user_operator.operator,
-            start_date="2024-01-01",
+            start_date="2024-01-01T00:00:00Z",
             end_date=None,
         )
 
         compliance_report_version = make_recipe(
             "compliance.tests.utils.compliance_report_version",
             report__operator=new_user_operator.operator,
-            compliance_report__created_at='2024-06-15',
+            compliance_report__created_at='2024-06-15T00:00:00Z',
             compliance_report__report__operation=operation,
         )
 

--- a/bc_obps/compliance/tests/service/automated_process/test_compliance_handlers.py
+++ b/bc_obps/compliance/tests/service/automated_process/test_compliance_handlers.py
@@ -330,7 +330,9 @@ class TestObligationPaidHandler:
                 self.obligation.compliance_report_version.compliance_report.compliance_period.compliance_deadline
             )
 
-            deadline_datetime = datetime(compliance_deadline.year, compliance_deadline.month, compliance_deadline.day)
+            deadline_datetime = timezone.make_aware(
+                datetime(compliance_deadline.year, compliance_deadline.month, compliance_deadline.day)
+            )
             self.compliance_report_version.is_supplementary = True
             self.obligation.created_at = deadline_datetime + timedelta(days=5)
             self.invoice.due_date = (deadline_datetime + timedelta(days=30)).date()
@@ -359,7 +361,9 @@ class TestObligationPaidHandler:
             deadline_date = (
                 self.obligation.compliance_report_version.compliance_report.compliance_period.compliance_deadline
             )
-            deadline_datetime = datetime(deadline_date.year, deadline_date.month, deadline_date.day)
+            deadline_datetime = timezone.make_aware(
+                datetime(deadline_date.year, deadline_date.month, deadline_date.day)
+            )
             self.obligation.created_at = deadline_datetime + timedelta(days=5)
             self.obligation.save()
 
@@ -384,7 +388,9 @@ class TestObligationPaidHandler:
             deadline_date = (
                 self.obligation.compliance_report_version.compliance_report.compliance_period.compliance_deadline
             )
-            deadline_datetime = datetime(deadline_date.year, deadline_date.month, deadline_date.day)
+            deadline_datetime = timezone.make_aware(
+                datetime(deadline_date.year, deadline_date.month, deadline_date.day)
+            )
             self.obligation.created_at = deadline_datetime - timedelta(days=5)
             self.obligation.save()
 

--- a/bc_obps/compliance/tests/service/elicensing/test_elicensing_obligation_service.py
+++ b/bc_obps/compliance/tests/service/elicensing/test_elicensing_obligation_service.py
@@ -2,7 +2,7 @@ from unittest.mock import patch, MagicMock
 import uuid
 from compliance.tests.utils.compliance_test_helper import ComplianceTestHelper
 from compliance.service.elicensing.elicensing_obligation_service import ElicensingObligationService
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 import pytest
 from compliance.models.compliance_obligation import ComplianceObligation
@@ -425,7 +425,7 @@ class TestElicensingObligationService:
         test_data = ComplianceTestHelper.build_test_data(
             reporting_year=2024, crv_status=ComplianceReportVersion.ComplianceStatus.OBLIGATION_NOT_MET
         )
-        test_data.compliance_obligation.created_at = datetime(2025, 12, 15, 11, 11)
+        test_data.compliance_obligation.created_at = datetime(2025, 12, 15, 11, 11, tzinfo=timezone.utc)
         test_data.compliance_obligation.save()
         client_operator = make_recipe(
             'compliance.tests.utils.elicensing_client_operator',

--- a/bc_obps/compliance/tests/service/test_compliance_dashboard_service.py
+++ b/bc_obps/compliance/tests/service/test_compliance_dashboard_service.py
@@ -171,8 +171,8 @@ class TestComplianceDashboardService:
         make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
             operation=xferred_test_data.operation,
-            start_date="2024-01-01 01:46:20.789146",
-            end_date="2026-02-27 01:46:20.789146",
+            start_date="2024-01-01 01:46:20.789146+00:00",
+            end_date="2026-02-27 01:46:20.789146+00:00",
             operator=previous_operator,
         )
 

--- a/bc_obps/compliance/tests/service/test_compliance_report_version_service.py
+++ b/bc_obps/compliance/tests/service/test_compliance_report_version_service.py
@@ -161,8 +161,8 @@ class TestComplianceReportVersionService:
         xferred_operation = baker.make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
             operation=baker.make_recipe('registration.tests.utils.operation', status=Operation.Statuses.REGISTERED),
-            start_date="2024-01-01 01:46:20.789146",
-            end_date="2026-02-27 01:46:20.789146",
+            start_date="2024-01-01 01:46:20.789146+00:00",
+            end_date="2026-02-27 01:46:20.789146+00:00",
             operator=operator,
         )
 
@@ -181,8 +181,8 @@ class TestComplianceReportVersionService:
         xferred_operation_2 = baker.make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
             operation=baker.make_recipe('registration.tests.utils.operation', status=Operation.Statuses.REGISTERED),
-            start_date="2024-01-01 01:46:20.789146",
-            end_date="2026-02-27 01:46:20.789146",
+            start_date="2024-01-01 01:46:20.789146+00:00",
+            end_date="2026-02-27 01:46:20.789146+00:00",
             operator=operator,
         )
 

--- a/bc_obps/compliance/tests/service/test_penalty_calculation_service.py
+++ b/bc_obps/compliance/tests/service/test_penalty_calculation_service.py
@@ -1,5 +1,6 @@
 import pytest
-from datetime import date, timedelta
+from datetime import date, datetime, time, timedelta
+from django.utils import timezone
 from decimal import Decimal
 from unittest.mock import patch
 from model_bakery import baker
@@ -157,7 +158,9 @@ class TestPenaltyCalculationService:
         self.obligation.elicensing_invoice = clean_invoice
         compliance_period = self.obligation.compliance_report_version.compliance_report.compliance_period
         compliance_deadline = compliance_period.compliance_deadline
-        self.obligation.created_at = compliance_deadline - timedelta(days=1)
+        self.obligation.created_at = timezone.make_aware(
+            datetime.combine(compliance_deadline - timedelta(days=1), time.min)
+        )
         self.obligation.save()
 
         mock_refresh_data.return_value = RefreshWrapperReturn(data_is_fresh=True, invoice=clean_invoice)
@@ -251,7 +254,9 @@ class TestPenaltyCalculationService:
         self.obligation.elicensing_invoice = clean_invoice
         compliance_period = self.obligation.compliance_report_version.compliance_report.compliance_period
         compliance_deadline = compliance_period.compliance_deadline
-        self.obligation.created_at = compliance_deadline - timedelta(days=1)
+        self.obligation.created_at = timezone.make_aware(
+            datetime.combine(compliance_deadline - timedelta(days=1), time.min)
+        )
         self.obligation.save(update_fields=["created_at"])
 
         last_transaction_date = PenaltyCalculationService.determine_last_transaction_date(obligation=self.obligation)

--- a/bc_obps/reporting/models/report_emission.py
+++ b/bc_obps/reporting/models/report_emission.py
@@ -67,7 +67,7 @@ class ReportEmission(ReportDataBaseModel):
         app_label = "reporting"
         constraints = [
             models.CheckConstraint(
-                check=~(Q(report_fuel__isnull=False) & Q(report_unit__isnull=False)),
+                condition=~(Q(report_fuel__isnull=False) & Q(report_unit__isnull=False)),
                 name="fuel_or_unit_but_not_both",
                 violation_error_message="An emission record must belong to either a fuel, a unit, or none, but not both",
             )

--- a/bc_obps/reporting/models/report_emission_allocation.py
+++ b/bc_obps/reporting/models/report_emission_allocation.py
@@ -57,7 +57,7 @@ class ReportEmissionAllocation(TimeStampedModel):
             ),
             models.CheckConstraint(
                 name="allocation_other_methodology_must_have_description",
-                check=~Q(
+                condition=~Q(
                     allocation_methodology="Other",
                     allocation_other_methodology_description__isnull=True,
                 ),

--- a/bc_obps/reporting/models/report_verification_visit.py
+++ b/bc_obps/reporting/models/report_verification_visit.py
@@ -54,7 +54,7 @@ class ReportVerificationVisit(TimeStampedModel):
         constraints = [
             models.CheckConstraint(
                 name="other_facility_must_have_coordinates",
-                check=Q(is_other_visit=False) | Q(visit_coordinates__isnull=False),
+                condition=Q(is_other_visit=False) | Q(visit_coordinates__isnull=False),
                 violation_error_message="Coordinates must be provided for an other facility visit",
             ),
         ]

--- a/bc_obps/reporting/tests/api/test_permissions.py
+++ b/bc_obps/reporting/tests/api/test_permissions.py
@@ -99,7 +99,7 @@ class TestOperationOwnershipFromPayload:
             "registration.tests.utils.operation_designated_operator_timeline",
             operation=operation,
             operator=user_operator.operator,
-            start_date="2023-01-01",
+            start_date="2023-01-01T00:00:00Z",
             end_date=None,
         )
 
@@ -120,7 +120,7 @@ class TestOperationOwnershipFromPayload:
             "registration.tests.utils.operation_designated_operator_timeline",
             operation=operation,
             operator=operation.operator,
-            start_date="2023-01-01",
+            start_date="2023-01-01T00:00:00Z",
             end_date=None,
         )
 
@@ -163,14 +163,14 @@ class TestOperationOwnershipFromPayload:
             "registration.tests.utils.operation_designated_operator_timeline",
             operation=operation,
             operator=old_user_operator.operator,
-            start_date="2024-01-01",
-            end_date="2025-01-31",
+            start_date="2024-01-01T00:00:00Z",
+            end_date="2025-01-31T00:00:00Z",
         )
         make_recipe(
             "registration.tests.utils.operation_designated_operator_timeline",
             operation=operation,
             operator=new_user_operator.operator,
-            start_date="2025-02-01",
+            start_date="2025-02-01T00:00:00Z",
             end_date=None,
         )
 

--- a/bc_obps/reporting/tests/endpoints/test_create_reports_endpoint.py
+++ b/bc_obps/reporting/tests/endpoints/test_create_reports_endpoint.py
@@ -53,7 +53,7 @@ class TestReportsEndpoint(CommonTestSetup):
             'registration.tests.utils.operation_designated_operator_timeline',
             operation=operation,
             operator=operation.operator,
-            start_date=timezone.datetime(2024, 1, 1).date(),
+            start_date=timezone.make_aware(timezone.datetime(2024, 1, 1)),
             end_date=None,
         )
 
@@ -68,7 +68,7 @@ class TestReportsEndpoint(CommonTestSetup):
             'registration.tests.utils.operation_designated_operator_timeline',
             operation=report.operation,
             operator=report.operation.operator,
-            start_date=timezone.datetime(2022, 1, 1).date(),
+            start_date=timezone.make_aware(timezone.datetime(2022, 1, 1)),
             end_date=None,
         )
 
@@ -94,7 +94,7 @@ class TestReportsEndpoint(CommonTestSetup):
             'registration.tests.utils.operation_designated_operator_timeline',
             operation=operation,
             operator=user_operator.operator,
-            start_date=timezone.datetime(2022, 1, 1).date(),
+            start_date=timezone.make_aware(timezone.datetime(2022, 1, 1)),
             end_date=None,
         )
 

--- a/bc_obps/reporting/tests/endpoints/test_report_new_entrant_endpoint.py
+++ b/bc_obps/reporting/tests/endpoints/test_report_new_entrant_endpoint.py
@@ -16,9 +16,9 @@ class TestNewEntrantDataApi(CommonTestSetup):
         self.report_new_entrant = baker.make_recipe(
             'reporting.tests.utils.report_new_entrant',
             report_version=self.report_version,
-            authorization_date='2022-01-01',
-            first_shipment_date='4999-01-02',
-            new_entrant_period_start='1999-01-02',
+            authorization_date='2022-01-01T00:00:00Z',
+            first_shipment_date='4999-01-02T00:00:00Z',
+            new_entrant_period_start='1999-01-02T00:00:00Z',
         )
 
         super().setup_method()
@@ -76,10 +76,10 @@ class TestNewEntrantDataApi(CommonTestSetup):
             'naics_code': '486210',
             'new_entrant_data': {
                 'assertion_statement': True,
-                'authorization_date': '2022-01-01T00:00:00',
-                'first_shipment_date': '4999-01-02T00:00:00',
+                'authorization_date': '2022-01-01T00:00:00Z',
+                'first_shipment_date': '4999-01-02T00:00:00Z',
                 'id': self.report_new_entrant.id,
-                'new_entrant_period_start': '1999-01-02T00:00:00',
+                'new_entrant_period_start': '1999-01-02T00:00:00Z',
             },
             'products': [
                 {
@@ -149,10 +149,10 @@ class TestNewEntrantDataApi(CommonTestSetup):
             'naics_code': '486210',
             'new_entrant_data': {
                 'assertion_statement': True,
-                'authorization_date': '2022-01-01T00:00:00',
-                'first_shipment_date': '4999-01-02T00:00:00',
+                'authorization_date': '2022-01-01T00:00:00Z',
+                'first_shipment_date': '4999-01-02T00:00:00Z',
                 'id': self.report_new_entrant.id,
-                'new_entrant_period_start': '1999-01-02T00:00:00',
+                'new_entrant_period_start': '1999-01-02T00:00:00Z',
             },
             'products': [
                 {

--- a/bc_obps/reporting/tests/service/test_compliance_service/test_regulatory_values.py
+++ b/bc_obps/reporting/tests/service/test_compliance_service/test_regulatory_values.py
@@ -1,4 +1,5 @@
-from datetime import date
+from datetime import date, datetime
+from django.utils import timezone
 from decimal import Decimal
 from django.test import TestCase
 from model_bakery.baker import make_recipe
@@ -102,8 +103,8 @@ class TestRegulatoryValues(TestCase):
         report_version = make_recipe(
             "reporting.tests.utils.report_version",
             report__reporting_year__reporting_year=2100,
-            report__reporting_year__reporting_window_start=date(2101, 3, 19),
-            report__reporting_year__reporting_window_end=date(2101, 3, 22),
+            report__reporting_year__reporting_window_start=timezone.make_aware(datetime(2101, 3, 19)),
+            report__reporting_year__reporting_window_end=timezone.make_aware(datetime(2101, 3, 22)),
         )
         make_recipe(
             "reporting.tests.utils.report_operation",
@@ -136,8 +137,8 @@ class TestRegulatoryValues(TestCase):
             "registration.tests.utils.operation_designated_operator_timeline",
             operation=operation,
             operator=operation.operator,
-            start_date=date(2023, 1, 1),
-            end_date=date(2030, 1, 1),
+            start_date=timezone.make_aware(datetime(2023, 1, 1)),
+            end_date=timezone.make_aware(datetime(2030, 1, 1)),
         )
         # create new report
         report_version_id = ReportService.create_report(

--- a/bc_obps/reporting/tests/service/test_report_facilities_service.py
+++ b/bc_obps/reporting/tests/service/test_report_facilities_service.py
@@ -156,7 +156,7 @@ class TestReportFacilitiesService(TestCase):
             FacilityDesignatedOperationTimeline,
             operation=self.operation,
             facility=facility,
-            end_date=timezone.now().date(),
+            end_date=timezone.now(),
         )
 
         # Act: Save the facility
@@ -265,7 +265,7 @@ class TestReportFacilitiesService(TestCase):
             FacilityDesignatedOperationTimeline,
             operation=self.operation,
             facility=past_facility,
-            end_date=timezone.now().date(),
+            end_date=timezone.now(),
         )
 
         # Act

--- a/bc_obps/reporting/tests/service/test_report_new_entrant_service.py
+++ b/bc_obps/reporting/tests/service/test_report_new_entrant_service.py
@@ -76,9 +76,9 @@ class TestReportNewEntrantService(TestCase):
         Test that the service saves or updates the new entrant data correctly.
         """
         data = ReportNewEntrantSchemaIn(
-            authorization_date='2024-01-01',
-            first_shipment_date='2024-02-01',
-            new_entrant_period_start='2024-03-01',
+            authorization_date='2024-01-01T00:00:00Z',
+            first_shipment_date='2024-02-01T00:00:00Z',
+            new_entrant_period_start='2024-03-01T00:00:00Z',
             assertion_statement=True,
             emissions=[
                 {
@@ -148,9 +148,9 @@ class TestReportNewEntrantService(TestCase):
         """
         # Submit empty data for emissions and products
         data = ReportNewEntrantSchemaIn(
-            authorization_date='2024-01-01',
-            first_shipment_date='2024-02-01',
-            new_entrant_period_start='2024-03-01',
+            authorization_date='2024-01-01T00:00:00Z',
+            first_shipment_date='2024-02-01T00:00:00Z',
+            new_entrant_period_start='2024-03-01T00:00:00Z',
             assertion_statement=True,
             emissions=[],
             products=[],

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -64,8 +64,8 @@ class TestReportingDashboardService:
             baker.make_recipe(
                 'registration.tests.utils.operation_designated_operator_timeline',
                 operation=operation,
-                start_date="5090-01-01 01:46:20.789146",
-                end_date="5092-12-31 23:59:59.000000",
+                start_date="5090-01-01 01:46:20.789146+00:00",
+                end_date="5092-12-31 23:59:59.000000+00:00",
                 operator=user_operator.operator,
             )
 
@@ -144,7 +144,7 @@ class TestReportingDashboardService:
                 'registration.tests.utils.operation_designated_operator_timeline',
                 operator=uo.operator,
                 operation=operation,
-                start_date="2023-01-01",
+                start_date="2023-01-01T00:00:00Z",
                 end_date=None,
             )
 
@@ -311,8 +311,8 @@ class TestReportingDashboardService:
             baker.make_recipe(
                 'registration.tests.utils.operation_designated_operator_timeline',
                 operation=operation,
-                start_date="5090-01-01 01:46:20.789146",
-                end_date="5092-12-31 23:59:59.000000",
+                start_date="5090-01-01 01:46:20.789146+00:00",
+                end_date="5092-12-31 23:59:59.000000+00:00",
                 operator=user_operator.operator,
             )
         # Change operation names so sorting by name produces consistent results
@@ -425,7 +425,7 @@ class TestReportingDashboardService:
                 'registration.tests.utils.operation_designated_operator_timeline',
                 operator=operation.operator,
                 operation=operation,
-                start_date="2023-01-01",
+                start_date="2023-01-01T00:00:00Z",
                 end_date=None,
             )
 

--- a/bc_obps/reporting/tests/utils/baker_recipes.py
+++ b/bc_obps/reporting/tests/utils/baker_recipes.py
@@ -103,8 +103,8 @@ electricity_import_data = Recipe(ReportElectricityImportData, report_version=for
 configuration = Recipe(
     Configuration,
     # We make one config per week
-    valid_from=seq(date(4001, 1, 1), start=date(3001, 1, 1), increment_by=timedelta(days=8)),
-    valid_to=seq(date(4001, 1, 7), start=date(3001, 1, 7), increment_by=timedelta(days=8)),
+    valid_from=seq(date(4001, 1, 1), increment_by=timedelta(days=8)),
+    valid_to=seq(date(4001, 1, 7), increment_by=timedelta(days=8)),
 )
 
 activity = Recipe(Activity)

--- a/bc_obps/service/tests/test_operation_designated_operator_timeline_service.py
+++ b/bc_obps/service/tests/test_operation_designated_operator_timeline_service.py
@@ -56,14 +56,14 @@ class TestOperationDesignatedOperatorTimelineService:
             'registration.tests.utils.operation_designated_operator_timeline',
             operation=operation,
             operator=operator1,
-            start_date=timezone.datetime(2024, 6, 1).date(),
-            end_date=timezone.datetime(2025, 5, 31).date(),
+            start_date=timezone.make_aware(timezone.datetime(2024, 6, 1)),
+            end_date=timezone.make_aware(timezone.datetime(2025, 5, 31)),
         )
         timeline2 = baker.make_recipe(
             'registration.tests.utils.operation_designated_operator_timeline',
             operation=operation,
             operator=operator2,
-            start_date=timezone.datetime(2025, 5, 31).date(),
+            start_date=timezone.make_aware(timezone.datetime(2025, 5, 31)),
             end_date=None,
         )
 

--- a/bc_obps/service/tests/test_report_service.py
+++ b/bc_obps/service/tests/test_report_service.py
@@ -35,7 +35,7 @@ class TestReportService(TestCase):
             'registration.tests.utils.operation_designated_operator_timeline',
             operator=operator,
             operation=operation,
-            start_date="2023-01-01",
+            start_date="2023-01-01T00:00:00Z",
             end_date=None,
         )
 
@@ -93,7 +93,7 @@ class TestReportService(TestCase):
                 'registration.tests.utils.operation_designated_operator_timeline',
                 operator=operation.operator,
                 operation=operation,
-                start_date="2023-01-01",
+                start_date="2023-01-01T00:00:00Z",
                 end_date=None,
             )
 
@@ -202,14 +202,14 @@ class TestReportService(TestCase):
                 'registration.tests.utils.operation_designated_operator_timeline',
                 operator=operator_old,
                 operation=operation,
-                start_date="2020-01-01",
-                end_date="2025-03-01",
+                start_date="2020-01-01T00:00:00Z",
+                end_date="2025-03-01T00:00:00Z",
             )
             make_recipe(
                 'registration.tests.utils.operation_designated_operator_timeline',
                 operator=operator_new,
                 operation=operation,
-                start_date="2025-03-02",
+                start_date="2025-03-02T00:00:00Z",
                 end_date=None,
             )
             # Create contacts for the old operator because they will be used as operation representatives instead of the operation contacts


### PR DESCRIPTION
## Summary

Running the backend test suite (`make pythontests_parallel`) emitted ~167 warnings. This PR removes most of them (22 remains which requires thorough testing) by fixing the underlying causes at the source rather than suppressing them. The warnings fell into three root causes:

1. A deprecated Django `CheckConstraint` API (`RemovedInDjango60Warning`)
2. Naive (timezone-unaware) datetimes assigned to `DateTimeField`s in tests (`RuntimeWarning`)
3. A `model_bakery` `seq()` misuse (`UserWarning`)

No production behavior changes are intended.

## Changes

### 1. Django `CheckConstraint.check` → `condition` deprecation

`RemovedInDjango60Warning: CheckConstraint.check is deprecated in favor of '.condition'.`

Verified with `manage.py makemigrations --check` that this produces **no new migration** (the constraint definition is unchanged; only the kwarg name differs).

### 2. Naive datetimes in test fixtures

`RuntimeWarning: DateTimeField <Model>.<field> received a naive datetime (...) while time zone support is active.`

Many test fixtures assigned naive date/datetime values (date-only strings, `datetime(...)` objects, or `.date()` calls) to `DateTimeField`s. Made these timezone-aware while preserving the exact value:

- Date/datetime **strings** → appended a UTC marker (e.g. `"2023-05-01"` → `"2023-05-01T00:00:00Z"`, `"2024-01-01 01:46:20.789146"` → `"...+00:00"`).
- **`datetime(...)` objects** → made aware via `tzinfo=timezone.utc` or `timezone.make_aware(...)`.
- **`.date()` / `timezone.now().date()`** assignments to `DateTimeField`s → replaced with aware datetimes.

Only lines targeting `DateTimeField`s were changed; assignments to `DateField`s (e.g. `CompliancePeriod.start_date`) were intentionally left alone since they don't trigger the warning.

#### Related assertion update — `reporting/tests/endpoints/test_report_new_entrant_endpoint.py`

Making the new-entrant date fixtures (`authorization_date`, `first_shipment_date`, `new_entrant_period_start`) timezone-aware changed the serialized API response from the naive form (`'2022-01-01T00:00:00'`) to the realistic aware form that production actually returns under `USE_TZ` (`'2022-01-01T00:00:00Z'`). Updated the expected values in the two affected `get_new_entrant_data` tests to match. (Verified the exact serialized output by running the response schema through Pydantic's JSON encoder.)

### 3. `model_bakery` `seq()` misuse — `reporting/tests/utils/baker_recipes.py`

`UserWarning: start parameter is ignored when using seq with date, time or datetime objects`

The `regulated_product` recipe passed both a positional start value **and** a `start=` kwarg to `seq()` with `date` objects. `model_bakery` ignores `start=` for date/time/datetime sequences (the positional value already seeds the sequence), so the kwarg was dead and emitted a warning. Removed the redundant `start=` kwarg — behavior is unchanged.

## Out of scope

A separate group of Pydantic serialization warnings (`PydanticSerializationUnexpectedValue` for `business_structure` / `app_role`) is **not** addressed here. Those stem from input schemas whose field validators intentionally coerce a name string into a Django model instance, and fixing them cleanly is a larger schema-design change best handled on its own.
