### PR TITLE
5022 API failure in metadata fetch causes full layout crash instead of graceful alert

### DIFF
--- a/bciers/apps/compliance/src/app/utils/getElicensingLastRefreshedMetaData.ts
+++ b/bciers/apps/compliance/src/app/utils/getElicensingLastRefreshedMetaData.ts
@@ -1,17 +1,13 @@
-import { actionHandler } from "@bciers/actions";
 import type { ElicensingLastRefreshData } from "@/compliance/src/app/types";
+import { safeFetchApi } from "@bciers/actions/safeFetchApi";
 
 export async function getElicensingLastRefreshedMetaData(
   complianceReportVersionId: number,
 ): Promise<ElicensingLastRefreshData> {
   const endpoint = `compliance/elicensing/compliance-report-versions/${complianceReportVersionId}/last-refreshed-metadata`;
-  const response = await actionHandler(endpoint, "GET", "");
 
-  if (response?.error) {
-    throw new Error(
-      `Failed to fetch Elicensing LastRefreshData for compliance report version ${complianceReportVersionId}: ${response.error}`,
-    );
-  }
-
-  return response;
+  return safeFetchApi<ElicensingLastRefreshData>(endpoint, {
+    last_refreshed_display: "",
+    data_is_fresh: false,
+  });
 }

--- a/bciers/libs/actions/src/safeFetchApi.ts
+++ b/bciers/libs/actions/src/safeFetchApi.ts
@@ -1,0 +1,56 @@
+import { getToken } from "@bciers/actions";
+import { fetchApi } from "@bciers/actions/api/fetchApi";
+import { captureException } from "@bciers/sentryConfig/sentry";
+
+/**
+ * Safely fetches data using fetchApi and getToken,
+ * returning a fallback value if any error occurs
+ */
+export async function safeFetchApi<T>(
+  endpoint: string,
+  fallback: T,
+  method: string = "GET",
+  body?: unknown,
+): Promise<T> {
+  let userGuid: string | undefined;
+
+  try {
+    const token = await getToken();
+    userGuid = token?.user_guid;
+
+    const response = await fetchApi(endpoint, token, method, body);
+    const apiError = response?.error || response?.message;
+
+    if (!response || apiError) {
+      if (apiError) {
+        try {
+          captureException(
+            new Error(`[API Error] ${endpoint}: ${apiError}`),
+            userGuid,
+          );
+        } catch (sentryErr) {
+          // eslint-disable-next-line no-console
+          console.error("Failed to report exception to Sentry:", sentryErr);
+        }
+      }
+      return fallback;
+    }
+
+    return response as T;
+  } catch (error: unknown) {
+    try {
+      const errObj = error instanceof Error ? error : null;
+      const message =
+        typeof error === "string"
+          ? error
+          : (JSON.stringify(error) ?? "Unknown error");
+
+      captureException(errObj || new Error(message), userGuid);
+    } catch (sentryErr) {
+      // eslint-disable-next-line no-console
+      console.error("Failed to report exception to Sentry:", sentryErr);
+    }
+
+    return fallback;
+  }
+}

