### PR TITLE
chore: define url for accessing attachments in local

### DIFF
--- a/bc_obps/bc_obps/storage_backends.py
+++ b/bc_obps/bc_obps/storage_backends.py
@@ -41,6 +41,9 @@ class SimpleLocal(FileSystemStorage):
 
     location = os.path.join(settings.MEDIA_ROOT)
 
+    def url(self, name: str | None = None) -> str:
+        return f"http://localhost:8000{super().url(name)}"
+
     def get_file_bucket(self, name: str) -> str | None:
         return "Clean"
 

--- a/bc_obps/bc_obps/urls.py
+++ b/bc_obps/bc_obps/urls.py
@@ -17,12 +17,14 @@ Including another URLconf
 
 from django.conf import settings
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, URLPattern, URLResolver
+from django.conf.urls.static import static
 from .api import api
 
 
-urlpatterns = [path("api/", api.urls)]
+urlpatterns: list[URLPattern | URLResolver] = [path("api/", api.urls)]
 if settings.NON_PROD_ENVIRONMENT:
     urlpatterns += [path("admin/", admin.site.urls)]
 if settings.DEBUG:
     urlpatterns += [path('silk/', include('silk.urls', namespace='silk'))]
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Card: https://github.com/bcgov/cas-registration/issues/4636

The card stated to add real files to act as attachments. We actually already have actual files associated with the attachments in the fixtures located in `bc_obps/test_media/report_attachments`. The problem was that the code just didn't support accessing from that location anymore.

The changes included so far correct that bug.

This bug was relevant to confirming behaviour in the E2E tests. Before, when hitting the `download` button for a test attachment, we would get a `resource not found` error. Now, a PDF preview tab is opened where the PDF can be downloaded. As the test files are not actual PDFs, this page displays a `could not load` error.

The point of this ticket was to allow for the full testing of downloading attachments in the E2E tests. Currently, the report-attachments E2E spec tests this functionality by confirming the server call. In order to be able to test downloading an actual file, we would have to make the test files valid PDFs, otherwise the download button on the PDF preview tab doesn't show (at least in the browser I was using)