### PR TITLE
Fix/airflow dag time

### DIFF
--- a/dags/bc_obps_reset_data.py
+++ b/dags/bc_obps_reset_data.py
@@ -2,7 +2,7 @@ from dag_configuration import default_dag_args
 from trigger_k8s_cronjob import trigger_k8s_cronjob
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from airflow.decorators import dag, task
 import os
 import sys
@@ -10,13 +10,13 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 RESET_DATA_DAG_NAME = "bc_obps_reset_data"
 WAIT_FOR_BACKEND_ROLLOUT_DAG_NAME = "bc_obps_reset_data_wait_for_backend_rollout"
-TWO_DAYS_AGO = datetime.now(timezone.utc) - timedelta(days=2)
+START_DATE = datetime(2025, 10, 1, tzinfo=timezone.utc)
 SERVICE_ACCOUNT_NAME = "airflow-deployer"
 BACKEND_DEPLOYMENT_NAME = "cas-bciers-backend"
 K8S_IMAGE = "alpine/k8s:1.29.15"
 BCIERS_NAMESPACE = os.getenv("BCIERS_NAMESPACE")
 
-default_args = {**default_dag_args}
+default_args = {**default_dag_args, "start_date": START_DATE}
 
 RESET_DAG_DOC = """
 DAG to reset the data in the BCIERS database to a freshly deployed state.
@@ -27,6 +27,7 @@ DAG to reset the data in the BCIERS database to a freshly deployed state.
     dag_id=RESET_DATA_DAG_NAME,
     schedule=None,  # This dag is intended to be run manually
     default_args=default_args,
+    catchup=False,
     is_paused_upon_creation=False,
     doc_md=RESET_DAG_DOC,
     tags=['bciers'],

--- a/dags/bc_obps_reset_data.py
+++ b/dags/bc_obps_reset_data.py
@@ -3,7 +3,7 @@ from trigger_k8s_cronjob import trigger_k8s_cronjob
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
 from datetime import datetime, timezone
-from airflow.decorators import dag, task
+from airflow.sdk import dag, task
 import os
 import sys
 

--- a/dags/bc_obps_test_migrations.py
+++ b/dags/bc_obps_test_migrations.py
@@ -2,7 +2,7 @@ from dag_configuration import default_dag_args
 from trigger_k8s_cronjob import trigger_k8s_cronjob
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
-from airflow.decorators import dag, task
+from airflow.sdk import dag, task
 from datetime import datetime, timedelta, timezone
 import os
 import sys

--- a/dags/bc_obps_test_migrations.py
+++ b/dags/bc_obps_test_migrations.py
@@ -3,12 +3,12 @@ from trigger_k8s_cronjob import trigger_k8s_cronjob
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
 from airflow.decorators import dag, task
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import os
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
-TWO_DAYS_AGO = datetime.now() - timedelta(days=2)
+START_DATE = datetime(2025, 6, 1, tzinfo=timezone.utc)
 TEST_MIGRATIONS_DAG_NAME = "cas_bciers_test_migrations"
 K8S_IMAGE = "alpine/k8s:1.29.15"
 SERVICE_ACCOUNT_NAME = "airflow-deployer"
@@ -28,7 +28,7 @@ BACKEND_CHART_TAG = os.getenv("BACKEND_CHART_TAG")
 # Jinja (runtime) template constant
 DESTINATION_NAMESPACE_TEMPLATE = "{{ params.destination_namespace }}"
 
-default_args = {**default_dag_args, "start_date": TWO_DAYS_AGO}
+default_args = {**default_dag_args, "start_date": START_DATE}
 
 DAG_DOC = """
 DAG to test the database and backend migrations. This DAG will uninstall the helm charts after the tests are complete, but **if the tests fail, the charts will remain installed**.

--- a/dags/cas_bciers_dags.py
+++ b/dags/cas_bciers_dags.py
@@ -2,7 +2,7 @@
 from dag_configuration import default_dag_args
 from trigger_k8s_cronjob import trigger_k8s_cronjob
 from datetime import datetime, timezone
-from airflow.decorators import dag, task
+from airflow.sdk import dag, task
 from airflow.models.dagrun import DagRun
 
 import os

--- a/dags/cas_bciers_dags.py
+++ b/dags/cas_bciers_dags.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from dag_configuration import default_dag_args
 from trigger_k8s_cronjob import trigger_k8s_cronjob
-from datetime import timedelta, datetime, timezone
+from datetime import datetime, timezone
 from airflow.decorators import dag, task
 from airflow.models.dagrun import DagRun
 
@@ -12,9 +12,9 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 PROCESS_DUE_TRANSFERS_DAG_NAME = 'cas_bciers_process_due_transfer_events'
 NIGHTLY_BUILD_DAG_NAME = "cas_bciers_nightly_build_report"
 BCIERS_NAMESPACE = os.getenv('BCIERS_NAMESPACE')
-TWO_DAYS_AGO = datetime.now(timezone.utc) - timedelta(days=2)
+START_DATE = datetime(2025, 1, 1, tzinfo=timezone.utc)
 
-default_args = {**default_dag_args, 'start_date': TWO_DAYS_AGO}
+default_args = {**default_dag_args, 'start_date': START_DATE}
 
 PROCESS_DUE_DAG_DOC = """
 DAG triggering cron job to process due transfers
@@ -25,6 +25,7 @@ DAG triggering cron job to process due transfers
     dag_id=PROCESS_DUE_TRANSFERS_DAG_NAME,
     schedule='0 8 * * *',
     default_args=default_args,
+    catchup=False,
     is_paused_upon_creation=False,
     doc_md=PROCESS_DUE_DAG_DOC,
     tags=['bciers'],
@@ -56,6 +57,7 @@ The following parameters are available:
     dag_id=NIGHTLY_BUILD_DAG_NAME,
     schedule=None,  # This dag is intended triggered
     default_args=default_args,
+    catchup=False,
     is_paused_upon_creation=False,
     doc_md=NIGHTLY_BUILD_DAG_DOC,
     tags=['bciers'],

--- a/prek.toml
+++ b/prek.toml
@@ -131,6 +131,12 @@ id = "ruff"
 args = ["bc_obps/", "--fix"]
 priority = 3
 
+[[repos.hooks]]
+id = "ruff-check"
+name = "ruff check Airflow Dags"
+args = ["dags/", "--select", "AIR3", "--fix"]
+priority = 3
+
 # Python dependency management
 
 [[repos]]


### PR DESCRIPTION
Addresses #4911. Sets the start time of Dags to a static time. As Dags are versioned as of Airflow 3, this prevents the version from increasing unnecessarily. 

## Changes 🚧

- Change Dags to use static time (based on initial adding of the Dag, since they are triggered so it's not particularly relevant).
- Run a Ruff check using [AIR ](https://docs.astral.sh/ruff/rules/#airflow-air) linter for Airflow 3 issues and correct them.
- Add Prek check for Dag Ruff check.

## Notes 📝

The issue flagged by 4911 is relevant to most of our Dags in other cas repos. Cloned that issue into Cas-Airflow to cover the rest of the repos as bcgov/cas-airflow#232.
