### PR TITLE
fix: display broken errors on responsible, review, and additional pages

### DIFF
--- a/bciers/apps/reporting/src/app/components/changeReview/ChangeReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/changeReview/ChangeReviewForm.tsx
@@ -12,6 +12,7 @@ import Loading from "@bciers/components/loading/SkeletonForm";
 import AlertNote from "@bciers/components/form/components/AlertNote";
 import { handleApiResponse } from "@reporting/src/app/utils/handleApiResponse";
 import { useFormErrors } from "@reporting/src/hooks/useFormErrors";
+import { createGenericReportValidationError } from "@reporting/src/app/components/shared/validation/utils";
 
 interface ChangeReviewProps {
   versionId: number;
@@ -55,6 +56,12 @@ export default function ChangeReviewForm({
   }, [versionId, displayChanges]);
 
   const handleSubmit = async (canContinue: boolean) => {
+    if (!reasonForChange || reasonForChange === "") {
+      setErrors([
+        createGenericReportValidationError("Reason for change is required."),
+      ]);
+      return false;
+    }
     const payload = {
       ...formData,
       reason_for_change: reasonForChange,

--- a/bciers/apps/reporting/src/app/components/changeReview/ChangeReviewForm.tsx
+++ b/bciers/apps/reporting/src/app/components/changeReview/ChangeReviewForm.tsx
@@ -56,7 +56,7 @@ export default function ChangeReviewForm({
   }, [versionId, displayChanges]);
 
   const handleSubmit = async (canContinue: boolean) => {
-    if (!reasonForChange || reasonForChange === "") {
+    if (!reasonForChange) {
       setErrors([
         createGenericReportValidationError("Reason for change is required."),
       ]);

--- a/bciers/apps/reporting/src/data/jsonSchema/newEntrantInformation/newEntrantInformationSchema.tsx
+++ b/bciers/apps/reporting/src/data/jsonSchema/newEntrantInformation/newEntrantInformationSchema.tsx
@@ -7,6 +7,7 @@ export const newEntrantSchema: RJSFSchema = {
     "authorization_date",
     "first_shipment_date",
     "new_entrant_period_start",
+    "assertion_statement",
   ],
   properties: {
     purpose_note: {
@@ -28,6 +29,7 @@ export const newEntrantSchema: RJSFSchema = {
     assertion_statement: {
       type: "boolean",
       title: "Assertion statement",
+      const: true,
       default: false,
     },
     products: {

--- a/bciers/apps/reporting/src/data/jsonSchema/personResponsible.ts
+++ b/bciers/apps/reporting/src/data/jsonSchema/personResponsible.ts
@@ -14,6 +14,7 @@ import { Contact } from "@reporting/src/app/components/operations/types";
 export const personResponsibleSchema: RJSFSchema = {
   title: "Person Responsible for Submitting Report",
   type: "object",
+  required: ["person_responsible"],
   properties: {
     purpose_note: {
       type: "object",

--- a/bciers/apps/reporting/src/tests/components/changeReview/ChangeReviewForm.test.tsx
+++ b/bciers/apps/reporting/src/tests/components/changeReview/ChangeReviewForm.test.tsx
@@ -78,7 +78,10 @@ describe("ChangeReviewForm", () => {
 
   const defaultProps = {
     versionId: 123,
-    initialFormData: { test: "initial", reason_for_change: "" },
+    initialFormData: {
+      test: "initial",
+      reason_for_change: "Initial reason for change",
+    },
     navigationInformation: {
       headerStepIndex: 1,
       headerSteps: [

--- a/bciers/libs/utils/src/customTransformErrors.ts
+++ b/bciers/libs/utils/src/customTransformErrors.ts
@@ -197,6 +197,12 @@ const customTransformErrors = (
       error.message = `Select at least one option`;
       return error;
     }
+    if (error?.name === "const" && error?.params?.allowedValue === true) {
+      error.message = error.title
+        ? `${error.title} must be accepted`
+        : "This field must be checked";
+      return error;
+    }
     // Only show the 0-100 message for biogenicIndustrialProcessEmissions fields
     if (
       (error?.name === "minimum" || error?.name === "maximum") &&


### PR DESCRIPTION
resolves: 4825

I got 3 out of the 4 of these errors displayed, however with the additional reporting page, there exists the allOf/if/then rjsf issue we dealt with before. See comment [here](https://github.com/bcgov/cas-registration/issues/4825#issuecomment-5137402298)
