### PR TITLE
fix: added correct operator filtering in ReportingDashboardService

### DIFF
--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -72,7 +72,7 @@ class ReportingDashboardService:
         the operation has since been transferred to another operator.
         """
         user = UserDataAccessService.get_by_guid(user_guid)
-        operator_id = UserOperatorService.get_current_user_approved_user_operator_or_raise(user).operator.id
+        operator_id = UserOperatorService.get_current_user_approved_user_operator_or_raise(user).operator_id
 
         # Related docs: https://docs.djangoproject.com/en/5.1/ref/models/expressions/#subquery-expressions
         report_queryset = Report.objects.filter(

--- a/bc_obps/reporting/service/reporting_dashboard_service.py
+++ b/bc_obps/reporting/service/reporting_dashboard_service.py
@@ -4,7 +4,6 @@ from django.db.models import OuterRef, QuerySet, Value, F, Subquery, Case, When,
 from django.db.models.functions import Concat, Coalesce
 from ninja import Query
 from registration.models.operation import Operation
-from registration.models.user_operator import UserOperator
 from reporting.models import ReportOperation
 from reporting.models.report import Report
 from reporting.models.report_version import ReportVersion
@@ -73,8 +72,7 @@ class ReportingDashboardService:
         the operation has since been transferred to another operator.
         """
         user = UserDataAccessService.get_by_guid(user_guid)
