### PR TITLE
Chore/drop fetch and save

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,17 +62,11 @@ install: CHART_DIR=./helm/cas-bciers
 install: CHART_INSTANCE=cas-bciers
 install: HELM_OPTS=--atomic --wait-for-jobs --timeout 2400s --namespace $(NAMESPACE) \
                                --set defaultImageTag=$(IMAGE_TAG) \
-                               --set download-dags.dagConfiguration="$$dagConfig" \
-                               --set download-migration-test-dags.dagConfiguration="$$migrationTestDagConfig" \
-                               --set download-database-reset-dag.dagConfiguration="$$resetDataDagConfig" \
                                --values $(CHART_DIR)/values-$(ENVIRONMENT).yaml \
                                --set airflowNamespace="$(AIRFLOW_NAMESPACE_PREFIX)-$(ENVIRONMENT)" \
                                --set cas-logging-sidecar.host=elasticsearch.$(GGIRCS_NAMESPACE_PREFIX)-tools.svc.cluster.local
 install:
 	@set -euo pipefail; \
-	dagConfig=$$(echo '{"org": "bcgov", "repo": "cas-registration", "ref": "$(GIT_SHA1)", "path": "dags/cas_bciers_dags.py"}' | base64 -w0); \
-	migrationTestDagConfig=$$(echo '{"org": "bcgov", "repo": "cas-registration", "ref": "$(GIT_SHA1)", "path": "dags/bc_obps_test_migrations.py"}' | base64 -w0); \
-	resetDataDagConfig=$$(echo '{"org": "bcgov", "repo": "cas-registration", "ref": "$(GIT_SHA1)", "path": "dags/bc_obps_reset_data.py"}' | base64 -w0); \
 	helm dep up $(CHART_DIR); \
 	if ! helm status --namespace $(NAMESPACE) cas-obps-postgres; then \
 	   echo "ERROR: Postgres is not deployed to $(NAMESPACE)."; \

--- a/dags/bc_obps_reset_data.py
+++ b/dags/bc_obps_reset_data.py
@@ -16,6 +16,10 @@ BACKEND_DEPLOYMENT_NAME = "cas-bciers-backend"
 K8S_IMAGE = "alpine/k8s:1.29.15"
 BCIERS_NAMESPACE = os.getenv("BCIERS_NAMESPACE")
 
+# Define which environments this Dag loads in to
+CURRENT_ENV = os.environ.get("ENVIRONMENT")
+ALLOWED_ENVIRONMENTS = ["dev", "test"]
+
 default_args = {**default_dag_args}
 
 RESET_DAG_DOC = """
@@ -90,5 +94,6 @@ def wait_for_backend_rollout():
     wait_for_backend_rollout_task  # NOSONAR
 
 
-reset_data()  # NOSONAR
-wait_for_backend_rollout()  # NOSONAR
+if CURRENT_ENV in ALLOWED_ENVIRONMENTS:
+    reset_data()  # NOSONAR
+    wait_for_backend_rollout()  # NOSONAR

--- a/dags/bc_obps_test_migrations.py
+++ b/dags/bc_obps_test_migrations.py
@@ -28,6 +28,11 @@ BACKEND_CHART_TAG = os.getenv("BACKEND_CHART_TAG")
 # Jinja (runtime) template constant
 DESTINATION_NAMESPACE_TEMPLATE = "{{ params.destination_namespace }}"
 
+# Define which environments this Dag loads in to
+CURRENT_ENV = os.environ.get("ENVIRONMENT")
+ALLOWED_ENVIRONMENTS = ["dev", "test"]
+
+
 default_args = {**default_dag_args, "start_date": TWO_DAYS_AGO}
 
 DAG_DOC = """
@@ -183,4 +188,5 @@ def test_migrations(
     )
 
 
-test_migrations()
+if CURRENT_ENV in ALLOWED_ENVIRONMENTS:
+    test_migrations()

--- a/dags/cas_bciers_dags.py
+++ b/dags/cas_bciers_dags.py
@@ -14,6 +14,10 @@ NIGHTLY_BUILD_DAG_NAME = "cas_bciers_nightly_build_report"
 BCIERS_NAMESPACE = os.getenv('BCIERS_NAMESPACE')
 TWO_DAYS_AGO = datetime.now(timezone.utc) - timedelta(days=2)
 
+# Define which environments this Dag loads in to
+CURRENT_ENV = os.environ.get("ENVIRONMENT")
+ALLOWED_ENVIRONMENTS = ["dev", "test", "prod"]
+
 default_args = {**default_dag_args, 'start_date': TWO_DAYS_AGO}
 
 PROCESS_DUE_DAG_DOC = """
@@ -40,7 +44,8 @@ def process_transfer_event():
     process_due_transfers()
 
 
-process_transfer_event()  # NOSONAR
+if CURRENT_ENV in ALLOWED_ENVIRONMENTS:
+    process_transfer_event()  # NOSONAR
 
 NIGHTLY_BUILD_DAG_DOC = """
 Dag reporting the status of the nightly CI workflow from GitHub.
