### PR TITLE
docs/contribution guidelines

### DIFF
--- a/.bin/hook-format.sh
+++ b/.bin/hook-format.sh
@@ -8,4 +8,4 @@ files=("${files[@]/#/../}") # add ../ to each element
 
 # --ignore-unknown prevents prettier from complaining about file types it doesn't know about
 # --log-level warn suppresses file list output and only shows warnings/errors
-yarn run prettier --ignore-unknown --write --log-level warn "${files[@]}"
+yarn exec prettier --ignore-unknown --write --log-level warn "${files[@]}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to BCIERS/OBPS
+
+Thank you for your interest in our project!
+
+## Code Contributions are Closed
+
+This repository is currently closed to external code contributions. Because this project requires tight integration with BCGov services and roadmaps, we cannot accept outside Pull Requests.
+
+Any Pull Requests opened by community members will be automatically closed without review.
+
+### How to Provide Feedback
+
+While we do not accept code, we highly value community feedback. You can still help us improve by:
+
+- **Reporting Bugs:** Open an issue using our bug report template if you encounter an error.
+
+Thank you for understanding!

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A web app for Registration in OBPS under the Clean Growth branch.
 
 [![Nightly Build and Test](https://github.com/bcgov/cas-registration/actions/workflows/nightly.yaml/badge.svg)](https://github.com/bcgov/cas-registration/actions/workflows/nightly.yaml)
 
+![](https://img.shields.io/badge/contributions-no_thank_you-red)
+
 ## Documentation
 
 - [Developer and Application Documentation](./docs/README.md)

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ A web app for Registration in OBPS under the Clean Growth branch.
 ## Documentation
 
 - [Developer and Application Documentation](./docs/README.md)
+
+## Contributions
+
+Notice: This project is open-source but closed to external contributions. Pull requests and contribution issues will be automatically closed.


### PR DESCRIPTION
Addresses #4916. Quick addition to readme and adding a contribution guidelines file.

## Changes 🚧

- Changed from `yarn run` to `yarn exec` to handle Prek Prettier run outside of monorepo (can get used for other docs.md as well)
- Add contribution line to `README.md`
- Add `CONTRIBUTING.md` 