### PR TITLE
4317 Chemical Pulp Mill: Warning note in the 2024 report

### DIFF
--- a/bciers/apps/reporting/src/app/components/operations/OperationReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/operations/OperationReviewForm.tsx
@@ -213,6 +213,7 @@ export default function OperationReviewForm({
             },
           }),
         }}
+        formContext={{ reportingYear }}
         formData={formDataState}
         saveButtonDisabled={!hasReps}
         submitButtonDisabled={!hasReps}

--- a/bciers/libs/components/src/form/widgets/RegulatedProductMultiSelectWidget.test.tsx
+++ b/bciers/libs/components/src/form/widgets/RegulatedProductMultiSelectWidget.test.tsx
@@ -7,6 +7,11 @@ import {
   LIME_RECOVERED_NAME,
 } from "./RegulatedProductMultiSelectWidget";
 
+const HELP_TEXT = /If this is a chemical pulp mill that recovered lime by kiln/;
+
+const REPORTING_YEAR_BEFORE_RULE = 2024;
+const REPORTING_YEAR_RULE_START = 2025;
+
 export const regulatedProductSchema = {
   type: "object",
   required: ["regulatedProducts"],
@@ -31,215 +36,129 @@ export const regulatedProductUiSchema = {
   },
 };
 
+const renderWidget = (
+  regulatedProducts: number[] = [],
+  reportingYear = REPORTING_YEAR_RULE_START,
+) =>
+  render(
+    <FormBase
+      schema={regulatedProductSchema}
+      formData={{ regulatedProducts }}
+      uiSchema={regulatedProductUiSchema}
+      formContext={{ reportingYear }}
+    />,
+  );
+
+const expectHelpTextVisible = async () => {
+  await waitFor(() => {
+    expect(screen.getByText(HELP_TEXT)).toBeVisible();
+  });
+};
+
+const expectHelpTextHidden = async () => {
+  await waitFor(() => {
+    expect(screen.queryByText(HELP_TEXT)).not.toBeInTheDocument();
+  });
+};
+
 describe("RegulatedProductMultiSelectWidget", () => {
-  it("does not show help text when no products are selected", async () => {
-    render(
-      <FormBase
-        schema={regulatedProductSchema}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
+  describe("reporting year rule", () => {
+    it("does not show help text for 2024 reports when only chemical pulp is selected", async () => {
+      renderWidget([16], REPORTING_YEAR_BEFORE_RULE);
 
-    await waitFor(() => {
-      expect(
-        screen.queryByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).not.toBeInTheDocument();
+      await expectHelpTextHidden();
+    });
+
+    it("shows help text starting in 2025 when only chemical pulp is selected", async () => {
+      renderWidget([16], REPORTING_YEAR_RULE_START);
+
+      await expectHelpTextVisible();
     });
   });
 
-  it("does not show help text when only other products are selected", async () => {
-    render(
-      <FormBase
-        schema={regulatedProductSchema}
-        formData={{ regulatedProducts: [1] }}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
+  describe("product selection rule for reports after 2024", () => {
+    it("does not show help text when no products are selected", async () => {
+      renderWidget([]);
 
-    await waitFor(() => {
-      expect(
-        screen.queryByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).not.toBeInTheDocument();
+      await expectHelpTextHidden();
+    });
+
+    it("does not show help text when only unrelated products are selected", async () => {
+      renderWidget([1]);
+
+      await expectHelpTextHidden();
+    });
+
+    it("shows help text when only chemical pulp is selected", async () => {
+      renderWidget([16]);
+
+      await expectHelpTextVisible();
+    });
+
+    it("shows help text when only lime recovered by kiln is selected", async () => {
+      renderWidget([43]);
+
+      await expectHelpTextVisible();
+    });
+
+    it("does not show help text when both matching products are selected", async () => {
+      renderWidget([16, 43]);
+
+      await expectHelpTextHidden();
+    });
+
+    it("shows help text when chemical pulp is selected with unrelated products", async () => {
+      renderWidget([1, 16]);
+
+      await expectHelpTextVisible();
+    });
+
+    it("shows help text when lime recovered by kiln is selected with unrelated products", async () => {
+      renderWidget([1, 43]);
+
+      await expectHelpTextVisible();
+    });
+
+    it("does not show help text when both matching products are selected with unrelated products", async () => {
+      renderWidget([1, 16, 43]);
+
+      await expectHelpTextHidden();
     });
   });
 
-  it("shows help text when only chemical pulp (16) is selected", async () => {
-    render(
-      <FormBase
-        schema={regulatedProductSchema}
-        formData={{ regulatedProducts: [16] }}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
+  describe("reactive updates", () => {
+    it("shows help text when the selection changes from none to chemical pulp", async () => {
+      const { rerender } = renderWidget([]);
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).toBeVisible();
-    });
-  });
+      await expectHelpTextHidden();
 
-  it("shows help text when only lime recovered by kiln (43) is selected", async () => {
-    render(
-      <FormBase
-        schema={regulatedProductSchema}
-        formData={{ regulatedProducts: [43] }}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
+      rerender(
+        <FormBase
+          schema={regulatedProductSchema}
+          formData={{ regulatedProducts: [16] }}
+          uiSchema={regulatedProductUiSchema}
+          formContext={{ reportingYear: REPORTING_YEAR_RULE_START }}
+        />,
+      );
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).toBeVisible();
-    });
-  });
-
-  it("does not show help text when both chemical pulp (16) and lime recovered by kiln (43) are selected", async () => {
-    render(
-      <FormBase
-        schema={regulatedProductSchema}
-        formData={{ regulatedProducts: [16, 43] }}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it("shows help text when chemical pulp (16) is selected with other products", async () => {
-    render(
-      <FormBase
-        schema={regulatedProductSchema}
-        formData={{ regulatedProducts: [1, 16] }}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).toBeVisible();
-    });
-  });
-
-  it("shows help text when lime recovered by kiln (43) is selected with other products", async () => {
-    render(
-      <FormBase
-        schema={regulatedProductSchema}
-        formData={{ regulatedProducts: [1, 43] }}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).toBeVisible();
-    });
-  });
-
-  it("does not show help text when both products (16 and 43) are selected with other products", async () => {
-    render(
-      <FormBase
-        schema={regulatedProductSchema}
-        formData={{ regulatedProducts: [1, 16, 43] }}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it("updates help text when value changes from no selection to product 16", async () => {
-    const { rerender } = render(
-      <FormBase
-        schema={regulatedProductSchema}
-        formData={{ regulatedProducts: [] }}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).not.toBeInTheDocument();
+      await expectHelpTextVisible();
     });
 
-    rerender(
-      <FormBase
-        schema={regulatedProductSchema}
-        formData={{ regulatedProducts: [16] }}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
+    it("removes help text when the selection changes to both matching products", async () => {
+      const { rerender } = renderWidget([16]);
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).toBeVisible();
-    });
-  });
+      await expectHelpTextVisible();
 
-  it("removes help text when value changes to not meet the pulp and paper help text condition", async () => {
-    const { rerender } = render(
-      <FormBase
-        schema={regulatedProductSchema}
-        formData={{ regulatedProducts: [16] }}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
+      rerender(
+        <FormBase
+          schema={regulatedProductSchema}
+          formData={{ regulatedProducts: [16, 43] }}
+          uiSchema={regulatedProductUiSchema}
+          formContext={{ reportingYear: REPORTING_YEAR_RULE_START }}
+        />,
+      );
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).toBeVisible();
-    });
-
-    rerender(
-      <FormBase
-        schema={regulatedProductSchema}
-        formData={{ regulatedProducts: [16, 43] }}
-        uiSchema={regulatedProductUiSchema}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByText(
-          /If this is a chemical pulp mill that recovered lime by kiln/,
-        ),
-      ).not.toBeInTheDocument();
+      await expectHelpTextHidden();
     });
   });
 });

--- a/bciers/libs/components/src/form/widgets/RegulatedProductMultiSelectWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/RegulatedProductMultiSelectWidget.tsx
@@ -7,10 +7,16 @@ import { WidgetProps } from "@rjsf/utils";
 
 export const CHEMICAL_PULP_NAME = "Pulp and paper: chemical pulp";
 export const LIME_RECOVERED_NAME = "Pulp and paper: lime recovered by kiln";
+interface RegulatedProductFormContext {
+  reportingYear?: number;
+}
 
-const RegulatedProductMultiSelectWidget = (props: WidgetProps) => {
-  const value = Array.isArray(props.value) ? props.value : [];
-  const selectedIds = value.map((item) => Number(item));
+const RegulatedProductMultiSelectWidget = ({
+  value,
+  registry,
+  ...props
+}: WidgetProps) => {
+  const selectedIds = Array.isArray(value) ? value.map(Number) : [];
 
   const fieldSchema = props.schema?.items as FieldSchemaWithTooltip;
   const enumIds = fieldSchema?.enum ?? [];
@@ -29,10 +35,11 @@ const RegulatedProductMultiSelectWidget = (props: WidgetProps) => {
     limeRecoveredByKilnProductId !== undefined &&
     selectedIds.includes(Number(limeRecoveredByKilnProductId));
 
+  // Show the warning only for > 2024 reports when exactly one of the
+  // Chemical Pulp or Lime Recovered by Kiln products is selected.
+  const { reportingYear } = registry.formContext as RegulatedProductFormContext;
   const showPulpPaperHelp =
-    (hasChemicalPulp && !hasLimeRecovered) ||
-    (!hasChemicalPulp && hasLimeRecovered);
-
+    Number(reportingYear) > 2024 && hasChemicalPulp !== hasLimeRecovered;
   const helpText = showPulpPaperHelp ? (
     <>
       <strong>Note: </strong>If this is a chemical pulp mill that recovered lime
@@ -45,9 +52,11 @@ const RegulatedProductMultiSelectWidget = (props: WidgetProps) => {
   return (
     <MultiSelectWidgetWithTooltip
       {...props}
+      value={value}
+      registry={registry}
       uiSchema={{
         ...props.uiSchema,
-        "ui:help": helpText as any, // must be cast as any to satisfy uiSchema which wants a string, but the underlying TextField supports a ReactNode
+        "ui:help": helpText as any,
       }}
     />
   );


### PR DESCRIPTION
Ticket: [4317](https://github.com/bcgov/cas-registration/issues/4317)


### 🚀 Impact

- For a 2024 report, the "select both 'Pulp and paper: chemical pulp' and 'Pulp and paper: lime recovered by kiln' is not visible


---

### 🔬 Local Testing:  

#### Start Test Environment
1. Start the API server:  
   ```sh
   cd bc_obps
   make prepare_backend
   ```  
2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

---

#### Test: Chemical Pulp warning note does not display in the 2024 reports

1. Log in using `bc-cas-dev`
2. Navigate to previous reports table, http://localhost:3000/reporting/reports/previous-years
3. Navigate to a report review operation information , ex: http://localhost:3000/reporting/reports/1/review-operation-information
4.In `Regulated products` select "Pulp and Paper: Chemical pulp"
**Expected Results:**
- Warning note is NOT displayed


---

#### Test: Chemical Pulp warning note does not display in the 202 reports

1. Log in using `bc-cas-dev`
2. Navigate to previous reports table, http://localhost:3000/reporting/reports/previous-years
3. Navigate to a report review operation information , ex: http://localhost:3000/reporting/reports/1/review-operation-information
4.In `Regulated products` select "Pulp and Paper: Chemical pulp"
**Expected Results:**
- Warning note is NOT displayed
<img width="723" height="287" alt="image" src="https://github.com/user-attachments/assets/76ff02a2-fb2c-42bc-a536-5c350a82235e" />


---

#### Test: Chemical Pulp warning note does not display in the 2025 reports

1. Log in using `bc-cas-dev`
2. Navigate to reports table, http://localhost:3000/reporting/reports
3. Navigate to a report review operation information , ex: http://localhost:3000/reporting/reports/3/review-operation-information
4.In `Regulated products` select "Pulp and Paper: Chemical pulp"
**Expected Results:**
- Warning note is displayed

<img width="723" height="287" alt="image" src="https://github.com/user-attachments/assets/d379ed68-82cb-4272-baee-10d0cfb3bf80" />
