### PR TITLE
4937 banner in pay obligation and track payments page did not update

### DIFF
--- a/bciers/apps/compliance-e2e/poms/manage-obligation/track-payments.ts
+++ b/bciers/apps/compliance-e2e/poms/manage-obligation/track-payments.ts
@@ -6,6 +6,45 @@ import {
 import { attachE2EStubEndpoint } from "@bciers/e2e/utils/e2eStubEndpoint";
 import { getCrvIdFromUrl } from "@bciers/e2e/utils/helpers";
 
+export interface ObligationPayment {
+  amount: string;
+  received_date: string;
+  method?: string;
+  receipt_number?: string;
+}
+
+// Matches PayObligationScenario.DEFAULT_PAYMENTS in pay_obligation.py - two
+// partial payments that leave a balance owing.
+export const PARTIAL_OBLIGATION_PAYMENTS: ObligationPayment[] = [
+  {
+    amount: "500000.00",
+    received_date: "2025-12-18",
+    method: "Wire Transfer",
+    receipt_number: "E2E-RECEIPT-001",
+  },
+  {
+    amount: "300000.00",
+    received_date: "2025-12-20",
+    method: "Wire Transfer",
+    receipt_number: "E2E-RECEIPT-002",
+  },
+];
+
+// The above two payments plus a third one that covers the remaining balance
+// (they sum to $1,000,968.64, the OBLIGATION_NOT_MET fixture's initial
+// balance - see _INITIAL_OUTSTANDING in
+// bc_obps/compliance/api/e2e_integration_stub/mocking/http_mocks.py), so the
+// obligation is fully paid off.
+export const FULL_OBLIGATION_PAYMENTS: ObligationPayment[] = [
+  ...PARTIAL_OBLIGATION_PAYMENTS,
+  {
+    amount: "200968.64",
+    received_date: "2025-12-22",
+    method: "Wire Transfer",
+    receipt_number: "E2E-RECEIPT-003",
+  },
+];
+
 export class TrackPaymentsPOM {
   readonly page: Page;
 
@@ -14,12 +53,16 @@ export class TrackPaymentsPOM {
   }
 
   /**
-   * Records partial payments against the obligation via the Django e2e stub.
+   * Records payments against the obligation via the Django e2e stub.
    *
    * Payments are made externally in eLicensing, which E2E can't reach, so the
    * stub writes the payment records and reduces the invoice balance directly.
+   * Defaults to PARTIAL_OBLIGATION_PAYMENTS, leaving a balance owing.
    */
-  async recordObligationPayments(apiContext: APIRequestContext) {
+  async recordObligationPayments(
+    apiContext: APIRequestContext,
+    payments?: ObligationPayment[],
+  ) {
     const crvId = getCrvIdFromUrl({ url: this.page.url() });
     await attachE2EStubEndpoint(
       this.page,
@@ -27,7 +70,7 @@ export class TrackPaymentsPOM {
       () => ({
         scenario: PAY_OBLIGATION_SCENARIO,
         compliance_report_version_id: Number(crvId),
-        payload: {},
+        payload: payments ? { payments } : {},
       }),
       PAY_OBLIGATION_SCENARIO,
     );
@@ -76,5 +119,25 @@ export class TrackPaymentsPOM {
   async assertHasPayments() {
     await expect(this.page.getByText("Payment 1")).toBeVisible();
     await expect(this.page.getByText("Payment 2")).toBeVisible();
+  }
+
+  /**
+   * Assert the PaymentStatusNote shows the "outstanding balance owing" message.
+   * Only differs visually from the fully paid message, so this and
+   * assertShowsFullyPaidStatus must both be exercised
+   */
+  async assertShowsOutstandingBalanceStatus() {
+    await expect(
+      this.page.getByText(/please pay the outstanding compliance obligation/i),
+    ).toBeVisible();
+  }
+
+  /**
+   * Assert the PaymentStatusNote shows the "fully met" success message.
+   */
+  async assertShowsFullyPaidStatus() {
+    await expect(
+      this.page.getByText(/your compliance obligation has been fully met/i),
+    ).toBeVisible();
   }
 }

--- a/bciers/apps/compliance-e2e/poms/request-issuance/track-status-of-issuance.ts
+++ b/bciers/apps/compliance-e2e/poms/request-issuance/track-status-of-issuance.ts
@@ -1,0 +1,22 @@
+import { Page, expect } from "@playwright/test";
+
+/**
+ * Industry-facing "Track Status of Issuance" detail page
+ * (apps/compliance/.../request-issuance/track-status-of-issuance).
+ */
+export class TrackStatusOfIssuancePOM {
+  private readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async assertShowsDeclinedNote(): Promise<void> {
+    await expect(
+      this.page.getByText(/your request is declined/i),
+    ).toBeVisible();
+    await expect(
+      this.page.getByRole("link", { name: /B\.C\. Carbon Registry/i }),
+    ).toBeVisible();
+  }
+}

--- a/bciers/apps/compliance-e2e/tests/workflows/manage-obligation/report-compliance/obligation.spec.ts
+++ b/bciers/apps/compliance-e2e/tests/workflows/manage-obligation/report-compliance/obligation.spec.ts
@@ -11,7 +11,10 @@ import { CurrentReportsPOM } from "@/reporting-e2e/poms/current-reports";
 import { ComplianceSummariesPOM } from "@/compliance-e2e/poms/compliance-summaries";
 import { ManageObligationTaskListPOM } from "@/compliance-e2e/poms/manage-obligation/tasklist";
 import { PaymentInstructionsPOM } from "@/compliance-e2e/poms/manage-obligation/payment-instructions";
-import { TrackPaymentsPOM } from "@/compliance-e2e/poms/manage-obligation/track-payments";
+import {
+  TrackPaymentsPOM,
+  FULL_OBLIGATION_PAYMENTS,
+} from "@/compliance-e2e/poms/manage-obligation/track-payments";
 
 import { ComplianceSetupPOM } from "@/compliance-e2e/poms/compliance-setup";
 import { takeStabilizedScreenshot } from "@bciers/e2e/utils/helpers";
@@ -80,11 +83,27 @@ test.describe("Test report version to compliance report version manage obligatio
     await trackPayments.continueToTrackPayments();
     await trackPayments.assertPageLoaded();
     await trackPayments.assertHasPayments();
+    await trackPayments.assertShowsOutstandingBalanceStatus();
 
     // happo screenshot
     await takeStabilizedScreenshot(happoScreenshot, page, {
       component: "Compliance obligation not met",
       variant: "pay obligation and track payments - partially paid",
+    });
+
+    // Record a third payment that covers the remaining balance, so the
+    // PaymentStatusNote's another branch (fully paid) is also exercised
+    await trackPayments.recordObligationPayments(
+      request,
+      FULL_OBLIGATION_PAYMENTS,
+    );
+    await page.reload();
+    await trackPayments.assertPageLoaded();
+    await trackPayments.assertShowsFullyPaidStatus();
+
+    await takeStabilizedScreenshot(happoScreenshot, page, {
+      component: "Compliance obligation not met",
+      variant: "pay obligation and track payments - fully paid",
     });
   });
 

--- a/bciers/apps/compliance-e2e/tests/workflows/request-issuance/earned-credits.spec.ts
+++ b/bciers/apps/compliance-e2e/tests/workflows/request-issuance/earned-credits.spec.ts
@@ -9,13 +9,17 @@ import {
   ComplianceDisplayStatus,
   GridActionText,
 } from "@/compliance-e2e/utils/enums";
-import { DirectorDecision } from "@/compliance-e2e/utils/constants";
+import {
+  DirectorDecision,
+  TRACK_ISSUANCE_URL_PATTERN,
+} from "@/compliance-e2e/utils/constants";
 import { CurrentReportsPOM } from "@/reporting-e2e/poms/current-reports";
 import { ComplianceSummariesPOM } from "@/compliance-e2e/poms/compliance-summaries";
 import { ReviewComplianceEarnedCreditsPOM } from "@/compliance-e2e/poms/request-issuance/review-compliance-earned-credits";
 import { RequestIssuanceTaskListPOM } from "@/compliance-e2e/poms/request-issuance/tasklist";
 import { InternalRequestIssuanceTaskListPOM } from "@/compliance-e2e/poms/request-issuance/internal/tasklist";
 import { InternalReviewComplianceEarnedCreditsPOM } from "@/compliance-e2e/poms/request-issuance/internal/internal-review-compliance-earned-credits";
+import { TrackStatusOfIssuancePOM } from "@/compliance-e2e/poms/request-issuance/track-status-of-issuance";
 import { AnalystSuggestion, IssuanceStatus } from "@bciers/utils/src/enums";
 
 // Seed environment once; each flow case re-seeds via its own beforeAll
@@ -300,6 +304,25 @@ test.describe("Test earned credits request issuance flow", () => {
             component: "Compliance earned credits - request issuance",
             variant: `Director decision - industry compliance summaries: ${title}`,
           });
+
+          // For the declined case, also open industry's own Track Status of
+          // Issuance detail page (not just the grid badge)
+          if (c.directorDecision === IssuanceStatus.DECLINED) {
+            await industrySummaries.openActionForOperation({
+              operationName: ComplianceOperations.EARNED_CREDITS,
+              linkName: GridActionText.VIEW_DETAILS,
+              urlPattern: TRACK_ISSUANCE_URL_PATTERN,
+            });
+
+            const trackStatusOfIssuance = new TrackStatusOfIssuancePOM(page);
+            await trackStatusOfIssuance.assertShowsDeclinedNote();
+
+            // happo screenshot - industry-facing declined issuance detail page
+            await takeStabilizedScreenshot(happoScreenshot, page, {
+              component: "Compliance earned credits - request issuance",
+              variant: "Industry - track status of issuance (declined)",
+            });
+          }
         });
       }
     });

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.tsx
@@ -45,7 +45,7 @@ export function ObligationTrackPaymentsComponent({
 
   return (
     <FormBase
-      schema={createPayObligationTrackPaymentsSchema()}
+      schema={createPayObligationTrackPaymentsSchema}
       uiSchema={payObligationTrackPaymentsUiSchema}
       formData={data}
       formContext={data}

--- a/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/pay-obligation-track-payments/PaymentStatusNoteWidget.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/manage-obligation/pay-obligation-track-payments/PaymentStatusNoteWidget.tsx
@@ -1,16 +1,19 @@
-import { WidgetProps } from "@rjsf/utils";
 import { PaymentStatusNote } from "./PaymentStatusNote";
 
-interface PaymentStatusNoteWidgetProps extends WidgetProps {
-  outstandingBalance: number;
+interface PaymentStatusNoteWidgetProps {
+  registry: {
+    formContext: {
+      outstanding_balance: number;
+    };
+  };
 }
 
-export const PaymentStatusNoteWidget = (
-  props: PaymentStatusNoteWidgetProps,
-) => {
+export const PaymentStatusNoteWidget = ({
+  registry,
+}: PaymentStatusNoteWidgetProps) => {
   return (
     <PaymentStatusNote
-      outstandingBalance={props.formContext?.outstanding_balance}
+      outstandingBalance={registry.formContext?.outstanding_balance}
     />
   );
 };

--- a/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/track-status-of-issuance/IssuanceStatusDeclinedNote.tsx
+++ b/bciers/apps/compliance/src/app/components/compliance-summary/request-issuance/track-status-of-issuance/IssuanceStatusDeclinedNote.tsx
@@ -8,18 +8,24 @@ import {
 import { AnalystSuggestion } from "@bciers/utils/src/enums";
 
 type Props = {
-  formContext?: {
-    analystSuggestion?: AnalystSuggestion;
-    latestComplianceReportVersionId?: number;
-    supplementaryDeclined?: boolean;
+  registry: {
+    formContext: {
+      analystSuggestion?: AnalystSuggestion;
+      latestComplianceReportVersionId?: number;
+      supplementaryDeclined?: boolean;
+    };
   };
 };
 
-export const IssuanceStatusDeclinedNote = (props: Props) => {
-  const analystSuggestion = props.formContext?.analystSuggestion;
-  const latestComplianceReportVersionId =
-    props.formContext?.latestComplianceReportVersionId;
-  const supplementaryDeclined = props.formContext?.supplementaryDeclined;
+export const IssuanceStatusDeclinedNote = ({
+  registry: {
+    formContext: {
+      analystSuggestion,
+      latestComplianceReportVersionId,
+      supplementaryDeclined,
+    },
+  },
+}: Props) => {
   const path = `/compliance/compliance-administration/compliance-summaries/${latestComplianceReportVersionId}/review-compliance-earned-credits-report`;
 
   return (

--- a/bciers/apps/compliance/src/app/data/jsonSchema/manageObligation/payObligationTrackPaymentsSchema.tsx
+++ b/bciers/apps/compliance/src/app/data/jsonSchema/manageObligation/payObligationTrackPaymentsSchema.tsx
@@ -23,7 +23,7 @@ const PaymentHeaderWidget = (props: WidgetProps) => {
   return <span>{`Payment ${paymentIndex + 1}`}</span>;
 };
 
-export const createPayObligationTrackPaymentsSchema = (): RJSFSchema => ({
+export const createPayObligationTrackPaymentsSchema: RJSFSchema = {
   type: "object",
   title: "Pay Obligation and Track Payment(s)",
   properties: {
@@ -73,7 +73,7 @@ export const createPayObligationTrackPaymentsSchema = (): RJSFSchema => ({
       },
     },
   ],
-});
+};
 
 export const payObligationTrackPaymentsUiSchema: UiSchema = {
   "ui:FieldTemplate": FieldTemplate,

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/manage-obligation/pay-obligation-track-payments/ObligationTrackPaymentsComponent.test.tsx
@@ -82,6 +82,27 @@ describe("ObligationTrackPaymentsComponent", () => {
 
     // Check the payment received date from mockData
     expect(screen.getByText("Dec 06, 2025")).toBeVisible();
+
+    expect(
+      screen.getByText(/your compliance obligation has been fully met/i),
+    ).toBeVisible();
+  });
+
+  it("shows the unpaid PaymentStatusNote when outstanding_balance is non-zero", () => {
+    const mockDataWithBalance = { ...mockData, outstanding_balance: 500 };
+
+    render(
+      <ObligationTrackPaymentsComponent
+        data={mockDataWithBalance}
+        complianceReportVersionId={mockComplianceReportVersionId}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        /please pay the outstanding compliance obligation following the payment instructions/i,
+      ),
+    ).toBeVisible();
   });
 
   it("renders step buttons with correct URLs when outstanding_balance is 0", () => {

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/request-issuance/track-status-of-issuance/IssuanceStatusDeclinedNote.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/request-issuance/track-status-of-issuance/IssuanceStatusDeclinedNote.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@bciers/components/icons/AlertIcon", () => ({
 
 describe("IssuanceStatusDeclinedNote", () => {
   it("displays the correct text content", () => {
-    render(<IssuanceStatusDeclinedNote />);
+    render(<IssuanceStatusDeclinedNote registry={{ formContext: {} }} />);
 
     const declinedNoteTextPatterns = [
       /your request is declined/i,
@@ -51,8 +51,10 @@ describe("IssuanceStatusDeclinedNote", () => {
   it("shows GHGRegulator email and supplementary instructions when analyst suggests supplementary report", () => {
     render(
       <IssuanceStatusDeclinedNote
-        formContext={{
-          analystSuggestion: AnalystSuggestion.REQUIRING_SUPPLEMENTARY_REPORT,
+        registry={{
+          formContext: {
+            analystSuggestion: AnalystSuggestion.REQUIRING_SUPPLEMENTARY_REPORT,
+          },
         }}
       />,
     );
@@ -82,9 +84,11 @@ describe("IssuanceStatusDeclinedNote", () => {
   it("displays the correct text content", () => {
     render(
       <IssuanceStatusDeclinedNote
-        formContext={{
-          latestComplianceReportVersionId: 2,
-          supplementaryDeclined: true,
+        registry={{
+          formContext: {
+            latestComplianceReportVersionId: 2,
+            supplementaryDeclined: true,
+          },
         }}
       />,
     );

--- a/bciers/apps/compliance/src/tests/components/compliance-summary/request-issuance/track-status-of-issuance/TrackStatusOfIssuanceComponent.test.tsx
+++ b/bciers/apps/compliance/src/tests/components/compliance-summary/request-issuance/track-status-of-issuance/TrackStatusOfIssuanceComponent.test.tsx
@@ -12,13 +12,6 @@ vi.mock(
 );
 
 vi.mock(
-  "@/compliance/src/app/components/compliance-summary/request-issuance/track-status-of-issuance/IssuanceStatusDeclinedNote",
-  () => ({
-    IssuanceStatusDeclinedNote: () => <div>Declined Note</div>,
-  }),
-);
-
-vi.mock(
   "@/compliance/src/app/components/compliance-summary/request-issuance/track-status-of-issuance/IssuanceStatusAwaitingNote",
   () => ({
     IssuanceStatusAwaitingNote: () => <div>Awaiting Note</div>,
@@ -181,7 +174,7 @@ describe("TrackStatusOfIssuanceComponent", () => {
     expect(screen.getByText("Approved Note")).toBeVisible();
   });
 
-  it("displays declined note for declined status", () => {
+  it("displays declined note for declined status, wired up with the real formContext values", () => {
     const declinedData = {
       ...mockData,
       issuance_status: IssuanceStatus.DECLINED,
@@ -194,7 +187,10 @@ describe("TrackStatusOfIssuanceComponent", () => {
       />,
     );
 
-    expect(screen.getByText("Declined Note")).toBeVisible();
+    expect(screen.getByText(/your request is declined/i)).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: /B\.C\. Carbon Registry/i }),
+    ).toBeVisible();
   });
 
   it("displays awaiting note for issuance requested status", () => {

--- a/bciers/libs/components/src/form/widgets/OperatorSearchWidget.test.tsx
+++ b/bciers/libs/components/src/form/widgets/OperatorSearchWidget.test.tsx
@@ -218,6 +218,31 @@ describe("RJSF OperatorSearchWidget", () => {
     await checkNoValidationErrorIsTriggered();
   });
 
+  it("should use the endpoint provided via formContext instead of the default", async () => {
+    render(
+      <FormBase
+        schema={operatorSearchFieldSchema}
+        uiSchema={operatorSearchFieldUiSchema}
+        formContext={{ endpoint: "custom/search/endpoint" }}
+      />,
+    );
+
+    const searchField = screen.getByRole("combobox");
+
+    await act(async () => {
+      await userEvent.type(searchField, "Operator");
+    });
+
+    actionHandler.mockResolvedValueOnce([]);
+
+    await waitFor(() => {
+      expect(actionHandler).toHaveBeenCalledWith(
+        expect.stringContaining("custom/search/endpoint?legal_name="),
+        "GET",
+      );
+    });
+  });
+
   it("should show the validation error message when the search field is required", async () => {
     render(
       <FormBase

--- a/bciers/libs/components/src/form/widgets/OperatorSearchWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/OperatorSearchWidget.tsx
@@ -19,8 +19,9 @@ const OperatorSearchWidget: React.FC<WidgetProps> = ({
   value,
   readonly,
   uiSchema,
-  formContext,
+  registry,
 }) => {
+  const { formContext } = registry;
   const [options, setOptions] = useState<string[]>([]);
   const [isSearchAttempted, setIsSearchAttempted] = useState(false);
 

--- a/bciers/libs/components/src/form/widgets/OptedOutOperationWidget.test.tsx
+++ b/bciers/libs/components/src/form/widgets/OptedOutOperationWidget.test.tsx
@@ -54,7 +54,6 @@ const baseProps: any = {
   id: "opted-out",
   value: { final_reporting_year: 2024 },
   onChange: vi.fn(),
-  registry: {},
   schema: {
     properties: {
       final_reporting_year: {},
@@ -70,7 +69,7 @@ const baseProps: any = {
 
 function renderWidget(formContext: FormContext) {
   return render(
-    <OptedOutOperationWidget {...baseProps} formContext={formContext} />,
+    <OptedOutOperationWidget {...baseProps} registry={{ formContext }} />,
   );
 }
 

--- a/bciers/libs/components/src/form/widgets/OptedOutOperationWidget.tsx
+++ b/bciers/libs/components/src/form/widgets/OptedOutOperationWidget.tsx
@@ -31,11 +31,11 @@ const OptedOutOperationWidget: React.FC<WidgetProps> = ({
   id,
   value,
   onChange,
-  formContext,
   schema,
   uiSchema,
   registry,
 }) => {
+  const { formContext } = registry;
   // Handle both object format ({ final_reporting_year: number }) and direct number format
   let finalReportingYear: number | undefined;
   if (typeof value === "object" && value !== null) {


### PR DESCRIPTION
[ISSUE 4937](https://github.com/bcgov/cas-registration/issues/4937)


## Summary

Fixes the `formContext` regression from the rjsf v6 upgrade.

## What was broken

- **`IssuanceStatusDeclinedNote`** — read `props.formContext` directly, so `analystSuggestion`/`latestComplianceReportVersionId`/`supplementaryDeclined` were always `undefined`.
- **`OptedOutOperationWidget`** — same pattern, breaking `isCasDirector` and `operationId`, which feed live save/clear API calls.
- **`OperatorSearchWidget`** — same pattern; silently masked in production because the widget's hardcoded fallback endpoint happened to match the only caller's intended override.

## Changes

### Unit test fixes
- Updated each component's own test to pass props shaped like the real rjsf `registry` object instead of the stale flat `formContext` prop.
- `TrackStatusOfIssuanceComponent.test.tsx` — stopped mocking `IssuanceStatusDeclinedNote` for the declined-status test so it exercises the real component end-to-end.
- `ObligationTrackPaymentsComponent.test.tsx` — added assertions on `PaymentStatusNote`'s rendered text for both the paid and unpaid branches.
- `OperatorSearchWidget.test.tsx` — added a test that passes a custom `formContext.endpoint` through the real `FormBase` and asserts it's used, covering the previously-dead override path.

### E2E / visual regression coverage
The existing Happo screenshots didn't actually catch this bug:
- `obligation.spec.ts` only screenshotted the **partially-paid** branch of `PaymentStatusNote`. Since the bug always renders that branch (undefined balance ≠ 0), a broken and fixed widget look identical there. Added a full-payment step (new `FULL_OBLIGATION_PAYMENTS` fixture in `TrackPaymentsPOM`) plus assertions/screenshot for the **fully-paid** branch, which is the one that actually differs.
- `earned-credits.spec.ts` only screenshotted the **internal/director** track-status-of-issuance page for the declined case — a different, already-correct component. The **industry-facing** page (with the buggy component) was never opened. Added a step that navigates to the industry's own "View Details" page, asserts the real declined-note content (new `TrackStatusOfIssuancePOM`), and screenshots it.