### PR TITLE
4830 remove report fixtures pre 2024

### DIFF
--- a/bc_obps/reporting/fixtures/mock/report.json
+++ b/bc_obps/reporting/fixtures/mock/report.json
@@ -2,7 +2,6 @@
   {
     "model": "reporting.report",
     "fields": {
-      "id": 1,
       "operation_id": "3b5b95ea-2a1a-450d-8e2e-2e15feed96c9",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2025-02-18 20:09:05.41476+00",
@@ -12,7 +11,6 @@
   {
     "model": "reporting.report",
     "fields": {
-      "id": 2,
       "operation_id": "002d5a9e-32a6-4191-938c-2c02bfec592d",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2025-02-18 20:09:05.41476+00",
@@ -22,7 +20,6 @@
   {
     "model": "reporting.report",
     "fields": {
-      "id": 3,
       "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488f",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2026-05-28 20:09:05.41476+00",
@@ -32,7 +29,6 @@
   {
     "model": "reporting.report",
     "fields": {
-      "id": 4,
       "operation_id": "84ea41f0-4039-44d8-9f91-0e1d5fd47930",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2026-05-28 20:09:05.41476+00",
@@ -42,7 +38,6 @@
   {
     "model": "reporting.report",
     "fields": {
-      "id": 5,
       "operation_id": "3f47b2e1-9a4c-4d3f-8b21-7e9a0c5d2f6b",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2026-05-28 20:09:05.41476+00",
@@ -52,7 +47,6 @@
   {
     "model": "reporting.report",
     "fields": {
-      "id": 6,
       "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488e",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2025-05-28 20:09:05.41476+00",
@@ -62,7 +56,6 @@
   {
     "model": "reporting.report",
     "fields": {
-      "id": 7,
       "operation_id": "3f47b2e1-9a4c-4d3f-8b21-7e9a0c5d2f6b",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2025-05-28 20:09:05.41476+00",
@@ -72,7 +65,6 @@
   {
     "model": "reporting.report",
     "fields": {
-      "id": 8,
       "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488f",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2025-05-28 20:09:05.41476+00",
@@ -82,7 +74,6 @@
   {
     "model": "reporting.report",
     "fields": {
-      "id": 9,
       "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488e",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2023-05-28 20:09:05.41476+00",
@@ -92,7 +83,6 @@
   {
     "model": "reporting.report",
     "fields": {
-      "id": 10,
       "operation_id": "002d5a9e-32a6-4191-938c-2c02bfec592d",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2024-05-28 20:09:05.41476+00",

--- a/bc_obps/reporting/fixtures/mock/report.json
+++ b/bc_obps/reporting/fixtures/mock/report.json
@@ -62,41 +62,21 @@
   {
     "model": "reporting.report",
     "fields": {
-      "id": 99,
+      "id": 7,
       "operation_id": "3f47b2e1-9a4c-4d3f-8b21-7e9a0c5d2f6b",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
-      "created_at": "2024-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2023
-    }
-  },
-  {
-    "model": "reporting.report",
-    "fields": {
-      "id": 100,
-      "operation_id": "002d5a9e-32a6-4191-938c-2c02bfec592d",
-      "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
-      "created_at": "2024-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2023
-    }
-  },
-  {
-    "model": "reporting.report",
-    "fields": {
-      "id": 7,
-      "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488f",
-      "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
-      "created_at": "2024-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2023
+      "created_at": "2025-05-28 20:09:05.41476+00",
+      "reporting_year_id": 2024
     }
   },
   {
     "model": "reporting.report",
     "fields": {
       "id": 8,
-      "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488e",
+      "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488f",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
-      "created_at": "2023-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2023
+      "created_at": "2025-05-28 20:09:05.41476+00",
+      "reporting_year_id": 2024
     }
   },
   {
@@ -106,33 +86,13 @@
       "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488e",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2023-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2022
-    }
-  },
-  {
-    "model": "reporting.report",
-    "fields": {
-      "id": 10,
-      "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488e",
-      "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
-      "created_at": "2022-05-28 20:09:05.41476+00",
-      "reporting_year_id": 2021
-    }
-  },
-  {
-    "model": "reporting.report",
-    "fields": {
-      "id": 103,
-      "operation_id": "b65a3fbc-c81a-49c0-a43a-67bd3a0b488e",
-      "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
-      "created_at": "2023-05-28 20:09:05.41476+00",
       "reporting_year_id": 2025
     }
   },
   {
     "model": "reporting.report",
     "fields": {
-      "id": 102,
+      "id": 10,
       "operation_id": "002d5a9e-32a6-4191-938c-2c02bfec592d",
       "operator_id": "4242ea9d-b917-4129-93c2-db00b7451051",
       "created_at": "2024-05-28 20:09:05.41476+00",

--- a/bc_obps/reporting/management/commands/load_reporting_fixtures.py
+++ b/bc_obps/reporting/management/commands/load_reporting_fixtures.py
@@ -38,27 +38,6 @@ class Command(BaseCommand):
         workflow = options.get('workflow')
         self.load_reports(workflow)
 
-        # Load any additional fixtures you need *after* reports exist
-        extra = [
-            f'{self.fixture_base_dir}/report_person_responsible.json',
-            f'{self.fixture_base_dir}/report_raw_activity_data.json',
-            f'{self.fixture_base_dir}/report_activity.json',
-            f'{self.fixture_base_dir}/report_source_type.json',
-            f'{self.fixture_base_dir}/report_unit.json',
-            f'{self.fixture_base_dir}/report_fuel.json',
-            f'{self.fixture_base_dir}/report_emission.json',
-            f'{self.fixture_base_dir}/report_methodology.json',
-            f'{self.fixture_base_dir}/report_product.json',
-            f'{self.fixture_base_dir}/report_emission_allocation.json',
-            f'{self.fixture_base_dir}/report_product_emission_allocation.json',
-            f'{self.fixture_base_dir}/report_additional_data.json',
-            f'{self.fixture_base_dir}/report_verification.json',
-            f'{self.fixture_base_dir}/report_attachment.json',
-        ]
-        for fixture in extra:
-            self.stdout.write(self.style.SUCCESS(f"Loading additional report fixture: {fixture}"))
-            call_command('loaddata', fixture)
-
     def load_reports(self, workflow):
         reports_fixture = f'{self.fixture_base_dir}/report.json'
         with open(reports_fixture) as f:
@@ -78,6 +57,27 @@ class Command(BaseCommand):
                 ro.operation_name = _strip_admin_suffix(ro.operation_name)
                 ro.save()
 
+            # Load fixtures before submission to preserve fixture state
+            extra = [
+                f'{self.fixture_base_dir}/report_person_responsible.json',
+                f'{self.fixture_base_dir}/report_raw_activity_data.json',
+                f'{self.fixture_base_dir}/report_activity.json',
+                f'{self.fixture_base_dir}/report_source_type.json',
+                f'{self.fixture_base_dir}/report_unit.json',
+                f'{self.fixture_base_dir}/report_fuel.json',
+                f'{self.fixture_base_dir}/report_emission.json',
+                f'{self.fixture_base_dir}/report_methodology.json',
+                f'{self.fixture_base_dir}/report_product.json',
+                f'{self.fixture_base_dir}/report_emission_allocation.json',
+                f'{self.fixture_base_dir}/report_product_emission_allocation.json',
+                f'{self.fixture_base_dir}/report_additional_data.json',
+                f'{self.fixture_base_dir}/report_verification.json',
+                f'{self.fixture_base_dir}/report_attachment.json',
+            ]
+            for fixture in extra:
+                self.stdout.write(self.style.SUCCESS(f"Loading additional report fixture: {fixture}"))
+                call_command('loaddata', fixture)
+
             # submit reports
             operation_ids_to_submit = [
                 UUID('002d5a9e-32a6-4191-938c-2c02bfec592d'),  # Banana LFO
@@ -92,8 +92,8 @@ class Command(BaseCommand):
                 )
 
                 for report_version in report_versions:
-
                     submit_report_from_fixture(report_version, UUID('ba2ba62a-1218-42e0-942a-ab9e92ce8822'))
+
             # create supplementary report
             for report in Report.objects.filter(operation_id=operation_ids_to_submit[0]):
                 ReportVersionService.create_report_version(report)

--- a/bciers/apps/reporting-e2e/poms/report-attachments-list.ts
+++ b/bciers/apps/reporting-e2e/poms/report-attachments-list.ts
@@ -65,11 +65,11 @@ export class ReportAttachmentsListPOM {
     ).toHaveCount(0);
   }
 
-  // 2021 = oldest submitted year, 2025 = newest (from fixture data).
+  // 2024 = oldest submitted year, 2025 = newest (from load fixture data)
   async assertSortedByReportingYear(order: "asc" | "desc"): Promise<void> {
     const dataRows = this.page.getByRole("row").filter({ hasText: /20\d\d/ });
     const [expectedFirst, expectedLast] =
-      order === "asc" ? ["2021", "2025"] : ["2025", "2021"];
+      order === "asc" ? ["2024", "2025"] : ["2025", "2024"];
 
     await expect(dataRows.first()).toContainText(expectedFirst);
     await expect(dataRows.last()).toContainText(expectedLast);

--- a/bciers/apps/reporting-e2e/tests/workflows/view-report-history.spec.ts
+++ b/bciers/apps/reporting-e2e/tests/workflows/view-report-history.spec.ts
@@ -9,6 +9,7 @@ import { ReportOperationPOM } from "@/reporting-e2e/poms/report-operation";
 
 const test = setupBeforeAllTest(UserRole.INDUSTRY_USER_ADMIN);
 const internalTest = setupBeforeAllTest(UserRole.CAS_ANALYST);
+const reportVersion = 10;
 
 test.describe.configure({ mode: "serial" });
 
@@ -18,7 +19,9 @@ test.describe("View Report History", () => {
     happoScreenshot,
   }) => {
     const grid = new ReportHistoryPOM(page);
-    await grid.route(8); // Navigate directly to the report history page for Banana LFO's 2023 report with id 8
+    // Navigate directly to the report history page for id reportVersion
+
+    await grid.route(reportVersion);
     await grid.validatePageElements(OPERATION_NAMES.BANANA_LFO);
 
     await takeStabilizedScreenshot(happoScreenshot, page, {
@@ -34,10 +37,10 @@ test.describe("View Report History", () => {
       true,
     );
 
-    await grid.route(8); // Navigate back to the report history page
+    await grid.route(reportVersion); // Navigate back to the report history page
 
     // Click "Continue" for the report history — navigates to the 'Review Operation Information' page for the selected version
-    await grid.continueReportFromHistory(16); // Continue from the draft report from the Report History page
+    await grid.continueReportFromHistory(12); // Continue from the draft report from the Report History page
     const operationInformation = new ReportOperationPOM(page);
     await operationInformation.verifyFieldVisibility();
   });
@@ -48,7 +51,7 @@ internalTest.describe("View Report History", () => {
     "CAS analyst views the report history for a submitted report",
     async ({ page, happoScreenshot }) => {
       const grid = new ReportHistoryPOM(page);
-      await grid.route(8); // Navigate directly to the report history page for Banana LFO's 2023 report with id 8
+      await grid.route(reportVersion); // Navigate directly to the report history page for id reportVersion
 
       await takeStabilizedScreenshot(happoScreenshot, page, {
         component: "Report History Grid",


### PR DESCRIPTION
Ticket: [4830](https://github.com/bcgov/cas-registration/issues/4830)


### 🚀 Impact

- Removed pre-2024 report fixtures to reflect real-world reporting year scenario
- Load ReportVersion-dependent fixtures immediately after reports are created and before report submission to ensure fixture data is initialized in the correct order prior to submission







<img width="1412" height="696" alt="image" src="https://github.com/user-attachments/assets/23c6a361-e5ed-4ee1-997f-7dd6653efa1c" />


<img width="1412" height="696" alt="image" src="https://github.com/user-attachments/assets/2e88cfdc-aed4-4dcd-9c97-89b9c3f4a307" />

