### PR TITLE
fix: disable broken backend JSON schema validator

### DIFF
--- a/bc_obps/reporting/service/report_validation/validators/__init__.py
+++ b/bc_obps/reporting/service/report_validation/validators/__init__.py
@@ -5,7 +5,7 @@ from . import (
     mandatory_verification_statement,
     operation_boroid_presence,
     report_attachments_are_scanned,
-    report_activity_json_validation,
+    # report_activity_json_validation,  # Suspended as part of https://github.com/bcgov/cas-registration/issues/4873
     report_data_by_fuel_type_validator,
     report_emission_allocation_other_excluded_category,
     report_emission_allocation_validator,
@@ -36,7 +36,7 @@ __all__ = [
     "report_attachments_are_scanned",
     "supplementary_report_version_change",
     "supplementary_report_attachments_confirmation",
-    "report_activity_json_validation",
+    # "report_activity_json_validation", # Suspended as part of https://github.com/bcgov/cas-registration/issues/4873
     "report_emission_allocation_validator",
     "report_emission_allocation_other_excluded_category",
     "report_data_by_fuel_type_validator",

--- a/bc_obps/reporting/tests/service/report_validation/test_report_validation_service.py
+++ b/bc_obps/reporting/tests/service/report_validation/test_report_validation_service.py
@@ -43,7 +43,6 @@ class TestReportValidationService:
             "reporting.service.report_validation.validators.report_attachments_are_scanned",
             "reporting.service.report_validation.validators.supplementary_report_version_change",
             "reporting.service.report_validation.validators.supplementary_report_attachments_confirmation",
-            "reporting.service.report_validation.validators.report_activity_json_validation",
             "reporting.service.report_validation.validators.report_emission_allocation_validator",
             "reporting.service.report_validation.validators.report_emission_allocation_other_excluded_category",
             "reporting.service.report_validation.validators.report_data_by_fuel_type_validator",


### PR DESCRIPTION
The JSON schema validator reports incorrect errors if the 'fuelUnit' field was filled in an older version, and isn't in a new supplementary report.
Disabling the validator for now until we narrow its scope