@@ -76,4 +81,5 @@ def nightly_build_report(
     record_status()
 
 
-nightly_build_report()  # NOSONAR
+if CURRENT_ENV in ALLOWED_ENVIRONMENTS:
+    nightly_build_report()  # NOSONAR

--- a/helm/cas-bciers/Chart.lock
+++ b/helm/cas-bciers/Chart.lock
@@ -5,17 +5,8 @@ dependencies:
 - name: cas-airflow-dag-trigger
   repository: https://bcgov.github.io/cas-airflow
   version: 1.2.2
-- name: cas-airflow-dag-trigger
-  repository: https://bcgov.github.io/cas-airflow
-  version: 1.2.2
-- name: cas-airflow-dag-trigger
-  repository: https://bcgov.github.io/cas-airflow
-  version: 1.2.2
-- name: cas-airflow-dag-trigger
-  repository: https://bcgov.github.io/cas-airflow
-  version: 1.2.2
 - name: cas-logging-sidecar
   repository: https://bcgov.github.io/cas-pipeline/
   version: 0.5.0
-digest: sha256:a09b9c2cde478e656a73a6eb83b014a411beab5d0033fc89b970dfe69379367d
-generated: "2025-12-02T14:54:49.474615-08:00"
+digest: sha256:872e1c8cbb6c90a871453f4ce9228dde6715fac935502cb640712777b98efa89
+generated: "2026-07-14T17:08:13.199985731-06:00"

--- a/helm/cas-bciers/Chart.yaml
+++ b/helm/cas-bciers/Chart.yaml
@@ -12,21 +12,6 @@ dependencies:
   - name: cas-airflow-dag-trigger
     version: 1.2.2
     repository: https://bcgov.github.io/cas-airflow
-    alias: download-dags
-    condition: download-dags.enabled
-  - name: cas-airflow-dag-trigger
-    version: 1.2.2
-    repository: https://bcgov.github.io/cas-airflow
-    alias: download-migration-test-dags
-    condition: download-migration-test-dags.enabled
-  - name: cas-airflow-dag-trigger
-    version: 1.2.2
-    repository: https://bcgov.github.io/cas-airflow
-    alias: download-database-reset-dag
-    condition: download-database-reset-dag.enabled
-  - name: cas-airflow-dag-trigger
-    version: 1.2.2
-    repository: https://bcgov.github.io/cas-airflow
     alias: run-reset-data-dag-on-upgrade
     condition: run-reset-data-dag-on-upgrade.enabled
   - name: cas-logging-sidecar

--- a/helm/cas-bciers/values-dev.yaml
+++ b/helm/cas-bciers/values-dev.yaml
@@ -118,16 +118,6 @@ dashboardFrontend:
     keycloakAuthUrl: https://dev.loginproxy.gov.bc.ca/auth
     siteminderAuthUrl: https://logontest7.gov.bc.ca
 
-download-dags:
-  airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca
-
-download-migration-test-dags:
-  airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca
-
-download-database-reset-dag:
-  enabled: true
-  airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca
-
 run-reset-data-dag-on-upgrade:
   enabled: true
   airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca

--- a/helm/cas-bciers/values-prod.yaml
+++ b/helm/cas-bciers/values-prod.yaml
@@ -146,15 +146,6 @@ dashboardFrontend:
     maxReplicas: 4
     targetCPUUtilizationPercentage: 80
 
-download-dags:
-  airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca
-
-download-migration-test-dags:
-  airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca
-
-download-database-reset-dag:
-  enabled: false
-
 run-reset-data-dag-on-upgrade:
   enabled: false
 

--- a/helm/cas-bciers/values-test.yaml
+++ b/helm/cas-bciers/values-test.yaml
@@ -120,16 +120,6 @@ dashboardFrontend:
       cpu: 60m
       memory: 128Mi
 
-download-dags:
-  airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca
-
-download-migration-test-dags:
-  airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca
-
-download-database-reset-dag:
-  enabled: true
-  airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca
-
 run-reset-data-dag-on-upgrade:
   enabled: true
   airflowEndpoint: https://cas-airflow-test.apps.silver.devops.gov.bc.ca

--- a/helm/cas-bciers/values.yaml
+++ b/helm/cas-bciers/values.yaml
@@ -227,27 +227,6 @@ terraform-bucket-provision:
     namespace_apps: '["bciers-attach"]' # Maximum of 13 characters
     workspace: bciers # This value is OPTIONAL, only set if required
 
-download-dags:
-  enabled: true
-  airflowEndpoint: ~
-  dagId: fetch_and_save_dag_from_github
-  helm:
-    hook: "pre-install,pre-upgrade"
-
-download-migration-test-dags:
-  enabled: true
-  airflowEndpoint: ~
-  dagId: fetch_and_save_dag_from_github
-  helm:
-    hook: "pre-install,pre-upgrade"
-
-download-database-reset-dag:
-  enabled: false
-  airflowEndpoint: ~
-  dagId: fetch_and_save_dag_from_github
-  helm:
-    hook: "pre-install,pre-upgrade"
-
 run-reset-data-dag-on-upgrade:
   enabled: false
   airflowEndpoint: ~


### PR DESCRIPTION
Addresses #4715. Removes legacy method of getting Dags into Airflow, once bcgov/cas-airflow#231 is merged.

## Changes 🚧

- Conditionally load Dags into bundle based on environment.
  - This followed patterns previously used in the fetch-and-save helm chart.
- Remove old fetch and save from chart deployments.
