### PR TITLE
chore: bump pg migration test PVC to match prod

### DIFF
--- a/helm/migration-test/cas-obps-postgres-migration-test/templates/postgres-cluster.yaml
+++ b/helm/migration-test/cas-obps-postgres-migration-test/templates/postgres-cluster.yaml
@@ -68,7 +68,7 @@ spec:
           - "ReadWriteOnce"
         resources:
           requests:
-            storage: 1000Mi
+            storage: 3000Mi
         storageClassName: netapp-block-standard
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
When the Migration Tests run, they've been hitting PVC volume limits. This PR changes the limits to match Prod.