### PR TITLE
BCCR load balancer session propagation lag

### DIFF
--- a/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
@@ -39,6 +39,7 @@ class BCCarbonRegistryAPIClient:
     api_url: Optional[str]
     client_id: Optional[str]
     client_secret: Optional[str]
+    _session: requests.Session
     token_expiry: Optional[datetime] = None
     COMPLIANCE_ACCOUNT_TYPE_ID = 14
     OPERATOR_OF_REGULATED_OPERATION_TYPE_ID = 11  # Only master accounts with this ID are allowed to request units
@@ -59,6 +60,7 @@ class BCCarbonRegistryAPIClient:
             cls._instance.api_url = settings.BCCR_API_URL.rstrip("/") if settings.BCCR_API_URL else None
             cls._instance.client_id = settings.BCCR_CLIENT_ID
             cls._instance.client_secret = settings.BCCR_CLIENT_SECRET
+            cls._instance._session = requests.Session()
             logger.info(
                 f'Initializing BCCarbonRegistryAPIClient for clientID {cls._instance.client_id} to connect to {cls._instance.api_url}'
             )
@@ -124,6 +126,7 @@ class BCCarbonRegistryAPIClient:
         data: Optional[BaseModel] = None,
         params: Optional[Dict] = None,
         response_model: Optional[type[BaseModel]] = None,
+        _retried: bool = False,
     ) -> Dict:
         """
         Make an authenticated API request.
@@ -145,7 +148,7 @@ class BCCarbonRegistryAPIClient:
         # exclude_none=True to remove None values (Cause issues when sending None values when filtering)
         data_dict = data.model_dump(exclude_none=True) if data else None
         try:
-            response = requests.request(method=method, url=url, headers=headers, json=data_dict, params=params)
+            response = self._session.request(method=method, url=url, headers=headers, json=data_dict, params=params)
             response.raise_for_status()
             response_json = response.json()
             if response_model:
@@ -156,6 +159,18 @@ class BCCarbonRegistryAPIClient:
         except ValidationError as e:
             logger.error("Invalid response from %s: %s", url, str(e), exc_info=True)
             raise BCCarbonRegistryError(f"Invalid response format: {str(e)}", endpoint=url) from e
+        except HTTPError as e:
+            # The BCCR API uses session-based auth. A 401 does not always mean the token is invalid
+            # it can mean the request landed on a node that has not yet received the session
+            # Force a fresh re-auth and retry once to recover without surfacing the error to the caller
+            if e.response is not None and e.response.status_code == 401 and not _retried:
+                logger.warning("Received 401 from %s, forcing re-authentication and retrying...", url)
+                self.token = None
+                self.token_expiry = None
+                return self._make_request(method, endpoint, data, params, response_model, _retried=True)
+            log_error_message(e)
+            logger.error("Request to %s failed: %s", url, str(e), exc_info=True)
+            raise BCCarbonRegistryError(f"Request failed: {str(e)}", endpoint=url) from e
         except Exception as e:
             log_error_message(e)  # If BCCR API returns a valid error response, this will log it
             logger.error("Request to %s failed: %s", url, str(e), exc_info=True)

--- a/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
@@ -87,10 +87,10 @@ class BCCarbonRegistryAPIClient:
             self.token = data.access_token
             self.token_expiry = timezone.now() + timedelta(seconds=data.expires_in)
         except Timeout as e:
-            logger.error("Authentication timed out: %s", str(e), exc_info=True)
+            logger.exception("Authentication timed out: %s", str(e))
             raise BCCarbonRegistryError(f"Request timed out: {str(e)}", endpoint=url) from e
         except ConnectionError as e:
-            logger.error("Authentication failed due to connection error: %s", str(e), exc_info=True)
+            logger.exception("Authentication failed due to connection error: %s", str(e))
             raise BCCarbonRegistryError(f"Connection error: {str(e)}", endpoint=url) from e
         except HTTPError as e:
             response_text = (
@@ -98,12 +98,10 @@ class BCCarbonRegistryAPIClient:
                 if hasattr(e, 'response')
                 else 'No response available'
             )
-            logger.error(
-                "Authentication failed with HTTP error: %s, response: %s", str(e), response_text, exc_info=True
-            )
+            logger.exception("Authentication failed with HTTP error: %s, response: %s", str(e), response_text)
             raise BCCarbonRegistryError(f"HTTP error: {str(e)}", endpoint=url) from e
         except (ValidationError, RequestException) as e:
-            logger.error("Authentication failed: %s", str(e), exc_info=True)
+            logger.exception("Authentication failed: %s", str(e))
             raise BCCarbonRegistryError(f"Invalid token response: {str(e)}", endpoint=url) from e
 
     def _ensure_authenticated(self) -> None:
@@ -114,8 +112,8 @@ class BCCarbonRegistryAPIClient:
         token_expiry = getattr(self, "token_expiry", None)
         # Re-authenticate 60 seconds before expiry to avoid the race where the
         # client considers the token valid but the server rejects it as expired.
-        buffer = timedelta(seconds=60)
-        if token is None or token_expiry is None or timezone.now() >= (token_expiry - buffer):
+        reauth_advance_delay = timedelta(seconds=60)
+        if token is None or token_expiry is None or timezone.now() >= (token_expiry - reauth_advance_delay):
             logger.warning("Token missing or expired. Re-authenticating...")
             self._authenticate()
 
@@ -157,7 +155,7 @@ class BCCarbonRegistryAPIClient:
                 validated_response = response_json
             return validated_response
         except ValidationError as e:
-            logger.error("Invalid response from %s: %s", url, str(e), exc_info=True)
+            logger.exception("Invalid response from %s: %s", url, str(e))
             raise BCCarbonRegistryError(f"Invalid response format: {str(e)}", endpoint=url) from e
         except HTTPError as e:
             # The BCCR API uses session-based auth. A 401 does not always mean the token is invalid
@@ -169,11 +167,11 @@ class BCCarbonRegistryAPIClient:
                 self.token_expiry = None
                 return self._make_request(method, endpoint, data, params, response_model, _retried=True)
             log_error_message(e)
-            logger.error("Request to %s failed: %s", url, str(e), exc_info=True)
+            logger.exception("Request to %s failed: %s", url, str(e))
             raise BCCarbonRegistryError(f"Request failed: {str(e)}", endpoint=url) from e
         except Exception as e:
             log_error_message(e)  # If BCCR API returns a valid error response, this will log it
-            logger.error("Request to %s failed: %s", url, str(e), exc_info=True)
+            logger.exception("Request to %s failed: %s", url, str(e))
             raise BCCarbonRegistryError(f"Request failed: {str(e)}", endpoint=url) from e
 
     def _submit_payload(

--- a/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/service/bc_carbon_registry/bc_carbon_registry_api_client.py
@@ -110,7 +110,10 @@ class BCCarbonRegistryAPIClient:
         """
         token = getattr(self, "token", None)
         token_expiry = getattr(self, "token_expiry", None)
