### PR TITLE
Chore/chart terraform revisions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 24.18.0
-gcloud 450.0.0
+gcloud 574.0.0
 python 3.14.6

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ DR_AUTO_CONFIRM ?= false
 # Provide defaults so helm --set flags are not empty when prefixes are not provided
 AIRFLOW_NAMESPACE_PREFIX ?= airflow
 GGIRCS_NAMESPACE_PREFIX ?= ggircs
+TERRAFORM_PROVISION ?= false
 
 help: ## Show this help.
 	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)
@@ -68,6 +69,7 @@ install: HELM_OPTS=--atomic --wait-for-jobs --timeout 2400s --namespace $(NAMESP
                                --values $(CHART_DIR)/values-$(ENVIRONMENT).yaml \
                                --set airflowNamespace="$(AIRFLOW_NAMESPACE_PREFIX)-$(ENVIRONMENT)" \
                                --set cas-logging-sidecar.host=elasticsearch.$(GGIRCS_NAMESPACE_PREFIX)-tools.svc.cluster.local
+                               --set terraform-bucket-provision.enabled=$(TERRAFORM_PROVISION) \
 install:
 	@set -euo pipefail; \
 	dagConfig=$$(echo '{"org": "bcgov", "repo": "cas-registration", "ref": "$(GIT_SHA1)", "path": "dags/cas_bciers_dags.py"}' | base64 -w0); \

--- a/docs/devops/state-and-container-setup.md
+++ b/docs/devops/state-and-container-setup.md
@@ -3,3 +3,6 @@
 An OpenShift job is integrated into a the 'cas-registration' Helm chart. It deploys at the pre-install, pre-upgrade hooks. The Terraform scripts are located in the `/terraform` subdirectory in the chart, which is then pulled in via a ConfigMap utilized by the job at `/templates/backend/job/terraform-apply.yaml`.
 
 [CAS-Pipeline](https://github.com/bcgov/cas-pipeline) was used to create the storage buckets that terraform uses to store state, and provision secrets used as credentials.
+
+> [!IMPORTANT]
+> By default, this is disabled in all chart deployments. It must be enabled via the `terraform-bucket-provision.enabled` value in the chart's `values.yaml`. Once charts are deployed with this enabled, the resources allocated by Terraform don't need to be remade each deployment.

--- a/helm/cas-bciers/Chart.yaml
+++ b/helm/cas-bciers/Chart.yaml
@@ -9,6 +9,7 @@ dependencies:
   - name: terraform-bucket-provision
     version: "0.1.4"
     repository: https://bcgov.github.io/cas-pipeline/
+    condition: terraform-bucket-provision.enabled
   - name: cas-airflow-dag-trigger
     version: 1.2.2
     repository: https://bcgov.github.io/cas-airflow

--- a/helm/cas-bciers/templates/backend/job/check-gcs.yaml
+++ b/helm/cas-bciers/templates/backend/job/check-gcs.yaml
@@ -31,6 +31,13 @@ spec:
               readOnly: true
             - mountPath: "/.config"
               name: config-volume
+          resources:
+            limits:
+              memory: 256Mi
+              ephemeral-storage: 50Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
           command:
             - /usr/bin/env
             - bash
@@ -54,6 +61,7 @@ spec:
                 exit 1
               fi
               exit 0
+      automountServiceAccountToken: false
       volumes:
         - name: attachment-credentials
           secret:

--- a/helm/cas-bciers/templates/backend/job/check-gcs.yaml
+++ b/helm/cas-bciers/templates/backend/job/check-gcs.yaml
@@ -5,16 +5,17 @@ metadata:
   labels: {{- include "cas-bciers.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-weight": "15" # Triggers after Terraform bucket provisioning, if enabled
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  backoffLimit: 0
   template:
     spec:
+      restartPolicy: "Never"
       containers:
         - name: check-for-active-gsc-bucket
           image: "gcr.io/google.com/cloudsdktool/google-cloud-cli:stable"
           imagePullPolicy: "Always"
-          restartPolicy: "Never"
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/attachment-credentials/attachment-credentials.json"
@@ -31,7 +32,7 @@ spec:
             - mountPath: "/.config"
               name: config-volume
           command:
-            - /usr/bin/bash
+            - /usr/bin/env
             - bash
             - -c
             - |

--- a/helm/cas-bciers/templates/backend/job/check-gcs.yaml
+++ b/helm/cas-bciers/templates/backend/job/check-gcs.yaml
@@ -1,0 +1,65 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-check-gcs
+  labels: {{- include "cas-bciers.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: check-for-active-gsc-bucket
+          image: "gcr.io/google.com/cloudsdktool/google-cloud-cli:stable"
+          imagePullPolicy: "Always"
+          restartPolicy: "Never"
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/attachment-credentials/attachment-credentials.json"
+            - name: GS_BUCKET_NAMES
+              value: >-
+                {{ .Release.Namespace }}-bciers-attach
+                {{ .Release.Namespace }}-bciers-attach-unscanned
+                {{ .Release.Namespace }}-bciers-attach-clean
+                {{ .Release.Namespace }}-bciers-attach-quarantined
+          volumeMounts:
+            - name: attachment-credentials
+              mountPath: /attachment-credentials
+              readOnly: true
+            - mountPath: "/.config"
+              name: config-volume
+          command:
+            - /usr/bin/bash
+            - bash
+            - -c
+            - |
+              set -eo pipefail
+              set -x
+              gcloud auth login --cred-file=$GOOGLE_APPLICATION_CREDENTIALS
+
+              FAILED=false
+              for bucket in $GS_BUCKET_NAMES; do
+                if ! gcloud storage buckets describe "gs://$bucket" > /dev/null 2>&1; then
+                  echo "Bucket $bucket does not exist"
+                  FAILED=true
+                else
+                  echo "Bucket $bucket exists"
+                fi
+              done
+
+              if [ "$FAILED" = true ]; then
+                exit 1
+              fi
+              exit 0
+      volumes:
+        - name: attachment-credentials
+          secret:
+            secretName: gcp-{{ .Release.Namespace }}-bciers-attach-service-account-key
+            items:
+            - key: credentials.json
+              path: attachment-credentials.json
+        - name: config-volume
+          emptyDir:
+            sizeLimit: 50Mi

--- a/helm/cas-bciers/values.yaml
+++ b/helm/cas-bciers/values.yaml
@@ -223,6 +223,7 @@ checkDocumentFileStatus:
       memory: 256Mi
 
 terraform-bucket-provision:
+  enabled: false
   terraform:
     namespace_apps: '["bciers-attach"]' # Maximum of 13 characters
     workspace: bciers # This value is OPTIONAL, only set if required

--- a/shipit.yml
+++ b/shipit.yml
@@ -10,6 +10,14 @@ deploy:
   override:
     - ./deploy.sh:
         timeout: 1800
+  variables:
+    -
+      name: TERRAFORM_PROVISION
+      title: Run Terraform provisioning for storage buckets
+      default: false
+      select:
+        - true
+        - false
 
 ci:
   allow_failures:

--- a/shipit.yml
+++ b/shipit.yml
@@ -2,7 +2,9 @@ dependencies:
   override: []
 
 review:
-  checklist: []
+  checklist:
+    - In the "test" namespace, did you check for orphan migration test resources?
+
 
 deploy:
   override:


### PR DESCRIPTION
Addresses #4798. Since our infrastructure deployed via Terraform is rarely changed, this PR makes the chart deployed version of it optional plus adds checks to see if the storage buckets already exist

## Changes 🚧

- Make `terraform-bucket-provision` optional, disabled by default.
  - Use an env variable in ShipIt or manually to enable.
- Add a pre-install,pre-upgrade container to check for the existence of the storage buckets. Runs *after* the terraform hook.