--- a/bciers/libs/utils/src/safeFetchApi.test.ts
+++ b/bciers/libs/utils/src/safeFetchApi.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { safeFetchApi } from "@bciers/actions/safeFetchApi";
+import { getToken } from "@bciers/actions";
+import { fetchApi } from "@bciers/actions/api/fetchApi";
+
+// Mock @bciers/actions dependencies
+vi.mock("@bciers/actions", () => ({
+  getToken: vi.fn(),
+}));
+
+vi.mock("@bciers/actions/api/fetchApi", () => ({
+  fetchApi: vi.fn(),
+}));
+
+// Mock Sentry using vi.hoisted to reference captureExceptionMock inside vi.mock factory
+const { captureExceptionMock } = vi.hoisted(() => {
+  return {
+    captureExceptionMock: vi.fn(),
+  };
+});
+
+vi.mock("@bciers/sentryConfig/sentry", () => ({
+  captureException: captureExceptionMock,
+}));
+
+const mockGetToken = getToken as ReturnType<typeof vi.fn>;
+const mockFetchApi = fetchApi as ReturnType<typeof vi.fn>;
+
+describe("safeFetchApi function", () => {
+  const fallbackValue = { fallback: true };
+  const mockToken = { user_guid: "user-guid-123" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetToken.mockResolvedValue(mockToken);
+  });
+
+  it("should return data on successful request", async () => {
+    const mockData = { id: 1, name: "Test Entity" };
+    mockFetchApi.mockResolvedValueOnce(mockData);
+
+    const result = await safeFetchApi("/endpoint", fallbackValue, "GET");
+
+    expect(result).toEqual(mockData);
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("should return fallback and forward to Sentry when fetchApi returns response.error or response.message", async () => {
+    mockFetchApi.mockResolvedValueOnce({
+      error: "Backend error message",
+    });
+
+    const result = await safeFetchApi("/endpoint", fallbackValue, "POST");
+
+    expect(result).toEqual(fallbackValue);
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "[API Error] /endpoint: Backend error message",
+      }),
+      "user-guid-123",
+    );
+  });
+
+  it("should return fallback and forward to Sentry when fetchApi throws an Error instance", async () => {
+    const thrownError = new Error("Network timeout");
+    mockFetchApi.mockRejectedValueOnce(thrownError);
+
+    const result = await safeFetchApi("/endpoint", fallbackValue, "GET");
+
+    expect(result).toEqual(fallbackValue);
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      thrownError,
+      "user-guid-123",
+    );
+  });
+
+  it("should handle non-Error thrown primitive values safely and convert them for Sentry", async () => {
+    mockFetchApi.mockRejectedValueOnce("Server crashed completely");
+
+    const result = await safeFetchApi("/endpoint", fallbackValue, "GET");
+
+    expect(result).toEqual(fallbackValue);
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Server crashed completely",
+      }),
+      "user-guid-123",
+    );
+  });
+
+  it("should handle non-Error thrown plain objects by stringifying them for Sentry", async () => {
+    const plainObjectError = { status: 500, detail: "Internal Server Error" };
+    mockFetchApi.mockRejectedValueOnce(plainObjectError);
+
+    const result = await safeFetchApi("/endpoint", fallbackValue, "GET");
+
+    expect(result).toEqual(fallbackValue);
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: JSON.stringify(plainObjectError),
+      }),
+      "user-guid-123",
+    );
+  });
+
+  it("should fail silently and still return fallback if captureException throws", async () => {
+    const networkError = new Error("Connection failed");
+    mockFetchApi.mockRejectedValueOnce(networkError);
+
+    // Force Sentry reporting itself to throw an exception
+    captureExceptionMock.mockImplementationOnce(() => {
+      throw new Error("Sentry server unreachable");
+    });
+
+    const result = await safeFetchApi("/endpoint", fallbackValue, "GET");
+
+    expect(result).toEqual(fallbackValue);
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Ticket: [5022](https://github.com/bcgov/cas-registration/issues/5022)

### 🚀 Impact

- Refactored `getElicensingLastRefreshedMetaData` from `actionHandler` to `safeFetchApi` 

---

### 🔬 Local Testing:  

#### Start Test Environment
1. Start the API server:  
   ```sh
   cd bc_obps
   make prepare_backend
   ```  
2. Start the app development server:  
   ```sh
   cd bciers && yarn dev-all
   ```  

---

#### Test Manage Obligation Handles API Failure via `ElicensingStaleDataAlert`

#### 📋 Prerequisites
 
Update invoice generation date
```
UPDATE erc.compliance_period
SET invoice_generation_date = CURRENT_DATE - INTERVAL '1 day'
WHERE reporting_year_id = 2025;

```   
Mock an error in `def get_last_refreshed_metadata`
```
def get_last_refreshed_metadata(
    request: HttpRequest, compliance_report_version_id: int
) -> Tuple[Literal[200], ElicensingLastRefreshOut]:
    
   
    raise ValueError(
        "Error."
    )
```   
1. Submit Compliance SFO - Obligation not met, navigate to http://localhost:3000/reporting/reports/3/sign-off
2. Complete the form
3. Click `Submit`
4. Navigate to compliance http://localhost:3000/compliance/compliance-administration/compliance-summaries
5. For compliance report version `Compliance SFO - Obligation not met`, click `Manage Obligation`, http://localhost:3000/compliance/compliance-administration/compliance-summaries/3/review-compliance-obligation-report
**Expected Results**

<img width="1695" height="913" alt="Image" src="https://github.com/user-attachments/assets/b4d5b855-e234-4f88-a8a4-daf5a22d070c" />