-        if token is None or token_expiry is None or timezone.now() >= token_expiry:
+        # Re-authenticate 60 seconds before expiry to avoid the race where the
+        # client considers the token valid but the server rejects it as expired.
+        buffer = timedelta(seconds=60)
+        if token is None or token_expiry is None or timezone.now() >= (token_expiry - buffer):
             logger.warning("Token missing or expired. Re-authenticating...")
             self._authenticate()
 

--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
@@ -306,6 +306,28 @@ class TestBCCarbonRegistryAPIClient:
         # Assert
         assert client.token == "new_token"
 
+    def test_ensure_authenticated_within_buffer_window(self, setup, mocker, caplog):
+        """Test re-authentication when token is within the 60-second buffer window"""
+        # Arrange
+        client = setup
+        client.token = "expiring_token"
+        client.token_expiry = timezone.now() + timedelta(seconds=30)  # inside 60s buffer
+        mock_post = mocker.patch("requests.post")
+        mock_post.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "access_token": "refreshed_token",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        )
+        # Act
+        with caplog.at_level(logging.WARNING):
+            client._ensure_authenticated()
+            assert "Token missing or expired" in caplog.text
+        # Assert
+        assert client.token == "refreshed_token"
+
     def test_make_request_success(self, authenticated_client, mock_success_response):
         # Arrange
         client, mock_request = authenticated_client

--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
@@ -306,12 +306,12 @@ class TestBCCarbonRegistryAPIClient:
         # Assert
         assert client.token == "new_token"
 
-    def test_ensure_authenticated_within_buffer_window(self, setup, mocker, caplog):
-        """Test re-authentication when token is within the 60-second buffer window"""
+    def test_ensure_authenticated_within_reauth_advance_delay(self, setup, mocker, caplog):
+        """Test re-authentication when token is within the 60-second reauth advance delay"""
         # Arrange
         client = setup
         client.token = "expiring_token"
