### PR TITLE
4729 fix naming of invoice file download

### DIFF
--- a/bc_obps/compliance/service/elicensing_invoice_service.py
+++ b/bc_obps/compliance/service/elicensing_invoice_service.py
@@ -64,6 +64,22 @@ class ElicensingInvoiceService:
         response["Content-Length"] = str(total_size)
         return response
 
+    @staticmethod
+    def _build_invoice_filename(prefix: str, invoice_number: str) -> str:
+        """
+        Builds a human-readable, searchable invoice filename.
+
+        Example: "OBPS Compliance Invoice OBI706800_20260619.pdf"
+
+        Args:
+            prefix: The descriptive invoice name (e.g. "OBPS Compliance Invoice").
+            invoice_number: The eLicensing invoice number.
+
+        Returns:
+            The filename including the ".pdf" extension.
+        """
+        return f"{prefix} {invoice_number}_{timezone.now().strftime('%Y%m%d')}.pdf"
+
     @classmethod
     def _prepare_partial_invoice_context(
         cls, compliance_report_version_id: int, invoice: ElicensingInvoice, compliance_obligation_id: str
@@ -206,7 +222,7 @@ class ElicensingInvoiceService:
             context.update(last_refresh_metadata)
 
             # Generate filename
-            filename = f"invoice_{context['invoice_number']}_{timezone.now().strftime('%Y%m%d')}.pdf"
+            filename = cls._build_invoice_filename("OBPS Compliance Invoice", context['invoice_number'])
 
             # Generate and return the PDF generator, filename, and size
             return PDFGeneratorService.generate_pdf(
@@ -287,7 +303,7 @@ class ElicensingInvoiceService:
             context.update(last_refresh_metadata)
 
             # Generate filename
-            filename = f"invoice_{context['invoice_number']}_{timezone.now().strftime('%Y%m%d')}.pdf"
+            filename = cls._build_invoice_filename("OBPS Automatic Overdue Penalty Invoice", context['invoice_number'])
 
             # Generate and return the PDF generator, filename, and size
             return PDFGeneratorService.generate_pdf(
@@ -354,7 +370,7 @@ class ElicensingInvoiceService:
             context = context_obj.__dict__
             context.update(last_refresh_metadata)
 
-            filename = f"invoice_{context['invoice_number']}_{timezone.now().strftime('%Y%m%d')}.pdf"
+            filename = cls._build_invoice_filename("OBPS GGEAPAR Penalty Invoice", context['invoice_number'])
 
             return PDFGeneratorService.generate_pdf(
                 template_name="automatic_overdue_penalty_invoice.html",

--- a/bc_obps/compliance/tests/service/test_elicensing_invoice_service.py
+++ b/bc_obps/compliance/tests/service/test_elicensing_invoice_service.py
@@ -62,6 +62,13 @@ class TestElicensingInvoiceService:
             penalty_type=CompliancePenalty.PenaltyType.LATE_SUBMISSION,
         )
 
+    def test_build_invoice_filename(self):
+        expected_date = timezone.now().strftime("%Y%m%d")
+        assert (
+            ElicensingInvoiceService._build_invoice_filename("OBPS Compliance Invoice", "OBI706800")
+            == f"OBPS Compliance Invoice OBI706800_{expected_date}.pdf"
+        )
+
     @patch("compliance.service.elicensing_invoice_service.PDFGeneratorService.generate_pdf")
     @patch(
         "compliance.service.elicensing_invoice_service.ComplianceReportVersionService.get_report_operation_by_compliance_report_version"
@@ -103,6 +110,11 @@ class TestElicensingInvoiceService:
         assert filename.endswith(".pdf")
         assert size == 2048
         mock_generate_pdf.assert_called_once()
+        expected_date = timezone.now().strftime("%Y%m%d")
+        assert (
+            mock_generate_pdf.call_args.kwargs["filename"]
+            == f"OBPS Compliance Invoice {self.test_data.invoice.invoice_number}_{expected_date}.pdf"
+        )
 
     @patch("compliance.service.elicensing_invoice_service.PDFGeneratorService.generate_pdf")
     @patch(
@@ -161,6 +173,11 @@ class TestElicensingInvoiceService:
         assert filename.endswith(".pdf")
         assert size == 2048
         mock_generate_pdf.assert_called_once()
+        expected_date = timezone.now().strftime("%Y%m%d")
+        assert (
+            mock_generate_pdf.call_args.kwargs["filename"] == f"OBPS GGEAPAR Penalty Invoice "
+            f"{self.test_data.compliance_obligation.elicensing_invoice.invoice_number}_{expected_date}.pdf"
+        )
 
     @pytest.mark.parametrize(
         "fee_amount, payments, adjustments, expected_due, expected_billing_count",
@@ -359,6 +376,11 @@ class TestElicensingInvoiceService:
         assert filename.endswith(".pdf")
         assert size == 2048
         mock_generate_pdf.assert_called_once()
+        expected_date = timezone.now().strftime("%Y%m%d")
+        assert (
+            mock_generate_pdf.call_args.kwargs["filename"] == f"OBPS Automatic Overdue Penalty Invoice "
+            f"{self.test_data.compliance_obligation.elicensing_invoice.invoice_number}_{expected_date}.pdf"
+        )
 
     def test_create_pdf_response_returns_error(self):
         error_payload = {"errors": {"unexpected_error": "Mocked: PDF generation failed"}}

--- a/bciers/apps/compliance/src/app/utils/generateInvoice.tsx
+++ b/bciers/apps/compliance/src/app/utils/generateInvoice.tsx
@@ -19,49 +19,62 @@ const generateInvoice = async (
       typeForUrl = "obligation";
   }
 
-  const res = await fetch(
-    `/compliance/api/invoice/${complianceReportVersionId}/${typeForUrl}`,
-    {
+  const url = `/compliance/api/invoice/${complianceReportVersionId}/${typeForUrl}`;
+
+  // NOTE: do not pass "noopener" here — it forces window.open to return null,
+  // which would leave the new tab empty and navigate the current page instead.
+  const previewTab = window.open("", "_blank");
+
+  try {
+    const res = await fetch(url, {
       method: "GET",
       cache: "no-store",
-    },
-  );
-  const contentType = res.headers.get("Content-Type") || "";
+    });
+    const contentType = res.headers.get("Content-Type") || "";
 
-  // Handle error or JSON payload
-  if (contentType.includes("application/json")) {
-    let payload: any = { message: `Failed with status ${res.status}` };
+    // Handle error or JSON payload
+    if (contentType.includes("application/json")) {
+      previewTab?.close();
 
-    try {
-      payload = await res.json();
-    } catch {
-      // ignore invalid JSON
+      let payload: any = { message: `Failed with status ${res.status}` };
+
+      try {
+        payload = await res.json();
+      } catch {
+        // ignore invalid JSON
+      }
+
+      if (typeof payload.message === "string") {
+        throw new Error(
+          payload.message ||
+            `Failed to generate penalty invoice (status ${res.status})`,
+        );
+      }
+
+      return;
     }
 
-    if (typeof payload.message === "string") {
+    // Handle non-JSON response errors
+    if (!res.ok) {
+      previewTab?.close();
       throw new Error(
-        payload.message ||
-          `Failed to generate penalty invoice (status ${res.status})`,
+        `Failed to generate penalty invoice (status ${res.status})`,
       );
     }
 
-    return;
+    // Navigate the tab directly to the route URL so the browser previews the
+    // PDF inline and honours the Content-Disposition filename when the user
+    // downloads it (a blob URL would download as a random UUID instead).
+    if (previewTab) {
+      previewTab.location.href = url;
+    } else {
+      // Popup was blocked; fall back to navigating the current window.
+      window.location.href = url;
+    }
+  } catch (err) {
+    previewTab?.close();
+    throw err;
   }
-
-  // Handle non-JSON response errors
-  if (!res.ok) {
-    throw new Error(
-      `Failed to generate penalty invoice (status ${res.status})`,
-    );
-  }
-
-  // Handle PDF response
-  const pdfBlob = await res.blob();
-  const objectUrl = URL.createObjectURL(pdfBlob);
-  window.open(objectUrl, "_blank", "noopener,noreferrer");
-
-  // Cleanup
-  setTimeout(() => URL.revokeObjectURL(objectUrl), 30_000);
 };
 
 export default generateInvoice;

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/automatic-overdue-penalty/review-penalty-summary/PenaltySummaryReviewComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/automatic-overdue-penalty/review-penalty-summary/PenaltySummaryReviewComponent.test.tsx
@@ -71,20 +71,18 @@ const mockData = {
 const mockWindowOpen = vi.fn();
 window.open = mockWindowOpen;
 
+// A fake browser tab returned by window.open that the util navigates to the PDF.
+let fakeTab: { location: { href: string }; close: ReturnType<typeof vi.fn> };
+
 const getGeneratePenaltyInvoiceButton = () =>
   screen.getByRole("button", { name: "Generate Penalty Invoice" });
 
 describe("PenaltySummaryReviewComponent", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockWindowOpen.mockClear();
-
-    if (!("createObjectURL" in URL)) {
-      // @ts-expect-error - URL.createObjectURL is not defined in the type system
-      URL.createObjectURL = vi.fn();
-    }
-
-    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:fake-invoice-url");
+    fakeTab = { location: { href: "" }, close: vi.fn() };
+    mockWindowOpen.mockReset();
+    mockWindowOpen.mockReturnValue(fakeTab);
     vi.stubGlobal("open", mockWindowOpen);
   });
   it("renders the form with correct data", () => {
@@ -159,13 +157,11 @@ describe("PenaltySummaryReviewComponent", () => {
   it("handles invoice generation correctly", async () => {
     const user = userEvent.setup();
 
-    const mockBlob = new Blob(["dummy PDF"], { type: "application/pdf" });
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
-        blob: async () => mockBlob,
         headers: new Headers(),
       }),
     );
@@ -188,13 +184,13 @@ describe("PenaltySummaryReviewComponent", () => {
       },
     );
 
-    expect(URL.createObjectURL).toHaveBeenCalledWith(mockBlob);
-
-    expect(mockWindowOpen).toHaveBeenCalledWith(
-      "blob:fake-invoice-url",
-      "_blank",
-      "noopener,noreferrer",
+    // A preview tab is opened synchronously, then navigated directly to the
+    // route URL so the browser honours the Content-Disposition filename.
+    expect(mockWindowOpen).toHaveBeenCalledWith("", "_blank");
+    expect(fakeTab.location.href).toBe(
+      "/compliance/api/invoice/123/automatic-overdue-penalty",
     );
+    expect(fakeTab.close).not.toHaveBeenCalled();
 
     expect(getGeneratePenaltyInvoiceButton()).toBeEnabled();
   });
@@ -232,7 +228,10 @@ describe("PenaltySummaryReviewComponent", () => {
       },
     );
 
-    expect(mockWindowOpen).not.toHaveBeenCalled();
+    // The placeholder tab is opened, then closed on error (never navigated).
+    expect(mockWindowOpen).toHaveBeenCalledWith("", "_blank");
+    expect(fakeTab.close).toHaveBeenCalled();
+    expect(fakeTab.location.href).toBe("");
 
     const alerts = await screen.findAllByRole("alert");
     const hasErrorText = alerts.some((el) =>

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/review-compliance-summary/ComplianceSummaryReviewComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/review-compliance-summary/ComplianceSummaryReviewComponent.test.tsx
@@ -7,6 +7,9 @@ import { ComplianceSummaryReviewPageData } from "@/compliance/src/app/types";
 const mockWindowOpen = vi.fn();
 window.open = mockWindowOpen;
 
+// A fake browser tab returned by window.open that the util navigates to the PDF.
+let fakeTab: { location: { href: string }; close: ReturnType<typeof vi.fn> };
+
 vi.mock(
   "@/compliance/src/app/components/compliance-summary/manage-obligation/review-compliance-summary/ComplianceUnitsGrid",
   () => ({
@@ -69,14 +72,9 @@ const getGenerateButton = () =>
 describe("ComplianceSummaryReviewComponent", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockWindowOpen.mockClear();
-
-    if (!("createObjectURL" in URL)) {
-      // @ts-expect-error - URL.createObjectURL is not defined in the type system
-      URL.createObjectURL = vi.fn();
-    }
-
-    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:fake-invoice-url");
+    fakeTab = { location: { href: "" }, close: vi.fn() };
+    mockWindowOpen.mockReset();
+    mockWindowOpen.mockReturnValue(fakeTab);
     vi.stubGlobal("open", mockWindowOpen);
   });
 
@@ -95,13 +93,11 @@ describe("ComplianceSummaryReviewComponent", () => {
   it("handles invoice generation correctly", async () => {
     const user = userEvent.setup();
 
-    const mockBlob = new Blob(["dummy PDF"], { type: "application/pdf" });
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
-        blob: async () => mockBlob,
         headers: new Headers(),
       }),
     );
@@ -118,13 +114,13 @@ describe("ComplianceSummaryReviewComponent", () => {
       },
     );
 
-    expect(URL.createObjectURL).toHaveBeenCalledWith(mockBlob);
-
-    expect(mockWindowOpen).toHaveBeenCalledWith(
-      "blob:fake-invoice-url",
-      "_blank",
-      "noopener,noreferrer",
+    // A preview tab is opened synchronously, then navigated directly to the
+    // route URL so the browser honours the Content-Disposition filename.
+    expect(mockWindowOpen).toHaveBeenCalledWith("", "_blank");
+    expect(fakeTab.location.href).toBe(
+      "/compliance/api/invoice/123/obligation",
     );
+    expect(fakeTab.close).not.toHaveBeenCalled();
 
     expect(getGenerateButton()).toBeEnabled();
   });
@@ -156,7 +152,10 @@ describe("ComplianceSummaryReviewComponent", () => {
       },
     );
 
-    expect(mockWindowOpen).not.toHaveBeenCalled();
+    // The placeholder tab is opened, then closed on error (never navigated).
+    expect(mockWindowOpen).toHaveBeenCalledWith("", "_blank");
+    expect(fakeTab.close).toHaveBeenCalled();
+    expect(fakeTab.location.href).toBe("");
 
     const alerts = await screen.findAllByRole("alert");
     const hasErrorText = alerts.some((el) =>

--- a/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReviewContent.tsx
+++ b/bciers/apps/reporting/src/app/components/finalReview/FacilityReportFinalReviewContent.tsx
@@ -25,7 +25,7 @@ export default function FacilityReportFinalReviewContent({
     const originalTitle = document.title;
 
     const handleBeforePrint = () => {
-      document.title = `CAS OBPS_Reporting_${data.facility_name}`;
+      document.title = `OBPS_Reporting_${data.facility_name}`;
     };
 
     const handleAfterPrint = () => {

--- a/bciers/apps/reporting/src/tests/components/finalReview/FacilityReportFinalReviewContent.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/finalReview/FacilityReportFinalReviewContent.test.tsx
@@ -59,7 +59,7 @@ describe("FacilityReportFinalReviewContent", () => {
     expect(document.title).toBe(originalTitle);
 
     globalThis.dispatchEvent(new Event("beforeprint"));
-    expect(document.title).toBe("CAS OBPS_Reporting_Test Facility");
+    expect(document.title).toBe("OBPS_Reporting_Test Facility");
 
     globalThis.dispatchEvent(new Event("afterprint"));
     expect(document.title).toBe(originalTitle);

--- a/bciers/libs/components/src/layout/RootLayout.tsx
+++ b/bciers/libs/components/src/layout/RootLayout.tsx
@@ -21,7 +21,7 @@ import SessionTimeoutHandler from "@bciers/components/auth/SessionTimeoutHandler
 import SentryUserContext from "@bciers/components/sentry/SentryUserContext";
 
 const rootMetadata: Metadata = {
-  title: "CAS OBPS",
+  title: "B.C. OBPS",
   description:
     "The OBPS is designed to ensure there is a price incentive for industrial emitters to reduce their greenhouse gas emissions and spur innovation while maintaining competitiveness and protecting against carbon leakage.",
   icons: {


### PR DESCRIPTION
[ISSUE 4729](https://github.com/bcgov/cas-registration/issues/4729)

### Root cause (invoice UUID name)
The frontend fetched the PDF as a blob and previewed it via `URL.createObjectURL()` + `window.open()`. A blob URL is `blob:.../<UUID>`, so the browser's PDF viewer used that UUID as the download filename and discarded the backend's `Content-Disposition` filename.

## Changes

### Invoice file naming
**Backend — `compliance/service/elicensing_invoice_service.py`**
- Added `_build_invoice_filename(prefix, invoice_number)` → `"<prefix> <invoice_number>_<YYYYMMDD>.pdf"`
- Named the three invoice types per spec:
  - Obligation → `OBPS Compliance Invoice <number>_<date>.pdf`
  - Automatic overdue → `OBPS Automatic Overdue Penalty Invoice <number>_<date>.pdf`
  - Late submission → `OBPS GGEAPAR Penalty Invoice <number>_<date>.pdf`

**Frontend — `apps/compliance/src/app/utils/generateInvoice.tsx`**
- Replaced blob-URL preview with **direct navigation** to the route URL, so the browser honours the `Content-Disposition` filename on download.
- Opens the preview tab synchronously (no `noopener`, which returns `null`), validates the response for JSON errors, then navigates the tab — closing it and surfacing the error on failure.

### "CAS" removal
- `apps/reporting/.../FacilityReportFinalReviewContent.tsx` — facility report filename `CAS OBPS_Reporting_<facility>` → `OBPS_Reporting_<facility>`
- `libs/components/src/layout/RootLayout.tsx` — global app title `CAS OBPS` → `B.C. OBPS` (covers the operation report download + all browser tab titles)