### PR TITLE
Bug/4767 Missing Selection errors cleared after making selection

### DIFF
--- a/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
+++ b/bciers/apps/reporting/src/app/components/activities/ActivityForm.tsx
@@ -125,6 +125,11 @@ export default function ActivityForm({
     for (const [k, v] of Object.entries(sourceTypeMap)) {
       if (newFormData[`${v}`]) selectedSourceTypes.push(k);
     }
+
+    if (selectedSourceTypes.length > 0) {
+      setErrors(undefined);
+    }
+
     if (!arrayEquals(selectedSourceTypes, selectedSourceTypeIds)) {
       const schemaData = await fetchSchemaData(selectedSourceTypes);
       if (schemaData.error) {
@@ -167,7 +172,16 @@ export default function ActivityForm({
     // Ensure we use the filtered formData with omitted extra data
     const filteredData = data.formData;
 
-    if (!filteredData.sourceTypes) {
+    const selectedSourceTypeData = Object.keys(filteredData.sourceTypes ?? {});
+
+    // Only filter the keys where the checkBox for that source type is checked IF there is more than one source type
+    const selectedSourceTypeDataFiltered =
+      sourceTypeCount > 1
+        ? selectedSourceTypeData.filter((slug) => filteredData[slug])
+        : selectedSourceTypeData;
+
+    // Validate that at least one source type is selected
+    if (selectedSourceTypeDataFiltered.length === 0) {
       setErrors([
         createGenericReportValidationError(
           "At least one source type must be selected to report for that activity.",
@@ -175,14 +189,6 @@ export default function ActivityForm({
       ]);
       return false;
     }
-
-    const selectedSourceTypeData = Object.keys(filteredData.sourceTypes);
-
-    // Only filter the keys where the checkBox for that source type is checked IF there is more than one source type
-    const selectedSourceTypeDataFiltered =
-      sourceTypeCount > 1
-        ? selectedSourceTypeData.filter((slug) => filteredData[slug])
-        : selectedSourceTypeData;
 
     // Only for selected source types we grab the form data
     const selectedSourceTypeDataReduced = selectedSourceTypeDataFiltered.reduce(

--- a/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
+++ b/bciers/apps/reporting/src/app/components/products/ProductionDataForm.tsx
@@ -146,6 +146,9 @@ const ProductionDataForm: React.FC<Props> = ({
           (item) => item.product_name === product_name,
         ) ?? allowedProducts.find((p) => p.product_name === product_name),
     );
+    if (newFormData.product_selection.length > 0) {
+      setErrors(undefined);
+    }
     setFormData({
       product_selection: newFormData.product_selection,
       production_data: updatedSelection,

--- a/bciers/apps/reporting/src/tests/components/activities/ActivityForm.missingSourceTypeSelection.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/activities/ActivityForm.missingSourceTypeSelection.test.tsx
@@ -1,0 +1,124 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { describe, expect, vi, it, beforeEach } from "vitest";
+import ActivityForm from "@reporting/src/app/components/activities/ActivityForm";
+import { dummyNavigationInformation } from "../taskList/utils";
+import { useRouter } from "@bciers/testConfig/mocks";
+import { RJSFSchema } from "@rjsf/utils";
+import MultiStepFormWithTaskList from "@bciers/components/form/MultiStepFormWithTaskList";
+import { getActivitySchema } from "@reporting/src/app/utils/getActivitySchema";
+import { createGenericReportValidationError } from "@reporting/src/app/components/shared/validation/utils";
+
+vi.mock("@bciers/components/form/MultiStepFormWithTaskList", () => ({
+  default: vi.fn(() => null),
+}));
+
+vi.mock("@reporting/src/app/utils/getActivitySchema", () => ({
+  getActivitySchema: vi.fn(),
+}));
+
+const mockMultiStepFormWithTaskList = MultiStepFormWithTaskList as ReturnType<
+  typeof vi.fn
+>;
+const mockGetActivitySchema = getActivitySchema as ReturnType<typeof vi.fn>;
+
+const mockActivityData = {
+  activityId: 1,
+  sourceTypeMap: {
+    1: "firstTestSourceType",
+    2: "secondTestSourceType",
+  },
+};
+
+const mockGasTypes = {
+  id: 1,
+  name: "Methane",
+  chemical_formula: "CH4",
+  cas_number: "74-82-8",
+};
+
+const initialSchema: RJSFSchema = {
+  type: "object",
+  title: "Activity Test Schema",
+  properties: {
+    firstTestSourceType: {
+      type: "boolean",
+      title: "First Test Source Type",
+    },
+    secondTestSourceType: {
+      type: "boolean",
+      title: "Second Test Source Type",
+    },
+  },
+};
+
+describe("ActivityForm missing source type selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useRouter.mockReturnValue({
+      push: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    mockGetActivitySchema.mockResolvedValue(
+      JSON.stringify({ schema: initialSchema }),
+    );
+  });
+
+  it("clears missing source type error after selecting a source type", async () => {
+    render(
+      <ActivityForm
+        activityData={mockActivityData}
+        currentActivity={{
+          id: 1,
+          name: "Test Activity",
+          slug: "electronics_manufacturing",
+        }}
+        navigationInformation={dummyNavigationInformation}
+        activityFormData={{}}
+        initialJsonSchema={initialSchema}
+        reportVersionId={1}
+        facilityId={"00000000-0000-0000-0000-000000000001"}
+        initialSelectedSourceTypeIds={[]}
+        gasTypes={mockGasTypes}
+        reportingYear={2024}
+        activityIndex={0}
+      />,
+    );
+
+    const initialProps = mockMultiStepFormWithTaskList.mock.calls[0][0];
+
+    await act(async () => {
+      await initialProps.onSubmit({ formData: {} }, false);
+    });
+
+    const afterSubmitProps =
+      mockMultiStepFormWithTaskList.mock.calls[
+        mockMultiStepFormWithTaskList.mock.calls.length - 1
+      ][0];
+
+    expect(afterSubmitProps.errors).toHaveLength(1);
+    expect(afterSubmitProps.errors[0].props.errors).toEqual([
+      createGenericReportValidationError(
+        "At least one source type must be selected to report for that activity.",
+      ),
+    ]);
+
+    await act(async () => {
+      afterSubmitProps.onChange({
+        formData: {
+          firstTestSourceType: true,
+        },
+      });
+    });
+
+    await waitFor(() => {
+      const afterChangeProps =
+        mockMultiStepFormWithTaskList.mock.calls[
+          mockMultiStepFormWithTaskList.mock.calls.length - 1
+        ][0];
+
+      expect(afterChangeProps.errors).toBeUndefined();
+    });
+  });
+});

--- a/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/products/ProductionDataForm.test.tsx
@@ -540,4 +540,67 @@ describe("The ProductionDataForm component", () => {
     expect(result).toBe(true);
     expect(mockReportValidationSummary).not.toHaveBeenCalled();
   });
+  it("clears the no product selected error when a product is selected", async () => {
+    render(
+      <ProductionDataForm
+        allowedProducts={[
+          { product_id: 16, product_name: "Pulp and paper: chemical pulp" },
+          { product_id: 1, product_name: "Other Product" },
+        ]}
+        initialData={[]}
+        facility_id="abcd"
+        report_version_id={1000}
+        schema={{ testSchema: true }}
+        navigationInformation={dummyNavigationInformation}
+        facilityType={""}
+        isPulpAndPaper={false}
+        overlappingIndustrialProcessEmissions={0}
+        reportingYear={2024}
+        isOptedOut={false}
+      />,
+    );
+
+    const calledProps = mockMultiStepFormWithTaskList.mock.calls[0][0];
+    mockPostProductionData.mockResolvedValue({});
+
+    const formData = {
+      formData: {
+        product_selection: [],
+        production_data: [],
+      },
+    };
+    // Act: Trigger submit with no products selected to generate the error
+    await act(async () => {
+      await calledProps.onSubmit(formData);
+    });
+
+    const updatedProps =
+      mockMultiStepFormWithTaskList.mock.calls[
+        mockMultiStepFormWithTaskList.mock.calls.length - 1
+      ][0];
+    // Assert: Verify that the missing selection error is present
+    expect(updatedProps.errors).toHaveLength(1);
+    expect(updatedProps.errors[0].props.errors).toEqual([
+      createGenericReportValidationError("A product must be selected."),
+    ]);
+
+    const newFormData = {
+      formData: {
+        product_selection: ["Other Product"],
+        production_data: [{ product_id: 1, product_name: "Other Product" }],
+      },
+    };
+    // Act: Trigger onChange with a product selected to clear the error
+    await act(async () => {
+      await updatedProps.onChange(newFormData);
+    });
+
+    const finalProps =
+      mockMultiStepFormWithTaskList.mock.calls[
+        mockMultiStepFormWithTaskList.mock.calls.length - 1
+      ][0];
+
+    // Assert: Verify that the error is cleared when a product is selected
+    expect(finalProps.errors).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-registration/issues/4767

### Changes
 - Added two new "missing selection" error configurations
 - Added new hook for formErrors : `removeErrorsByKey`
 - **In `ActivityForm` and `ProductionDataForm`, the missing-selection errors are now keyed and, once a selection is made, removed via that key.**
 - 2 new tests to show error being added and removed (note: the activity test was moved to its own file because the other activity form tests were all DOM based, and in that style of test I couldn't get past an RJSF required field error blocking attempts to submit. So I copied the ProductionDataForm test and tested the error state)

### Testing
1. Start or continue a report
2. Ensure that an activity with multiple source types is selected (such as `LNG activities`) and at least one regulated product
3. Progress to the activity form
4. With no source types selected, click `Save`
 - Expect to see error `A source type must be selected.`
5. Select a source type
 - NEW BEHAVIOUR: Expect error to be removed
6. Click `Save`
 - Expect to see only error `This form can't be saved yet. Please fix the errors above.`
 7. Progress to the `production-data` page
 8. With no products selected, click `Save`
  - Expect to see error `A product must be selected.`
 9. Select a product
  - Expect error to be removed
 10. Click `Save`
  - Expect to see only error `This form can't be saved yet. Please fix the errors above.`