### PR TITLE
4828 - prevent supplementary report cloning of Person Responsible when the source contact no longer exists 

### DIFF
--- a/bc_obps/reporting/service/report_supplementary_version_service/report_supplementary_cloning.py
+++ b/bc_obps/reporting/service/report_supplementary_version_service/report_supplementary_cloning.py
@@ -31,6 +31,9 @@ from reporting.models import (
     ReportVersion,
 )
 
+from django.db.models import Q
+from registration.models import Contact
+
 
 def clone_report_version_operation(old_report_version: ReportVersion, new_report_version: ReportVersion) -> None:
     # Retrieve the original operation from the old report version
@@ -62,18 +65,32 @@ def clone_report_version_representatives(old_report_version: ReportVersion, new_
 
 
 def clone_report_version_person_responsible(
-    old_report_version: ReportVersion, new_report_version: ReportVersion
+    old_report_version: ReportVersion,
+    new_report_version: ReportVersion,
 ) -> None:
     # Retrieve the ReportPersonResponsible instance associated with the old report version
     report_person_responsible_to_clone = ReportPersonResponsible.objects.filter(
         report_version=old_report_version
     ).first()
 
-    if report_person_responsible_to_clone:
-        # Clone the instance by resetting the primary key and updating the report version
-        report_person_responsible_to_clone.pk = None
-        report_person_responsible_to_clone.report_version = new_report_version
-        report_person_responsible_to_clone.save()
+    # Do not clone if the report version has no Person Responsible
+    if not report_person_responsible_to_clone:
+        return
+
+    # Check if the PersonResponsible referenced contact still exists
+    contact_exists = Contact.objects.filter(
+        Q(id=report_person_responsible_to_clone.contact_id) | Q(email=report_person_responsible_to_clone.email),
+        archived_at__isnull=True,
+    ).exists()
+
+    # Do not clone if the contact no longer exists
+    if not contact_exists:
+        return
+
+    # Clone the instance by resetting the primary key and updating the report version
+    report_person_responsible_to_clone.pk = None
+    report_person_responsible_to_clone.report_version = new_report_version
+    report_person_responsible_to_clone.save()
 
 
 def clone_report_version_additional_data(old_report_version: ReportVersion, new_report_version: ReportVersion) -> None:

--- a/bc_obps/reporting/tests/service/test_report_supplementary_service/test_report_supplementary_cloning.py
+++ b/bc_obps/reporting/tests/service/test_report_supplementary_service/test_report_supplementary_cloning.py
@@ -36,6 +36,8 @@ from reporting.models import (
     ReportVersion,
 )
 import common.lib.pgtrigger as pgtrigger
+from django.db.models import Q
+from registration.models import Contact
 
 
 class ReportSupplementaryCloningTests(TestCase):
@@ -229,12 +231,17 @@ class ReportSupplementaryCloningTests(TestCase):
 
     def test_clone_report_version_person_responsible(self):
         """
-        Test that clone_report_version_person_responsible correctly clones the ReportPersonResponsible
-        from the old report version to the new report version by copying all relevant fields.
+        Test that clone_report_version_person_responsible correctly clones the
+        ReportPersonResponsible when the referenced contact still exists.
         """
         # PRE-ACT: Verify that a ReportPersonResponsible exists for the old report version and none for the new version.
         self.assertIsNotNone(ReportPersonResponsible.objects.filter(report_version=self.old_report_version).first())
         self.assertIsNone(ReportPersonResponsible.objects.filter(report_version=self.new_report_version).first())
+        # Create an active Contact with the same email
+        make_recipe(
+            "registration.tests.utils.contact",
+            email=self.old_person.email,
+        )
 
         # ACT: Clone the ReportPersonResponsible.
         clone_report_version_person_responsible(self.old_report_version, self.new_report_version)
@@ -252,6 +259,27 @@ class ReportSupplementaryCloningTests(TestCase):
         self.assertEqual(new_person.municipality, self.old_person.municipality)
         self.assertEqual(new_person.province, self.old_person.province)
         self.assertEqual(new_person.postal_code, self.old_person.postal_code)
+
+    def test_clone_report_version_person_responsible_does_not_clone_when_contact_does_not_exist(
+        self,
+    ):
+        """
+        Test that clone_report_version_person_responsible does not clone the
+        ReportPersonResponsible when the referenced contact no longer exists.
+        """
+        # PRE-ACT: Ensure there is no matching active Contact
+        Contact.objects.filter(Q(id=self.old_person.contact_id) | Q(email=self.old_person.email)).delete()
+
+        self.assertIsNone(ReportPersonResponsible.objects.filter(report_version=self.new_report_version).first())
+
+        # ACT
+        clone_report_version_person_responsible(
+            self.old_report_version,
+            self.new_report_version,
+        )
+
+        # ASSERT
+        self.assertIsNone(ReportPersonResponsible.objects.filter(report_version=self.new_report_version).first())
 
     def test_clone_report_version_additional_data(self):
         """

--- a/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsibleForm.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/personResponsible/PersonResponsibleForm.tsx
@@ -18,6 +18,8 @@ import { NavigationInformation } from "@reporting/src/app/components/taskList/ty
 import { AddressErrorWidget } from "@reporting/src/data/jsonSchema/personResponsibleWidgets";
 import SnackBar from "@bciers/components/form/components/SnackBar";
 import useKey from "@bciers/utils/src/useKey";
+import { handleApiResponse } from "@reporting/src/app/utils/handleApiResponse";
+import { useFormErrors } from "@reporting/src/hooks/useFormErrors";
 
 interface PersonResponsibleFormData {
   person_responsible: number | undefined;
@@ -51,6 +53,7 @@ const PersonResponsibleForm = ({
 }: Props) => {
   const [isSnackbarOpen, setIsSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState("");
+  const { setErrors, renderedErrors } = useFormErrors();
 
   const [componentState, setComponentState] = useState<ComponentState>({
     availableContacts: initialContacts,
@@ -162,9 +165,11 @@ const PersonResponsibleForm = ({
     if (componentState.hasError) {
       return false;
     }
+
     const endpoint = `reporting/report-version/${versionId}/report-contact`;
     const pathToRevalidate = `reporting/reports/${versionId}/person-responsible`;
     const method = "POST";
+
     const payload = {
       ...componentState.contactToSubmit,
       contact_id: componentState.selectedContactId,
@@ -174,12 +179,7 @@ const PersonResponsibleForm = ({
       body: JSON.stringify(payload),
     });
 
-    // Check for errors
-    if (response?.error) {
-      return false;
-    }
-    // Return Success
-    return true;
+    return handleApiResponse(response, setErrors);
   };
 
   const handleSync = async () => {
@@ -264,6 +264,7 @@ const PersonResponsibleForm = ({
         formData={componentState.formData}
         onChange={handleChange}
         onSubmit={handleSave}
+        errors={renderedErrors}
       />
       <SnackBar
         isSnackbarOpen={isSnackbarOpen}


### PR DESCRIPTION
Ticket: [4828](https://github.com/bcgov/cas-registration/issues/4828)

### 🚀 Impact

- Supplementary reports requires a valid existing contact. If the original report's contact has been deleted the Person Responsible section is not cloned and must be reselected by the user
-  PersonResponsibleForm uses the shared handleApiResponse + useFormErrors pattern

---

### 🔬 Local Testing:  

#### Start Test Environment
1. Start the API server:  
   ```sh
   cd bc_obps
   make prepare_backend
   ```  
2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

---

#### Test: Supplementary report does not clone the ReportPersonResponsible when the referenced contact no longer exists
1. Log in using `bc-cas-dev`
2. Navigate to contact `Blair Balloons - no address` http://localhost:3000/administration/contacts/5?contacts_title=Blair%20Balloons%20-%20no%20address
3. Complete the address information
4. Navigate to report `Compliance SFO - Obligation not met` person responsible http://localhost:3000/reporting/reports/3/person-responsible
5. In `Select contact if they are already a BCIERS user` select `Blair Balloons - no address`
6. Click `Save & Continue`
7. Submit the report
8.  Navigate to contact `Blair Balloons - no address` http://localhost:3000/administration/contacts/5?contacts_title=Blair%20Balloons%20-%20no%20address
9. Click `Delete Contact`
10. Navigate to reports table, http://localhost:3000/reporting/reports
11. On `Compliance SFO - Obligation not met`, click `More Actions\Create Supplementary Report`
12. Navigate to report person responsible
**Expected Results:**
- Person Responsible must be reselected by the user
<img width="1692" height="754" alt="image" src="https://github.com/user-attachments/assets/eff649c5-29e6-4457-9a24-7a2b9b7079f3" />


#### Test: Supplementary report clones the ReportPersonResponsible when the referenced contact exists

1. Navigate to reports table, http://localhost:3000/reporting/reports
2. On a submitted report, click `More Actions\Create Supplementary Report`
4. Navigate to report person responsible
**Expected Results:**
- Person Responsible displays as expected

<img width="1403" height="881" alt="image" src="https://github.com/user-attachments/assets/091f63e0-9bc9-4416-bc19-0f39e3414cfb" />