-        user_operator: Optional[UserOperator] = user.user_operators.first()
-        operator_id: Optional[UUID] = user_operator.operator_id if user_operator else None
+        operator_id = UserOperatorService.get_current_user_approved_user_operator_or_raise(user).operator.id
 
         # Related docs: https://docs.djangoproject.com/en/5.1/ref/models/expressions/#subquery-expressions
         report_queryset = Report.objects.filter(

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 import pytest
 from registration.models.operation import Operation
 from registration.models.naics_code import NaicsCode
+from registration.models.user_operator import UserOperator
 from model_bakery.baker import make_recipe
 from reporting.models.report_operation import ReportOperation
 from registration.models.operation_designated_operator_timeline import OperationDesignatedOperatorTimeline
@@ -618,3 +619,73 @@ class TestReportingDashboardService:
         assert operation.id in list(queryset_2025_new_user.values_list("id", flat=True))
         # assert new_user doesn't get results for operations from other operators
         assert queryset_2025_new_user.count() == 1
+
+    def test_current_reports_visible_after_declined_then_approved_access_on_different_operators(self):
+        reporting_year = ReportingYear.objects.filter(reporting_year=2025).first()
+
+        user = baker.make_recipe('registration.tests.utils.industry_operator_user')
+        delta_operator = operator_baker({"id": "aaa11149-e303-4788-9ba9-806232a5f711", "legal_name": "Delta"})
+        bravo_operator = operator_baker({"id": "fafabd03-b7b8-47f1-a3b0-b80761697e45", "legal_name": "Bravo"})
+
+        baker.make(
+            UserOperator,
+            user=user,
+            operator=delta_operator,
+            role=UserOperator.Roles.PENDING,
+            status=UserOperator.Statuses.DECLINED,
+        )
+        baker.make(
+            UserOperator,
+            user=user,
+            operator=bravo_operator,
+            role=UserOperator.Roles.REPORTER,
+            status=UserOperator.Statuses.APPROVED,
+        )
+
+        bravo_operation = operation_baker(
+            operator_id=bravo_operator.id,
+            status=Operation.Statuses.REGISTERED,
+            name="Bravo Operation",
+        )
+        delta_operation = operation_baker(
+            operator_id=delta_operator.id,
+            status=Operation.Statuses.REGISTERED,
+            name="Delta Operation",
+        )
+
+        make_recipe(
+            'registration.tests.utils.operation_designated_operator_timeline',
+            operator=bravo_operator,
+            operation=bravo_operation,
+            start_date="2024-01-01T00:00:00Z",
+            end_date=None,
+        )
+        make_recipe(
+            'registration.tests.utils.operation_designated_operator_timeline',
+            operator=delta_operator,
+            operation=delta_operation,
+            start_date="2024-01-01T00:00:00Z",
+            end_date=None,
+        )
+
+        # create a report for Delta Operation, but it shouldn't appear in user's results
+        ReportService.create_report(delta_operation.id, reporting_year.reporting_year)
+        bravo_report_version_id = ReportService.create_report(bravo_operation.id, reporting_year.reporting_year)
+        bravo_report_version = ReportVersion.objects.get(id=bravo_report_version_id)
+        bravo_report_version.status = "Submitted"
+        bravo_report_version.is_latest_submitted = True
+        bravo_report_version.save(update_fields=["status", "is_latest_submitted"])
+
+        result = ReportingDashboardService.get_operations_for_reporting_dashboard(
+            user.user_guid,
+            reporting_year.reporting_year,
+            filters=ReportingDashboardOperationFilterSchema(),
+        ).values()
+        # user only has access to Bravo Operator's operation, so they should only see that report in the results
+        result_list = list(result)
+        assert len(result_list) == 1
+        assert result_list[0]["id"] == bravo_operation.id
+        assert result_list[0]["report_id"] == bravo_report_version.report.id
+        assert result_list[0]["report_version_id"] == bravo_report_version.id
+        assert result_list[0]["report_status"] == "Submitted"
+        assert result_list[0]["operation_name"] == bravo_report_version.report_operation.operation_name

--- a/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
+++ b/bc_obps/reporting/tests/service/test_reporting_dashboard_service.py
@@ -621,7 +621,7 @@ class TestReportingDashboardService:
         assert queryset_2025_new_user.count() == 1
 
     def test_current_reports_visible_after_declined_then_approved_access_on_different_operators(self):
-        reporting_year = ReportingYear.objects.filter(reporting_year=2025).first()
+        reporting_year = ReportingYear.objects.get(reporting_year=2025)
 
         user = baker.make_recipe('registration.tests.utils.industry_operator_user')
         delta_operator = operator_baker({"id": "aaa11149-e303-4788-9ba9-806232a5f711", "legal_name": "Delta"})


### PR DESCRIPTION
Issue: #4908 
Bug reported in this thread: https://teams.microsoft.com/l/message/19:3b0107d27a7b452a89e6ffd7e16ed4a8@thread.tacv2/1782861346657?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&groupId=29821293-3244-455d-beae-e01d27762cfe&parentMessageId=1782861346657&teamName=External%3A%20CAS%20-%20Clean%20Growth%20Digital%20Service%20Team&channelName=BCIERS%20Internal%20Users&createdTime=1782861346657&ngc=true 

## Summary of Bug
An external user reported that they couldn't view submitted reports for their operations, even though they had access to the Reporting dashboard and their operations were listed, but all were appearing with a "Start" button next to them. Then when they tried to Start a report the app showed an ungraceful error message.

This was a bit of an edge case, where the user in question had first requested access to Operator A, which was Declined, and then subsequently requested access to Operator B, which was Approved. This revealed a bug in the logic for `get_operations_for_reporting_dashboard()` in which the user's operator was not being queried correctly, and so the "first" operator only was being returned (i.e., Operator A), not the one the user is actually associated with (Operator B).

## Changes Made
- `ReportingDashboardService.get_operations_for_reporting_dashboard()` no longer takes the first user_operator record for the user, but instead uses the proper `UserOperatorService.get_current_user_approved_user_operator_or_raise(user)` query as used elsewhere
- added regression test

## Manual Testing

To observe the bug in action, from the `develop` branch:
1. Sign in as `bc-cas-dev-secondary`, then request access to the Delta operator. Log out.
2. Sign in as an internal user with your own IDIR, grant yourself `cas_analyst` role, then approve the prime admin access request for Delta. Log out.
3. Sign in as `bc-cas-dev-three`, then request access to the Delta operator. Log out.
4. Sign in as `bc-cas-dev-secondary`, and decline **-three**'s access request. Log out.
5. Sign in as `bc-cas-dev-three`, then request access to the Bravo operator. Log out.
6. Sign in as `bc-cas-dev`, then approve **-three**'s access request. Log out.
7. Sign in as `bc-cas-dev-three`, then navigate to the Reporting dashboard (current year reports).

**Expected behaviour**: some operations for Bravo operator should already have a report submitted, or a draft supplementary report in progress. You (`bc-cas-dev-three`) should be able to see that.
**Actual Behaviour**: all Bravo's operations appear in the grid, but there are "Start" buttons in the Action cell for each operation. Clicking the "Start" button results in an error if you select for an operation that already has a report submitted.

Now switch over to this branch (`fix/get-operations-for-report-dashboard`)

While signed in as `bc-cas-dev-three`, you should now see this in the grid:
<img width="1268" height="800" alt="Screenshot 2026-07-06 at 3 36 20 PM" src="https://github.com/user-attachments/assets/b8755ae3-9e52-437b-b341-000fdb64c4ae" />