-        client.token_expiry = timezone.now() + timedelta(seconds=30)  # inside 60s buffer
+        client.token_expiry = timezone.now() + timedelta(seconds=30)  # inside 60s reauth advance delay
         mock_post = mocker.patch("requests.post")
         mock_post.return_value = Mock(
             status_code=200,

--- a/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
+++ b/bc_obps/compliance/tests/service/bc_carbon_registry/test_bc_carbon_registry_api_client.py
@@ -72,7 +72,7 @@ def authenticated_client(setup, mocker):
     client = setup
     client.token = TOKEN
     client.token_expiry = VALID_TOKEN_EXPIRY
-    mock_request = mocker.patch("requests.request")
+    mock_request = mocker.patch.object(client._session, "request")
     return client, mock_request
 
 
@@ -380,6 +380,66 @@ class TestBCCarbonRegistryAPIClient:
             with pytest.raises(BCCarbonRegistryError, match="Request failed"):
                 client._make_request(method="GET", endpoint="/test")
             assert "Request to" in caplog.text
+
+    def test_make_request_retries_once_on_401(self, authenticated_client, mocker, caplog):
+        # Arrange
+        client, mock_request = authenticated_client
+        mock_401 = Mock(status_code=401)
+        mock_401._content = b""
+        http_error = requests.HTTPError("401 Client Error: Unauthorized")
+        http_error.response = mock_401
+        mock_401.raise_for_status.side_effect = http_error
+
+        mock_200 = Mock(status_code=200, json=lambda: {"success": True})
+        mock_200.raise_for_status.return_value = None
+
+        # First call → 401, second call → 200
+        mock_request.side_effect = [mock_401, mock_200]
+
+        mock_post = mocker.patch("requests.post")
+        mock_post.return_value = Mock(
+            status_code=200,
+            json=lambda: {"access_token": "new_token", "expires_in": 3600, "token_type": "Bearer"},
+        )
+
+        # Act
+        with caplog.at_level(logging.WARNING):
+            result = client._make_request(method="POST", endpoint="/test")
+            assert "forcing re-authentication and retrying" in caplog.text
+
+        # Assert: re-authed with new token, retried, returned the 200 body
+        assert result == {"success": True}
+        assert client.token == "new_token"
+        assert mock_request.call_count == 2
+        mock_post.assert_called_once()  # auth was called exactly once
+
+    def test_make_request_raises_after_retry_401(self, authenticated_client, mocker, caplog):
+        # Arrange
+        client, mock_request = authenticated_client
+
+        def make_401():
+            m = Mock(status_code=401)
+            m._content = b""
+            err = requests.HTTPError("401 Client Error: Unauthorized")
+            err.response = m
+            m.raise_for_status.side_effect = err
+            return m
+
+        mock_request.side_effect = [make_401(), make_401()]
+
+        mocker.patch(
+            "requests.post",
+            return_value=Mock(
+                status_code=200,
+                json=lambda: {"access_token": "new_token", "expires_in": 3600, "token_type": "Bearer"},
+            ),
+        )
+
+        # Act & Assert
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(BCCarbonRegistryError, match="Request failed"):
+                client._make_request(method="POST", endpoint="/test")
+        assert mock_request.call_count == 2  # original + one retry, no third attempt
 
     def test_check_pagination_params_invalid(self, setup, caplog):
         # Arrange


### PR DESCRIPTION
## Problem

The BCCR API was returning intermittent 401 Unauthorized errors even when the cached JWT token was valid. The errors were non-deterministic — the same request would succeed on retry.

## Root Cause

**Load balancer session propagation lag** — the BCCR API uses stateful session-based authentication on POST search endpoints. Sessions are not instantly shared across all load-balanced nodes. A valid token could still receive a 401 if the request landed on a node that had not yet received the session.

## Changes

**`bc_carbon_registry_api_client.py`**

- **Persistent `requests.Session`** — added a `requests.Session` instance to the singleton in `__new__`. All data requests now go through `self._session.request(...)` instead of `requests.request(...)`. This reuses the underlying TCP connection across calls, pinning the client to the same backend node and eliminating the session propagation 401s.

- **60-second pre-expiry buffer** — `_ensure_authenticated` now re-authenticates when `timezone.now() >= token_expiry - 60s`, preventing requests from being sent with a token that is about to expire.

- **Retry-on-401 with `_retried` guard** — if `_make_request` receives a 401, it clears the cached token, forces re-authentication, and retries the request once. The `_retried` flag prevents infinite recursion. This handles the case where the persistent connection drops (server timeout, network blip) and the next connection lands on a different node mid-session.

## Test Plan

- [x] Manually trigger the BCCR-dependent endpoint multiple times in a row and confirm no 401 errors surface