### PR TITLE
fix: push correct fee description for penalties to elicensing

### DIFF
--- a/bc_obps/compliance/service/penalty_calculation_service.py
+++ b/bc_obps/compliance/service/penalty_calculation_service.py
@@ -188,7 +188,6 @@ class PenaltyCalculationService:
     def create_penalty_invoice(
         compliance_penalty: CompliancePenalty,
         total_penalty: Decimal,
-        penalty_type: CompliancePenalty.PenaltyType = CompliancePenalty.PenaltyType.AUTOMATIC_OVERDUE,
     ) -> None:
         """
         Create a fee and invoice for the penalty in elicensing
@@ -207,12 +206,18 @@ class PenaltyCalculationService:
             operator_id=compliance_penalty.compliance_obligation.compliance_report_version.compliance_report.report.operator_id
         )
 
+        penalty_description = (
+            compliance_penalty.penalty_type == 'GGEAPAR Interest'
+            if CompliancePenalty.PenaltyType.LATE_SUBMISSION
+            else 'Automatic Overdue Penalty'
+        )
+
         # Compose the fee data for the penalty fee
         fee_data: Dict[str, Any] = {
             "businessAreaCode": "OBPS",
             "feeGUID": str(uuid.uuid4()),
             "feeProfileGroupName": "OBPS Administrative Penalty",
-            "feeDescription": penalty_type,
+            "feeDescription": penalty_description,
             "feeAmount": float(total_penalty),
             "feeDate": date.today().strftime("%Y-%m-%d"),
         }

--- a/bc_obps/compliance/service/penalty_calculation_service.py
+++ b/bc_obps/compliance/service/penalty_calculation_service.py
@@ -207,8 +207,8 @@ class PenaltyCalculationService:
         )
 
         penalty_description = (
-            compliance_penalty.penalty_type == 'GGEAPAR Interest'
-            if CompliancePenalty.PenaltyType.LATE_SUBMISSION
+            'GGEAPAR Interest'
+            if compliance_penalty.penalty_type == CompliancePenalty.PenaltyType.LATE_SUBMISSION
             else 'Automatic Overdue Penalty'
         )
 


### PR DESCRIPTION
#4930
Updates the fee description pushed to eLicensing for the 2 types of penalties to:
Late Submission: 'GGEAPAR Interest'
Automatic Overdue: 'Automatic Overdue Penalty'

This is what the line item description should now show on both the eLicensing invoice and the invoice generated by BCIERS