### PR TITLE
chore: update migration-test chart version

### DIFF
--- a/helm/migration-test/cas-obps-postgres-migration-test/Chart.yaml
+++ b/helm/migration-test/cas-obps-postgres-migration-test/Chart.yaml
@@ -4,6 +4,6 @@ description: A chart for testing the backups of the CAS BCIERS Postgres cluster.
 
 type: application
 
-version: 0.2.2
+version: 0.2.3
 
 appVersion: "0.1.0"


### PR DESCRIPTION
Missed chart version bump caused the release-charts job to fail in previous BCIERS release 5.18.1. This will fix that