### PR TITLE
Fix flaky transfers grid order

### DIFF
--- a/bc_obps/registration/fixtures/mock/transfer_event.json
+++ b/bc_obps/registration/fixtures/mock/transfer_event.json
@@ -1,6 +1,7 @@
 [
   {
     "model": "registration.transferevent",
+    "pk": "1e5a9c3a-4b1a-4e2a-8f5a-1a2b3c4d5e01",
     "fields": {
       "created_by": "00000000-0000-0000-0000-000000000028",
       "created_at": "2024-07-05T23:25:37.892Z",
@@ -13,6 +14,7 @@
   },
   {
     "model": "registration.transferevent",
+    "pk": "1e5a9c3a-4b1a-4e2a-8f5a-1a2b3c4d5e02",
     "fields": {
       "created_by": "00000000-0000-0000-0000-000000000028",
       "created_at": "2024-07-05T23:25:37.892Z",
@@ -27,6 +29,7 @@
   },
   {
     "model": "registration.transferevent",
+    "pk": "1e5a9c3a-4b1a-4e2a-8f5a-1a2b3c4d5e03",
     "fields": {
       "created_by": "00000000-0000-0000-0000-000000000028",
       "created_at": "2024-07-05T23:25:37.892Z",
@@ -46,6 +49,7 @@
   },
   {
     "model": "registration.transferevent",
+    "pk": "1e5a9c3a-4b1a-4e2a-8f5a-1a2b3c4d5e04",
     "fields": {
       "created_by": "00000000-0000-0000-0000-000000000028",
       "created_at": "2025-01-10T23:42:44.039Z",

--- a/bc_obps/service/transfer_event_service.py
+++ b/bc_obps/service/transfer_event_service.py
@@ -43,7 +43,7 @@ class TransferEventService:
         sort_direction = "-" if sort_order == "desc" else ""
         sort_by = f"{sort_direction}{sort_field}"
         queryset = (
-            filters.filter(TransferEvent.objects.order_by(sort_by))
+            filters.filter(TransferEvent.objects.order_by(sort_by, "id"))
             .values(
                 'id',
                 'effective_date',


### PR DESCRIPTION
Happo screenshots for Transfers grid are flaky — row order in the transfers grid changed randomly between runs, causing false-positive screenshot diffs.

**Why:**
- The transfers query only sorted by `status` (3 possible values), so rows tied on status had no tiebreaker and Postgres returned them in undefined order.
- The `id` field could've served as a tiebreaker, but the fixture (`transfer_event.json`) didn't pin explicit `pk` values, so a new random UUID was generated on every fixture reload — making `id` itself unstable across runs.

**Fix:**
- Pinned fixed `pk` values in `transfer_event.json` (matching convention used in other event fixtures).
- Added `id` as a secondary sort key in `transfer_event_service.py` (`order_by(sort_by, "id")`).
