### PR TITLE
4748: filter products by year

### DIFF
--- a/bc_obps/common/tests/endpoints/auth/constants.py
+++ b/bc_obps/common/tests/endpoints/auth/constants.py
@@ -81,11 +81,6 @@ ENDPOINTS = {
             "endpoint_name": "get_report_verification_by_version_id",
             "kwargs": {"version_id": MOCK_INT},
         },
-        {
-            "method": "get",
-            "endpoint_name": "get_regulated_products_by_version_id",
-            "kwargs": {"version_id": MOCK_INT},
-        },
         {"method": "get", "endpoint_name": "get_gas_type"},
         {"method": "get", "endpoint_name": "get_emission_category"},
         {

--- a/bc_obps/registration/api/regulated_products.py
+++ b/bc_obps/registration/api/regulated_products.py
@@ -15,9 +15,9 @@ from django.db.models import QuerySet
     "/regulated_products",
     response=List[RegulatedProductSchema],
     tags=REGULATED_PRODUCT_TAGS,
-    description="""Retrieves a list of regulated products.
+    description="""Retrieves a list of valid regulated products.
     The endpoint returns cached data if available; otherwise, it queries the database and caches the results for future requests.""",
     auth=authorize("authorized_roles"),
 )
 def list_regulated_products(request: HttpRequest) -> Tuple[Literal[200], QuerySet[RegulatedProduct]]:
-    return 200, RegulatedProductDataAccessService.get_regulated_products()
+    return 200, RegulatedProductDataAccessService.get_valid_regulated_products()

--- a/bc_obps/registration/tests/endpoints/test_regulated_products.py
+++ b/bc_obps/registration/tests/endpoints/test_regulated_products.py
@@ -13,3 +13,17 @@ class TestRegulatedProductsEndpoint(CommonTestSetup):
         assert response.json()[0]["id"] is not None
         assert response.json()[0]["name"] is not None
         assert response.json()[0]["is_regulated"] is not None
+
+    def test_get_only_valid_products(self):
+        RegulatedProduct.objects.create(
+            name="Valid Product", is_regulated=True, valid_from="2023-01-01", valid_to="2099-01-01"
+        )
+        RegulatedProduct.objects.create(
+            name="Invalid Product", is_regulated=True, valid_from="2050-01-01", valid_to="2099-01-01"
+        )
+        response = TestUtils.mock_get_with_auth_role(
+            self, "industry_user", custom_reverse_lazy("list_regulated_products")
+        )
+        product_names = [prod["name"] for prod in response.json()]
+        assert "Valid Product" in product_names
+        assert "Invalid Product" not in product_names

--- a/bc_obps/reporting/api/__init__.py
+++ b/bc_obps/reporting/api/__init__.py
@@ -11,7 +11,6 @@ from .fuel import get_fuel_data
 from .report_person_responsible import get_report_person_responsible_by_version_id
 from .report_person_responsible import save_report_contact
 from .reports import get_registration_purpose_by_version_id
-from .reports import get_regulated_products_by_version_id
 from .reports import get_report_version
 from .reports import delete_report_version
 from .reports import create_report_version

--- a/bc_obps/reporting/api/reports.py
+++ b/bc_obps/reporting/api/reports.py
@@ -4,7 +4,8 @@ from django.db.models import QuerySet
 
 from common.permissions import authorize, compose_auth
 from django.http import HttpRequest
-from registration.models import RegulatedProduct
+
+# from registration.models import RegulatedProduct
 from reporting.api.permissions import check_operation_ownership
 from reporting.constants import EMISSIONS_REPORT_TAGS
 from reporting.schema.generic import Message
@@ -15,7 +16,8 @@ from service.reporting_year_service import ReportingYearService
 from service.error_service.custom_codes_4xx import custom_codes_4xx
 from reporting.schema.reporting_year import ReportingYearOut
 from .router import router
-from ..schema.report_regulated_products import RegulatedProductOut
+
+# from ..schema.report_regulated_products import RegulatedProductOut
 from ..schema.report_version import ReportVersionTypeIn, ReportVersionIn, ReportingVersionOut
 from reporting.api.permissions import (
     approved_industry_user_report_version_composite_auth,
@@ -76,20 +78,6 @@ def get_all_reporting_years(
     request: HttpRequest, exclude_past: Optional[bool] = None
 ) -> Tuple[Literal[200], QuerySet[ReportingYear]]:
     return 200, ReportingYearService.get_all_reporting_years(exclude_past or False)
-
-
-@router.get(
-    "/report-version/{version_id}/report-operation/regulated-products",
-    response={200: List[RegulatedProductOut], custom_codes_4xx: Message},
-    tags=EMISSIONS_REPORT_TAGS,
-    description="""Retrieves all regulated products associated with a report operation identified by its version ID.""",
-    auth=approved_industry_user_report_version_composite_auth,
-)
-def get_regulated_products_by_version_id(
-    request: HttpRequest, version_id: int
-) -> tuple[Literal[200], QuerySet[RegulatedProduct]]:
-    regulated_products = ReportService.get_regulated_products_by_version_id(version_id)
-    return 200, regulated_products
 
 
 @router.get(

--- a/bc_obps/reporting/service/report_operation_service.py
+++ b/bc_obps/reporting/service/report_operation_service.py
@@ -20,7 +20,7 @@ class ReportOperationService:
         report_operation = cls.get_report_operation_by_version_id(version_id)
         all_activities = ActivityService.get_all_activities()
         reporting_year = ReportingYearService.get_reporting_year_by_version_id(version_id)
-        regulated_products = RegulatedProductDataAccessService.get_regulated_products(
+        regulated_products = RegulatedProductDataAccessService.get_valid_regulated_products(
             date(reporting_year.reporting_year, 1, 1)
         )
         purpose = report_operation["registration_purpose"]

--- a/bc_obps/reporting/service/report_operation_service.py
+++ b/bc_obps/reporting/service/report_operation_service.py
@@ -1,3 +1,4 @@
+from datetime import date
 from django.db import transaction
 
 from django.forms import model_to_dict
@@ -18,8 +19,10 @@ class ReportOperationService:
     def get_report_operation_data_by_version_id(cls, version_id: int) -> dict:
         report_operation = cls.get_report_operation_by_version_id(version_id)
         all_activities = ActivityService.get_all_activities()
-        regulated_products = RegulatedProductDataAccessService.get_regulated_products()
         reporting_year = ReportingYearService.get_reporting_year_by_version_id(version_id)
+        regulated_products = RegulatedProductDataAccessService.get_regulated_products(
+            date(reporting_year.reporting_year, 1, 1)
+        )
         purpose = report_operation["registration_purpose"]
         facility_id = FacilityReportService.get_facility_report_by_version_id(version_id)
         is_sync_allowed = SyncValidationService.is_sync_allowed(version_id)

--- a/bc_obps/reporting/tests/endpoints/test_create_reports_endpoint.py
+++ b/bc_obps/reporting/tests/endpoints/test_create_reports_endpoint.py
@@ -149,7 +149,6 @@ class TestReportsEndpoint(CommonTestSetup):
         assert_report_version_ownership_is_validated("get_report_operation_by_version_id")
         assert_report_version_ownership_is_validated("save_report")
         assert_report_version_ownership_is_validated("change_report_version_type", "post")
-        assert_report_version_ownership_is_validated("get_regulated_products_by_version_id")
         assert_report_version_ownership_is_validated("get_report_version")
 
     @patch("service.report_version_service.ReportVersionService.delete_report_version")

--- a/bc_obps/reporting/tests/service/test_report_operation_service.py
+++ b/bc_obps/reporting/tests/service/test_report_operation_service.py
@@ -10,9 +10,12 @@ class TestReportOperationService:
     def setup_method(self):
         self.operator = baker.make_recipe("registration.tests.utils.operator")
         self.operation = baker.make_recipe("registration.tests.utils.operation", operator=self.operator)
+        self.reporting_year = baker.make_recipe("reporting.tests.utils.reporting_year", reporting_year=2029)
         self.report_version = baker.make_recipe(
             "reporting.tests.utils.report_version",
-            report=baker.make_recipe("reporting.tests.utils.report", operation=self.operation),
+            report=baker.make_recipe(
+                "reporting.tests.utils.report", operation=self.operation, reporting_year=self.reporting_year
+            ),
             report_type="Annual Report",
             status="Draft",
         )
@@ -77,6 +80,20 @@ class TestReportOperationService:
         assert "is_sync_allowed" in result
         assert isinstance(result["is_sync_allowed"], bool)
         assert result["reporting_year"] == self.report_version.report.reporting_year.reporting_year
+
+    def test_get_report_operation_data_by_version_id_shows_valid_regulated_products(self):
+        valid_product = baker.make_recipe(
+            "registration.tests.utils.regulated_product",
+        )
+        expired_product = baker.make_recipe(
+            "registration.tests.utils.regulated_product",
+            valid_from=f"{self.reporting_year.reporting_year + 5}-01-01",
+        )
+
+        result = ReportOperationService.get_report_operation_data_by_version_id(self.report_version.id)
+
+        assert valid_product in result["all_regulated_products"]
+        assert expired_product not in result["all_regulated_products"]
 
     def test_update_report_service(self):
         self.operation.name = "New Operation Name"

--- a/bc_obps/service/data_access_service/regulated_product_service.py
+++ b/bc_obps/service/data_access_service/regulated_product_service.py
@@ -8,7 +8,7 @@ from datetime import date
 
 class RegulatedProductDataAccessService:
     @classmethod
-    def get_regulated_products(cls, request_date: date = date.today()) -> QuerySet[RegulatedProduct]:
+    def get_valid_regulated_products(cls, request_date: date = date.today()) -> QuerySet[RegulatedProduct]:
         cached_data: Optional[QuerySet[RegulatedProduct]] = cache.get("regulated_products")
         if cached_data:
             return cached_data

--- a/bc_obps/service/data_access_service/regulated_product_service.py
+++ b/bc_obps/service/data_access_service/regulated_product_service.py
@@ -3,15 +3,18 @@ from registration.models import RegulatedProduct
 from registration.schema import RegulatedProductSchema
 from django.core.cache import cache
 from django.db.models import QuerySet
+from datetime import date
 
 
 class RegulatedProductDataAccessService:
     @classmethod
-    def get_regulated_products(cls) -> QuerySet[RegulatedProduct]:
+    def get_regulated_products(cls, request_date: date = date.today()) -> QuerySet[RegulatedProduct]:
         cached_data: Optional[QuerySet[RegulatedProduct]] = cache.get("regulated_products")
         if cached_data:
             return cached_data
         else:
-            regulated_products = RegulatedProduct.objects.only(*RegulatedProductSchema.Meta.fields)
+            regulated_products = RegulatedProduct.objects.filter(
+                valid_from__lte=request_date, valid_to__gte=request_date
+            ).only(*RegulatedProductSchema.Meta.fields)
             cache.set("regulated_products", regulated_products, 60 * 60 * 24 * 1)  # 1 day
             return regulated_products

--- a/bc_obps/service/report_service.py
+++ b/bc_obps/service/report_service.py
@@ -148,14 +148,6 @@ class ReportService:
 
         return report_operation
 
-    @classmethod
-    def get_regulated_products_by_version_id(cls, version_id: int) -> QuerySet[RegulatedProduct]:
-        report_operation = ReportOperation.objects.get(report_version_id=version_id)
-
-        regulated_products = report_operation.regulated_products.all()
-
-        return regulated_products
-
     @staticmethod
     def get_registration_purpose_by_version_id(version_id: int) -> dict:
         registration_purpose = ReportOperation.objects.get(report_version__id=version_id).registration_purpose


### PR DESCRIPTION
closes: [4748](https://github.com/bcgov/cas-registration/issues/4748)
also deals with: https://github.com/bcgov/cas-registration/issues/4317

- **feat: filter get_regulated_products by year w/ today as default**
- **test: remove unused get_regulated_products_by_id() function**
- **test: update and add tests to get valid regulated products**

to test:

- create a new operation and check the products dropdown for `Pulp and paper: lime recovered by kiln`
- check any report products dropdown also for `Pulp and paper: lime recovered by kiln`
- check any past report for products dropdown to **NOT** show `Pulp and paper: lime recovered by kiln`